### PR TITLE
Switch widget visual fixes

### DIFF
--- a/src/widget/core.rs
+++ b/src/widget/core.rs
@@ -278,7 +278,7 @@ impl Pod {
                 had_active || hot_changed
             }
             Event::TargetedAccessibilityAction(action) => {
-                println!("TODO: {:?}", action);
+                // println!("TODO: {:?}", action);
                 self.state
                     .sub_tree
                     .may_contain(&Id::try_from_accesskit(action.target).unwrap())

--- a/src/widget/linear_layout.rs
+++ b/src/widget/linear_layout.rs
@@ -75,7 +75,7 @@ impl Widget for LinearLayout {
             if index < child_count - 1 {
                 major_used += self.spacing;
 
-                println!("insert spacing {}", self.spacing);
+                // println!("insert spacing {}", self.spacing);
             }
             max_minor = max_minor.max(self.axis.minor(size));
         }
@@ -102,7 +102,7 @@ impl Widget for LinearLayout {
 
     fn paint(&mut self, cx: &mut PaintCx, builder: &mut SceneBuilder) {
         for child in &mut self.children {
-            println!("paint child!");
+            // println!("paint child!");
             child.paint(cx, builder);
         }
     }


### PR DESCRIPTION
I have fixed the visuals of the knob in the hot (bigger and lighter), active (smaller and darker) and idle configuration.

The knob would also jump if the dragging started from the negative area of the widget and it seemed kinda jerky.

I have also disabled some of print statement in other places to cleanup the terminal output