### PR TITLE
Introduce ChangeFlags and use it instead of bools to track changes in views

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -244,16 +244,14 @@ where
             let state =
                 if let Some(element) = self.root_pod.as_mut().and_then(|pod| pod.downcast_mut()) {
                     let mut state = response.state.unwrap();
-                    let changed = response.view.rebuild(
+                    let changes = response.view.rebuild(
                         &mut self.cx,
                         response.prev.as_ref().unwrap(),
                         self.id.as_mut().unwrap(),
                         &mut state,
                         element,
                     );
-                    if changed {
-                        self.root_pod.as_mut().unwrap().request_update();
-                    }
+                    self.root_pod.as_mut().unwrap().mark(changes);
                     assert!(self.cx.is_empty(), "id path imbalance on rebuild");
                     state
                 } else {

--- a/src/view.rs
+++ b/src/view.rs
@@ -35,7 +35,7 @@ use futures_task::{ArcWake, Waker};
 use crate::{
     event::EventResult,
     id::{Id, IdPath},
-    widget::{UpdateFlags, Widget},
+    widget::{ChangeFlags, Widget},
 };
 
 /// A view object representing a node in the UI.
@@ -73,7 +73,7 @@ pub trait View<T, A = ()>: Send {
         id: &mut Id,
         state: &mut Self::State,
         element: &mut Self::Element,
-    ) -> UpdateFlags;
+    ) -> ChangeFlags;
 
     /// Propagate an event.
     ///

--- a/src/view.rs
+++ b/src/view.rs
@@ -35,7 +35,7 @@ use futures_task::{ArcWake, Waker};
 use crate::{
     event::EventResult,
     id::{Id, IdPath},
-    widget::Widget,
+    widget::{UpdateFlags, Widget},
 };
 
 /// A view object representing a node in the UI.
@@ -73,7 +73,7 @@ pub trait View<T, A = ()>: Send {
         id: &mut Id,
         state: &mut Self::State,
         element: &mut Self::Element,
-    ) -> bool;
+    ) -> UpdateFlags;
 
     /// Propagate an event.
     ///

--- a/src/view/button.rs
+++ b/src/view/button.rs
@@ -14,7 +14,7 @@
 
 use std::any::Any;
 
-use crate::{event::EventResult, id::Id};
+use crate::{event::EventResult, id::Id, widget::UpdateFlags};
 
 use super::{Cx, View};
 
@@ -58,12 +58,11 @@ impl<T, A> View<T, A> for Button<T, A> {
         _id: &mut crate::id::Id,
         _state: &mut Self::State,
         element: &mut Self::Element,
-    ) -> bool {
+    ) -> UpdateFlags {
         if prev.label != self.label {
-            element.set_label(self.label.clone());
-            true
+            element.set_label(self.label.clone())
         } else {
-            false
+            UpdateFlags::empty()
         }
     }
 

--- a/src/view/button.rs
+++ b/src/view/button.rs
@@ -14,7 +14,7 @@
 
 use std::any::Any;
 
-use crate::{event::EventResult, id::Id, widget::UpdateFlags};
+use crate::{event::EventResult, id::Id, widget::ChangeFlags};
 
 use super::{Cx, View};
 
@@ -58,11 +58,11 @@ impl<T, A> View<T, A> for Button<T, A> {
         _id: &mut crate::id::Id,
         _state: &mut Self::State,
         element: &mut Self::Element,
-    ) -> UpdateFlags {
+    ) -> ChangeFlags {
         if prev.label != self.label {
             element.set_label(self.label.clone())
         } else {
-            UpdateFlags::empty()
+            ChangeFlags::empty()
         }
     }
 

--- a/src/view/text.rs
+++ b/src/view/text.rs
@@ -14,7 +14,7 @@
 
 use std::any::Any;
 
-use crate::{event::EventResult, id::Id, widget::UpdateFlags};
+use crate::{event::EventResult, id::Id, widget::ChangeFlags};
 
 use super::{Cx, View};
 
@@ -35,11 +35,11 @@ impl<T, A> View<T, A> for String {
         _id: &mut crate::id::Id,
         _state: &mut Self::State,
         element: &mut Self::Element,
-    ) -> UpdateFlags {
+    ) -> ChangeFlags {
         if prev != self {
             element.set_text(self.clone())
         } else {
-            UpdateFlags::empty()
+            ChangeFlags::empty()
         }
     }
 

--- a/src/view/text.rs
+++ b/src/view/text.rs
@@ -14,7 +14,7 @@
 
 use std::any::Any;
 
