### PR TITLE
Experimental composable widgets for styling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe557ebe0829511ddff4ad3011d159c0e6f144e05e3e8c3ab5095a131900a7b"
+checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
 dependencies = [
  "async-lock",
  "autocfg",
@@ -125,7 +125,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -157,9 +157,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "glazier"
 version = "0.7.0"
-source = "git+https://github.com/linebender/glazier#464c328ff842a07543461c9991adfaa3cd78181d"
+source = "git+https://github.com/linebender/glazier#aaa01da0f98adc61601279ca866156c6b425ef12"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -1564,9 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1612,7 +1612,7 @@ dependencies = [
 [[package]]
 name = "piet-scene"
 version = "0.1.0"
-source = "git+https://github.com/linebender/piet-gpu#5882fbf4af41d3b506f733bc65f62cc23eaa315c"
+source = "git+https://github.com/linebender/piet-gpu#ab3ef4381d4007951e7ff27c958533b17aef4d44"
 dependencies = [
  "bytemuck",
  "moscato",
@@ -1623,7 +1623,7 @@ dependencies = [
 [[package]]
 name = "piet-wgsl"
 version = "0.1.0"
-source = "git+https://github.com/linebender/piet-gpu#5882fbf4af41d3b506f733bc65f62cc23eaa315c"
+source = "git+https://github.com/linebender/piet-gpu#ab3ef4381d4007951e7ff27c958533b17aef4d44"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
@@ -1671,16 +1671,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
+checksum = "9f7d73f1eaed1ca1fb37b54dcc9b38e3b17d6c7b8ecb7abfffcac8d0351f17d4"
 dependencies = [
  "autocfg",
  "cfg-if",
  "libc",
  "log",
  "wepoll-ffi",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1945,18 +1945,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2091,9 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ pub use app_main::AppLauncher;
 pub use view::button::button;
 pub use view::View;
 pub use widget::align::VertAlignment;
+pub use widget::compose_style::background::background;
+pub use widget::compose_style::padding::padding;
 pub use widget::Widget;
 
 use glazier::kurbo::Size;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,9 @@ mod widget;
 pub use app::App;
 pub use app_main::AppLauncher;
 pub use view::button::button;
+pub use view::style::{background, padding};
 pub use view::View;
 pub use widget::align::VertAlignment;
-pub use widget::compose_style::background::background;
-pub use widget::compose_style::padding::padding;
 pub use widget::Widget;
 
 use glazier::kurbo::Size;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,11 @@
-use xilem::{button, App, AppLauncher, View};
+use piet_scene::Color;
+use xilem::{background, button, padding, App, AppLauncher, View};
 
 fn app_logic(_data: &mut ()) -> impl View<()> {
-    button("click me", |_| println!("clicked"))
+    background(
+        Color::RED,
+        padding(40., button("Click me", |_| println!("Clicked"))),
+    )
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,13 @@
 use piet_scene::Color;
 use xilem::{background, button, padding, App, AppLauncher, View};
 
-fn app_logic(_data: &mut ()) -> impl View<()> {
+fn app_logic(data: &mut f64) -> impl View<f64> {
     background(
         Color::RED,
-        padding(40., button("Click me", |_| println!("Clicked"))),
+        padding(
+            *data,
+            button(format!("Padding {data}px"), |data| *data += 1.),
+        ),
     )
 }
 
@@ -19,6 +22,6 @@ fn main() {
     window_handle.show();
     app.run(None);
     */
-    let app = App::new((), app_logic);
+    let app = App::new(10., app_logic);
     AppLauncher::new(app).run()
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -20,6 +20,7 @@ pub mod button;
 // pub mod list;
 // pub mod memoize;
 // pub mod scroll_view;
+pub mod style;
 pub mod text;
 // pub mod use_state;
 // pub mod vstack;

--- a/src/view/style.rs
+++ b/src/view/style.rs
@@ -1,0 +1,150 @@
+use piet_scene::Color;
+
+use crate::{
+    id::Id,
+    widget::{
+        compose_style::{background::BackgroundWidget, padding::PaddingWidget},
+        Pod,
+    },
+    View,
+};
+
+pub fn padding<V: View<T, A>, T, A>(width: f64, view: V) -> impl View<T, A>
+where
+    V::Element: 'static,
+{
+    PaddingView::new(width, view)
+}
+
+pub struct PaddingView<V> {
+    width: f64,
+    view: V,
+}
+
+impl<T, A, V: View<T, A>> View<T, A> for PaddingView<V>
+where
+    V::Element: 'static,
+{
+    type State = (Id, V::State);
+
+    type Element = PaddingWidget;
+
+    fn build(&self, cx: &mut crate::view::Cx) -> (crate::id::Id, Self::State, Self::Element) {
+        let (id, (child_id, state, element)) = cx.with_new_id(|cx| self.view.build(cx));
+        let element = PaddingWidget::new(Pod::new(element), self.width);
+        (id, (child_id, state), element)
+    }
+
+    fn rebuild(
+        &self,
+        cx: &mut crate::view::Cx,
+        prev: &Self,
+        id: &mut crate::id::Id,
+        (child_id, state): &mut Self::State,
+        element: &mut Self::Element,
+    ) -> bool {
+        let mut changed = prev.width != self.width;
+        if changed {
+            element.set_width(self.width);
+        }
+        cx.with_id(*id, |cx| {
+            let child_element = element.widget.downcast_mut().unwrap();
+            let child_changed = self
+                .view
+                .rebuild(cx, &prev.view, child_id, state, child_element);
+            if child_changed {
+                changed = true;
+                element.widget.request_update();
+            }
+        });
+        changed
+    }
+
+    fn event(
+        &self,
+        id_path: &[crate::id::Id],
+        (child_id, state): &mut Self::State,
+        event: Box<dyn std::any::Any>,
+        app_state: &mut T,
+    ) -> crate::event::EventResult<A> {
+        let (left, right) = id_path.split_at(1);
+        assert!(left[0] == *child_id);
+        self.view.event(right, state, event, app_state)
+    }
+}
+
+impl<V> PaddingView<V> {
+    fn new(width: f64, view: V) -> Self {
+        PaddingView { width, view }
+    }
+}
+
+pub fn background<V: View<T, A>, T, A>(color: Color, view: V) -> impl View<T, A>
+where
+    V::Element: 'static,
+{
+    BackgroundView::new(color, view)
+}
+
+pub struct BackgroundView<V> {
+    color: Color,
+    view: V,
+}
+
+impl<T, A, V: View<T, A>> View<T, A> for BackgroundView<V>
+where
+    V::Element: 'static,
+{
+    type State = (Id, V::State);
+
+    type Element = BackgroundWidget;
+
+    fn build(&self, cx: &mut crate::view::Cx) -> (crate::id::Id, Self::State, Self::Element) {
+        let (id, (child_id, state, element)) = cx.with_new_id(|cx| self.view.build(cx));
+        let element = BackgroundWidget::new(Pod::new(element), self.color);
+        (id, (child_id, state), element)
+    }
+
+    fn rebuild(
+        &self,
+        cx: &mut crate::view::Cx,
+        prev: &Self,
+        id: &mut crate::id::Id,
+        (child_id, state): &mut Self::State,
+        element: &mut Self::Element,
+    ) -> bool {
+        let mut changed = prev.color != self.color;
+        if changed {
+            element.set_color(self.color);
+        }
+        cx.with_id(*id, |cx| {
+            let child_element = element.widget.downcast_mut().unwrap();
+            let child_changed = self
+                .view
+                .rebuild(cx, &prev.view, child_id, state, child_element);
+            if child_changed {
+                changed = true;
+                element.widget.request_update();
+            }
+        });
+        changed
+    }
+
+    fn event(
+        &self,
+        id_path: &[crate::id::Id],
+        (child_id, state): &mut Self::State,
+        event: Box<dyn std::any::Any>,
+        app_state: &mut T,
+    ) -> crate::event::EventResult<A> {
+        let (left, right) = id_path.split_at(1);
+        assert!(left[0] == *child_id);
+        self.view.event(right, state, event, app_state)
+    }
+}
+
+impl<V> BackgroundView<V> {
+    fn new(color: Color, view: V) -> Self {
+        BackgroundView { color, view }
+    }
+}

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -21,6 +21,7 @@ mod core;
 pub mod piet_scene_helpers;
 mod raw_event;
 //pub mod scroll_view;
+pub mod compose_style;
 pub mod text;
 //pub mod vstack;
 

--- a/src/widget/compose_style.rs
+++ b/src/widget/compose_style.rs
@@ -1,0 +1,2 @@
+pub mod background;
+pub mod padding;

--- a/src/widget/compose_style/background.rs
+++ b/src/widget/compose_style/background.rs
@@ -1,0 +1,124 @@
+use glazier::kurbo::Affine;
+use piet_scene::{Color, Fill};
+
+use crate::{id::Id, widget::Pod, View, Widget};
+
+pub fn background<V: View<T, A>, T, A>(color: Color, view: V) -> impl View<T, A>
+where
+    V::Element: 'static,
+{
+    BackgroundView::new(color, view)
+}
+
+pub struct BackgroundView<V> {
+    color: Color,
+    view: V,
+}
+
+impl<T, A, V: View<T, A>> View<T, A> for BackgroundView<V>
+where
+    V::Element: 'static,
+{
+    type State = (Id, V::State);
+
+    type Element = BackgroundWidget;
+
+    fn build(&self, cx: &mut crate::view::Cx) -> (crate::id::Id, Self::State, Self::Element) {
+        let (id, (child_id, state, element)) = cx.with_new_id(|cx| self.view.build(cx));
+        let element = BackgroundWidget::new(Pod::new(element), self.color);
+        (id, (child_id, state), element)
+    }
+
+    fn rebuild(
+        &self,
+        cx: &mut crate::view::Cx,
+        prev: &Self,
+        id: &mut crate::id::Id,
+        (child_id, state): &mut Self::State,
+        element: &mut Self::Element,
+    ) -> bool {
+        let mut changed = prev.color != self.color;
+        cx.with_id(*id, |cx| {
+            let child_element = element.widget.downcast_mut().unwrap();
+            changed |= self
+                .view
+                .rebuild(cx, &prev.view, child_id, state, child_element)
+        });
+        changed
+    }
+
+    fn event(
+        &self,
+        id_path: &[crate::id::Id],
+        (child_id, state): &mut Self::State,
+        event: Box<dyn std::any::Any>,
+        app_state: &mut T,
+    ) -> crate::event::EventResult<A> {
+        let (left, right) = id_path.split_at(1);
+        assert!(left[0] == *child_id);
+        self.view.event(right, state, event, app_state)
+    }
+}
+
+impl<V> BackgroundView<V> {
+    fn new(color: Color, view: V) -> Self {
+        BackgroundView { color, view }
+    }
+}
+
+pub struct BackgroundWidget {
+    widget: Pod,
+    color: Color,
+}
+
+impl BackgroundWidget {
+    pub fn new(widget: Pod, color: Color) -> Self {
+        Self { widget, color }
+    }
+}
+
+impl Widget for BackgroundWidget {
+    fn event(&mut self, cx: &mut crate::widget::EventCx, event: &crate::widget::RawEvent) {
+        self.widget.event(cx, event)
+    }
+
+    fn lifecycle(
+        &mut self,
+        cx: &mut crate::widget::contexts::LifeCycleCx,
+        event: &crate::widget::LifeCycle,
+    ) {
+        self.widget.lifecycle(cx, event)
+    }
+
+    fn update(&mut self, cx: &mut crate::widget::UpdateCx) {
+        self.widget.update(cx)
+    }
+
+    fn measure(
+        &mut self,
+        cx: &mut crate::widget::LayoutCx,
+    ) -> (glazier::kurbo::Size, glazier::kurbo::Size) {
+        self.widget.measure(cx)
+    }
+
+    fn layout(
+        &mut self,
+        cx: &mut crate::widget::LayoutCx,
+        proposed_size: glazier::kurbo::Size,
+    ) -> glazier::kurbo::Size {
+        self.widget.layout(cx, proposed_size)
+    }
+
+    fn paint(&mut self, cx: &mut crate::widget::PaintCx, builder: &mut piet_scene::SceneBuilder) {
+        self.widget.paint(cx);
+        let fragment = self.widget.fragment();
+        builder.fill(
+            Fill::NonZero,
+            Affine::IDENTITY,
+            self.color,
+            None,
+            &cx.size().to_rect(),
+        );
+        builder.append(fragment, None)
+    }
+}

--- a/src/widget/compose_style/background.rs
+++ b/src/widget/compose_style/background.rs
@@ -3,77 +3,17 @@ use piet_scene::{Color, Fill};
 
 use crate::{id::Id, widget::Pod, View, Widget};
 
-pub fn background<V: View<T, A>, T, A>(color: Color, view: V) -> impl View<T, A>
-where
-    V::Element: 'static,
-{
-    BackgroundView::new(color, view)
-}
-
-pub struct BackgroundView<V> {
-    color: Color,
-    view: V,
-}
-
-impl<T, A, V: View<T, A>> View<T, A> for BackgroundView<V>
-where
-    V::Element: 'static,
-{
-    type State = (Id, V::State);
-
-    type Element = BackgroundWidget;
-
-    fn build(&self, cx: &mut crate::view::Cx) -> (crate::id::Id, Self::State, Self::Element) {
-        let (id, (child_id, state, element)) = cx.with_new_id(|cx| self.view.build(cx));
-        let element = BackgroundWidget::new(Pod::new(element), self.color);
-        (id, (child_id, state), element)
-    }
-
-    fn rebuild(
-        &self,
-        cx: &mut crate::view::Cx,
-        prev: &Self,
-        id: &mut crate::id::Id,
-        (child_id, state): &mut Self::State,
-        element: &mut Self::Element,
-    ) -> bool {
-        let mut changed = prev.color != self.color;
-        cx.with_id(*id, |cx| {
-            let child_element = element.widget.downcast_mut().unwrap();
-            changed |= self
-                .view
-                .rebuild(cx, &prev.view, child_id, state, child_element)
-        });
-        changed
-    }
-
-    fn event(
-        &self,
-        id_path: &[crate::id::Id],
-        (child_id, state): &mut Self::State,
-        event: Box<dyn std::any::Any>,
-        app_state: &mut T,
-    ) -> crate::event::EventResult<A> {
-        let (left, right) = id_path.split_at(1);
-        assert!(left[0] == *child_id);
-        self.view.event(right, state, event, app_state)
-    }
-}
-
-impl<V> BackgroundView<V> {
-    fn new(color: Color, view: V) -> Self {
-        BackgroundView { color, view }
-    }
-}
-
 pub struct BackgroundWidget {
-    widget: Pod,
+    pub(crate) widget: Pod,
     color: Color,
 }
 
 impl BackgroundWidget {
     pub fn new(widget: Pod, color: Color) -> Self {
         Self { widget, color }
+    }
+    pub(crate) fn set_color(&mut self, color: Color) {
+        self.color = color;
     }
 }
 

--- a/src/widget/compose_style/padding.rs
+++ b/src/widget/compose_style/padding.rs
@@ -1,0 +1,122 @@
+use glazier::kurbo::{Affine, Size};
+
+use crate::{id::Id, widget::Pod, View, Widget};
+
+pub fn padding<V: View<T, A>, T, A>(width: f64, view: V) -> impl View<T, A>
+where
+    V::Element: 'static,
+{
+    PaddingView::new(width, view)
+}
+
+pub struct PaddingView<V> {
+    width: f64,
+    view: V,
+}
+
+impl<T, A, V: View<T, A>> View<T, A> for PaddingView<V>
+where
+    V::Element: 'static,
+{
+    type State = (Id, V::State);
+
+    type Element = PaddingWidget;
+
+    fn build(&self, cx: &mut crate::view::Cx) -> (crate::id::Id, Self::State, Self::Element) {
+        let (id, (child_id, state, element)) = cx.with_new_id(|cx| self.view.build(cx));
+        let element = PaddingWidget::new(Pod::new(element), self.width);
+        (id, (child_id, state), element)
+    }
+
+    fn rebuild(
+        &self,
+        cx: &mut crate::view::Cx,
+        prev: &Self,
+        id: &mut crate::id::Id,
+        (child_id, state): &mut Self::State,
+        element: &mut Self::Element,
+    ) -> bool {
+        let mut changed = prev.width != self.width;
+        cx.with_id(*id, |cx| {
+            let child_element = element.widget.downcast_mut().unwrap();
+            changed |= self
+                .view
+                .rebuild(cx, &prev.view, child_id, state, child_element)
+        });
+        changed
+    }
+
+    fn event(
+        &self,
+        id_path: &[crate::id::Id],
+        (child_id, state): &mut Self::State,
+        event: Box<dyn std::any::Any>,
+        app_state: &mut T,
+    ) -> crate::event::EventResult<A> {
+        let (left, right) = id_path.split_at(1);
+        assert!(left[0] == *child_id);
+        self.view.event(right, state, event, app_state)
+    }
+}
+
+impl<V> PaddingView<V> {
+    fn new(width: f64, view: V) -> Self {
+        PaddingView { width, view }
+    }
+}
+
+pub struct PaddingWidget {
+    widget: Pod,
+    width: f64,
+}
+
+impl PaddingWidget {
+    pub fn new(widget: Pod, width: f64) -> Self {
+        Self {
+            widget: widget,
+            width,
+        }
+    }
+}
+
+impl Widget for PaddingWidget {
+    fn event(&mut self, cx: &mut crate::widget::EventCx, event: &crate::widget::RawEvent) {
+        self.widget.event(cx, event)
+    }
+
+    fn lifecycle(
+        &mut self,
+        cx: &mut crate::widget::contexts::LifeCycleCx,
+        event: &crate::widget::LifeCycle,
+    ) {
+        self.widget.lifecycle(cx, event)
+    }
+
+    fn update(&mut self, cx: &mut crate::widget::UpdateCx) {
+        self.widget.update(cx)
+    }
+
+    fn measure(
+        &mut self,
+        cx: &mut crate::widget::LayoutCx,
+    ) -> (glazier::kurbo::Size, glazier::kurbo::Size) {
+        let (min, max) = self.widget.measure(cx);
+        let size = Size::new(self.width * 2., self.width * 2.);
+        (min + size, max + size)
+    }
+
+    fn layout(
+        &mut self,
+        cx: &mut crate::widget::LayoutCx,
+        proposed_size: glazier::kurbo::Size,
+    ) -> glazier::kurbo::Size {
+        let padding_size = Size::new(self.width * 2., self.width * 2.);
+        self.widget.layout(cx, proposed_size - padding_size) + padding_size
+    }
+
+    fn paint(&mut self, cx: &mut crate::widget::PaintCx, builder: &mut piet_scene::SceneBuilder) {
+        self.widget.paint(cx);
+        let fragment = self.widget.fragment();
+        builder.append(fragment, Some(Affine::translate((self.width, self.width))))
+    }
+}

--- a/src/widget/compose_style/padding.rs
+++ b/src/widget/compose_style/padding.rs
@@ -1,81 +1,19 @@
-use glazier::kurbo::{Affine, Size};
+use glazier::kurbo::{Affine, Point, Size};
 
-use crate::{id::Id, widget::Pod, View, Widget};
-
-pub fn padding<V: View<T, A>, T, A>(width: f64, view: V) -> impl View<T, A>
-where
-    V::Element: 'static,
-{
-    PaddingView::new(width, view)
-}
-
-pub struct PaddingView<V> {
-    width: f64,
-    view: V,
-}
-
-impl<T, A, V: View<T, A>> View<T, A> for PaddingView<V>
-where
-    V::Element: 'static,
-{
-    type State = (Id, V::State);
-
-    type Element = PaddingWidget;
-
-    fn build(&self, cx: &mut crate::view::Cx) -> (crate::id::Id, Self::State, Self::Element) {
-        let (id, (child_id, state, element)) = cx.with_new_id(|cx| self.view.build(cx));
-        let element = PaddingWidget::new(Pod::new(element), self.width);
-        (id, (child_id, state), element)
-    }
-
-    fn rebuild(
-        &self,
-        cx: &mut crate::view::Cx,
-        prev: &Self,
-        id: &mut crate::id::Id,
-        (child_id, state): &mut Self::State,
-        element: &mut Self::Element,
-    ) -> bool {
-        let mut changed = prev.width != self.width;
-        cx.with_id(*id, |cx| {
-            let child_element = element.widget.downcast_mut().unwrap();
-            changed |= self
-                .view
-                .rebuild(cx, &prev.view, child_id, state, child_element)
-        });
-        changed
-    }
-
-    fn event(
-        &self,
-        id_path: &[crate::id::Id],
-        (child_id, state): &mut Self::State,
-        event: Box<dyn std::any::Any>,
-        app_state: &mut T,
-    ) -> crate::event::EventResult<A> {
-        let (left, right) = id_path.split_at(1);
-        assert!(left[0] == *child_id);
-        self.view.event(right, state, event, app_state)
-    }
-}
-
-impl<V> PaddingView<V> {
-    fn new(width: f64, view: V) -> Self {
-        PaddingView { width, view }
-    }
-}
+use crate::{widget::Pod, View, Widget};
 
 pub struct PaddingWidget {
-    widget: Pod,
+    pub(crate) widget: Pod,
     width: f64,
 }
 
 impl PaddingWidget {
     pub fn new(widget: Pod, width: f64) -> Self {
-        Self {
-            widget: widget,
-            width,
-        }
+        Self { widget, width }
+    }
+
+    pub fn set_width(&mut self, width: f64) {
+        self.width = width;
     }
 }
 
@@ -93,6 +31,7 @@ impl Widget for PaddingWidget {
     }
 
     fn update(&mut self, cx: &mut crate::widget::UpdateCx) {
+        cx.request_layout();
         self.widget.update(cx)
     }
 
@@ -111,7 +50,12 @@ impl Widget for PaddingWidget {
         proposed_size: glazier::kurbo::Size,
     ) -> glazier::kurbo::Size {
         let padding_size = Size::new(self.width * 2., self.width * 2.);
-        self.widget.layout(cx, proposed_size - padding_size) + padding_size
+        let result = self.widget.layout(cx, proposed_size - padding_size) + padding_size;
+        self.widget.state.origin = Point {
+            x: self.width,
+            y: self.width,
+        };
+        result
     }
 
     fn paint(&mut self, cx: &mut crate::widget::PaintCx, builder: &mut piet_scene::SceneBuilder) {


### PR DESCRIPTION
Inspired by https://tonsky.me/blog/clojure-ui/#tweak-and-reuse and [Tailwind CSS](https://tailwindcss.com/), this demonstrates how our current widget model lends itself to view level styling.

For reference, the user-facing part of this is:
```rust
fn app_logic(data: &mut f64) -> impl View<f64> {
    background(
        Color::RED,
        padding(
            *data,
            button(format!("Padding {data}px"), |data| *data += 1.),
        ),
    )
}
```

Which creates the following application.

Initial state:
![image](https://user-images.githubusercontent.com/36049421/204528863-76f186c4-da4b-43a0-9636-e70c1e3fdc20.png)

After 37 clicks:
![image](https://user-images.githubusercontent.com/36049421/204528928-b7d3a5a4-f9fd-4cfe-b8f6-667474e2225c.png)

Beautiful, I know.