### PR TITLE
Export crates/modules to facilitate external widget definitions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod app_main;
 mod bloom;
 mod geometry;
 mod id;
-mod text;
+pub mod text;
 pub mod view;
 pub mod widget;
 
@@ -17,3 +17,7 @@ pub use app::App;
 pub use app_main::AppLauncher;
 pub(crate) use bloom::Bloom;
 pub use geometry::Axis;
+
+pub use accesskit;
+pub use parley;
+pub use vello;

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -19,7 +19,7 @@ mod core;
 //mod layout_observer;
 //mod list;
 mod linear_layout;
-mod piet_scene_helpers;
+pub mod piet_scene_helpers;
 mod raw_event;
 mod switch;
 //mod scroll_view;


### PR DESCRIPTION
Trivial change to allow programs using xilem to share its components, for custom widgets without using a local patch.