### PR TITLE
Add a type alias for Box<dyn View> in the anyview macro

### DIFF
--- a/crates/xilem_core/src/any_view.rs
+++ b/crates/xilem_core/src/any_view.rs
@@ -3,7 +3,7 @@
 
 #[macro_export]
 macro_rules! generate_anyview_trait {
-    ($anyview:ident, $viewtrait:ident, $viewmarker:ty, $cx:ty, $changeflags:ty, $anywidget:ident $($ss:tt)*) => {
+    ($anyview:ident, $viewtrait:ident, $viewmarker:ty, $cx:ty, $changeflags:ty, $anywidget:ident, $boxedview:ident; $($ss:tt)*) => {
         /// A trait enabling type erasure of views.
         pub trait $anyview<T, A = ()> {
             fn as_any(&self) -> &dyn std::any::Any;
@@ -94,7 +94,11 @@ macro_rules! generate_anyview_trait {
             }
         }
 
-        impl<T, A> $viewtrait<T, A> for Box<dyn $anyview<T, A> $( $ss )* > {
+        pub type $boxedview<T, A = ()> = Box<dyn $anyview<T, A> $( $ss )* >;
+
+        impl<T, A> $viewmarker for $boxedview<T, A> {}
+
+        impl<T, A> $viewtrait<T, A> for $boxedview<T, A> {
             type State = Box<dyn std::any::Any $( $ss )* >;
 
             type Element = Box<dyn $anywidget>;
@@ -129,7 +133,5 @@ macro_rules! generate_anyview_trait {
                     .dyn_message(id_path, state.deref_mut(), message, app_state)
             }
         }
-
-        impl<T, A> $viewmarker for Box<dyn $anyview<T, A> $( $ss )*> {}
     };
 }

--- a/src/view/view.rs
+++ b/src/view/view.rs
@@ -25,7 +25,7 @@ use crate::widget::{AnyWidget, ChangeFlags, Pod, Widget};
 
 xilem_core::generate_view_trait! {View, Widget, Cx, ChangeFlags; : Send}
 xilem_core::generate_viewsequence_trait! {ViewSequence, View, ViewMarker, Widget, Cx, ChangeFlags, Pod; : Send}
-xilem_core::generate_anyview_trait! {AnyView, View, ViewMarker, Cx, ChangeFlags, AnyWidget + Send}
+xilem_core::generate_anyview_trait! {AnyView, View, ViewMarker, Cx, ChangeFlags, AnyWidget, BoxedView; + Send}
 
 #[derive(Clone)]
 pub struct Cx {


### PR DESCRIPTION
This should make writing boxed Anyviews as type a little bit less convoluted.

Motivation for this was a bigger refactor in [trui](https://github.com/Philipp-M/trui), where the View additionally needed the super trait `Send`. I had a lot of unidentifiable error messages because the `Box<dyn View>` should've been `Box<dyn View + Send>` somewhere in the view-tree (generally a topic that needs some research, to avoid hair-pulling, I think...).

I think adding a type alias that automatically has all these extra trait bounds might be generally helpful.