### PR TITLE
Correctly pass the `HAS_ACTIVE` state up

### DIFF
--- a/src/widget/core.rs
+++ b/src/widget/core.rs
@@ -285,6 +285,14 @@ impl Pod {
             }
         };
         if recurse {
+            // This clears the has_active state. Pod needs to clear this state since merge up can
+            // only set flags.
+            // This needs to happen before the `event` call, as that will also set our `HAS_ACTIVE`
+            // flag if any of our children were active
+            self.state.flags.set(
+                PodFlags::HAS_ACTIVE,
+                self.state.flags.contains(PodFlags::IS_ACTIVE),
+            );
             let mut inner_cx = EventCx {
                 cx_state: cx.cx_state,
                 widget_state: &mut self.state,
@@ -294,12 +302,6 @@ impl Pod {
                 .event(&mut inner_cx, modified_event.as_ref().unwrap_or(event));
             cx.is_handled |= inner_cx.is_handled;
 
-            // This clears the has_active state. Pod needs to clear this state since merge up can
-            // only set flags.
-            self.state.flags.set(
-                PodFlags::HAS_ACTIVE,
-                self.state.flags.contains(PodFlags::IS_ACTIVE),
-            );
             cx.widget_state.merge_up(&mut self.state);
         }
     }

--- a/src/widget/core.rs
+++ b/src/widget/core.rs
@@ -547,6 +547,7 @@ impl Pod {
     /// is dragged away.
     ///
     /// [`set_active`]: EventCx::set_active
+    // TODO: Determine why this is the same as [Self::has_active]
     pub fn is_active(&self) -> bool {
         self.state.flags.contains(PodFlags::HAS_ACTIVE)
     }


### PR DESCRIPTION
Previously, this was being overwritten by each widget as the event went up the tree, so only the root widget could be active

This aligns this code with the druid version (see https://github.com/linebender/druid/blob/e53a5ab72c40191b3f92edef9ebf4da07da254f3/druid/src/core.rs#L812)