### PR TITLE
Make function trait-bounds of the `Memoize`, `Adapt` and `AdaptState` views configurable (mostly to mirror the `View` trait bounds)

### DIFF
--- a/crates/xilem_core/src/view/adapt.rs
+++ b/crates/xilem_core/src/view/adapt.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! generate_adapt_view {
-    ($viewtrait:ident, $cx:ty, $changeflags:ty) => {
+    ($viewtrait:ident, $cx:ty, $changeflags:ty; $($ss:tt)*) => {
         /// A view that wraps a child view and modifies the state that callbacks have access to.
         ///
         /// # Examples
@@ -81,7 +81,7 @@ macro_rules! generate_adapt_view {
         impl<ParentT, ParentA, ChildT, ChildA, V, F> Adapt<ParentT, ParentA, ChildT, ChildA, V, F>
         where
             V: $viewtrait<ChildT, ChildA>,
-            F: Fn(&mut ParentT, AdaptThunk<ChildT, ChildA, V>) -> $crate::MessageResult<ParentA>,
+            F: Fn(&mut ParentT, AdaptThunk<ChildT, ChildA, V>) -> $crate::MessageResult<ParentA> $( $ss )*,
         {
             pub fn new(f: F, child: V) -> Self {
                 Adapt {
@@ -103,8 +103,7 @@ macro_rules! generate_adapt_view {
             for Adapt<ParentT, ParentA, ChildT, ChildA, V, F>
         where
             V: $viewtrait<ChildT, ChildA>,
-            F: Fn(&mut ParentT, AdaptThunk<ChildT, ChildA, V>) -> $crate::MessageResult<ParentA>
-                + Send,
+            F: Fn(&mut ParentT, AdaptThunk<ChildT, ChildA, V>) -> $crate::MessageResult<ParentA> $( $ss )*,
         {
             type State = V::State;
 
@@ -146,7 +145,7 @@ macro_rules! generate_adapt_view {
             for Adapt<ParentT, ParentA, ChildT, ChildA, V, F>
         where
             V: $viewtrait<ChildT, ChildA>,
-            F: Fn(&mut ParentT, AdaptThunk<ChildT, ChildA, V>) -> $crate::MessageResult<ParentA>,
+            F: Fn(&mut ParentT, AdaptThunk<ChildT, ChildA, V>) -> $crate::MessageResult<ParentA> $( $ss )*,
         {
         }
     };
@@ -154,7 +153,7 @@ macro_rules! generate_adapt_view {
 
 #[macro_export]
 macro_rules! generate_adapt_state_view {
-    ($viewtrait:ident, $cx:ty, $changeflags:ty) => {
+    ($viewtrait:ident, $cx:ty, $changeflags:ty; $($ss:tt)*) => {
         /// A view that wraps a child view and modifies the state that callbacks have access to.
         pub struct AdaptState<ParentT, ChildT, V, F = fn(&mut ParentT) -> &mut ChildT> {
             f: F,
@@ -164,7 +163,7 @@ macro_rules! generate_adapt_state_view {
 
         impl<ParentT, ChildT, V, F> AdaptState<ParentT, ChildT, V, F>
         where
-            F: Fn(&mut ParentT) -> &mut ChildT + Send,
+            F: Fn(&mut ParentT) -> &mut ChildT $( $ss )*,
         {
             pub fn new(f: F, child: V) -> Self {
                 Self {
@@ -178,7 +177,7 @@ macro_rules! generate_adapt_state_view {
         impl<ParentT, ChildT, A, V, F> $viewtrait<ParentT, A> for AdaptState<ParentT, ChildT, V, F>
         where
             V: $viewtrait<ChildT, A>,
-            F: Fn(&mut ParentT) -> &mut ChildT + Send,
+            F: Fn(&mut ParentT) -> &mut ChildT $( $ss )*,
         {
             type State = V::State;
             type Element = V::Element;
@@ -211,7 +210,7 @@ macro_rules! generate_adapt_state_view {
         }
 
         impl<ParentT, ChildT, V, F> ViewMarker for AdaptState<ParentT, ChildT, V, F> where
-            F: Fn(&mut ParentT) -> &mut ChildT
+            F: Fn(&mut ParentT) -> &mut ChildT $( $ss )*
         {
         }
     };

--- a/crates/xilem_core/src/view/memoize.rs
+++ b/crates/xilem_core/src/view/memoize.rs
@@ -10,7 +10,8 @@ macro_rules! generate_memoize_view {
      $cx:ty,
      $changeflags:ty,
      $staticviewfunction:ident,
-     $memoizeviewfunction:ident
+     $memoizeviewfunction:ident;
+     $($ss:tt)*
     ) => {
         pub struct $memoizeview<D, F> {
             data: D,
@@ -36,9 +37,9 @@ macro_rules! generate_memoize_view {
 
         impl<T, A, D, V, F> $viewtrait<T, A> for $memoizeview<D, F>
         where
-            D: PartialEq + Send + 'static,
+            D: PartialEq $( $ss )* + 'static,
             V: $viewtrait<T, A>,
-            F: Fn(&D) -> V + Send,
+            F: Fn(&D) -> V $( $ss )*,
         {
             type State = $memoizestate<T, A, V>;
 
@@ -93,7 +94,7 @@ macro_rules! generate_memoize_view {
         /// A static view, all of the content of the `view` should be constant, as this function is only run once
         pub fn $staticviewfunction<V, F>(view: F) -> $memoizeview<(), impl Fn(&()) -> V>
         where
-            F: Fn() -> V + 'static,
+            F: Fn() -> V $( $ss )* + 'static,
         {
             $memoizeview::new((), move |_: &()| view())
         }
@@ -101,7 +102,7 @@ macro_rules! generate_memoize_view {
         /// Memoize the view, until the `data` changes (in which case `view` is called again)
         pub fn $memoizeviewfunction<D, V, F>(data: D, view: F) -> $memoizeview<D, F>
         where
-            F: Fn(&D) -> V,
+            F: Fn(&D) -> V $( $ss )*,
         {
             $memoizeview::new(data, view)
         }

--- a/crates/xilem_html/src/view.rs
+++ b/crates/xilem_html/src/view.rs
@@ -100,9 +100,9 @@ impl Pod {
 xilem_core::generate_view_trait! {View, DomNode, Cx, ChangeFlags;}
 xilem_core::generate_viewsequence_trait! {ViewSequence, View, ViewMarker, DomNode, Cx, ChangeFlags, Pod;}
 xilem_core::generate_anyview_trait! {AnyView, View, ViewMarker, Cx, ChangeFlags, AnyNode, BoxedView;}
-xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, s, memoize}
-xilem_core::generate_adapt_view! {View, Cx, ChangeFlags}
-xilem_core::generate_adapt_state_view! {View, Cx, ChangeFlags}
+xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, s, memoize;}
+xilem_core::generate_adapt_view! {View, Cx, ChangeFlags;}
+xilem_core::generate_adapt_state_view! {View, Cx, ChangeFlags;}
 
 /// This view container can switch between two views.
 ///

--- a/crates/xilem_svg/src/view.rs
+++ b/crates/xilem_svg/src/view.rs
@@ -75,4 +75,6 @@ impl Pod {
 xilem_core::generate_view_trait! {View, DomElement, Cx, ChangeFlags;}
 xilem_core::generate_viewsequence_trait! {ViewSequence, View, ViewMarker, DomElement, Cx, ChangeFlags, Pod;}
 xilem_core::generate_anyview_trait! {AnyView, View, ViewMarker, Cx, ChangeFlags, AnyElement, BoxedView;}
-xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, s, memoize}
+xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, s, memoize;}
+xilem_core::generate_adapt_view! {View, Cx, ChangeFlags;}
+xilem_core::generate_adapt_state_view! {View, Cx, ChangeFlags;}

--- a/src/view/view.rs
+++ b/src/view/view.rs
@@ -26,9 +26,9 @@ use crate::widget::{AnyWidget, ChangeFlags, Pod, Widget};
 xilem_core::generate_view_trait! {View, Widget, Cx, ChangeFlags; : Send}
 xilem_core::generate_viewsequence_trait! {ViewSequence, View, ViewMarker, Widget, Cx, ChangeFlags, Pod; : Send}
 xilem_core::generate_anyview_trait! {AnyView, View, ViewMarker, Cx, ChangeFlags, AnyWidget, BoxedView; + Send}
-xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, s, memoize}
-xilem_core::generate_adapt_view! {View, Cx, ChangeFlags}
-xilem_core::generate_adapt_state_view! {View, Cx, ChangeFlags}
+xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, s, memoize; + Send}
+xilem_core::generate_adapt_view! {View, Cx, ChangeFlags; + Send}
+xilem_core::generate_adapt_state_view! {View, Cx, ChangeFlags; + Send}
 
 #[derive(Clone)]
 pub struct Cx {


### PR DESCRIPTION
This PR mostly removes the unnecessary `Send` trait bounds for the `Adapt`, `AdaptState` and `Memoize` views in xilem_html and xilem_svg.
It's split off of #108, as I'm not sure whether to proceed with that PR.