-use crate::{event::EventResult, id::Id};
+use crate::{event::EventResult, id::Id, widget::UpdateFlags};
 
 use super::{Cx, View};
 
@@ -35,12 +35,11 @@ impl<T, A> View<T, A> for String {
         _id: &mut crate::id::Id,
         _state: &mut Self::State,
         element: &mut Self::Element,
-    ) -> bool {
+    ) -> UpdateFlags {
         if prev != self {
-            element.set_text(self.clone());
-            true
+            element.set_text(self.clone())
         } else {
-            false
+            UpdateFlags::empty()
         }
     }
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -33,7 +33,7 @@ use piet_scene::SceneBuilder;
 use self::contexts::LifeCycleCx;
 pub use self::contexts::{AlignCx, CxState, EventCx, LayoutCx, PaintCx, PreparePaintCx, UpdateCx};
 pub use self::core::Pod;
-pub(crate) use self::core::{PodFlags, WidgetState};
+pub(crate) use self::core::{PodFlags, UpdateFlags, WidgetState};
 pub use self::raw_event::{LifeCycle, RawEvent};
 
 use self::align::SingleAlignment;

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -33,7 +33,7 @@ use piet_scene::SceneBuilder;
 use self::contexts::LifeCycleCx;
 pub use self::contexts::{AlignCx, CxState, EventCx, LayoutCx, PaintCx, PreparePaintCx, UpdateCx};
 pub use self::core::Pod;
-pub(crate) use self::core::{PodFlags, UpdateFlags, WidgetState};
+pub(crate) use self::core::{ChangeFlags, PodFlags, WidgetState};
 pub use self::raw_event::{LifeCycle, RawEvent};
 
 use self::align::SingleAlignment;

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -22,7 +22,7 @@ use super::{
     align::{FirstBaseline, LastBaseline, SingleAlignment},
     contexts::LifeCycleCx,
     piet_scene_helpers::{self, UnitPoint},
-    AlignCx, EventCx, LayoutCx, LifeCycle, PaintCx, RawEvent, UpdateCx, Widget,
+    AlignCx, EventCx, LayoutCx, LifeCycle, PaintCx, RawEvent, UpdateCx, UpdateFlags, Widget,
 };
 
 pub struct Button {
@@ -40,9 +40,10 @@ impl Button {
         }
     }
 
-    pub fn set_label(&mut self, label: String) {
+    pub fn set_label(&mut self, label: String) -> UpdateFlags {
         self.label = label;
         self.layout = None;
+        UpdateFlags::REQUEST_LAYOUT | UpdateFlags::REQUEST_PAINT
     }
 }
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -22,7 +22,7 @@ use super::{
     align::{FirstBaseline, LastBaseline, SingleAlignment},
     contexts::LifeCycleCx,
     piet_scene_helpers::{self, UnitPoint},
-    AlignCx, EventCx, LayoutCx, LifeCycle, PaintCx, RawEvent, UpdateCx, UpdateFlags, Widget,
+    AlignCx, ChangeFlags, EventCx, LayoutCx, LifeCycle, PaintCx, RawEvent, UpdateCx, Widget,
 };
 
 pub struct Button {
@@ -40,10 +40,10 @@ impl Button {
         }
     }
 
-    pub fn set_label(&mut self, label: String) -> UpdateFlags {
+    pub fn set_label(&mut self, label: String) -> ChangeFlags {
         self.label = label;
         self.layout = None;
-        UpdateFlags::REQUEST_LAYOUT | UpdateFlags::REQUEST_PAINT
+        ChangeFlags::REQUEST_LAYOUT | ChangeFlags::REQUEST_PAINT
     }
 }
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -43,7 +43,7 @@ impl Button {
     pub fn set_label(&mut self, label: String) -> ChangeFlags {
         self.label = label;
         self.layout = None;
-        ChangeFlags::REQUEST_LAYOUT | ChangeFlags::REQUEST_PAINT
+        ChangeFlags::LAYOUT | ChangeFlags::PAINT
     }
 }
 

--- a/src/widget/core.rs
+++ b/src/widget/core.rs
@@ -49,6 +49,16 @@ bitflags! {
     }
 }
 
