### PR TITLE
Implement ViewSequence for Either

### DIFF
--- a/crates/xilem_html/src/view.rs
+++ b/crates/xilem_html/src/view.rs
@@ -126,8 +126,8 @@ where
 
 impl<T, A, V1, V2> View<T, A> for Either<V1, V2>
 where
-    V1: View<T, A>,
-    V2: View<T, A>,
+    V1: View<T, A> + ViewMarker,
+    V2: View<T, A> + ViewMarker,
     V1::Element: AsRef<web_sys::Node> + 'static,
     V2::Element: AsRef<web_sys::Node> + 'static,
 {
@@ -206,6 +206,94 @@ where
                     throw_str("invalid state/view in Either (unreachable)");
                 };
                 view.message(id_path, state, message, app_state)
+            }
+        }
+    }
+}
+
+impl<T, A, V1, V2> ViewSequence<T, A> for Either<V1, V2>
+where
+    V1: ViewSequence<T, A>,
+    V2: ViewSequence<T, A>,
+{
+    type State = Either<V1::State, V2::State>;
+
+    fn build(&self, cx: &mut Cx, elements: &mut Vec<Pod>) -> Self::State {
+        match self {
+            Either::Left(view_sequence) => Either::Left(view_sequence.build(cx, elements)),
+            Either::Right(view_sequence) => Either::Right(view_sequence.build(cx, elements)),
+        }
+    }
+
+    fn rebuild(
+        &self,
+        cx: &mut Cx,
+        prev: &Self,
+        state: &mut Self::State,
+        element: &mut xilem_core::VecSplice<Pod>,
+    ) -> ChangeFlags {
+        match (prev, self) {
+            (Either::Left(_), Either::Right(view_sequence)) => {
+                let new_state = element.as_vec(|elements| view_sequence.build(cx, elements));
+                *state = Either::Right(new_state);
+                ChangeFlags::STRUCTURE
+            }
+            (Either::Right(_), Either::Left(view_sequence)) => {
+                let new_state = element.as_vec(|elements| view_sequence.build(cx, elements));
+                *state = Either::Left(new_state);
+                ChangeFlags::STRUCTURE
+            }
+            (Either::Left(prev_view), Either::Left(view_sequence)) => {
+                let Either::Left(state) = state else {
+                    throw_str("invalid state/view_sequence in Either (unreachable)");
+                };
+                view_sequence.rebuild(cx, prev_view, state, element)
+            }
+            (Either::Right(prev_view), Either::Right(view_sequence)) => {
+                let Either::Right(state) = state else {
+                    throw_str("invalid state/view_sequence in Either (unreachable)");
+                };
+                view_sequence.rebuild(cx, prev_view, state, element)
+            }
+        }
+    }
+
+    fn message(
+        &self,
+        id_path: &[xilem_core::Id],
+        state: &mut Self::State,
+        message: Box<dyn std::any::Any>,
+        app_state: &mut T,
+    ) -> MessageResult<A> {
+        match self {
+            Either::Left(view_sequence) => {
+                let Either::Left(state) = state else {
+                    throw_str("invalid state/view_sequence in Either (unreachable)");
+                };
+                view_sequence.message(id_path, state, message, app_state)
+            }
+            Either::Right(view_sequence) => {
+                let Either::Right(state) = state else {
+                    throw_str("invalid state/view_sequence in Either (unreachable)");
+                };
+                view_sequence.message(id_path, state, message, app_state)
+            }
+        }
+    }
+
+    fn count(&self, state: &Self::State) -> usize {
+        match self {
+            Either::Left(view_sequence) => {
+                let Either::Left(state) = state else {
+                    throw_str("invalid state/view_sequence in Either (unreachable)");
+                };
+                view_sequence.count(state)
+            }
+            Either::Right(view_sequence) => {
+                let Either::Right(state) = state else {
+                    throw_str("invalid state/view_sequence in Either (unreachable)");
+                };
+                view_sequence.count(state)
             }
         }
     }

--- a/crates/xilem_html/src/view.rs
+++ b/crates/xilem_html/src/view.rs
@@ -155,38 +155,36 @@ where
         state: &mut Self::State,
         element: &mut Self::Element,
     ) -> ChangeFlags {
-        let mut change_flags = ChangeFlags::empty();
         match (prev, self) {
             (Either::Left(_), Either::Right(view)) => {
                 let (new_id, new_state, new_element) = view.build(cx);
                 *id = new_id;
                 *state = Either::Right(new_state);
                 *element = Either::Right(new_element);
-                change_flags |= ChangeFlags::STRUCTURE;
+                ChangeFlags::STRUCTURE
             }
             (Either::Right(_), Either::Left(view)) => {
                 let (new_id, new_state, new_element) = view.build(cx);
                 *id = new_id;
                 *state = Either::Left(new_state);
                 *element = Either::Left(new_element);
-                change_flags |= ChangeFlags::STRUCTURE;
+                ChangeFlags::STRUCTURE
             }
             (Either::Left(prev_view), Either::Left(view)) => {
                 let (Either::Left(state), Either::Left(element)) = (state, element) else {
                     throw_str("invalid state/view in Either (unreachable)");
                 };
                 // Cannot do mutable casting, so take ownership of state.
-                change_flags |= view.rebuild(cx, prev_view, id, state, element);
+                view.rebuild(cx, prev_view, id, state, element)
             }
             (Either::Right(prev_view), Either::Right(view)) => {
                 let (Either::Right(state), Either::Right(element)) = (state, element) else {
                     throw_str("invalid state/view in Either (unreachable)");
                 };
                 // Cannot do mutable casting, so take ownership of state.
-                change_flags |= view.rebuild(cx, prev_view, id, state, element);
+                view.rebuild(cx, prev_view, id, state, element)
             }
         }
-        change_flags
     }
 
     fn message(


### PR DESCRIPTION
I don't have a deep understanding of these traits, but this achieves:

- `Either<impl ViewSequence, impl ViewSequence>` implementing `ViewSequence`
- `Either<impl View + ViewMarker, impl View + ViewMarker>` implementing `View` and thus `ViewSequence`

Regarding the new implementation of `ViewSequence`, I have no idea if it's correct, in particular the `rebuild` method. I just implemented it in as closely to the existing `View::rebuild`, and such that the types line up. Please check if I did it right 😅 