### PR TITLE
xilem_html: Add support for non-passive event handlers

### DIFF
--- a/crates/xilem_html/src/event/events.rs
+++ b/crates/xilem_html/src/event/events.rs
@@ -26,6 +26,24 @@ macro_rules! event {
             optional_action: std::marker::PhantomData<OA>,
         }
 
+        impl<T, A, V, F, OA> $ty_name<T, A, V, F, OA>
+        where
+            V: crate::view::View<T, A>,
+            F: Fn(&mut T, &$crate::Event<$web_sys_ty, V::Element>) -> OA,
+            V::Element: 'static,
+            OA: $crate::event::OptionalAction<A>,
+        {
+            /// Whether the event handler should be passive. (default = `true`)
+            ///
+            /// Passive event handlers can't prevent the browser's default action from
+            /// running (otherwise possible with `event.prevent_default()`), which
+            /// restricts what they can be used for, but reduces overhead.
+            pub fn passive(mut self, value: bool) -> Self {
+                self.inner.passive = value;
+                self
+            }
+        }
+
         /// Builder for the
         #[doc = concat!("`", $name, "`")]
         /// event listener.

--- a/crates/xilem_html/web_examples/todomvc/src/main.rs
+++ b/crates/xilem_html/web_examples/todomvc/src/main.rs
@@ -64,6 +64,7 @@ fn todo_item(todo: &mut Todo, editing: bool) -> impl View<Todo, TodoAction> + Vi
                 state.title_editing.push_str(&evt.target().value());
                 evt.prevent_default();
             })
+            .passive(false)
             .on_blur(|_, _| TodoAction::CancelEditing),
     ))
     .attr("class", class)
@@ -202,7 +203,8 @@ fn app_logic(state: &mut AppState) -> impl View<AppState> {
                 .on_input(|state: &mut AppState, evt| {
                     state.update_new_todo(&evt.target().value());
                     evt.prevent_default();
-                }),
+                })
+                .passive(false),
         ))
         .attr("class", "header"),
         main,


### PR DESCRIPTION
Allows adding `.passive(false)` after `.on_click(/* closure */)`. Maybe not the most intuitive but since optional args aren't a thing, I don't have another idea for now.