### PR TITLE
svg: Rename `xilemsvg` to `xilem_svg`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3314,7 +3314,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "xilemsvg"
+name = "xilem_svg"
 version = "0.1.0"
 dependencies = [
  "bitflags 1.3.2",

--- a/crates/xilem_svg/Cargo.toml
+++ b/crates/xilem_svg/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xilemsvg"
+name = "xilem_svg"
 version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
There are 2 other crates (so far) with similar naming, but are using the underscore: `xilem_core` and `xilem_html`.