### PR TITLE
Fix and use module UseState

### DIFF
--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -18,9 +18,9 @@ mod button;
 // mod list;
 // mod scroll_view;
 // mod text;
-// mod use_state;
 mod linear_layout;
 mod list;
+mod use_state;
 mod view;
 
 pub use xilem_core::{Id, IdPath, VecSplice};
@@ -28,4 +28,5 @@ pub use xilem_core::{Id, IdPath, VecSplice};
 pub use button::button;
 pub use linear_layout::{h_stack, v_stack, LinearLayout};
 pub use list::{list, List};
+pub use use_state::{use_state, UseState};
 pub use view::{Adapt, Cx, Memoize, View, ViewMarker, ViewSequence};

--- a/src/view/use_state.rs
+++ b/src/view/use_state.rs
@@ -109,6 +109,9 @@ where
     }
 }
 
+/// "Injects" additional local state into the provided view (which is returned by `f`)
+/// Requires that the parent state is of `Arc<T>`.
+/// The initial state is provided by `f_init` (when this view is first built)
 pub fn use_state<T, A, S, V, FInit, F>(f_init: FInit, f: F) -> UseState<T, A, S, V, FInit, F>
 where
     V: View<(Arc<T>, S), A>,


### PR DESCRIPTION
This fixes the `UseState` module to be compilable and usable again with the current xilem architecture.

A port to `xilem_core` should be straightforward (and could be done in a follow-up PR).