### PR TITLE
Add 'cache-all-crates' to avoid cache miss in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,8 @@ jobs:
         # components: ${{ runner.os == 'Linux' && 'rustfmt' || '' }}
     - name: Restore Cache
       uses: Swatinem/rust-cache@v2
+      with:
+        cache-all-crates: true
     - name: Cargo Format
       # We'll only run this on one platform.
       run: cargo fmt --all -- --check


### PR DESCRIPTION
Currently it seems that the web based crates (I think `xilem_svg`, `xilem_html` and their examples) aren't cached in CI, I think it's because they are not referenced in the main crate, I have added `cache-all-crates: true` which seems to fix this issue.