### PR TITLE
Update for the piet-wgsl -> vello name change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,30 +1595,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "piet-scene"
-version = "0.1.0"
-source = "git+https://github.com/linebender/piet-gpu#571822248c92a5e57761ef29391638c5ff942cd7"
-dependencies = [
- "bytemuck",
- "moscato",
- "peniko",
- "smallvec",
-]
-
-[[package]]
-name = "piet-wgsl"
-version = "0.1.0"
-source = "git+https://github.com/linebender/piet-gpu#571822248c92a5e57761ef29391638c5ff942cd7"
-dependencies = [
- "bytemuck",
- "futures-intrusive",
- "parking_lot",
- "piet-scene",
- "raw-window-handle",
- "wgpu",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2252,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "vello"
+version = "0.1.0"
+source = "git+https://github.com/linebender/piet-gpu#3bc81afbf669f9e195dac34a03ecbd1d744ce087"
+dependencies = [
+ "bytemuck",
+ "futures-intrusive",
+ "moscato",
+ "parking_lot",
+ "peniko",
+ "raw-window-handle",
+ "smallvec",
+ "wgpu",
+]
+
+[[package]]
 name = "version-compare"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,14 +2703,13 @@ dependencies = [
  "futures-task",
  "glazier",
  "parley",
- "piet-scene",
- "piet-wgsl",
  "png",
  "rand 0.7.3",
  "raw-window-handle",
  "roxmltree",
  "swash 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
+ "vello",
  "wgpu",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2254,7 +2254,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 [[package]]
 name = "vello"
 version = "0.1.0"
-source = "git+https://github.com/linebender/piet-gpu#3bc81afbf669f9e195dac34a03ecbd1d744ce087"
+source = "git+https://github.com/linebender/vello#3bc81afbf669f9e195dac34a03ecbd1d744ce087"
 dependencies = [
  "bytemuck",
  "futures-intrusive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ wayland = ["glazier/wayland"]
 
 [dependencies]
 glazier = { git = "https://github.com/linebender/glazier", default-features = false }
-vello = { git = "https://github.com/linebender/piet-gpu" }
+vello = { git = "https://github.com/linebender/vello" }
 wgpu = "0.14"
 raw-window-handle = "0.5"
 png = "0.16.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ wayland = ["glazier/wayland"]
 
 [dependencies]
 glazier = { git = "https://github.com/linebender/glazier", default-features = false }
-piet-wgsl = { git = "https://github.com/linebender/piet-gpu" }
-piet-scene = { git = "https://github.com/linebender/piet-gpu" }
+vello = { git = "https://github.com/linebender/piet-gpu" }
 wgpu = "0.14"
 raw-window-handle = "0.5"
 png = "0.16.2"

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,8 +19,8 @@ use std::time::Duration;
 use glazier::kurbo::Size;
 use glazier::{IdleHandle, IdleToken, WindowHandle};
 use parley::FontContext;
-use piet_scene::{SceneBuilder, SceneFragment};
 use tokio::runtime::Runtime;
+use vello::{SceneBuilder, SceneFragment};
 
 use crate::event::{AsyncWake, EventResult};
 use crate::id::IdPath;

--- a/src/app_main.rs
+++ b/src/app_main.rs
@@ -20,11 +20,11 @@ use glazier::{
     WinHandler, WindowBuilder, WindowHandle,
 };
 use parley::FontContext;
-use piet_scene::{Scene, SceneBuilder, SceneFragment};
-use piet_wgsl::{
+use vello::{
     util::{RenderContext, RenderSurface},
     Renderer,
 };
+use vello::{Scene, SceneBuilder, SceneFragment};
 
 use crate::{app::App, widget::RawEvent, View, Widget};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@ use glazier::{
     Scalable, TimerToken, WinHandler, WindowHandle,
 };
 use parley::FontContext;
-use piet_scene::Scene;
 use std::any::Any;
+use vello::Scene;
 
 pub struct WindowState {
     handle: WindowHandle,

--- a/src/test_scenes.rs
+++ b/src/test_scenes.rs
@@ -1,7 +1,8 @@
 use super::text::*;
 use parley::FontContext;
-use piet_scene::kurbo::{Affine, Rect};
-use piet_scene::*;
+use vello::kurbo::{Affine, Rect};
+use vello::peniko::*;
+use vello::{Scene, SceneBuilder};
 
 pub fn render(fcx: &mut FontContext, scene: &mut Scene, which: usize, arg: u64) {
     match which {

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,10 +1,11 @@
 use parley::Layout;
-use piet_scene::kurbo::Affine;
-use piet_scene::{
+use vello::kurbo::Affine;
+use vello::{
     glyph::{
         pinot::{types::Tag, FontRef},
         GlyphContext,
     },
+    peniko::{Brush, Color},
     *,
 };
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -28,7 +28,7 @@ use std::any::Any;
 use std::ops::{Deref, DerefMut};
 
 use glazier::kurbo::{Rect, Size};
-use piet_scene::SceneBuilder;
+use vello::SceneBuilder;
 
 use self::contexts::LifeCycleCx;
 pub use self::contexts::{AlignCx, CxState, EventCx, LayoutCx, PaintCx, PreparePaintCx, UpdateCx};

--- a/src/widget/align.rs
+++ b/src/widget/align.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use glazier::kurbo::{Point, Size};
-use piet_scene::SceneBuilder;
+use vello::SceneBuilder;
 
 use super::{contexts::LifeCycleCx, AlignCx, AnyWidget, EventCx, LifeCycle, Widget, WidgetState};
 

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -14,7 +14,10 @@
 
 use glazier::kurbo::{Affine, Insets, Size};
 use parley::Layout;
-use piet_scene::{Brush, Color, SceneBuilder, SceneFragment, Stroke};
+use vello::{
+    peniko::{Brush, Color, Stroke},
+    SceneBuilder, SceneFragment,
+};
 
 use crate::{event::Event, id::IdPath, text::ParleyBrush, VertAlignment};
 

--- a/src/widget/core.rs
+++ b/src/widget/core.rs
@@ -19,7 +19,7 @@
 
 use bitflags::bitflags;
 use glazier::kurbo::{Point, Rect, Size};
-use piet_scene::{SceneBuilder, SceneFragment};
+use vello::{SceneBuilder, SceneFragment};
 
 use crate::Widget;
 

--- a/src/widget/piet_scene_helpers.rs
+++ b/src/widget/piet_scene_helpers.rs
@@ -1,5 +1,6 @@
 use glazier::kurbo::{self, Affine, Rect, Shape};
-use piet_scene::{BrushRef, ColorStopsSource, Fill, LinearGradient, SceneBuilder, Stroke};
+use vello::peniko::{BrushRef, ColorStopsSource, Fill, LinearGradient, Stroke};
+use vello::SceneBuilder;
 
 #[derive(Debug, Clone, Copy)]
 pub struct UnitPoint {

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -14,7 +14,10 @@
 
 use glazier::kurbo::{Affine, Point, Size};
 use parley::Layout;
-use piet_scene::{Brush, Color, SceneBuilder, SceneFragment};
+use vello::{
+    peniko::{Brush, Color},
+    SceneBuilder, SceneFragment,
+};
 
 use crate::text::ParleyBrush;
 


### PR DESCRIPTION
Removes the `piet-scene` dependency and changes `piet-wgsl` to `vello`. Updates all imports for the new crate name. This leaves the git reference as linebender/piet-gpu for now. We can change that to vello in this PR (after the repo is renamed) or in a subsequent one.