### PR TITLE
Styling experiment with `ButtonStyles` struct

### DIFF
--- a/src/view/button.rs
+++ b/src/view/button.rs
@@ -14,7 +14,7 @@
 
 use std::any::Any;
 
-use crate::{event::EventResult, id::Id, widget::ChangeFlags};
+use crate::{event::EventResult, id::Id, widget::{ChangeFlags, button::ButtonStyle}};
 
 use super::{Cx, View};
 
@@ -47,7 +47,7 @@ impl<T, A> View<T, A> for Button<T, A> {
 
     fn build(&self, cx: &mut Cx) -> (Id, Self::State, Self::Element) {
         let (id, element) = cx
-            .with_new_id(|cx| crate::widget::button::Button::new(cx.id_path(), self.label.clone()));
+            .with_new_id(|cx| crate::widget::button::Button::new(cx.id_path(), self.label.clone(), ButtonStyle::default()));
         (id, (), element)
     }
 


### PR DESCRIPTION
This is my idea for how styling can be done in the future. Buttons seem like a good start because they have different internal states that I think are best represented as 3 different stylings.

I really like the idea for strongly-typed styling instead of a `HashMap` or other alternatives. Each component has a specific set of styles it can use and I think it's best to create structs for each.
```rust
pub struct ButtonStyleState {
    border_radius: f64,
    stroke: Option<Stroke>,
    background_color: Option<Color>,
}

pub struct ButtonStyle {
    default: ButtonStyleState,
    hot: ButtonStyleState,
    active: ButtonStyleState,
}
```
