### PR TITLE
Dynamic ViewSequence

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -356,7 +356,7 @@ where
                         .downcast_mut()
                         .expect("the root widget changed its type, this should never happen!"),
                 );
-                self.root_pod.as_mut().unwrap().mark(changes);
+                let _ = self.root_pod.as_mut().unwrap().mark(changes);
                 assert!(self.cx.is_empty(), "id path imbalance on rebuild");
                 state
             } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -408,13 +408,18 @@ impl<T, V: View<T>, F: FnMut(&mut T) -> V> AppTask<T, V, F> {
                         }
                     }
                     AppReq::Wake(id_path) => {
-                        let result = self.view.as_ref().unwrap().message(
-                            &id_path[1..],
-                            self.state.as_mut().unwrap(),
-                            Box::new(AsyncWake),
-                            &mut self.data,
-                        );
-                        if matches!(result, MessageResult::RequestRebuild) {
+                        let needs_rebuild;
+                        {
+                            let result = self.view.as_ref().unwrap().message(
+                                &id_path[1..],
+                                self.state.as_mut().unwrap(),
+                                Box::new(AsyncWake),
+                                &mut self.data,
+                            );
+                            needs_rebuild = matches!(result, MessageResult::RequestRebuild);
+                        }
+
+                        if needs_rebuild {
                             // request re-render from UI thread
                             if self.ui_state == UiState::Start {
                                 if let Some(handle) = self.idle_handle.as_mut() {

--- a/src/event.rs
+++ b/src/event.rs
@@ -45,7 +45,9 @@ impl<A> MessageResult<A> {
     pub fn map<B>(self, f: impl FnOnce(A) -> B) -> MessageResult<B> {
         match self {
             MessageResult::Action(a) => MessageResult::Action(f(a)),
-            _ => self
+            MessageResult::RequestRebuild => MessageResult::RequestRebuild,
+            MessageResult::Stale(event) => MessageResult::Stale(event),
+            MessageResult::Nop => MessageResult::Nop,
         }
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -35,7 +35,7 @@ pub enum MessageResult<A> {
     ///
     /// This is a normal outcome for async operation when the tree is changing
     /// dynamically, but otherwise indicates a logic error.
-    Stale,
+    Stale(Box<dyn Any>),
 }
 
 pub struct AsyncWake;
@@ -45,9 +45,14 @@ impl<A> MessageResult<A> {
     pub fn map<B>(self, f: impl FnOnce(A) -> B) -> MessageResult<B> {
         match self {
             MessageResult::Action(a) => MessageResult::Action(f(a)),
-            MessageResult::RequestRebuild => MessageResult::RequestRebuild,
-            MessageResult::Stale => MessageResult::Stale,
-            MessageResult::Nop => MessageResult::Nop,
+            _ => self
+        }
+    }
+
+    pub fn or(self, f: impl FnOnce(Box<dyn Any>) -> Self) -> Self {
+        match self {
+            MessageResult::Stale(event) => f(event),
+            _ => self,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod test_scenes;
 mod text;
 pub mod view;
 pub mod widget;
+mod vec_splice;
 
 pub use app::App;
 pub use app_main::AppLauncher;
@@ -17,3 +18,4 @@ pub(crate) use bloom::Bloom;
 pub use event::{Message, MessageResult};
 pub use geometry::Axis;
 pub use id::Id;
+pub use vec_splice::VecSplice;

--- a/src/vec_splice.rs
+++ b/src/vec_splice.rs
@@ -1,0 +1,57 @@
+pub struct VecSplice<'a, 'b, T> {
+    v: &'a mut Vec<T>,
+    scratch: &'b mut Vec<T>,
+    ix: usize,
+}
+
+impl<'a, 'b, T> VecSplice<'a, 'b, T> {
+    pub fn new(v: &'a mut Vec<T>, scratch: &'b mut Vec<T>) -> Self {
+        let ix = 0;
+        VecSplice { v, scratch, ix }
+    }
+
+    pub fn skip(&mut self, n: usize) {
+        if self.v.len() < self.ix + n {
+            let l = self.scratch.len();
+            self.v.extend(self.scratch.splice(l - n.., []));
+            self.v[self.ix..].reverse();
+        }
+        self.ix += n;
+    }
+
+    pub fn delete(&mut self, n: usize) {
+        if self.v.len() < self.ix + n {
+            self.scratch.truncate(self.scratch.len() - n);
+        } else {
+            if self.v.len() > self.ix + n {
+                let l = self.scratch.len();
+                self.scratch.extend(self.v.splice(self.ix + n.., []));
+                self.scratch[l..].reverse();
+            }
+            self.v.truncate(self.ix);
+        }
+    }
+
+    pub fn push(&mut self, value: T) {
+        if self.v.len() > self.ix {
+            let l = self.scratch.len();
+            self.scratch.extend(self.v.splice(self.ix.., []));
+            self.scratch[l..].reverse();
+        }
+        self.v.push(value);
+        self.ix += 1;
+    }
+
+    pub fn mutate(&mut self) -> &mut T {
+        if self.v.len() == self.ix {
+            self.v.push(self.scratch.pop().unwrap());
+        }
+        let ix = self.ix;
+        self.ix += 1;
+        &mut self.v[ix]
+    }
+
+    pub fn len(&self) -> usize {
+        self.ix
+    }
+}

--- a/src/vec_splice.rs
+++ b/src/vec_splice.rs
@@ -33,11 +33,7 @@ impl<'a, 'b, T> VecSplice<'a, 'b, T> {
     }
 
     pub fn push(&mut self, value: T) {
-        if self.v.len() > self.ix {
-            let l = self.scratch.len();
-            self.scratch.extend(self.v.splice(self.ix.., []));
-            self.scratch[l..].reverse();
-        }
+        self.clear_tail();
         self.v.push(value);
         self.ix += 1;
     }
@@ -53,5 +49,20 @@ impl<'a, 'b, T> VecSplice<'a, 'b, T> {
 
     pub fn len(&self) -> usize {
         self.ix
+    }
+
+    pub fn as_vec<R, F: FnOnce(&mut Vec<T>) -> R>(&mut self, f: F) -> R {
+        self.clear_tail();
+        let ret = f(&mut self.v);
+        self.ix = self.v.len();
+        ret
+    }
+
+    fn clear_tail(&mut self) {
+        if self.v.len() > self.ix {
+            let l = self.scratch.len();
+            self.scratch.extend(self.v.splice(self.ix.., []));
+            self.scratch[l..].reverse();
+        }
     }
 }

--- a/src/view/any_view.rs
+++ b/src/view/any_view.rs
@@ -21,6 +21,7 @@ use crate::{
     id::Id,
     widget::{AnyWidget, ChangeFlags},
 };
+use crate::view::ViewMarker;
 
 use super::{Cx, View};
 
@@ -116,6 +117,8 @@ where
         }
     }
 }
+
+impl<T, A> ViewMarker for Box<dyn AnyView<T, A> + Send> {}
 
 impl<T, A> View<T, A> for Box<dyn AnyView<T, A> + Send> {
     type State = Box<dyn Any + Send>;

--- a/src/view/any_view.rs
+++ b/src/view/any_view.rs
@@ -16,12 +16,12 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+use crate::view::ViewMarker;
 use crate::{
     event::MessageResult,
     id::Id,
     widget::{AnyWidget, ChangeFlags},
 };
-use crate::view::ViewMarker;
 
 use super::{Cx, View};
 

--- a/src/view/button.rs
+++ b/src/view/button.rs
@@ -15,6 +15,7 @@
 use std::any::Any;
 
 use crate::{event::MessageResult, id::Id, widget::ChangeFlags};
+use crate::view::ViewMarker;
 
 use super::{Cx, View};
 
@@ -39,6 +40,8 @@ impl<T, A> Button<T, A> {
         }
     }
 }
+
+impl<T, A> ViewMarker for Button<T, A> {}
 
 impl<T, A> View<T, A> for Button<T, A> {
     type State = ();

--- a/src/view/button.rs
+++ b/src/view/button.rs
@@ -14,8 +14,8 @@
 
 use std::any::Any;
 
-use crate::{event::MessageResult, id::Id, widget::ChangeFlags};
 use crate::view::ViewMarker;
+use crate::{event::MessageResult, id::Id, widget::ChangeFlags};
 
 use super::{Cx, View};
 

--- a/src/view/linear_layout.rs
+++ b/src/view/linear_layout.rs
@@ -81,9 +81,9 @@ impl<T, A, VT: ViewSequence<T, A>> View<T, A> for LinearLayout<T, A, VT> {
         state: &mut Self::State,
         element: &mut Self::Element,
     ) -> ChangeFlags {
-        let mut flags = cx.with_id(*id, |cx| {
+        let (mut flags, _) = cx.with_id(*id, |cx| {
             self.children
-                .rebuild(cx, &prev.children, state, &mut element.children)
+                .rebuild(cx, &prev.children, state, 0, &mut element.children)
         });
 
         if self.spacing != prev.spacing || self.axis != prev.axis {

--- a/src/view/linear_layout.rs
+++ b/src/view/linear_layout.rs
@@ -18,8 +18,8 @@ use crate::event::MessageResult;
 use crate::geometry::Axis;
 use crate::id::Id;
 use crate::view::sequence::ViewSequence;
-use crate::widget::{self, ChangeFlags};
 use crate::view::ViewMarker;
+use crate::widget::{self, ChangeFlags};
 
 use super::{Cx, View};
 

--- a/src/view/linear_layout.rs
+++ b/src/view/linear_layout.rs
@@ -86,7 +86,8 @@ impl<T, A, VT: ViewSequence<T, A>> View<T, A> for LinearLayout<T, A, VT> {
         state: &mut Self::State,
         element: &mut Self::Element,
     ) -> ChangeFlags {
-        let mut splice = VecSplice::new(&mut element.children, &mut vec![]);
+        let mut scratch = vec![];
+        let mut splice = VecSplice::new(&mut element.children, &mut scratch);
 
         let mut flags = cx.with_id(*id, |cx| {
             self.children

--- a/src/view/linear_layout.rs
+++ b/src/view/linear_layout.rs
@@ -17,6 +17,7 @@ use std::{any::Any, marker::PhantomData};
 use crate::event::MessageResult;
 use crate::geometry::Axis;
 use crate::id::Id;
+use crate::VecSplice;
 use crate::view::sequence::ViewSequence;
 use crate::view::ViewMarker;
 use crate::widget::{self, ChangeFlags};
@@ -71,7 +72,8 @@ impl<T, A, VT: ViewSequence<T, A>> View<T, A> for LinearLayout<T, A, VT> {
     type Element = widget::LinearLayout;
 
     fn build(&self, cx: &mut Cx) -> (Id, Self::State, Self::Element) {
-        let (id, (state, elements)) = cx.with_new_id(|cx| self.children.build(cx));
+        let mut elements = vec![];
+        let (id, state) = cx.with_new_id(|cx| self.children.build(cx, &mut elements));
         let column = widget::LinearLayout::new(elements, self.spacing, self.axis);
         (id, state, column)
     }
@@ -84,9 +86,11 @@ impl<T, A, VT: ViewSequence<T, A>> View<T, A> for LinearLayout<T, A, VT> {
         state: &mut Self::State,
         element: &mut Self::Element,
     ) -> ChangeFlags {
-        let (mut flags, _) = cx.with_id(*id, |cx| {
+        let mut splice = VecSplice::new(&mut element.children, &mut vec![]);
+
+        let mut flags = cx.with_id(*id, |cx| {
             self.children
-                .rebuild(cx, &prev.children, state, 0, &mut element.children)
+                .rebuild(cx, &prev.children, state, &mut splice)
         });
 
         if self.spacing != prev.spacing || self.axis != prev.axis {

--- a/src/view/linear_layout.rs
+++ b/src/view/linear_layout.rs
@@ -19,6 +19,7 @@ use crate::geometry::Axis;
 use crate::id::Id;
 use crate::view::sequence::ViewSequence;
 use crate::widget::{self, ChangeFlags};
+use crate::view::ViewMarker;
 
 use super::{Cx, View};
 
@@ -61,6 +62,8 @@ impl<T, A, VT: ViewSequence<T, A>> LinearLayout<T, A, VT> {
         self
     }
 }
+
+impl<T, A, VT: ViewSequence<T, A>> ViewMarker for LinearLayout<T, A, VT> {}
 
 impl<T, A, VT: ViewSequence<T, A>> View<T, A> for LinearLayout<T, A, VT> {
     type State = VT::State;

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -23,11 +23,13 @@ mod button;
 // mod text;
 // mod use_state;
 mod linear_layout;
+mod list;
 mod sequence;
 mod view;
 
 pub use any_view::AnyView;
 pub use button::button;
 pub use linear_layout::{h_stack, v_stack, LinearLayout};
+pub use list::{List, list};
 pub use sequence::ViewSequence;
 pub use view::{Cx, View, ViewMarker};

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -30,6 +30,6 @@ mod view;
 pub use any_view::AnyView;
 pub use button::button;
 pub use linear_layout::{h_stack, v_stack, LinearLayout};
-pub use list::{List, list};
+pub use list::{list, List};
 pub use sequence::ViewSequence;
 pub use view::{Cx, View, ViewMarker};

--- a/src/view/sequence.rs
+++ b/src/view/sequence.rs
@@ -106,7 +106,7 @@ impl<T, A, VT: ViewSequence<T, A>> ViewSequence<T, A> for Option<VT> {
                     element.remove(offset);
                 }
                 *state = None;
-                (ChangeFlags::TREE, offset)
+                (ChangeFlags::all(), offset)
             }
             (Some(this), None, None) => {
                 let (seq_state, mut elements) = this.build(cx);
@@ -115,7 +115,7 @@ impl<T, A, VT: ViewSequence<T, A>> ViewSequence<T, A> for Option<VT> {
                 while !elements.is_empty() {
                     element.insert(offset, elements.pop().unwrap());
                 }
-                (ChangeFlags::TREE, offset + additional)
+                (ChangeFlags::all(), offset + additional)
             }
             (None, None, None) => (ChangeFlags::empty(), offset),
             _ => panic!("non matching state and prev value"),

--- a/src/view/sequence.rs
+++ b/src/view/sequence.rs
@@ -136,12 +136,8 @@ impl<T, A, VT: ViewSequence<T, A>> ViewSequence<T, A> for Option<VT> {
                 ChangeFlags::all()
             }
             (Some(this), None, None) => {
-                let (seq_state, mut elements) = this.build(cx);
-
+                let seq_state = element.as_vec(|vec|this.build(cx, vec));
                 *state = Some(seq_state);
-                for el in elements {
-                    element.push(el);
-                }
 
                 ChangeFlags::all()
             }
@@ -190,7 +186,7 @@ macro_rules! impl_view_tuple {
                 prev: &Self,
                 state: &mut Self::State,
                 els: &mut VecSplice<Pod>,
-            ) -> (ChangeFlags, usize) {
+            ) -> ChangeFlags {
                 let mut changed = ChangeFlags::default();
                 $(
                     let el_changed = self.$i.rebuild(cx, &prev.$i, &mut state.$i, els);

--- a/src/view/sequence.rs
+++ b/src/view/sequence.rs
@@ -1,7 +1,7 @@
 use crate::event::MessageResult;
 use crate::id::Id;
 use crate::view::{Cx, View};
-use crate::widget::{ChangeFlags, Pod};
+use crate::widget::{ChangeFlags, Pod, Widget};
 use std::any::Any;
 
 /// A sequence on view nodes.
@@ -32,8 +32,9 @@ pub trait ViewSequence<T, A = ()>: Send {
         cx: &mut Cx,
         prev: &Self,
         state: &mut Self::State,
+        offset: usize,
         element: &mut Vec<Pod>,
-    ) -> ChangeFlags;
+    ) -> (ChangeFlags, usize);
 
     /// Propagate a message.
     ///
@@ -46,19 +47,107 @@ pub trait ViewSequence<T, A = ()>: Send {
         message: Box<dyn Any>,
         app_state: &mut T,
     ) -> MessageResult<A>;
+
+    /// Returns the current amount of widgets build by this sequence.
+    fn count(&self, state: &Self::State) -> usize;
+}
+
+impl<T, A, V: View<T, A>> ViewSequence<T, A> for V where V::Element: Widget + 'static {
+    type State = (<V as View<T, A>>::State, Id);
+
+    fn build(&self, cx: &mut Cx) -> (Self::State, Vec<Pod>) {
+        let (id, state, element) = <V as View<T, A>>::build(self, cx);
+        ((state, id), vec![Pod::new(element)])
+    }
+
+    fn rebuild(&self, cx: &mut Cx, prev: &Self, state: &mut Self::State, offset: usize, element: &mut Vec<Pod>) -> (ChangeFlags, usize) {
+        let downcast = element[offset].downcast_mut().unwrap();
+        let flags = <V as View<T, A>>::rebuild(self, cx, prev, &mut state.0, &mut state.1, downcast);
+        let flags = element[offset].mark(flags);
+        (flags, offset + 1)
+    }
+
+    fn message(&self, id_path: &[Id], state: &mut Self::State, message: Box<dyn Any>, app_state: &mut T) -> MessageResult<A> {
+        if let Some((first, rest_path)) = id_path.split_first() {
+            if first == state.0 {
+                return <V as View<T, A>>::message(self, rest_path, &mut state.1, message, app_state);
+            }
+        }
+        MessageResult::Stale(message)
+    }
+
+    fn count(&self, state: &Self::State) -> usize {
+        1
+    }
+}
+
+impl<T, A, VT: ViewSequence<T, A>> ViewSequence<T, A> for Option<VT> {
+    type State = Option<VT::State>;
+
+    fn build(&self, cx: &mut Cx) -> (Self::State, Vec<Pod>) {
+        match self {
+            None => (None, vec![]),
+            Some(vt) => {
+                let (state, elements) = vt.build();
+                (Some(state), elements)
+            }
+        }
+    }
+
+    fn rebuild(&self, cx: &mut Cx, prev: &Self, state: &mut Self::State, offset: usize, element: &mut Vec<Pod>) -> (ChangeFlags, usize) {
+        match (self, state, prev) {
+            (Some(this), Some(state), Some(prev)) => {
+                this.rebuild(cx, prev, state, offset, element)
+            }
+            (None, Some(state), Some(prev)) => {
+                let mut count = prev.count(&state);
+                while count > 0 {
+                    element.remove(offset);
+                }
+                *state = None;
+                (ChangeFlags::TREE, offset)
+            }
+            (Some(this), None, None) => {
+                let (state, mut elements) = this.build(cx);
+                let additional = elements.len();
+                *state = Some(state);
+                while !elements.is_empty() {
+                    element.insert(offset, elements.pop().unwrap());
+                }
+                (ChangeFlags::TREE, offset + additional)
+            }
+            (None, None, None) => (ChangeFlags::empty(), offset),
+            _ => panic!("non matching state and prev value"),
+        }
+    }
+
+    fn message(&self, id_path: &[Id], state: &mut Self::State, message: Box<dyn Any>, app_state: &mut T) -> MessageResult<A> {
+        match (self, state) {
+            (Some(vt), Some(state)) => vt.message(id_path, state, message, app_state),
+            (None, None) => MessageResult::Stale(message),
+            _ => panic!("non matching state and prev value"),
+        }
+    }
+
+    fn count(&self, state: &Self::State) -> usize {
+        match (self, state) {
+            (Some(vt), Some(state)) => vt.count(state),
+            (None, None) => 0,
+            _ => panic!("non matching state and prev value"),
+        }
+    }
 }
 
 macro_rules! impl_view_tuple {
-    ( $n: tt; $( $t:ident),* ; $( $i:tt ),* ) => {
-        impl<T, A, $( $t: View<T, A> ),* > ViewSequence<T, A> for ( $( $t, )* )
-            where $( <$t as View<T, A>>::Element: 'static ),*
-        {
-            type State = ( $( $t::State, )* [Id; $n]);
+    ( $( $t:ident),* ; $( $i:tt ),* ) => {
+        impl<T, A, $( $t: ViewSequence<T, A> ),* > ViewSequence<T, A> for ( $( $t, )* ) {
+            type State = ( $( $t::State, )*);
 
             fn build(&self, cx: &mut Cx) -> (Self::State, Vec<Pod>) {
                 let b = ( $( self.$i.build(cx), )* );
-                let state = ( $( b.$i.1, )* [ $( b.$i.0 ),* ]);
-                let els = vec![ $( Pod::new(b.$i.2) ),* ];
+                let state = ( $( b.$i.0, )*);
+                let mut els = vec![];
+                $( els.append(b.$i.1); )*
                 (state, els)
             }
 
@@ -67,15 +156,15 @@ macro_rules! impl_view_tuple {
                 cx: &mut Cx,
                 prev: &Self,
                 state: &mut Self::State,
+                offset: usize,
                 els: &mut Vec<Pod>,
-            ) -> ChangeFlags {
+            ) -> (ChangeFlags, usize) {
                 let mut changed = ChangeFlags::default();
-                $({
-                    let el_changed = self.$i.rebuild(cx, &prev.$i, &mut state.$n[$i], &mut state.$i, els[$i].downcast_mut().unwrap());
-                    changed |= els[$i].mark(el_changed);
-                })*
-
-                changed
+                $(
+                    let (el_changed, offset) = self.$i.rebuild(cx, &prev.$i, &mut state.$i, offset, els);
+                    changed |= el_changed;
+                )*
+                (changed, offset)
             }
 
             fn message(
@@ -85,35 +174,37 @@ macro_rules! impl_view_tuple {
                 message: Box<dyn Any>,
                 app_state: &mut T,
             ) -> MessageResult<A> {
-                let hd = id_path[0];
-                let tl = &id_path[1..];
+                MessageResult::Stale(message)
                 $(
-                if hd == state.$n[$i] {
-                    self.$i.message(tl, &mut state.$i, message, app_state)
-                } else )* {
-                    crate::event::MessageResult::Stale
-                }
+                    .or(|message|{
+                        self.$i.message(id_path, &mut state.$i, message, app_state)
+                    })
+                )*
+            }
+
+            fn count(&self, state: &Self::State) -> usize {
+                0
+                $(
+                    + self.$i.count(&state.$i)
+                )*
             }
         }
     }
 }
 
-impl_view_tuple!(1; V0; 0);
-impl_view_tuple!(2; V0, V1; 0, 1);
-impl_view_tuple!(3; V0, V1, V2; 0, 1, 2);
-impl_view_tuple!(4; V0, V1, V2, V3; 0, 1, 2, 3);
-impl_view_tuple!(5; V0, V1, V2, V3, V4; 0, 1, 2, 3, 4);
-impl_view_tuple!(6; V0, V1, V2, V3, V4, V5; 0, 1, 2, 3, 4, 5);
-impl_view_tuple!(7; V0, V1, V2, V3, V4, V5, V6; 0, 1, 2, 3, 4, 5, 6);
-impl_view_tuple!(8;
-    V0, V1, V2, V3, V4, V5, V6, V7;
+impl_view_tuple!(V0; 0);
+impl_view_tuple!(V0, V1; 0, 1);
+impl_view_tuple!(V0, V1, V2; 0, 1, 2);
+impl_view_tuple!(V0, V1, V2, V3; 0, 1, 2, 3);
+impl_view_tuple!(V0, V1, V2, V3, V4; 0, 1, 2, 3, 4);
+impl_view_tuple!(V0, V1, V2, V3, V4, V5; 0, 1, 2, 3, 4, 5);
+impl_view_tuple!(V0, V1, V2, V3, V4, V5, V6; 0, 1, 2, 3, 4, 5, 6);
+impl_view_tuple!(V0, V1, V2, V3, V4, V5, V6, V7;
     0, 1, 2, 3, 4, 5, 6, 7
 );
-impl_view_tuple!(9;
-    V0, V1, V2, V3, V4, V5, V6, V7, V8;
+impl_view_tuple!(V0, V1, V2, V3, V4, V5, V6, V7, V8;
     0, 1, 2, 3, 4, 5, 6, 7, 8
 );
-impl_view_tuple!(10;
-    V0, V1, V2, V3, V4, V5, V6, V7, V8, V9;
+impl_view_tuple!(V0, V1, V2, V3, V4, V5, V6, V7, V8, V9;
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9
 );

--- a/src/view/view.rs
+++ b/src/view/view.rs
@@ -41,7 +41,9 @@ use crate::{
 /// and also a type for actions which are passed up the tree in event
 /// propagation. During event handling, mutable access to the app state is
 /// given to view nodes, which in turn can make expose it to callbacks.
-pub trait View<T, A = ()>: Send {
+// We depend on ViewMarker to disallow any View implementations which dont implement ViewMarker.
+// Doing that would lead to pretty strange bugs.
+pub trait View<T, A = ()>: ViewMarker + Send {
     /// Associated state for the view.
     type State: Send;
 
@@ -76,6 +78,11 @@ pub trait View<T, A = ()>: Send {
     ) -> MessageResult<A>;
 }
 
+/// This trait marks a type a View.
+///
+/// This trait is a workaround for rusts orphan rules. It serves as a switch between default and
+/// custom `ViewSequence` implementation. You cant implement `ViewSequence` for types which also
+/// implement `ViewMarker`.
 pub trait ViewMarker {}
 
 #[derive(Clone)]

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -56,22 +56,18 @@ impl Button {
 const LABEL_INSETS: Insets = Insets::uniform_xy(8., 2.);
 
 impl Widget for Button {
-    fn update(&mut self, cx: &mut UpdateCx) {
-        cx.request_layout();
-    }
-
     fn event(&mut self, cx: &mut EventCx, event: &Event) {
         match event {
             Event::MouseDown(_) => {
                 cx.set_active(true);
-                // TODO: request paint
+                cx.request_paint();
             }
             Event::MouseUp(_) => {
-                if cx.is_hot() {
+                if cx.is_hot() && cx.is_active() {
                     cx.add_message(Message::new(self.id_path.clone(), ()));
                 }
                 cx.set_active(false);
-                // TODO: request paint
+                cx.request_paint();
             }
             Event::TargetedAccessibilityAction(request) => match request.action {
                 accesskit::Action::Default => {
@@ -90,6 +86,10 @@ impl Widget for Button {
             LifeCycle::HotChanged(_) => cx.request_paint(),
             _ => (),
         }
+    }
+
+    fn update(&mut self, cx: &mut UpdateCx) {
+        cx.request_layout();
     }
 
     fn layout(&mut self, cx: &mut LayoutCx, bc: &BoxConstraints) -> Size {


### PR DESCRIPTION
This PR adds a `ViewSequence` implementation for `View`, `Option<ViewSequence>`, tupels of ViewSequences and `List`.

To create no conflicts whith the orphan rules, this PR adds the `ViewMarker` trait. It lets the author decide, whether they need to implement `ViewSequence` for their type.
Currently it is not possible to implement a wrapper types like `Adapt` for `ViewSequence`. This would also be possible by adding a second helper trait. Like this:
```rust

trait ViewMarker {}

trait ViewImpl<T, A> {}

trait View<T, A>: ViewImpl<T, A> { ... }

impl<T, A, V> ViewImpl<T, A> for V where V: View<T, A> {}

impl<T, A, V> ViewImpl<T, A> for V where V: ViewSequence<T, A> {}

impl<T, A, V> ViewSequence<T, A> for V where V: View<T, A> + ViewMarker { ... }
```
This way it is not possible to impl View for a Type without it also having a ViewSequence implementation, while having the flexibility to provide both.

But i am not sure if this is the right way forward. Considering that we probably want to be generic over the element type, we could also define View as:
```rust 
trait View<T, A>: ViewSequence<T, A> {}
```
and have a seperate `TypedView` trait which looks like the current `View` trait. 
This way View only asserts that this sequence has only one element.