+bitflags! {
+    #[derive(Default)]
+    #[must_use]
+    pub struct UpdateFlags: u8 {
+        const REQUEST_UPDATE = 1;
+        const REQUEST_LAYOUT = 2;
+        const REQUEST_PAINT = 4;
+    }
+}
+
 /// A pod that contains a widget (in a container).
 pub struct Pod {
     pub(crate) state: WidgetState,
@@ -125,6 +135,11 @@ impl Pod {
 
     pub fn downcast_mut<T: 'static>(&mut self) -> Option<&mut T> {
         (*self.widget).as_any_mut().downcast_mut()
+    }
+
+    pub fn mark(&mut self, flags: UpdateFlags) {
+        self.state
+            .request(PodFlags::from_bits(flags.bits().into()).unwrap());
     }
 
     pub fn request_update(&mut self) {

--- a/src/widget/core.rs
+++ b/src/widget/core.rs
@@ -52,7 +52,7 @@ bitflags! {
 bitflags! {
     #[derive(Default)]
     #[must_use]
-    pub struct UpdateFlags: u8 {
+    pub struct ChangeFlags: u8 {
         const REQUEST_UPDATE = 1;
         const REQUEST_LAYOUT = 2;
         const REQUEST_PAINT = 4;
@@ -137,7 +137,7 @@ impl Pod {
         (*self.widget).as_any_mut().downcast_mut()
     }
 
-    pub fn mark(&mut self, flags: UpdateFlags) {
+    pub fn mark(&mut self, flags: ChangeFlags) {
         self.state
             .request(PodFlags::from_bits(flags.bits().into()).unwrap());
     }

--- a/src/widget/core.rs
+++ b/src/widget/core.rs
@@ -53,9 +53,9 @@ bitflags! {
     #[derive(Default)]
     #[must_use]
     pub struct ChangeFlags: u8 {
-        const REQUEST_UPDATE = 1;
-        const REQUEST_LAYOUT = 2;
-        const REQUEST_PAINT = 4;
+        const UPDATE = 1;
+        const LAYOUT = 2;
+        const PAINT = 4;
     }
 }
 

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -41,7 +41,7 @@ impl TextWidget {
 
     pub fn set_text(&mut self, text: String) -> ChangeFlags {
         self.text = text;
-        ChangeFlags::REQUEST_LAYOUT | ChangeFlags::REQUEST_PAINT
+        ChangeFlags::LAYOUT | ChangeFlags::PAINT
     }
 }
 

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -21,7 +21,7 @@ use crate::text::ParleyBrush;
 use super::{
     align::{FirstBaseline, LastBaseline, SingleAlignment, VertAlignment},
     contexts::LifeCycleCx,
-    AlignCx, EventCx, LayoutCx, LifeCycle, PaintCx, RawEvent, UpdateCx, UpdateFlags, Widget,
+    AlignCx, ChangeFlags, EventCx, LayoutCx, LifeCycle, PaintCx, RawEvent, UpdateCx, Widget,
 };
 
 pub struct TextWidget {
@@ -39,9 +39,9 @@ impl TextWidget {
         }
     }
 
-    pub fn set_text(&mut self, text: String) -> UpdateFlags {
+    pub fn set_text(&mut self, text: String) -> ChangeFlags {
         self.text = text;
-        UpdateFlags::REQUEST_LAYOUT | UpdateFlags::REQUEST_PAINT
+        ChangeFlags::REQUEST_LAYOUT | ChangeFlags::REQUEST_PAINT
     }
 }
 

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -21,7 +21,7 @@ use crate::text::ParleyBrush;
 use super::{
     align::{FirstBaseline, LastBaseline, SingleAlignment, VertAlignment},
     contexts::LifeCycleCx,
-    AlignCx, EventCx, LayoutCx, LifeCycle, PaintCx, RawEvent, UpdateCx, Widget,
+    AlignCx, EventCx, LayoutCx, LifeCycle, PaintCx, RawEvent, UpdateCx, UpdateFlags, Widget,
 };
 
 pub struct TextWidget {
@@ -39,8 +39,9 @@ impl TextWidget {
         }
     }
 
-    pub fn set_text(&mut self, text: String) {
+    pub fn set_text(&mut self, text: String) -> UpdateFlags {
         self.text = text;
+        UpdateFlags::REQUEST_LAYOUT | UpdateFlags::REQUEST_PAINT
     }
 }
 


### PR DESCRIPTION
This approach has a number of advantages.

- It makes it clear that `set_label` and `set_text` do not themselves set the flags and that these functions are the source of these flags.
- The type is marked as `#[must_use]` so flags are not accidentally missed, which I have done previously when writing views.
- It seems to make the `update` phase unnecessary.

`ChangeFlags` or `Changes` could be some alternative names. The current name could easily be confused with the `update` phase.