### PR TITLE
Remove Clone trait bound in Memoize view

### DIFF
--- a/crates/xilem_core/src/view/memoize.rs
+++ b/crates/xilem_core/src/view/memoize.rs
@@ -34,7 +34,7 @@ macro_rules! generate_memoize_view {
         impl<
                 T,
                 A,
-                D: PartialEq + Clone + Send + 'static,
+                D: PartialEq + Send + 'static,
                 V: $viewtrait<T, A>,
                 F: Fn(&D) -> V + Send,
             > $viewtrait<T, A> for $memoizeview<D, F>


### PR DESCRIPTION
I have skimmed over #65 and saw that the `Clone` trait bound in the `Memoize` view doesn't seem to be necessary (which it indeed isn't).