### PR TITLE
xilem_core: Remove redundant macro match arm in message macro

### DIFF
--- a/crates/xilem_core/src/message.rs
+++ b/crates/xilem_core/src/message.rs
@@ -5,22 +5,6 @@ use std::any::Any;
 
 #[macro_export]
 macro_rules! message {
-    () => {
-        pub struct Message {
-            pub id_path: xilem_core::IdPath,
-            pub body: Box<dyn std::any::Any>,
-        }
-
-        impl Message {
-            pub fn new(id_path: xilem_core::IdPath, event: impl std::any::Any) -> Message {
-                Message {
-                    id_path,
-                    body: Box::new(event),
-                }
-            }
-        }
-    };
-
     ($($bounds:tt)*) => {
         pub struct Message {
             pub id_path: xilem_core::IdPath,


### PR DESCRIPTION
The match arm is already covered in the arm below (the removed one).