### PR TITLE
Add more String views (`&'static str`, `Cow<'static, str>`)

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -16,7 +16,7 @@ fn app_logic(data: &mut i32) -> impl View<i32> {
             *data += 1;
         }),
         h_stack((
-            String::from("Buttons: "),
+            "Buttons: ",
             button("decrease", |data| {
                 println!("clicked decrease");
                 *data -= 1;

--- a/src/view/text.rs
+++ b/src/view/text.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use crate::view::{Id, ViewMarker};
 use crate::widget::ChangeFlags;
 
@@ -20,6 +22,83 @@ use super::{Cx, View};
 impl ViewMarker for String {}
 
 impl<T, A> View<T, A> for String {
+    type State = ();
+
+    type Element = crate::widget::TextWidget;
+
+    fn build(&self, cx: &mut Cx) -> (crate::view::Id, Self::State, Self::Element) {
+        let (id, element) =
+            cx.with_new_id(|_| crate::widget::TextWidget::new(Cow::from(self.clone())));
+        (id, (), element)
+    }
+
+    fn rebuild(
+        &self,
+        _cx: &mut Cx,
+        prev: &Self,
+        _id: &mut Id,
+        _state: &mut Self::State,
+        element: &mut Self::Element,
+    ) -> ChangeFlags {
+        if prev != self {
+            element.set_text(Cow::from(self.clone()))
+        } else {
+            ChangeFlags::empty()
+        }
+    }
+
+    fn message(
+        &self,
+        _id_path: &[xilem_core::Id],
+        _state: &mut Self::State,
+        _message: Box<dyn std::any::Any>,
+        _app_state: &mut T,
+    ) -> xilem_core::MessageResult<A> {
+        xilem_core::MessageResult::Nop
+    }
+}
+
+impl ViewMarker for &'static str {}
+
+impl<T, A> View<T, A> for &'static str {
+    type State = ();
+
+    type Element = crate::widget::TextWidget;
+
+    fn build(&self, cx: &mut Cx) -> (crate::view::Id, Self::State, Self::Element) {
+        let (id, element) = cx.with_new_id(|_| crate::widget::TextWidget::new(Cow::from(*self)));
+        (id, (), element)
+    }
+
+    fn rebuild(
+        &self,
+        _cx: &mut Cx,
+        prev: &Self,
+        _id: &mut Id,
+        _state: &mut Self::State,
+        element: &mut Self::Element,
+    ) -> ChangeFlags {
+        if prev != self {
+            element.set_text(Cow::from(*self))
+        } else {
+            ChangeFlags::empty()
+        }
+    }
+
+    fn message(
+        &self,
+        _id_path: &[xilem_core::Id],
+        _state: &mut Self::State,
+        _message: Box<dyn std::any::Any>,
+        _app_state: &mut T,
+    ) -> xilem_core::MessageResult<A> {
+        xilem_core::MessageResult::Nop
+    }
+}
+
+impl ViewMarker for Cow<'static, str> {}
+
+impl<T, A> View<T, A> for Cow<'static, str> {
     type State = ();
 
     type Element = crate::widget::TextWidget;

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use parley::{FontContext, Layout};
+use std::borrow::Cow;
 use vello::{
     kurbo::{Affine, Size},
     peniko::{Brush, Color},
@@ -27,16 +28,16 @@ use super::{
 };
 
 pub struct TextWidget {
-    text: String,
+    text: Cow<'static, str>,
     layout: Option<Layout<ParleyBrush>>,
 }
 
 impl TextWidget {
-    pub fn new(text: String) -> TextWidget {
+    pub fn new(text: Cow<'static, str>) -> TextWidget {
         TextWidget { text, layout: None }
     }
 
-    pub fn set_text(&mut self, text: String) -> ChangeFlags {
+    pub fn set_text(&mut self, text: Cow<'static, str>) -> ChangeFlags {
         self.text = text;
         ChangeFlags::LAYOUT | ChangeFlags::PAINT
     }


### PR DESCRIPTION
Adds a few more string based views, using the existing `TextWidget` widget