### PR TITLE
Bump vello (and wgpu versions)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
  "cocoa-foundation",
  "core-foundation",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "objc",
 ]
@@ -484,7 +484,7 @@ dependencies = [
  "block",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "objc",
 ]
@@ -549,7 +549,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
@@ -561,7 +561,7 @@ checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
@@ -596,12 +596,12 @@ dependencies = [
 
 [[package]]
 name = "d3d12"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f0de2f5a8e7bd4a9eec0e3c781992a4ce1724f68aec7d7a3715344de8b39da"
+checksum = "e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20"
 dependencies = [
- "bitflags 1.3.2",
- "libloading 0.7.4",
+ "bitflags 2.3.3",
+ "libloading 0.8.0",
  "winapi",
 ]
 
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "fello"
 version = "0.1.0"
-source = "git+https://github.com/dfrg/fount?rev=58a284eaae67512fb61cf76177c5d33238d79cb1#58a284eaae67512fb61cf76177c5d33238d79cb1"
+source = "git+https://github.com/dfrg/fount?rev=0a7c809716aeb96795325a74c91c048cf4980d73#0a7c809716aeb96795325a74c91c048cf4980d73"
 dependencies = [
  "read-fonts",
 ]
@@ -756,8 +756,8 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "font-types"
-version = "0.1.4"
-source = "git+https://github.com/googlefonts/fontations?rev=49cfbd9#49cfbd93ba81a712bb533fae2cfbeee761d05bfb"
+version = "0.3.0"
+source = "git+https://github.com/googlefonts/fontations?rev=91ebdfd91bec9ae4ec34f6a7d5f01736b1b2eb6e#91ebdfd91bec9ae4ec34f6a7d5f01736b1b2eb6e"
 
 [[package]]
 name = "foreign-types"
@@ -765,7 +765,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -773,6 +794,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "fount"
@@ -942,7 +969,7 @@ dependencies = [
  "cfg-if",
  "cocoa",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.3.2",
  "futures",
  "im",
  "instant",
@@ -1011,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807edf58b70c0b5b2181dd39fe1839dbdb3ba02645630dc5f753e23da307f762"
+checksum = "ca0fe580e4b60a8ab24a868bc08e2f03cbcb20d3d676601fa909386713333728"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1023,21 +1050,21 @@ dependencies = [
 
 [[package]]
 name = "gpu-alloc"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22beaafc29b38204457ea030f6fb7a84c9e4dd1b86e311ba0542533453d87f62"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "gpu-alloc-types",
 ]
 
 [[package]]
 name = "gpu-alloc-types"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
 ]
 
 [[package]]
@@ -1344,16 +1371,17 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de11355d1f6781482d027a3b4d4de7825dcedb197bf573e0596d00008402d060"
+checksum = "623b5e6cefd76e58f774bd3cc0c6f5c7615c58c03a97815245a25c3c9bdee318"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "block",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
+ "paste",
 ]
 
 [[package]]
@@ -1384,12 +1412,12 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80cd00bd6180a8790f1c020ed258a46b8d73dd5bd6af104a238c9d71f806938e"
+checksum = "c1ceaaa4eedaece7e4ec08c55c640ba03dbb73fb812a6570a59bcf1930d0f70e"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
@@ -1744,8 +1772,8 @@ checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "read-fonts"
-version = "0.1.4"
-source = "git+https://github.com/googlefonts/fontations?rev=49cfbd9#49cfbd93ba81a712bb533fae2cfbeee761d05bfb"
+version = "0.6.0"
+source = "git+https://github.com/googlefonts/fontations?rev=91ebdfd91bec9ae4ec34f6a7d5f01736b1b2eb6e#91ebdfd91bec9ae4ec34f6a7d5f01736b1b2eb6e"
 dependencies = [
  "font-types",
 ]
@@ -2307,15 +2335,13 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 [[package]]
 name = "vello"
 version = "0.0.1"
