### PR TITLE
xilem_core: Add support for generic type parameters in the `View` trait

### DIFF
--- a/crates/xilem_core/src/any_view.rs
+++ b/crates/xilem_core/src/any_view.rs
@@ -3,9 +3,17 @@
 
 #[macro_export]
 macro_rules! generate_anyview_trait {
-    ($anyview:ident, $viewtrait:ident, $viewmarker:ty, $cx:ty, $changeflags:ty, $anywidget:ident, $boxedview:ident; $($ss:tt)*) => {
+    ($anyview:ident,
+     $viewtrait:ident <$($tp:ident),*>,
+     $viewmarker:ty,
+     $cx:ty,
+     $changeflags:ty,
+     $anywidget:ident,
+     $boxedview:ident;
+     $($ss:tt)*
+    ) => {
         /// A trait enabling type erasure of views.
-        pub trait $anyview<T, A = ()> {
+        pub trait $anyview<T, $( $tp, )* A = ()> {
             fn as_any(&self) -> &dyn std::any::Any;
 
             fn dyn_build(
@@ -16,7 +24,7 @@ macro_rules! generate_anyview_trait {
             fn dyn_rebuild(
                 &self,
                 cx: &mut $cx,
-                prev: &dyn $anyview<T, A>,
+                prev: &dyn $anyview<T, $( $tp, )* A>,
                 id: &mut $crate::Id,
                 state: &mut Box<dyn std::any::Any $( $ss )* >,
                 element: &mut Box<dyn $anywidget>,
@@ -31,7 +39,7 @@ macro_rules! generate_anyview_trait {
             ) -> $crate::MessageResult<A>;
         }
 
-        impl<T, A, V: $viewtrait<T, A> + 'static> $anyview<T, A> for V
+        impl<T, $( $tp, )* A, V: $viewtrait<T, $( $tp, )* A> + 'static> $anyview<T, $( $tp, )* A> for V
         where
             V::State: 'static,
             V::Element: $anywidget + 'static,
@@ -51,7 +59,7 @@ macro_rules! generate_anyview_trait {
             fn dyn_rebuild(
                 &self,
                 cx: &mut $cx,
-                prev: &dyn $anyview<T, A>,
+                prev: &dyn $anyview<T, $( $tp, )* A>,
                 id: &mut $crate::Id,
                 state: &mut Box<dyn std::any::Any $( $ss )* >,
                 element: &mut Box<dyn $anywidget>,
@@ -94,11 +102,11 @@ macro_rules! generate_anyview_trait {
             }
         }
 
-        pub type $boxedview<T, A = ()> = Box<dyn $anyview<T, A> $( $ss )* >;
+        pub type $boxedview<T, $( $tp, )* A = ()> = Box<dyn $anyview<T, $( $tp, )* A> $( $ss )* >;
 
-        impl<T, A> $viewmarker for $boxedview<T, A> {}
+        impl<T, $( $tp, )* A> $viewmarker for $boxedview<T, $( $tp, )* A> {}
 
-        impl<T, A> $viewtrait<T, A> for $boxedview<T, A> {
+        impl<T, $( $tp, )* A> $viewtrait<T, $( $tp, )* A> for $boxedview<T, $( $tp, )* A> {
             type State = Box<dyn std::any::Any $( $ss )* >;
 
             type Element = Box<dyn $anywidget>;

--- a/crates/xilem_core/src/view/memoize.rs
+++ b/crates/xilem_core/src/view/memoize.rs
@@ -5,19 +5,20 @@
 macro_rules! generate_memoize_view {
     ($memoizeview:ident,
      $memoizestate:ident,
-     $viewtrait:ident,
+     $viewtrait:ident <$($tp:ident),*>,
      $viewmarker:ty,
      $cx:ty,
      $changeflags:ty,
      $staticviewfunction:ident,
-     $memoizeviewfunction:ident
+     $memoizeviewfunction:ident;
+     $($ss:tt)*
     ) => {
         pub struct $memoizeview<D, F> {
             data: D,
             child_cb: F,
         }
 
-        pub struct $memoizestate<T, A, V: $viewtrait<T, A>> {
+        pub struct $memoizestate<T, $( $tp, )* A, V: $viewtrait<T, $( $tp, )* A>> {
             view: V,
             view_state: V::State,
             dirty: bool,
@@ -34,13 +35,13 @@ macro_rules! generate_memoize_view {
 
         impl<D, F> $viewmarker for $memoizeview<D, F> {}
 
-        impl<T, A, D, V, F> $viewtrait<T, A> for $memoizeview<D, F>
+        impl<T, $( $tp, )* A, D, V, F> $viewtrait<T, $( $tp, )* A> for $memoizeview<D, F>
         where
-            D: PartialEq + Send + 'static,
-            V: $viewtrait<T, A>,
-            F: Fn(&D) -> V + Send,
+            D: PartialEq + 'static $( $ss )*,
+            V: $viewtrait<T, $( $tp, )* A>,
+            F: Fn(&D) -> V $( $ss )*,
         {
-            type State = $memoizestate<T, A, V>;
+            type State = $memoizestate<T, $( $tp, )* A, V>;
 
             type Element = V::Element;
 

--- a/crates/xilem_core/src/view/mod.rs
+++ b/crates/xilem_core/src/view/mod.rs
@@ -9,6 +9,8 @@ mod memoize;
 /// Arguments are
 ///
 ///  - `$viewtrait` - The name of the view trait we want to generate.
+///  - `$tp` - (optional) Additional generic type parameters for the view trait.
+///     E.g. for a generic `$cx`
 ///  - `$bound` - A bound on all element types that will be used.
 ///  - `$cx` - The name of text context type that will be passed to the `build`/`rebuild`
 ///    methods, and be responsible for managing element creation & deletion.
@@ -18,7 +20,7 @@ mod memoize;
 ///    the state type requirements
 #[macro_export]
 macro_rules! generate_view_trait {
-    ($viewtrait:ident, $bound:ident, $cx:ty, $changeflags:ty; $($ss:tt)*) => {
+    ($viewtrait:ident <$($tp:ident),*>, $bound:ident, $cx:ty, $changeflags:ty; $($ss:tt)*) => {
         /// A view object representing a node in the UI.
         ///
         /// This is a central trait for representing UI. An app will generate a tree of
@@ -36,7 +38,7 @@ macro_rules! generate_view_trait {
         /// and also a type for actions which are passed up the tree in message
         /// propagation. During message handling, mutable access to the app state is
         /// given to view nodes, which in turn can expose it to callbacks.
-        pub trait $viewtrait<T, A = ()> $( $ss )* {
+        pub trait $viewtrait<T, $( $tp, )* A = ()> $( $ss )* {
             /// Associated state for the view.
             type State $( $ss )*;
 

--- a/crates/xilem_html/src/view.rs
+++ b/crates/xilem_html/src/view.rs
@@ -97,12 +97,12 @@ impl Pod {
     }
 }
 
-xilem_core::generate_view_trait! {View, DomNode, Cx, ChangeFlags;}
-xilem_core::generate_viewsequence_trait! {ViewSequence, View, ViewMarker, DomNode, Cx, ChangeFlags, Pod;}
-xilem_core::generate_anyview_trait! {AnyView, View, ViewMarker, Cx, ChangeFlags, AnyNode, BoxedView;}
-xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, s, memoize}
-xilem_core::generate_adapt_view! {View, Cx, ChangeFlags}
-xilem_core::generate_adapt_state_view! {View, Cx, ChangeFlags}
+xilem_core::generate_view_trait! {View <>, DomNode, Cx, ChangeFlags;}
+xilem_core::generate_viewsequence_trait! {ViewSequence, View <>, ViewMarker, DomNode, Cx, ChangeFlags, Pod;}
+xilem_core::generate_anyview_trait! {AnyView, View <>, ViewMarker, Cx, ChangeFlags, AnyNode, BoxedView;}
+xilem_core::generate_memoize_view! {Memoize, MemoizeState, View <>, ViewMarker, Cx, ChangeFlags, s, memoize;}
+xilem_core::generate_adapt_view! {View <>, Cx, ChangeFlags;}
+xilem_core::generate_adapt_state_view! {View <>, Cx, ChangeFlags;}
 
 /// This view container can switch between two views.
 ///

--- a/crates/xilem_svg/src/view.rs
+++ b/crates/xilem_svg/src/view.rs
@@ -72,7 +72,7 @@ impl Pod {
     }
 }
 
-xilem_core::generate_view_trait! {View, DomElement, Cx, ChangeFlags;}
-xilem_core::generate_viewsequence_trait! {ViewSequence, View, ViewMarker, DomElement, Cx, ChangeFlags, Pod;}
-xilem_core::generate_anyview_trait! {AnyView, View, ViewMarker, Cx, ChangeFlags, AnyElement, BoxedView;}
-xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, s, memoize}
+xilem_core::generate_view_trait! {View <>, DomElement, Cx, ChangeFlags;}
+xilem_core::generate_viewsequence_trait! {ViewSequence, View <>, ViewMarker, DomElement, Cx, ChangeFlags, Pod;}
+xilem_core::generate_anyview_trait! {AnyView, View <>, ViewMarker, Cx, ChangeFlags, AnyElement, BoxedView;}
+xilem_core::generate_memoize_view! {Memoize, MemoizeState, View <>, ViewMarker, Cx, ChangeFlags, s, memoize;}

--- a/src/view/view.rs
+++ b/src/view/view.rs
@@ -23,12 +23,12 @@ use xilem_core::{Id, IdPath};
 
 use crate::widget::{AnyWidget, ChangeFlags, Pod, Widget};
 
-xilem_core::generate_view_trait! {View, Widget, Cx, ChangeFlags; : Send}
-xilem_core::generate_viewsequence_trait! {ViewSequence, View, ViewMarker, Widget, Cx, ChangeFlags, Pod; : Send}
-xilem_core::generate_anyview_trait! {AnyView, View, ViewMarker, Cx, ChangeFlags, AnyWidget, BoxedView; + Send}
-xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, s, memoize}
-xilem_core::generate_adapt_view! {View, Cx, ChangeFlags}
-xilem_core::generate_adapt_state_view! {View, Cx, ChangeFlags}
+xilem_core::generate_view_trait! {View <>, Widget, Cx, ChangeFlags; : Send}
+xilem_core::generate_viewsequence_trait! {ViewSequence, View <>, ViewMarker, Widget, Cx, ChangeFlags, Pod; : Send}
+xilem_core::generate_anyview_trait! {AnyView, View <>, ViewMarker, Cx, ChangeFlags, AnyWidget, BoxedView; + Send}
+xilem_core::generate_memoize_view! {Memoize, MemoizeState, View <>, ViewMarker, Cx, ChangeFlags, s, memoize; + Send}
+xilem_core::generate_adapt_view! {View <>, Cx, ChangeFlags; + Send}
+xilem_core::generate_adapt_state_view! {View <>, Cx, ChangeFlags; + Send}
 
 #[derive(Clone)]
 pub struct Cx {


### PR DESCRIPTION
This can be useful for example if the context is itself generic.

Also makes the trait bounds of the `Memoize` and the `Adapt` views configurable (mostly to mirror the trait bounds of the `View`).

I've implemented a [dummy](https://github.com/Philipp-M/xilem_dummy) implementation of xilem_core to test the (compilation of the) macros, I guess something like this could be useful for testing xilem_core in general, as some usecases might not be covered by the crates of this repo itself.

I needed this for experimentation with an application specific App context that can be used inside View implementations.