### PR TITLE
Create Utility functions

### DIFF
--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -41,6 +41,5 @@ fn app_logic(data: &mut AppData) -> impl View<AppData> {
 }
 
 pub fn main() {
-    let app = App::new(AppData::default(), app_logic);
-    AppLauncher::new(app).run();
+    App::new(AppData::default(), app_logic).run()
 }

--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -33,6 +33,5 @@ fn app_logic(_: &mut ()) -> impl View<()> {
 }
 
 fn main() {
-    let app = App::new((), app_logic);
-    AppLauncher::new(app).run();
+    App::new((), app_logic).run()
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,6 +25,7 @@ use tokio::runtime::Runtime;
 use crate::event::{AsyncWake, EventResult};
 use crate::id::IdPath;
 use crate::widget::{CxState, EventCx, LayoutCx, PaintCx, Pod, UpdateCx, WidgetState};
+use crate::AppLauncher;
 use crate::{
     event::Event,
     id::Id,
@@ -270,6 +271,16 @@ where
         } else {
             false
         }
+    }
+
+    /// Runs the app inside a window.
+    pub fn run_with_title(self, title: impl Into<String>) {
+        AppLauncher::new(self).title(title).run()
+    }
+
+    /// Runs the app inside a window.
+    pub fn run(self) {
+        AppLauncher::new(self).run()
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -274,11 +274,15 @@ where
     }
 
     /// Runs the app inside a window.
+    ///
+    /// This is a thin convinience wrapper around [AppLauncher](xilem::AppLauncher)
     pub fn run_with_title(self, title: impl Into<String>) {
         AppLauncher::new(self).title(title).run()
     }
 
     /// Runs the app inside a window.
+    ///
+    /// This is a thin convinience wrapper around [AppLauncher](xilem::AppLauncher)
     pub fn run(self) {
         AppLauncher::new(self).run()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use xilem::{button, App, AppLauncher, View};
+use xilem::{button, App, View};
 
 fn app_logic(_data: &mut ()) -> impl View<()> {
     button("click me", |_| println!("clicked"))
@@ -15,6 +15,5 @@ fn main() {
     window_handle.show();
     app.run(None);
     */
-    let app = App::new((), app_logic);
-    AppLauncher::new(app).run()
+    App::new((), app_logic).run()
 }


### PR DESCRIPTION
This PR introduces wrappers around `AppLauncher`.
I think it's nice to have this, because there is one less struct for newcomers to worry about, when they just want to get into creating UIs.

At the same the additional wrapper-code can be expected to remain this simple.
When AppLauncher grows in functionality, people will be pointed to it this way.