### PR TITLE
xilem_html: Add support for different types in el.attr("attr", <value>) 

### DIFF
--- a/crates/xilem_html/src/element/attribute_value.rs
+++ b/crates/xilem_html/src/element/attribute_value.rs
@@ -1,8 +1,4 @@
-use std::borrow::Cow;
-
-use crate::vecmap::VecMap;
-
-type CowStr = Cow<'static, str>;
+type CowStr = std::borrow::Cow<'static, str>;
 
 #[derive(PartialEq, Debug)]
 pub enum AttributeValue {
@@ -92,35 +88,5 @@ impl IntoAttributeValue for CowStr {
 impl IntoAttributeValue for &'static str {
     fn into_attribute_value(self) -> Option<AttributeValue> {
         Some(AttributeValue::String(self.into()))
-    }
-}
-
-#[derive(Default)]
-pub struct Attributes(VecMap<CowStr, AttributeValue>);
-
-impl<'a> IntoIterator for &'a Attributes {
-    type Item = (&'a CowStr, &'a AttributeValue);
-
-    type IntoIter = <&'a VecMap<CowStr, AttributeValue> as std::iter::IntoIterator>::IntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-impl Attributes {
-    // TODO return the previous attribute as an Option?
-    pub fn insert(&mut self, name: impl Into<CowStr>, value: impl IntoAttributeValue) {
-        let value = value.into_attribute_value();
-        // This is a simple optimization in case this is the first attribute inserted to the map (saves an allocation for the Vec)
-        if let Some(value) = value.into_attribute_value() {
-            self.0.insert(name.into(), value);
-        } else {
-            self.0.remove(&name.into());
-        }
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (&CowStr, &AttributeValue)> {
-        self.0.iter()
     }
 }

--- a/crates/xilem_html/src/element/attributes.rs
+++ b/crates/xilem_html/src/element/attributes.rs
@@ -1,0 +1,126 @@
+use std::borrow::Cow;
+
+use crate::vecmap::VecMap;
+
+type CowStr = Cow<'static, str>;
+
+#[derive(PartialEq, Debug)]
+pub enum AttributeValue {
+    Null,
+    True, // for the boolean true, this serializes to an empty string (e.g. for <input checked>)
+    I32(i32),
+    U32(u32),
+    F32(f32),
+    F64(f64),
+    String(CowStr),
+}
+
+impl AttributeValue {
+    pub fn serialize(&self) -> CowStr {
+        match self {
+            AttributeValue::True => "".into(), // empty string is equivalent to a true set attribute
+            AttributeValue::I32(n) => n.to_string().into(),
+            AttributeValue::U32(n) => n.to_string().into(),
+            AttributeValue::F32(n) => n.to_string().into(),
+            AttributeValue::F64(n) => n.to_string().into(),
+            AttributeValue::String(s) => s.clone(),
+            // AttributeValue::Null shouldn't be serialized within attribute serialization/diffing
+            // as null values should never show up in the attributes map, but for completeness it's serialized to an empty string
+            AttributeValue::Null => "".into(),
+        }
+    }
+}
+
+// A few convenient From implementations for less boilerplate when setting attributes
+
+impl<T: Into<AttributeValue>> From<Option<T>> for AttributeValue {
+    fn from(value: Option<T>) -> Self {
+        if let Some(value) = value {
+            value.into()
+        } else {
+            AttributeValue::Null
+        }
+    }
+}
+
+impl From<bool> for AttributeValue {
+    fn from(value: bool) -> Self {
+        if value {
+            AttributeValue::True
+        } else {
+            AttributeValue::Null
+        }
+    }
+}
+
+impl From<u32> for AttributeValue {
+    fn from(value: u32) -> Self {
+        AttributeValue::U32(value)
+    }
+}
+
+impl From<i32> for AttributeValue {
+    fn from(value: i32) -> Self {
+        AttributeValue::I32(value)
+    }
+}
+
+impl From<f32> for AttributeValue {
+    fn from(value: f32) -> Self {
+        AttributeValue::F32(value)
+    }
+}
+
+impl From<f64> for AttributeValue {
+    fn from(value: f64) -> Self {
+        AttributeValue::F64(value)
+    }
+}
+
+impl From<String> for AttributeValue {
+    fn from(value: String) -> Self {
+        AttributeValue::String(value.into())
+    }
+}
+
+impl From<CowStr> for AttributeValue {
+    fn from(value: CowStr) -> Self {
+        AttributeValue::String(value)
+    }
+}
+
+impl From<&'static str> for AttributeValue {
+    fn from(value: &'static str) -> Self {
+        AttributeValue::String(value.into())
+    }
+}
+
+#[derive(Default)]
+pub struct Attributes(VecMap<CowStr, AttributeValue>);
+
+impl<'a> IntoIterator for &'a Attributes {
+    type Item = (&'a CowStr, &'a AttributeValue);
+
+    type IntoIter = <&'a VecMap<CowStr, AttributeValue> as std::iter::IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl Attributes {
+    // TODO return the previous attribute as an Option?
+    pub fn insert(&mut self, name: impl Into<CowStr>, value: impl Into<AttributeValue>) {
+        let value = value.into();
+        // This is a simple optimization in case this is the first attribute inserted to the map (saves an allocation for the Vec)
+        if matches!(value, AttributeValue::Null) {
+            self.0.remove(&name.into());
+        } else {
+            self.0.insert(name.into(), value);
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&CowStr, &AttributeValue)> {
+        self.0.iter()
+    }
+}

--- a/crates/xilem_html/src/element/elements.rs
+++ b/crates/xilem_html/src/element/elements.rs
@@ -53,6 +53,14 @@ macro_rules! element {
                 self
             }
 
+            pub fn remove_attr(
+                &mut self,
+                name: impl Into<std::borrow::Cow<'static, str>>,
+            ) -> &mut Self {
+                self.0.remove_attr(name);
+                self
+            }
+
             pub fn after_update(mut self, after_update: impl Fn(&$web_sys_ty) + 'static) -> Self {
                 self.0 = self.0.after_update(after_update);
                 self

--- a/crates/xilem_html/src/element/elements.rs
+++ b/crates/xilem_html/src/element/elements.rs
@@ -32,7 +32,7 @@ macro_rules! element {
             pub fn attr(
                 mut self,
                 name: impl Into<std::borrow::Cow<'static, str>>,
-                value: impl Into<std::borrow::Cow<'static, str>>,
+                value: impl Into<crate::AttributeValue>,
             ) -> Self {
                 self.0.set_attr(name, value);
                 self
@@ -47,7 +47,7 @@ macro_rules! element {
             pub fn set_attr(
                 &mut self,
                 name: impl Into<std::borrow::Cow<'static, str>>,
-                value: impl Into<std::borrow::Cow<'static, str>>,
+                value: impl Into<crate::AttributeValue>,
             ) -> &mut Self {
                 self.0.set_attr(name, value);
                 self

--- a/crates/xilem_html/src/element/elements.rs
+++ b/crates/xilem_html/src/element/elements.rs
@@ -32,7 +32,7 @@ macro_rules! element {
             pub fn attr(
                 mut self,
                 name: impl Into<std::borrow::Cow<'static, str>>,
-                value: impl Into<crate::AttributeValue>,
+                value: impl crate::IntoAttributeValue,
             ) -> Self {
                 self.0.set_attr(name, value);
                 self
@@ -47,7 +47,7 @@ macro_rules! element {
             pub fn set_attr(
                 &mut self,
                 name: impl Into<std::borrow::Cow<'static, str>>,
-                value: impl Into<crate::AttributeValue>,
+                value: impl crate::IntoAttributeValue,
             ) -> &mut Self {
                 self.0.set_attr(name, value);
                 self

--- a/crates/xilem_html/src/element/mod.rs
+++ b/crates/xilem_html/src/element/mod.rs
@@ -16,7 +16,7 @@ pub mod attributes;
 #[cfg(feature = "typed")]
 pub mod elements;
 
-pub use attributes::{AttributeValue, Attributes};
+pub use attributes::{AttributeValue, Attributes, IntoAttributeValue};
 
 type CowStr = Cow<'static, str>;
 
@@ -75,7 +75,7 @@ impl<El, ViewSeq> Element<El, ViewSeq> {
     ///
     /// If the name contains characters that are not valid in an attribute name,
     /// then the `View::build`/`View::rebuild` functions will panic for this view.
-    pub fn attr(mut self, name: impl Into<CowStr>, value: impl Into<AttributeValue>) -> Self {
+    pub fn attr(mut self, name: impl Into<CowStr>, value: impl IntoAttributeValue) -> Self {
         self.set_attr(name, value);
         self
     }
@@ -86,7 +86,7 @@ impl<El, ViewSeq> Element<El, ViewSeq> {
     ///
     /// If the name contains characters that are not valid in an attribute name,
     /// then the `View::build`/`View::rebuild` functions will panic for this view.
-    pub fn set_attr(&mut self, name: impl Into<CowStr>, value: impl Into<AttributeValue>) {
+    pub fn set_attr(&mut self, name: impl Into<CowStr>, value: impl IntoAttributeValue) {
         self.attributes.insert(name, value);
     }
 

--- a/crates/xilem_html/src/element/mod.rs
+++ b/crates/xilem_html/src/element/mod.rs
@@ -5,7 +5,6 @@
 use crate::{
     context::{ChangeFlags, Cx},
     diff::{diff_kv_iterables, Diff},
-    vecmap::VecMap,
     view::{DomElement, Pod, View, ViewMarker, ViewSequence},
 };
 
@@ -13,15 +12,20 @@ use std::{borrow::Cow, fmt};
 use wasm_bindgen::{JsCast, UnwrapThrowExt};
 use xilem_core::{Id, MessageResult, VecSplice};
 
+pub mod attributes;
 #[cfg(feature = "typed")]
 pub mod elements;
+
+pub use attributes::{AttributeValue, Attributes};
+
+type CowStr = Cow<'static, str>;
 
 /// A view representing a HTML element.
 ///
 /// If the element has no children, use the unit type (e.g. `let view = element("div", ())`).
 pub struct Element<El, Children = ()> {
-    name: Cow<'static, str>,
-    attributes: VecMap<Cow<'static, str>, Cow<'static, str>>,
+    name: CowStr,
+    attributes: Attributes,
     children: Children,
     #[allow(clippy::type_complexity)]
     after_update: Option<Box<dyn Fn(&El)>>,
@@ -34,7 +38,7 @@ impl<El, ViewSeq> Element<El, ViewSeq> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 write!(f, "<{}", self.0.name)?;
                 for (name, value) in &self.0.attributes {
-                    write!(f, " {name}=\"{value}\"")?;
+                    write!(f, " {name}=\"{}\"", value.serialize())?;
                 }
                 write!(f, ">")
             }
@@ -55,13 +59,10 @@ pub struct ElementState<ViewSeqState> {
 /// Create a new element view
 ///
 /// If the element has no children, use the unit type (e.g. `let view = element("div", ())`).
-pub fn element<El, ViewSeq>(
-    name: impl Into<Cow<'static, str>>,
-    children: ViewSeq,
-) -> Element<El, ViewSeq> {
+pub fn element<El, ViewSeq>(name: impl Into<CowStr>, children: ViewSeq) -> Element<El, ViewSeq> {
     Element {
         name: name.into(),
-        attributes: VecMap::default(),
+        attributes: Attributes::default(),
         children,
         after_update: None,
     }
@@ -74,11 +75,7 @@ impl<El, ViewSeq> Element<El, ViewSeq> {
     ///
     /// If the name contains characters that are not valid in an attribute name,
     /// then the `View::build`/`View::rebuild` functions will panic for this view.
-    pub fn attr(
-        mut self,
-        name: impl Into<Cow<'static, str>>,
-        value: impl Into<Cow<'static, str>>,
-    ) -> Self {
+    pub fn attr(mut self, name: impl Into<CowStr>, value: impl Into<AttributeValue>) -> Self {
         self.set_attr(name, value);
         self
     }
@@ -89,12 +86,8 @@ impl<El, ViewSeq> Element<El, ViewSeq> {
     ///
     /// If the name contains characters that are not valid in an attribute name,
     /// then the `View::build`/`View::rebuild` functions will panic for this view.
-    pub fn set_attr(
-        &mut self,
-        name: impl Into<Cow<'static, str>>,
-        value: impl Into<Cow<'static, str>>,
-    ) {
-        self.attributes.insert(name.into(), value.into());
+    pub fn set_attr(&mut self, name: impl Into<CowStr>, value: impl Into<AttributeValue>) {
+        self.attributes.insert(name, value);
     }
 
     /// Set a function to run after the new view tree has been created.
@@ -125,8 +118,9 @@ where
     fn build(&self, cx: &mut Cx) -> (Id, Self::State, Self::Element) {
         let el = cx.create_html_element(&self.name);
         for (name, value) in &self.attributes {
-            el.set_attribute(name, value).unwrap_throw();
+            el.set_attribute(name, &value.serialize()).unwrap_throw();
         }
+
         let mut child_elements = vec![];
         let (id, child_states) = cx.with_new_id(|cx| self.children.build(cx, &mut child_elements));
         for child in &child_elements {
@@ -185,7 +179,7 @@ where
         for itm in diff_kv_iterables(&prev.attributes, &self.attributes) {
             match itm {
                 Diff::Add(name, value) | Diff::Change(name, value) => {
-                    set_attribute(element, name, value);
+                    set_attribute(element, name, &value.serialize());
                     changed |= ChangeFlags::OTHER_CHANGE;
                 }
                 Diff::Remove(name) => {

--- a/crates/xilem_html/src/element/mod.rs
+++ b/crates/xilem_html/src/element/mod.rs
@@ -96,6 +96,10 @@ impl<El, ViewSeq> Element<El, ViewSeq> {
         }
     }
 
+    pub fn remove_attr(&mut self, name: impl Into<CowStr>) {
+        self.attributes.remove(&name.into());
+    }
+
     /// Set a function to run after the new view tree has been created.
     ///
     /// This offers functionality similar to `ref` in React.

--- a/crates/xilem_html/src/lib.rs
+++ b/crates/xilem_html/src/lib.rs
@@ -26,7 +26,7 @@ pub use class::class;
 pub use context::{ChangeFlags, Cx};
 #[cfg(feature = "typed")]
 pub use element::elements;
-pub use element::{element, Element, ElementState};
+pub use element::{element, AttributeValue, Element, ElementState};
 #[cfg(feature = "typed")]
 pub use event::events;
 pub use event::{on_event, Action, Event, OnEvent, OnEventState, OptionalAction};

--- a/crates/xilem_html/src/lib.rs
+++ b/crates/xilem_html/src/lib.rs
@@ -26,7 +26,7 @@ pub use class::class;
 pub use context::{ChangeFlags, Cx};
 #[cfg(feature = "typed")]
 pub use element::elements;
-pub use element::{element, AttributeValue, Element, ElementState};
+pub use element::{element, AttributeValue, Element, ElementState, IntoAttributeValue};
 #[cfg(feature = "typed")]
 pub use event::events;
 pub use event::{on_event, Action, Event, OnEvent, OnEventState, OptionalAction};

--- a/crates/xilem_html/web_examples/todomvc/src/main.rs
+++ b/crates/xilem_html/web_examples/todomvc/src/main.rs
@@ -26,12 +26,10 @@ fn todo_item(todo: &mut Todo, editing: bool) -> impl View<Todo, TodoAction> + Vi
     if editing {
         class.push_str(" editing");
     }
-    let mut input = el::input(())
+    let input = el::input(())
         .attr("class", "toggle")
-        .attr("type", "checkbox");
-    if todo.completed {
-        input.set_attr("checked", "checked");
-    };
+        .attr("type", "checkbox")
+        .attr("checked", todo.completed);
 
     el::li((
         el::div((
@@ -86,13 +84,7 @@ fn footer_view(state: &mut AppState, should_display: bool) -> impl View<AppState
         )
     });
 
-    let filter_class = |filter| {
-        if state.filter == filter {
-            "selected"
-        } else {
-            ""
-        }
-    };
+    let filter_class = |filter| (state.filter == filter).then_some("selected");
 
     let mut footer = el::footer((
         el::span((
@@ -162,13 +154,11 @@ fn main_view(state: &mut AppState, should_display: bool) -> impl View<AppState> 
             )
         })
         .collect();
-    let mut toggle_all = el::input(())
+    let toggle_all = el::input(())
         .attr("id", "toggle-all")
         .attr("class", "toggle-all")
-        .attr("type", "checkbox");
-    if state.are_all_complete() {
-        toggle_all.set_attr("checked", "true");
-    }
+        .attr("type", "checkbox")
+        .attr("checked", state.are_all_complete());
     let mut section = el::section((
         toggle_all.on_click(|state: &mut AppState, _| state.toggle_all_complete()),
         el::label(()).attr("for", "toggle-all"),
@@ -190,7 +180,7 @@ fn app_logic(state: &mut AppState) -> impl View<AppState> {
         .attr("class", "new-todo")
         .attr("placeholder", "What needs to be done?")
         .attr("value", state.new_todo.clone())
-        .attr("autofocus", "true");
+        .attr("autofocus", true);
     el::div((
         el::header((
             el::h1("TODOs"),


### PR DESCRIPTION
Where \<value\> can be numbers, booleans and strings and options of values.
This is achieved via an enum that serializes to a string and the From trait.
if the attribute is either set to `None` or `false`, the attribute won't be serialized at all (or added to the attributes map at that).

This is slightly less ambitious (and controversial?) than #119 and is used as basis for all attributes there (slightly different implementation, this PR is an improved version without the `BTreeSet` that is used there for classes). 

(This is also ready to merge/review but is built on top of #124 and #125, so those have to be merged/reviewed first).