### PR TITLE
Add use_state View to xilem-core

### DIFF
--- a/crates/xilem_core/src/view/mod.rs
+++ b/crates/xilem_core/src/view/mod.rs
@@ -3,6 +3,7 @@
 
 mod adapt;
 mod memoize;
+mod use_state;
 
 /// Create the `View` trait for a particular xilem context (e.g. html, native, ...).
 ///

--- a/crates/xilem_core/src/view/use_state.rs
+++ b/crates/xilem_core/src/view/use_state.rs
@@ -1,0 +1,62 @@
+#[macro_export]
+macro_rules! generate_use_state_view {
+    ($viewtrait:ident, $cx:ty, $changeflags:ty; $($ss:tt)*) => {
+        pub fn use_state<F, S, G, V>(make_state: F, make_view: G) -> UseState<F, S, G, V> {
+            UseState::new(make_state, make_view)
+        }
+
+        pub struct UseState<F, S, G, V> {
+            make_state: F,
+            state: Option<S>,
+            make_view: G,
+            view: Option<V>,
+        }
+
+        impl<F, S, G, V> UseState<F, S, G, V> {
+            pub fn new(make_state: F, make_view: G) -> Self {
+                Self {
+                    make_state,
+                    state: None,
+                    make_view,
+                    view: None,
+                }
+            }
+        }
+
+        impl<T, A, F, S, G, V> View<T, A> for UseState<F, S, G, V>
+        where
+            S: Send,
+            F: FnMut() -> S + Send,
+            G: FnMut(&mut S) -> V + Send,
+            V: $viewtrait<S, A>,
+        {
+            type State = V::State;
+            type Element = V::Element;
+
+            fn build(&self, cx: &mut $cx) -> (Id, Self::State, Self::Element) {
+                todo!()
+            }
+
+            fn rebuild(
+                &self,
+                cx: &mut $cx,
+                prev: &Self,
+                id: &mut Id,
+                state: &mut Self::State,
+                element: &mut Self::Element,
+            ) -> $changeflags {
+               todo!()
+            }
+
+            fn message(
+                &self,
+                id_path: &[$crate::Id],
+                state: &mut Self::State,
+                message: Box<dyn std::any::Any>,
+                app_state: &mut T,
+            ) -> $crate::MessageResult<A> {
+                todo!()
+            }
+        }
+    };
+}

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -29,4 +29,4 @@ pub use xilem_core::{Id, IdPath, VecSplice};
 pub use button::button;
 pub use linear_layout::{h_stack, v_stack, LinearLayout};
 pub use list::{list, List};
-pub use view::{Adapt, AdaptState, Cx, Memoize, View, ViewMarker, ViewSequence};
+pub use view::{use_state, Adapt, AdaptState, Cx, Memoize, View, ViewMarker, ViewSequence, UseState};

--- a/src/view/view.rs
+++ b/src/view/view.rs
@@ -29,6 +29,7 @@ xilem_core::generate_anyview_trait! {AnyView, View, ViewMarker, Cx, ChangeFlags,
 xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, s, memoize; + Send}
 xilem_core::generate_adapt_view! {View, Cx, ChangeFlags; + Send}
 xilem_core::generate_adapt_state_view! {View, Cx, ChangeFlags; + Send}
+xilem_core::generate_use_state_view! {View, Cx, ChangeFlags; + Send}
 
 #[derive(Clone)]
 pub struct Cx {


### PR DESCRIPTION
Add  the generic `use_state` view to xilem-core.

```rust
fn use_state<F, S, G, V>(
    make_state: F,
    make_view: G
) -> UseState<F, S, G, V>
```

This would generalize and replace the current `UseState` view in the main xilem crate. The main benefit here is no `Arc` to hold the current state. This is still a WIP and is being ported from the [`remember`](https://concoct-rs.github.io/concoct/view/struct.Remember.html) view in my UI crate.

I think this has huge benefits as it would allow us to compose state at no runtime cost. For example, global app state could be replaced by small sections of state created with this view.
