### PR TITLE
xilem_core: Move bounds to where clauses in macros

### DIFF
--- a/crates/xilem_core/src/view/adapt.rs
+++ b/crates/xilem_core/src/view/adapt.rs
@@ -59,9 +59,8 @@ macro_rules! generate_adapt_view {
             ParentA,
             ChildT,
             ChildA,
-            V: $viewtrait<ChildT, ChildA>,
-            F: Fn(&mut ParentT, AdaptThunk<ChildT, ChildA, V>) -> $crate::MessageResult<ParentA> =
-                fn(&mut ParentT, AdaptThunk<ChildT, ChildA, V>) -> $crate::MessageResult<ParentA>,
+            V,
+            F = fn(&mut ParentT, AdaptThunk<ChildT, ChildA, V>) -> $crate::MessageResult<ParentA>,
         > {
             f: F,
             child: V,
@@ -79,14 +78,10 @@ macro_rules! generate_adapt_view {
             message: Box<dyn std::any::Any>,
         }
 
-        impl<
-            ParentT,
-            ParentA,
-            ChildT,
-            ChildA,
+        impl<ParentT, ParentA, ChildT, ChildA, V, F> Adapt<ParentT, ParentA, ChildT, ChildA, V, F>
+        where
             V: $viewtrait<ChildT, ChildA>,
             F: Fn(&mut ParentT, AdaptThunk<ChildT, ChildA, V>) -> $crate::MessageResult<ParentA>,
-        > Adapt<ParentT, ParentA, ChildT, ChildA, V, F>
         {
             pub fn new(f: F, child: V) -> Self {
                 Adapt {
@@ -104,14 +99,12 @@ macro_rules! generate_adapt_view {
             }
         }
 
-        impl<
-            ParentT,
-            ParentA,
-            ChildT,
-            ChildA,
+        impl<ParentT, ParentA, ChildT, ChildA, V, F> $viewtrait<ParentT, ParentA>
+            for Adapt<ParentT, ParentA, ChildT, ChildA, V, F>
+        where
             V: $viewtrait<ChildT, ChildA>,
-            F: Fn(&mut ParentT, AdaptThunk<ChildT, ChildA, V>) -> $crate::MessageResult<ParentA> + Send,
-        > $viewtrait<ParentT, ParentA> for Adapt<ParentT, ParentA, ChildT, ChildA, V, F>
+            F: Fn(&mut ParentT, AdaptThunk<ChildT, ChildA, V>) -> $crate::MessageResult<ParentA>
+                + Send,
         {
             type State = V::State;
 
@@ -149,14 +142,11 @@ macro_rules! generate_adapt_view {
             }
         }
 
-        impl<
-            ParentT,
-            ParentA,
-            ChildT,
-            ChildA,
+        impl<ParentT, ParentA, ChildT, ChildA, V, F> ViewMarker
+            for Adapt<ParentT, ParentA, ChildT, ChildA, V, F>
+        where
             V: $viewtrait<ChildT, ChildA>,
             F: Fn(&mut ParentT, AdaptThunk<ChildT, ChildA, V>) -> $crate::MessageResult<ParentA>,
-        > ViewMarker for Adapt<ParentT, ParentA, ChildT, ChildA, V, F>
         {
         }
     };
@@ -166,19 +156,15 @@ macro_rules! generate_adapt_view {
 macro_rules! generate_adapt_state_view {
     ($viewtrait:ident, $cx:ty, $changeflags:ty) => {
         /// A view that wraps a child view and modifies the state that callbacks have access to.
-        pub struct AdaptState<
-            ParentT,
-            ChildT,
-            V,
-            F: Fn(&mut ParentT) -> &mut ChildT = fn(&mut ParentT) -> &mut ChildT,
-        > {
+        pub struct AdaptState<ParentT, ChildT, V, F = fn(&mut ParentT) -> &mut ChildT> {
             f: F,
             child: V,
             phantom: std::marker::PhantomData<fn() -> (ParentT, ChildT)>,
         }
 
-        impl<ParentT, ChildT, V, F: Fn(&mut ParentT) -> &mut ChildT + Send>
-            AdaptState<ParentT, ChildT, V, F>
+        impl<ParentT, ChildT, V, F> AdaptState<ParentT, ChildT, V, F>
+        where
+            F: Fn(&mut ParentT) -> &mut ChildT + Send,
         {
             pub fn new(f: F, child: V) -> Self {
                 Self {
@@ -189,13 +175,10 @@ macro_rules! generate_adapt_state_view {
             }
         }
 
-        impl<
-                ParentT,
-                ChildT,
-                A,
-                V: $viewtrait<ChildT, A>,
-                F: Fn(&mut ParentT) -> &mut ChildT + Send,
-            > $viewtrait<ParentT, A> for AdaptState<ParentT, ChildT, V, F>
+        impl<ParentT, ChildT, A, V, F> $viewtrait<ParentT, A> for AdaptState<ParentT, ChildT, V, F>
+        where
+            V: $viewtrait<ChildT, A>,
+            F: Fn(&mut ParentT) -> &mut ChildT + Send,
         {
             type State = V::State;
             type Element = V::Element;
@@ -227,8 +210,8 @@ macro_rules! generate_adapt_state_view {
             }
         }
 
-        impl<ParentT, ChildT, V, F: Fn(&mut ParentT) -> &mut ChildT> ViewMarker
-            for AdaptState<ParentT, ChildT, V, F>
+        impl<ParentT, ChildT, V, F> ViewMarker for AdaptState<ParentT, ChildT, V, F> where
+            F: Fn(&mut ParentT) -> &mut ChildT
         {
         }
     };

--- a/crates/xilem_core/src/view/memoize.rs
+++ b/crates/xilem_core/src/view/memoize.rs
@@ -23,7 +23,10 @@ macro_rules! generate_memoize_view {
             dirty: bool,
         }
 
-        impl<D, V, F: Fn(&D) -> V> $memoizeview<D, F> {
+        impl<D, V, F> $memoizeview<D, F>
+        where
+            F: Fn(&D) -> V,
+        {
             pub fn new(data: D, child_cb: F) -> Self {
                 $memoizeview { data, child_cb }
             }
@@ -31,8 +34,11 @@ macro_rules! generate_memoize_view {
 
         impl<D, F> $viewmarker for $memoizeview<D, F> {}
 
-        impl<T, A, D: PartialEq + Send + 'static, V: $viewtrait<T, A>, F: Fn(&D) -> V + Send>
-            $viewtrait<T, A> for $memoizeview<D, F>
+        impl<T, A, D, V, F> $viewtrait<T, A> for $memoizeview<D, F>
+        where
+            D: PartialEq + Send + 'static,
+            V: $viewtrait<T, A>,
+            F: Fn(&D) -> V + Send,
         {
             type State = $memoizestate<T, A, V>;
 
@@ -85,14 +91,18 @@ macro_rules! generate_memoize_view {
         }
 
         /// A static view, all of the content of the `view` should be constant, as this function is only run once
-        pub fn $staticviewfunction<V, F: Fn() -> V + 'static>(
-            view: F,
-        ) -> $memoizeview<(), impl Fn(&()) -> V> {
+        pub fn $staticviewfunction<V, F>(view: F) -> $memoizeview<(), impl Fn(&()) -> V>
+        where
+            F: Fn() -> V + 'static,
+        {
             $memoizeview::new((), move |_: &()| view())
         }
 
         /// Memoize the view, until the `data` changes (in which case `view` is called again)
-        pub fn $memoizeviewfunction<D, V, F: Fn(&D) -> V>(data: D, view: F) -> $memoizeview<D, F> {
+        pub fn $memoizeviewfunction<D, V, F>(data: D, view: F) -> $memoizeview<D, F>
+        where
+            F: Fn(&D) -> V,
+        {
             $memoizeview::new(data, view)
         }
     };


### PR DESCRIPTION
More readable in documentation, and improves rustfmt's output.

Before:

![Screenshot 2023-07-23 at 12-36-45 AdaptState in xilem_html - Rust](https://github.com/linebender/xilem/assets/951129/c53c6a9a-1b3e-45f9-8469-b802499ad908)

After:

![Screenshot 2023-07-23 at 12-37-24 AdaptState in xilem_html - Rust](https://github.com/linebender/xilem/assets/951129/45fc1e93-6a46-44c8-9e49-cb63da84b49b)
