### PR TITLE
Prototype of generic view trait

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -33,7 +33,7 @@ use crate::widget::{
 use crate::{
     event::Message,
     id::Id,
-    view::{Cx, View},
+    view::{Cx, TraitBound, View},
     widget::Event,
 };
 
@@ -362,7 +362,7 @@ where
             } else {
                 let (id, state, element) = response.view.build(&mut self.cx);
                 assert!(self.cx.is_empty(), "id path imbalance on build");
-                self.root_pod = Some(Pod::new(element));
+                self.root_pod = Some(Pod::new_from_box(element.boxed()));
                 self.id = Some(id);
                 state
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use xilem::view::{button, h_stack, v_stack};
+use xilem::view::{button, h_stack, v_stack, AnyView, WidgetBound};
 use xilem::{view::View, App, AppLauncher};
 
 fn app_logic(data: &mut i32) -> impl View<i32> {
@@ -8,13 +8,14 @@ fn app_logic(data: &mut i32) -> impl View<i32> {
     } else {
         format!("clicked {data} times")
     };
+    let widget: Box<dyn AnyView<i32, WidgetBound> + Send> = Box::new(button(label, |data| {
+        println!("clicked");
+        *data += 1;
+    }));
 
     // The actual UI Code starts here
     v_stack((
-        button(label, |data| {
-            println!("clicked");
-            *data += 1;
-        }),
+        widget,
         h_stack((
             button("decrease", |data| {
                 println!("clicked decrease");

--- a/src/view/any_view.rs
+++ b/src/view/any_view.rs
@@ -37,7 +37,7 @@ use super::{
 /// be well beyond the capability of Rust's type system. If type-erased
 /// views with other bounds are needed, the best approach is probably
 /// duplication of the code, probably with a macro.
-pub trait AnyView<T, W, A = ()> {
+pub trait AnyView<T, W: ?Sized, A = ()> {
     fn as_any(&self) -> &dyn Any;
 
     fn dyn_build(&self, cx: &mut Cx) -> (Id, Box<dyn Any + Send>, Box<W>);
@@ -60,7 +60,7 @@ pub trait AnyView<T, W, A = ()> {
     ) -> MessageResult<A>;
 }
 
-impl<T, W, A, V: GenericView<T, W, A> + 'static> AnyView<T, W, A> for V
+impl<T, W: ?Sized, A, V: GenericView<T, W, A> + 'static> AnyView<T, W, A> for V
 where
     V::State: 'static,
     V::Element: TraitBound<W> + 'static,
@@ -122,9 +122,9 @@ where
     }
 }
 
-impl<T, W, A> ViewMarker for Box<dyn AnyView<T, W, A> + Send> {}
+impl<T, W: ?Sized, A> ViewMarker for Box<dyn AnyView<T, W, A> + Send> {}
 
-impl<T, W, A> GenericView<T, W, A> for Box<dyn AnyView<T, W, A> + Send>
+impl<T, W: ?Sized, A> GenericView<T, W, A> for Box<dyn AnyView<T, W, A> + Send>
     where Box<W>: TraitBound<W>
 {
     type State = Box<dyn Any + Send>;

--- a/src/view/any_view.rs
+++ b/src/view/any_view.rs
@@ -23,7 +23,10 @@ use crate::{
     widget::{AnyWidget, ChangeFlags},
 };
 
-use super::{Cx, View, view::{GenericView, WidgetBound}};
+use super::{
+    view::{GenericView, WidgetBound},
+    Cx, View,
+};
 
 /// A trait enabling type erasure of views.
 ///

--- a/src/view/any_view.rs
+++ b/src/view/any_view.rs
@@ -23,7 +23,7 @@ use crate::{
     widget::{AnyWidget, ChangeFlags},
 };
 
-use super::{Cx, View};
+use super::{Cx, View, view::{GenericView, WidgetBound}};
 
 /// A trait enabling type erasure of views.
 ///
@@ -120,7 +120,7 @@ where
 
 impl<T, A> ViewMarker for Box<dyn AnyView<T, A> + Send> {}
 
-impl<T, A> View<T, A> for Box<dyn AnyView<T, A> + Send> {
+impl<T, A> GenericView<T, WidgetBound, A> for Box<dyn AnyView<T, A> + Send> {
     type State = Box<dyn Any + Send>;
 
     type Element = Box<dyn AnyWidget>;

--- a/src/view/any_view.rs
+++ b/src/view/any_view.rs
@@ -16,17 +16,15 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use crate::{view::ViewMarker, widget::AsAny};
-use crate::{
-    event::MessageResult,
-    id::Id,
-    widget::ChangeFlags,
-};
+use crate::view::ViewMarker;
+use crate::{event::MessageResult, id::Id, widget::ChangeFlags};
 
-use super::{
-    view::GenericView,
-    Cx, TraitBound,
-};
+use super::{view::GenericView, Cx, TraitBound};
+
+/// A trait allowing access to dynamic typing.
+pub trait AsAnyMut {
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
 
 /// A trait enabling type erasure of views.
 ///
@@ -64,7 +62,7 @@ impl<T, W: ?Sized, A, V: GenericView<T, W, A> + 'static> AnyView<T, W, A> for V
 where
     V::State: 'static,
     V::Element: TraitBound<W> + 'static,
-    Box<W>: AsAny,
+    Box<W>: AsAnyMut,
 {
     fn as_any(&self) -> &dyn Any {
         self
@@ -125,7 +123,8 @@ where
 impl<T, W: ?Sized, A> ViewMarker for Box<dyn AnyView<T, W, A> + Send> {}
 
 impl<T, W: ?Sized, A> GenericView<T, W, A> for Box<dyn AnyView<T, W, A> + Send>
-    where Box<W>: TraitBound<W>
+where
+    Box<W>: TraitBound<W>,
 {
     type State = Box<dyn Any + Send>;
 

--- a/src/view/button.rs
+++ b/src/view/button.rs
@@ -17,8 +17,7 @@ use std::any::Any;
 use crate::view::ViewMarker;
 use crate::{event::MessageResult, id::Id, widget::ChangeFlags};
 
-use super::view::{GenericView, WidgetBound};
-use super::{Cx, View};
+use super::{Cx, GenericView, WidgetBound};
 
 pub struct Button<T, A> {
     label: String,

--- a/src/view/button.rs
+++ b/src/view/button.rs
@@ -17,6 +17,7 @@ use std::any::Any;
 use crate::view::ViewMarker;
 use crate::{event::MessageResult, id::Id, widget::ChangeFlags};
 
+use super::view::{GenericView, WidgetBound};
 use super::{Cx, View};
 
 pub struct Button<T, A> {
@@ -43,7 +44,7 @@ impl<T, A> Button<T, A> {
 
 impl<T, A> ViewMarker for Button<T, A> {}
 
-impl<T, A> View<T, A> for Button<T, A> {
+impl<T, A> GenericView<T, WidgetBound, A> for Button<T, A> {
     type State = ();
 
     type Element = crate::widget::Button;

--- a/src/view/linear_layout.rs
+++ b/src/view/linear_layout.rs
@@ -22,8 +22,7 @@ use crate::view::ViewMarker;
 use crate::widget::{self, ChangeFlags};
 use crate::VecSplice;
 
-use super::view::{GenericView, WidgetBound};
-use super::{Cx, View};
+use super::{Cx, GenericView, WidgetBound};
 
 /// LinearLayout is a simple view which does layout for the specified ViewSequence.
 ///
@@ -31,7 +30,7 @@ use super::{Cx, View};
 ///
 /// This View is only temporary is probably going to be replaced by something like Druid's Flex
 /// widget.
-pub struct LinearLayout<T, A, VT: ViewSequence<T, A>> {
+pub struct LinearLayout<T, A, VT: ViewSequence<T, WidgetBound, A>> {
     children: VT,
     spacing: f64,
     axis: Axis,
@@ -39,16 +38,16 @@ pub struct LinearLayout<T, A, VT: ViewSequence<T, A>> {
 }
 
 /// creates a vertical [`LinearLayout`].
-pub fn v_stack<T, A, VT: ViewSequence<T, A>>(children: VT) -> LinearLayout<T, A, VT> {
+pub fn v_stack<T, A, VT: ViewSequence<T, WidgetBound, A>>(children: VT) -> LinearLayout<T, A, VT> {
     LinearLayout::new(children, Axis::Vertical)
 }
 
 /// creates a horizontal [`LinearLayout`].
-pub fn h_stack<T, A, VT: ViewSequence<T, A>>(children: VT) -> LinearLayout<T, A, VT> {
+pub fn h_stack<T, A, VT: ViewSequence<T, WidgetBound, A>>(children: VT) -> LinearLayout<T, A, VT> {
     LinearLayout::new(children, Axis::Horizontal)
 }
 
-impl<T, A, VT: ViewSequence<T, A>> LinearLayout<T, A, VT> {
+impl<T, A, VT: ViewSequence<T, WidgetBound, A>> LinearLayout<T, A, VT> {
     pub fn new(children: VT, axis: Axis) -> Self {
         let phantom = Default::default();
         LinearLayout {
@@ -65,9 +64,11 @@ impl<T, A, VT: ViewSequence<T, A>> LinearLayout<T, A, VT> {
     }
 }
 
-impl<T, A, VT: ViewSequence<T, A>> ViewMarker for LinearLayout<T, A, VT> {}
+impl<T, A, VT: ViewSequence<T, WidgetBound, A>> ViewMarker for LinearLayout<T, A, VT> {}
 
-impl<T, A, VT: ViewSequence<T, A>> GenericView<T, WidgetBound, A> for LinearLayout<T, A, VT> {
+impl<T, A, VT: ViewSequence<T, WidgetBound, A>> GenericView<T, WidgetBound, A>
+    for LinearLayout<T, A, VT>
+{
     type State = VT::State;
 
     type Element = widget::LinearLayout;

--- a/src/view/linear_layout.rs
+++ b/src/view/linear_layout.rs
@@ -22,6 +22,7 @@ use crate::view::ViewMarker;
 use crate::widget::{self, ChangeFlags};
 use crate::VecSplice;
 
+use super::view::{GenericView, WidgetBound};
 use super::{Cx, View};
 
 /// LinearLayout is a simple view which does layout for the specified ViewSequence.
@@ -66,7 +67,7 @@ impl<T, A, VT: ViewSequence<T, A>> LinearLayout<T, A, VT> {
 
 impl<T, A, VT: ViewSequence<T, A>> ViewMarker for LinearLayout<T, A, VT> {}
 
-impl<T, A, VT: ViewSequence<T, A>> View<T, A> for LinearLayout<T, A, VT> {
+impl<T, A, VT: ViewSequence<T, A>> GenericView<T, WidgetBound, A> for LinearLayout<T, A, VT> {
     type State = VT::State;
 
     type Element = widget::LinearLayout;

--- a/src/view/list.rs
+++ b/src/view/list.rs
@@ -18,21 +18,23 @@ use crate::{Id, MessageResult, VecSplice};
 use std::any::Any;
 use std::marker::PhantomData;
 
+use super::WidgetBound;
+
 /// A simple view sequence which builds a dynamic amount of sub sequences.
-pub struct List<T, A, VT: ViewSequence<T, A>, F: Fn(usize) -> VT + Send> {
+pub struct List<T, A, VT: ViewSequence<T, WidgetBound, A>, F: Fn(usize) -> VT + Send> {
     items: usize,
     build: F,
     phantom: PhantomData<fn() -> (T, A, VT)>,
 }
 
 /// The state of a List sequence
-pub struct ListState<T, A, VT: ViewSequence<T, A>> {
+pub struct ListState<T, A, VT: ViewSequence<T, WidgetBound, A>> {
     views: Vec<(VT, VT::State)>,
     element_count: usize,
 }
 
 /// creates a new `List` sequence.
-pub fn list<T, A, VT: ViewSequence<T, A>, F: Fn(usize) -> VT + Send>(
+pub fn list<T, A, VT: ViewSequence<T, WidgetBound, A>, F: Fn(usize) -> VT + Send>(
     items: usize,
     build: F,
 ) -> List<T, A, VT, F> {
@@ -43,8 +45,8 @@ pub fn list<T, A, VT: ViewSequence<T, A>, F: Fn(usize) -> VT + Send>(
     }
 }
 
-impl<T, A, VT: ViewSequence<T, A>, F: Fn(usize) -> VT + Send> ViewSequence<T, A>
-    for List<T, A, VT, F>
+impl<T, A, VT: ViewSequence<T, WidgetBound, A>, F: Fn(usize) -> VT + Send>
+    ViewSequence<T, WidgetBound, A> for List<T, A, VT, F>
 {
     type State = ListState<T, A, VT>;
 

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -27,7 +27,7 @@ mod list;
 mod sequence;
 mod view;
 
-pub use any_view::AnyView;
+pub use any_view::{AnyView, AsAnyMut};
 pub use button::button;
 pub use linear_layout::{h_stack, v_stack, LinearLayout};
 pub use list::{list, List};

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -32,4 +32,4 @@ pub use button::button;
 pub use linear_layout::{h_stack, v_stack, LinearLayout};
 pub use list::{list, List};
 pub use sequence::ViewSequence;
-pub use view::{Cx, View, ViewMarker};
+pub use view::{Cx, GenericView, TraitBound, View, ViewMarker, WidgetBound};

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -31,5 +31,5 @@ pub use any_view::AnyView;
 pub use button::button;
 pub use linear_layout::{h_stack, v_stack, LinearLayout};
 pub use list::{list, List};
-pub use sequence::ViewSequence;
+pub use sequence::{Element, ViewSequence};
 pub use view::{Cx, GenericView, TraitBound, View, ViewMarker, WidgetBound};

--- a/src/view/sequence.rs
+++ b/src/view/sequence.rs
@@ -5,6 +5,8 @@ use crate::widget::{ChangeFlags, Pod, Widget};
 use crate::VecSplice;
 use std::any::Any;
 
+use super::view::{GenericView, WidgetBound};
+
 /// A sequence on view nodes.
 ///
 /// This is one of the central traits for representing UI. Every view which has a collection of
@@ -57,10 +59,10 @@ impl<T, A, V: View<T, A> + ViewMarker> ViewSequence<T, A> for V
 where
     V::Element: Widget + 'static,
 {
-    type State = (<V as View<T, A>>::State, Id);
+    type State = (<V as GenericView<T, WidgetBound, A>>::State, Id);
 
     fn build(&self, cx: &mut Cx, elements: &mut Vec<Pod>) -> Self::State {
-        let (id, state, element) = <V as View<T, A>>::build(self, cx);
+        let (id, state, element) = <V as GenericView<T, WidgetBound, A>>::build(self, cx);
         elements.push(Pod::new(element));
         (state, id)
     }
@@ -75,7 +77,7 @@ where
         let el = element.mutate();
         let downcast = el.downcast_mut().unwrap();
         let flags =
-            <V as View<T, A>>::rebuild(self, cx, prev, &mut state.1, &mut state.0, downcast);
+            <V as GenericView<T, WidgetBound, A>>::rebuild(self, cx, prev, &mut state.1, &mut state.0, downcast);
 
         el.mark(flags)
     }
@@ -89,7 +91,7 @@ where
     ) -> MessageResult<A> {
         if let Some((first, rest_path)) = id_path.split_first() {
             if first == &state.1 {
-                return <V as View<T, A>>::message(
+                return <V as GenericView<T, WidgetBound, A>>::message(
                     self,
                     rest_path,
                     &mut state.0,

--- a/src/view/view.rs
+++ b/src/view/view.rs
@@ -59,7 +59,7 @@ pub type WidgetBound = dyn AnyWidget + 'static;
 /// and also a type for actions which are passed up the tree in event
 /// propagation. During event handling, mutable access to the app state is
 /// given to view nodes, which in turn can make expose it to callbacks.
-// We depend on ViewMarker to disallow any View implementations which dont implement ViewMarker.
+// We depend on ViewMarker to disallow any View implementations which don't implement ViewMarker.
 // Doing that would lead to pretty strange bugs.
 pub trait GenericView<T, W: ?Sized, A = ()>: ViewMarker + Send {
     /// Associated state for the view.
@@ -103,7 +103,7 @@ impl<T, A, V: GenericView<T, WidgetBound, A>> View<T, A> for V {}
 /// This trait marks a type a View.
 ///
 /// This trait is a workaround for rusts orphan rules. It serves as a switch between default and
-/// custom `ViewSequence` implementation. You cant implement `ViewSequence` for types which also
+/// custom `ViewSequence` implementation. You can't implement `ViewSequence` for types which also
 /// implement `ViewMarker`.
 pub trait ViewMarker {}
 

--- a/src/view/view.rs
+++ b/src/view/view.rs
@@ -23,7 +23,7 @@ use futures_task::{ArcWake, Waker};
 use crate::{
     event::MessageResult,
     id::{Id, IdPath},
-    widget::{ChangeFlags, Widget, AnyWidget},
+    widget::{AnyWidget, ChangeFlags, Widget},
 };
 
 pub trait TraitBound<W: ?Sized> {

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -32,4 +32,4 @@ pub use button::Button;
 pub use contexts::{AccessCx, CxState, EventCx, LayoutCx, LifeCycleCx, PaintCx, UpdateCx};
 pub use linear_layout::LinearLayout;
 pub use raw_event::{Event, LifeCycle, MouseEvent, ViewContext};
-pub use widget::{AnyWidget, Widget};
+pub use widget::{AsAny, AnyWidget, Widget};

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -32,4 +32,4 @@ pub use button::Button;
 pub use contexts::{AccessCx, CxState, EventCx, LayoutCx, LifeCycleCx, PaintCx, UpdateCx};
 pub use linear_layout::LinearLayout;
 pub use raw_event::{Event, LifeCycle, MouseEvent, ViewContext};
-pub use widget::{AsAny, AnyWidget, Widget};
+pub use widget::{AnyWidget, Widget};

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -16,6 +16,7 @@ use std::any::Any;
 use std::ops::DerefMut;
 
 use crate::geometry::Axis;
+use crate::view::AsAnyMut;
 use glazier::kurbo::Size;
 use vello::SceneBuilder;
 
@@ -183,10 +184,6 @@ pub trait Widget {
     }
 }
 
-pub trait AsAny {
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-}
-
 pub trait AnyWidget: Widget {
     fn as_any(&self) -> &dyn Any;
 
@@ -235,7 +232,7 @@ impl Widget for Box<dyn AnyWidget> {
     }
 }
 
-impl AsAny for Box<dyn AnyWidget> {
+impl AsAnyMut for Box<dyn AnyWidget> {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self.deref_mut().as_any_mut()
     }

--- a/src/widget/widget.rs
+++ b/src/widget/widget.rs
@@ -183,6 +183,10 @@ pub trait Widget {
     }
 }
 
+pub trait AsAny {
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
 pub trait AnyWidget: Widget {
     fn as_any(&self) -> &dyn Any;
 
@@ -228,5 +232,11 @@ impl Widget for Box<dyn AnyWidget> {
 
     fn paint(&mut self, cx: &mut PaintCx, builder: &mut SceneBuilder) {
         self.deref_mut().paint(cx, builder);
+    }
+}
+
+impl AsAny for Box<dyn AnyWidget> {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self.deref_mut().as_any_mut()
     }
 }


### PR DESCRIPTION
Use type system hackery to represent a generic bound over traits.

Note: this patch *just* makes the view itself generic, and doesn't address any of the supporting machinery (ViewSequence, AnyView, etc).