### PR TITLE
Added `cargo clippy` to the CI workflows and fixed/disabled a few clippy lints

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,15 +22,17 @@ jobs:
         sudo apt install libx11-dev libpango1.0-dev libxkbcommon-dev libxkbcommon-x11-dev
       if: runner.os == 'Linux'
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@master
+    - name: Rust Toolchain
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-        components: ${{ runner.os == 'Linux' && 'rustfmt' || '' }}
-    - name: restore cache
+        # rustfmt is already in the default components, but this is how platform dependencies could be used conditionally
+        # components: ${{ runner.os == 'Linux' && 'rustfmt' || '' }}
+    - name: Restore Cache
       uses: Swatinem/rust-cache@v2
-    - name: cargo fmt
+    - name: Cargo Format
       # We'll only run this on one platform.
       run: cargo fmt --all -- --check
       if: runner.os == 'Linux'
-    - name: Check
-      run: cargo check
+    - name: Cargo Clippy
+      run: cargo clippy --workspace -- -D warnings

--- a/src/app_main.rs
+++ b/src/app_main.rs
@@ -19,7 +19,6 @@ use glazier::{
     Application, Cursor, HotKey, IdleToken, Menu, MouseEvent, Region, Scalable, SysMods,
     WinHandler, WindowBuilder, WindowHandle,
 };
-use parley::FontContext;
 use vello::{
     kurbo::{Affine, Size},
     peniko::Color,
@@ -44,7 +43,6 @@ struct MainState<T, V: View<T>> {
     render_cx: RenderContext,
     surface: Option<RenderSurface>,
     renderer: Option<Renderer>,
-    font_context: FontContext,
     scene: Scene,
     counter: u64,
 }
@@ -187,7 +185,6 @@ where
             render_cx,
             surface: None,
             renderer: None,
-            font_context: FontContext::new(),
             scene: Scene::default(),
             counter: 0,
         }

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -21,6 +21,7 @@ mod button;
 // mod use_state;
 mod linear_layout;
 mod list;
+#[allow(clippy::module_inception)]
 mod view;
 
 pub use xilem_core::{Id, IdPath, VecSplice};

--- a/src/widget/contexts.rs
+++ b/src/widget/contexts.rs
@@ -29,6 +29,7 @@ use crate::Message;
 
 /// Static state that is shared between most contexts.
 pub struct CxState<'a> {
+    #[allow(unused)]
     window: &'a WindowHandle,
     font_cx: &'a mut FontContext,
     messages: &'a mut Vec<Message>,

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -23,6 +23,7 @@ mod piet_scene_helpers;
 mod raw_event;
 //mod scroll_view;
 //mod text;
+#[allow(clippy::module_inception)]
 mod widget;
 
 pub use self::core::{ChangeFlags, Pod};

--- a/src/widget/piet_scene_helpers.rs
+++ b/src/widget/piet_scene_helpers.rs
@@ -24,6 +24,7 @@ pub fn stroke<'b>(
 }
 
 // Note: copied from piet
+#[allow(unused)]
 impl UnitPoint {
     /// `(0.0, 0.0)`
     pub const TOP_LEFT: UnitPoint = UnitPoint::new(0.0, 0.0);


### PR DESCRIPTION
Currently there are two warnings left, that I think need discussion, like the following:

```
error: module has the same name as its containing module
  --> src/view/mod.rs:24:1
   |
24 | mod view;
```

I think these are good points, and I have named these `core` in my TUI framework for each of these modules (widget and view), and would suggest doing this as well here.