### PR TITLE
xilem_html: minor improvement in `Element::remove_attr` (use `&str` instead of `Into<CowStr`)

### DIFF
--- a/crates/xilem_html/src/element/elements.rs
+++ b/crates/xilem_html/src/element/elements.rs
@@ -53,10 +53,7 @@ macro_rules! element {
                 self
             }
 
-            pub fn remove_attr(
-                &mut self,
-                name: impl Into<std::borrow::Cow<'static, str>>,
-            ) -> &mut Self {
+            pub fn remove_attr(&mut self, name: &str) -> &mut Self {
                 self.0.remove_attr(name);
                 self
             }

--- a/crates/xilem_html/src/element/mod.rs
+++ b/crates/xilem_html/src/element/mod.rs
@@ -92,12 +92,12 @@ impl<El, ViewSeq> Element<El, ViewSeq> {
         if let Some(value) = value.into_attribute_value() {
             self.attributes.insert(name, value);
         } else {
-            self.attributes.remove(&name);
+            self.remove_attr(&name);
         }
     }
 
-    pub fn remove_attr(&mut self, name: impl Into<CowStr>) {
-        self.attributes.remove(&name.into());
+    pub fn remove_attr(&mut self, name: &str) {
+        self.attributes.remove(name);
     }
 
     /// Set a function to run after the new view tree has been created.


### PR DESCRIPTION
I guess I was a little bit too fast with merging the previous PR (not my day today). Minor improvement, replace the unnecessary `impl Into<CowStr>` with `&str`