### PR TITLE
xilem_html: Add a VecMap which is an ordered Map similar as BTreeMap for small `n`

### DIFF
--- a/crates/xilem_html/src/diff.rs
+++ b/crates/xilem_html/src/diff.rs
@@ -1,0 +1,61 @@
+use std::{cmp::Ordering, collections::BTreeMap, iter::Peekable};
+
+pub fn diff_tree_maps<'a, K: Ord, V: PartialEq>(
+    prev: &'a BTreeMap<K, V>,
+    next: &'a BTreeMap<K, V>,
+) -> impl Iterator<Item = Diff<&'a K, &'a V>> + 'a {
+    DiffMapIterator {
+        prev: prev.iter().peekable(),
+        next: next.iter().peekable(),
+    }
+}
+
+/// An iterator that compares two ordered maps (like a `BTreeMap`) and outputs a `Diff` for each added, removed or changed key/value pair)
+struct DiffMapIterator<'a, K: 'a, V: 'a, I: Iterator<Item = (&'a K, &'a V)>> {
+    prev: Peekable<I>,
+    next: Peekable<I>,
+}
+
+impl<'a, K: Ord + 'a, V: PartialEq, I: Iterator<Item = (&'a K, &'a V)>> Iterator
+    for DiffMapIterator<'a, K, V, I>
+{
+    type Item = Diff<&'a K, &'a V>;
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match (self.prev.peek(), self.next.peek()) {
+                (Some(&(prev_k, prev_v)), Some(&(next_k, next_v))) => match prev_k.cmp(next_k) {
+                    Ordering::Less => {
+                        self.prev.next();
+                        return Some(Diff::Remove(prev_k));
+                    }
+                    Ordering::Greater => {
+                        self.next.next();
+                        return Some(Diff::Add(next_k, next_v));
+                    }
+                    Ordering::Equal => {
+                        self.prev.next();
+                        self.next.next();
+                        if prev_v != next_v {
+                            return Some(Diff::Change(next_k, next_v));
+                        }
+                    }
+                },
+                (Some(&(prev_k, _)), None) => {
+                    self.prev.next();
+                    return Some(Diff::Remove(prev_k));
+                }
+                (None, Some(&(next_k, next_v))) => {
+                    self.next.next();
+                    return Some(Diff::Add(next_k, next_v));
+                }
+                (None, None) => return None,
+            }
+        }
+    }
+}
+
+pub enum Diff<K, V> {
+    Add(K, V),
+    Remove(K),
+    Change(K, V),
+}

--- a/crates/xilem_html/src/diff.rs
+++ b/crates/xilem_html/src/diff.rs
@@ -1,5 +1,6 @@
 use std::{cmp::Ordering, collections::BTreeMap, iter::Peekable};
 
+#[allow(unused)]
 pub fn diff_tree_maps<'a, K: Ord, V: PartialEq>(
     prev: &'a BTreeMap<K, V>,
     next: &'a BTreeMap<K, V>,
@@ -11,9 +12,9 @@ pub fn diff_tree_maps<'a, K: Ord, V: PartialEq>(
 }
 
 /// An iterator that compares two ordered maps (like a `BTreeMap`) and outputs a `Diff` for each added, removed or changed key/value pair)
-struct DiffMapIterator<'a, K: 'a, V: 'a, I: Iterator<Item = (&'a K, &'a V)>> {
-    prev: Peekable<I>,
-    next: Peekable<I>,
+pub(crate) struct DiffMapIterator<'a, K: 'a, V: 'a, I: Iterator<Item = (&'a K, &'a V)>> {
+    pub(crate) prev: Peekable<I>,
+    pub(crate) next: Peekable<I>,
 }
 
 impl<'a, K: Ord + 'a, V: PartialEq, I: Iterator<Item = (&'a K, &'a V)>> Iterator

--- a/crates/xilem_html/src/lib.rs
+++ b/crates/xilem_html/src/lib.rs
@@ -10,6 +10,7 @@ use wasm_bindgen::JsCast;
 mod app;
 mod class;
 mod context;
+mod diff;
 mod element;
 mod event;
 mod one_of;

--- a/crates/xilem_html/src/lib.rs
+++ b/crates/xilem_html/src/lib.rs
@@ -11,6 +11,7 @@ mod app;
 mod class;
 mod context;
 mod diff;
+pub mod vecmap;
 mod element;
 mod event;
 mod one_of;

