### PR TITLE
xilem_html examples: Use bin crates to work with `trunk`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,7 @@ dependencies = [
 name = "counter"
 version = "0.1.0"
 dependencies = [
+ "console_error_panic_hook",
  "wasm-bindgen",
  "web-sys",
  "xilem_html",
@@ -633,6 +634,7 @@ dependencies = [
 name = "counter_untyped"
 version = "0.1.0"
 dependencies = [
+ "console_error_panic_hook",
  "wasm-bindgen",
  "web-sys",
  "xilem_html",

--- a/crates/xilem_html/web_examples/counter/Cargo.toml
+++ b/crates/xilem_html/web_examples/counter/Cargo.toml
@@ -4,10 +4,8 @@ version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"
 
-[lib]
-crate-type = ["cdylib"]
-
 [dependencies]
+console_error_panic_hook = "0.1"
 wasm-bindgen = "0.2.87"
 web-sys = "0.3.64"
 xilem_html = { path = "../.." }

--- a/crates/xilem_html/web_examples/counter/src/main.rs
+++ b/crates/xilem_html/web_examples/counter/src/main.rs
@@ -1,4 +1,3 @@
-use wasm_bindgen::{prelude::*, JsValue};
 use xilem_html::{
     document_body, elements as el,
     events::{self as evt},
@@ -64,11 +63,8 @@ fn app_logic(state: &mut AppState) -> impl View<AppState> {
     ))
 }
 
-// Called by our JS entry point to run the example
-#[wasm_bindgen(start)]
-pub fn run() -> Result<(), JsValue> {
+pub fn main() {
+    console_error_panic_hook::set_once();
     let app = App::new(AppState::default(), app_logic);
     app.run(&document_body());
-
-    Ok(())
 }

--- a/crates/xilem_html/web_examples/counter_untyped/Cargo.toml
+++ b/crates/xilem_html/web_examples/counter_untyped/Cargo.toml
@@ -4,10 +4,8 @@ version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"
 
-[lib]
-crate-type = ["cdylib"]
-
 [dependencies]
+console_error_panic_hook = "0.1"
 wasm-bindgen = "0.2.87"
 web-sys = { version = "0.3.64", features = ["HtmlButtonElement"] }
 xilem_html = { path = "../..", default-features = false }

--- a/crates/xilem_html/web_examples/counter_untyped/src/main.rs
+++ b/crates/xilem_html/web_examples/counter_untyped/src/main.rs
@@ -1,4 +1,3 @@
-use wasm_bindgen::{prelude::*, JsValue};
 use xilem_html::{document_body, element, on_event, App, Event, View, ViewMarker};
 
 #[derive(Default)]
@@ -43,11 +42,8 @@ fn app_logic(state: &mut AppState) -> impl View<AppState> {
     )
 }
 
-// Called by our JS entry point to run the example
-#[wasm_bindgen(start)]
-pub fn run() -> Result<(), JsValue> {
+pub fn main() {
+    console_error_panic_hook::set_once();
     let app = App::new(AppState::default(), app_logic);
     app.run(&document_body());
-
-    Ok(())
 }

--- a/crates/xilem_html/web_examples/todomvc/Cargo.toml
+++ b/crates/xilem_html/web_examples/todomvc/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"
 
-[lib]
-crate-type = ["cdylib"]
-
 [dependencies]
 console_error_panic_hook = "0.1.7"
 console_log = { version = "1.0.0", features = ["color"] }

--- a/crates/xilem_html/web_examples/todomvc/src/main.rs
+++ b/crates/xilem_html/web_examples/todomvc/src/main.rs
@@ -1,10 +1,7 @@
-use std::panic;
-
 mod state;
 
 use state::{AppState, Filter, Todo};
 
-use wasm_bindgen::{prelude::*, JsValue};
 use xilem_html::{
     elements as el, events::on_click, get_element_by_id, Action, Adapt, App, MessageResult, View,
     ViewExt, ViewMarker,
@@ -195,12 +192,8 @@ fn app_logic(state: &mut AppState) -> impl View<AppState> {
     ))
 }
 
-// Called by our JS entry point to run the example
-#[wasm_bindgen(start)]
-pub fn run() -> Result<(), JsValue> {
-    panic::set_hook(Box::new(console_error_panic_hook::hook));
+pub fn main() {
+    console_error_panic_hook::set_once();
     console_log::init_with_level(log::Level::Debug).unwrap();
     App::new(AppState::default(), app_logic).run(&get_element_by_id("todoapp"));
-
-    Ok(())
 }


### PR DESCRIPTION
`trunk` wants `bin` crates rather than `lib`. This has been supported by `wasm-bindgen` since 0.2.54 (released 2019-11-07).

Also, add panic hooks to the `counter` and `counter_untyped` examples. (And make `todomvc` use the `set_once` method of setting the panic hook.)