### PR TITLE
Assign view id paths by parents

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -15,7 +15,7 @@
 use std::num::NonZeroU64;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Hash)]
-/// A stable identifier for an element.
+/// A stable identifier for a view tree path segment.
 pub struct Id(NonZeroU64);
 
 pub type IdPath = Vec<Id>;

--- a/src/view.rs
+++ b/src/view.rs
@@ -61,7 +61,7 @@ pub trait View<T, A = ()>: Send {
     type Element: Widget;
 
     /// Build the associated widget and initialize state.
-    fn build(&self, cx: &mut Cx) -> (Id, Self::State, Self::Element);
+    fn build(&self, cx: &mut Cx) -> (Self::State, Self::Element);
 
     /// Update the associated widget.
     ///
@@ -70,7 +70,6 @@ pub trait View<T, A = ()>: Send {
         &self,
         cx: &mut Cx,
         prev: &Self,
-        id: &mut Id,
         state: &mut Self::State,
         element: &mut Self::Element,
     ) -> bool;
@@ -92,7 +91,7 @@ pub trait View<T, A = ()>: Send {
 pub struct Cx {
     id_path: IdPath,
     req_chan: SyncSender<IdPath>,
-    pub(crate) pending_async: HashSet<Id>,
+    pub(crate) pending_async: HashSet<IdPath>,
 }
 
 struct MyWaker {
@@ -165,7 +164,7 @@ impl Cx {
     /// Rendering may be delayed when there are pending async futures, to avoid
     /// flashing, and continues when all futures complete, or a timeout, whichever
     /// is first.
-    pub fn add_pending_async(&mut self, id: Id) {
-        self.pending_async.insert(id);
+    pub fn add_pending_async(&mut self, id_path: IdPath) {
+        self.pending_async.insert(id_path);
     }
 }

--- a/src/view/button.rs
+++ b/src/view/button.rs
@@ -45,17 +45,15 @@ impl<T, A> View<T, A> for Button<T, A> {
 
     type Element = crate::widget::button::Button;
 
-    fn build(&self, cx: &mut Cx) -> (Id, Self::State, Self::Element) {
-        let (id, element) = cx
-            .with_new_id(|cx| crate::widget::button::Button::new(cx.id_path(), self.label.clone()));
-        (id, (), element)
+    fn build(&self, cx: &mut Cx) -> (Self::State, Self::Element) {
+        let element = crate::widget::button::Button::new(cx.id_path(), self.label.clone());
+        ((), element)
     }
 
     fn rebuild(
         &self,
         _cx: &mut Cx,
         prev: &Self,
-        _id: &mut crate::id::Id,
         _state: &mut Self::State,
         element: &mut Self::Element,
     ) -> bool {

--- a/src/view/text.rs
+++ b/src/view/text.rs
@@ -23,16 +23,15 @@ impl<T, A> View<T, A> for String {
 
     type Element = crate::widget::text::TextWidget;
 
-    fn build(&self, cx: &mut Cx) -> (Id, Self::State, Self::Element) {
-        let (id, element) = cx.with_new_id(|_| crate::widget::text::TextWidget::new(self.clone()));
-        (id, (), element)
+    fn build(&self, _cx: &mut Cx) -> (Self::State, Self::Element) {
+        let element = crate::widget::text::TextWidget::new(self.clone());
+        ((), element)
     }
 
     fn rebuild(
         &self,
         _cx: &mut Cx,
         prev: &Self,
-        _id: &mut crate::id::Id,
         _state: &mut Self::State,
         element: &mut Self::Element,
     ) -> bool {


### PR DESCRIPTION
This changes `Id` allocation from using a global unique id per view to letting containers pick unique `Id` segments for their children. The `IdPath` when the `build` method on a view is called uniquely identifies an view. This results in slightly cleaner code. Views like `VStack` can process event dispatch with a jump table by hardcoding children ids instead of using an if/else tree.

A further optimization would be to change `IdPath` to `Vec<u8>` and let containers only use the number of bytes required, reducing `IdPath` sizes overall.