### PR TITLE
Fix swapped arguments regression when adding menu

### DIFF
--- a/src/app_main.rs
+++ b/src/app_main.rs
@@ -72,8 +72,8 @@ impl<T: Send + 'static, V: View<T> + 'static> AppLauncher<T, V> {
             QUIT_MENU_ID,
             "E&xit",
             Some(&HotKey::new(SysMods::Cmd, "q")),
-            Some(true),
-            false,
+            Some(false),
+            true,
         );
         let mut menubar = Menu::new();
         menubar.add_dropdown(Menu::new(), "Application", true);


### PR DESCRIPTION
It looks like `enabled` and `selected` arguments values for [glazier::menu::Menu::add_item](https://github.com/linebender/glazier/blob/bb4bc453a949b74fc4de16ce6be66b901dcf4ab4/src/menu.rs#L69) call should be swapped. The order changed in [this commit](https://github.com/linebender/druid/commit/7c08b326578aa2b25057f5f1af09f9a6b1f51da4#diff-0f63e54d7096d613a02825d47679656d3cd119abea8bc85c59cba648269b6ae0) in druid-shell, but remained unchanged in Xilem. I cannot see the menu either way on Linux, so cannot verify if it works, but I'm relying on the response to [this comment](https://github.com/linebender/druid/pull/2357#discussion_r1103622282).