-source = "git+https://github.com/linebender/vello?rev=006faab69fc519c9c7ed6002be740914efad9ffe#006faab69fc519c9c7ed6002be740914efad9ffe"
+source = "git+https://github.com/linebender/vello?rev=3cb54627de0c1fc40af46429ae67458f07174713#3cb54627de0c1fc40af46429ae67458f07174713"
 dependencies = [
  "bytemuck",
  "fello",
  "futures-intrusive",
- "parking_lot",
  "peniko",
  "raw-window-handle",
- "smallvec",
  "vello_encoding",
  "wgpu",
 ]
@@ -2323,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "vello_encoding"
 version = "0.1.0"
-source = "git+https://github.com/linebender/vello?rev=006faab69fc519c9c7ed6002be740914efad9ffe#006faab69fc519c9c7ed6002be740914efad9ffe"
+source = "git+https://github.com/linebender/vello?rev=3cb54627de0c1fc40af46429ae67458f07174713#3cb54627de0c1fc40af46429ae67458f07174713"
 dependencies = [
  "bytemuck",
  "fello",
@@ -2503,9 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3059ea4ddec41ca14f356833e2af65e7e38c0a8f91273867ed526fb9bafcca95"
+checksum = "7472f3b69449a8ae073f6ec41d05b6f846902d92a6c45313c50cb25857b736ce"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -2527,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f478237b4bf0d5b70a39898a66fa67ca3a007d79f2520485b8b0c3dfc46f8c2"
+checksum = "ecf7454d9386f602f7399225c92dd2fbdcde52c519bc8fb0bd6fbeb388075dc2"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -2550,9 +2576,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74851c2c8e5d97652e74c241d41b0656b31c924a45dcdecde83975717362cfa4"
+checksum = "6654a13885a17f475e8324efb46dc6986d7aaaa98353330f8de2077b153d0101"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -2562,7 +2588,6 @@ dependencies = [
  "block",
  "core-graphics-types",
  "d3d12",
- "foreign-types",
  "glow",
  "gpu-alloc",
  "gpu-allocator",
@@ -2592,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd33a976130f03dcdcd39b3810c0c3fc05daf86f0aaf867db14bfb7c4a9a32b"
+checksum = "ee64d7398d0c2f9ca48922c902ef69c42d000c759f3db41e355f4a570b052b67"
 dependencies = [
  "bitflags 2.3.3",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ wayland = ["glazier/wayland"]
 
 [dependencies]
 xilem_core.workspace = true
-vello = { git = "https://github.com/linebender/vello", rev = "006faab69fc519c9c7ed6002be740914efad9ffe" }
-wgpu = "0.16.0"
+vello = { git = "https://github.com/linebender/vello", rev = "3cb54627de0c1fc40af46429ae67458f07174713" }
+wgpu = "0.17.0"
 parley = { git = "https://github.com/dfrg/parley", rev = "2371bf4b702ec91edee2d58ffb2d432539580e1e" }
 tokio = { version = "1.21", features = ["full"] }
 futures-task = "0.3"

--- a/src/app_main.rs
+++ b/src/app_main.rs
@@ -217,7 +217,8 @@ where
             //println!("render size: {:?}", size);
             self.surface = Some(
                 tokio::runtime::Handle::current()
-                    .block_on(self.render_cx.create_surface(handle, width, height)),
+                    .block_on(self.render_cx.create_surface(handle, width, height))
+                    .unwrap(),
             );
         }
         if let Some(surface) = self.surface.as_mut() {
@@ -242,6 +243,7 @@ where
             let queue = &self.render_cx.devices[dev_id].queue;
             let renderer_options = RendererOptions {
                 surface_format: Some(surface.format),
+                timestamp_period: queue.get_timestamp_period(),
             };
             let render_params = RenderParams {
                 base_color: Color::BLACK,


### PR DESCRIPTION
Updates xilem to the latest vello. Also bumps wgpu to 0.17.0.

This should enable CFF/CFF2 support.