--- a/crates/xilem_html/src/vecmap.rs
+++ b/crates/xilem_html/src/vecmap.rs
@@ -1,0 +1,226 @@
+use std::{borrow::Borrow, ops::Index};
+
+use crate::diff::{Diff, DiffMapIterator};
+
+/// Basically an ordered Map (similar as BTreeMap) with a Vec as backend for very few elements
+/// As it uses linear search instead of a tree traversal,
+/// which seems to be faster for small `n` (currently roughly `n < ~20` for the use case of diffing html attributes)
+pub struct VecMap<K, V>(Vec<(K, V)>);
+
+impl<K, V> Default for VecMap<K, V> {
+    fn default() -> Self {
+        Self(Vec::new())
+    }
+}
+
+impl<K, V> VecMap<K, V> {
+    /// Returns a reference to the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but the ordering
+    /// on the borrowed form *must* match the ordering on the key type.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use xilem_html::vecmap::VecMap;
+    ///
+    /// let mut map = VecMap::default();
+    /// map.insert(1, "a");
+    /// assert_eq!(map.get(&1), Some(&"a"));
+    /// assert_eq!(map.get(&2), None);
+    /// ```
+    pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q> + PartialEq,
+        Q: PartialEq,
+    {
+        self.0
+            .iter()
+            .find_map(|(k, v)| if key.eq(k.borrow()) { Some(v) } else { None })
+    }
+
+    /// Returns a mutable reference to the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but the ordering
+    /// on the borrowed form *must* match the ordering on the key type.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use xilem_html::vecmap::VecMap;
+    ///
+    /// let mut map = VecMap::default();
+    /// map.insert(1, "a");
+    /// if let Some(x) = map.get_mut(&1) {
+    ///     *x = "b";
+    /// }
+    /// assert_eq!(map[&1], "b");
+    /// ```
+    // See `get` for implementation notes, this is basically a copy-paste with mut's added
+    pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q> + Ord,
+        Q: Ord,
+    {
+        self.0
+            .iter_mut()
+            .find_map(|(k, v)| if key.eq((*k).borrow()) { Some(v) } else { None })
+    }
+
+    /// Gets an iterator over the keys of the map, in sorted order.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use xilem_html::vecmap::VecMap;
+    ///
+    /// let mut a = VecMap::default();
+    /// a.insert(2, "b");
+    /// a.insert(1, "a");
+    ///
+    /// let keys: Vec<_> = a.keys().cloned().collect();
+    /// assert_eq!(keys, [1, 2]);
+    /// ```
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.0.iter().map(|(name, _)| name)
+    }
+
+    /// Gets an iterator over the entries of the map, sorted by key.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use xilem_html::vecmap::VecMap;
+    ///
+    /// let mut map = VecMap::default();
+    /// map.insert(3, "c");
+    /// map.insert(2, "b");
+    /// map.insert(1, "a");
+    ///
+    /// for (key, value) in map.iter() {
+    ///     println!("{key}: {value}");
+    /// }
+    ///
+    /// let (first_key, first_value) = map.iter().next().unwrap();
+    /// assert_eq!((*first_key, *first_value), (1, "a"));
+    /// ```
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.0.iter().map(|(k, v)| (k, v))
+    }
+
+    /// Computes the diff between two `VecMap`s
+    /// `other` is the "newer" map,
+    /// i.e. when `other` contains an element that this map doesn't the diff iterator outputs Diff::Add
+    pub fn diff<'a>(&'a self, other: &'a Self) -> impl Iterator<Item = Diff<&'a K, &'a V>> + 'a
+    where
+        K: Ord,
+        V: PartialEq,
+    {
+        DiffMapIterator {
+            prev: self.iter().peekable(),
+            next: other.iter().peekable(),
+        }
+    }
+
+    /// Inserts a key-value pair into the map.
+    ///
+    /// If the map did not have this key present, `None` is returned.
+    ///
+    /// If the map did have this key present, the value is updated, and the old
+    /// value is returned. The key is not updated, though; this matters for
+    /// types that can be `==` without being identical.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use xilem_html::vecmap::VecMap;
+    ///
+    /// let mut map = VecMap::default();
+    /// assert_eq!(map.insert(37, "a"), None);
+    /// assert_eq!(map.is_empty(), false);
+    ///
+    /// map.insert(37, "b");
+    /// assert_eq!(map.insert(37, "c"), Some("b"));
+    /// assert_eq!(map[&37], "c");
+    /// ```
+    pub fn insert(&mut self, key: K, value: V) -> Option<V>
+    where
+        K: Ord,
+    {
+        match self.0.binary_search_by_key(&&key, |(n, _)| n) {
+            Ok(pos) => {
+                let mut val = (key, value);
+                std::mem::swap(&mut self.0[pos], &mut val);
+                Some(val.1)
+            }
+            Err(pos) => {
+                self.0.insert(pos, (key, value));
+                None
+            }
+        }
+    }
+
+    /// Returns `true` if the map contains no elements.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use xilem_html::vecmap::VecMap;
+    ///
+    /// let mut a = VecMap::default();
+    /// assert!(a.is_empty());
+    /// a.insert(1, "a");
+    /// assert!(!a.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the number of elements in the map.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use xilem_html::vecmap::VecMap;
+    ///
+    /// let mut a = VecMap::default();
+    /// assert_eq!(a.len(), 0);
+    /// a.insert(1, "a");
+    /// assert_eq!(a.len(), 1);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl<K, Q: ?Sized, V> Index<&Q> for VecMap<K, V>
+where
+    K: Borrow<Q> + Ord,
+    Q: Ord,
+{
+    type Output = V;
+
+    /// Returns a reference to the value corresponding to the supplied key.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the key is not present in the `VecMap`.
+    #[inline]
+    fn index(&self, key: &Q) -> &V {
+        self.get(key).expect("no entry found for key")
+    }
+}


### PR DESCRIPTION
A few benchmarks have showed, that for small n (roughly `n < ~20`, with small types < 50 bytes) a Vec is faster than a BTreeMap.
This seems to be the average case for html attributes.

Since it was a low hanging fruit to boldly copy the docs from the `std::collections::BTreeMap`, I have done so, it also implicitly adds doc tests for this (I guess it makes sense to add `cargo test` to the CI).

The VecMap is now used instead of the BTreeMap for the element attributes

(This is currently a draft *only* because it's built on top of #124 and I can't target-branch this on top of that as then the PR is opened on my repo, otherwise it's fine to merge, so the other PR has to be merged first)