### PR TITLE
Handle MouseLeft event

### DIFF
--- a/src/app_main.rs
+++ b/src/app_main.rs
@@ -146,6 +146,11 @@ where
         self.handle.invalidate();
     }
 
+    fn mouse_leave(&mut self) {
+        self.app.window_event(RawEvent::MouseLeft());
+        self.handle.invalidate();
+    }
+
     fn size(&mut self, size: Size) {
         self.app.size(size);
     }

--- a/src/widget/core.rs
+++ b/src/widget/core.rs
@@ -225,11 +225,12 @@ impl Pod {
                 }
             }
             RawEvent::MouseLeft() => {
-                Pod::set_hot_state(&mut self.widget, &mut self.state, cx.cx_state, rect, None);
-                if had_active || self.state.flags.contains(PodFlags::IS_HOT) {
-                    false
-                } else {
+                let hot_changed =
+                    Pod::set_hot_state(&mut self.widget, &mut self.state, cx.cx_state, rect, None);
+                if had_active || hot_changed {
                     true
+                } else {
+                    false
                 }
             }
         };

--- a/src/widget/core.rs
+++ b/src/widget/core.rs
@@ -224,6 +224,14 @@ impl Pod {
                     false
                 }
             }
+            RawEvent::MouseLeft() => {
+                Pod::set_hot_state(&mut self.widget, &mut self.state, cx.cx_state, rect, None);
+                if had_active || self.state.flags.contains(PodFlags::IS_HOT) {
+                    false
+                } else {
+                    true
+                }
+            }
         };
         if recurse {
             let mut inner_cx = EventCx {

--- a/src/widget/raw_event.rs
+++ b/src/widget/raw_event.rs
@@ -23,6 +23,7 @@ pub enum RawEvent {
     MouseUp(MouseEvent),
     MouseMove(MouseEvent),
     MouseWheel(MouseEvent),
+    MouseLeft(),
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Fixes #13, but requires that the active glazier backend listens for mouse leave events. Support under x11 is added in linebender/glazier#45, remaining platforms will be added as time allows.