### PR TITLE
xilem: invalidate `TaffyLayout` cache on child layout request

### DIFF
--- a/src/widget/taffy_layout.rs
+++ b/src/widget/taffy_layout.rs
@@ -310,6 +310,11 @@ impl Widget for TaffyLayout {
         );
         let node_id = taffy::NodeId::from(usize::MAX);
 
+        // Invalidate cache on child layout request.
+        if self.children.iter().any(|child| child.layout_requested()) {
+            self.cache.clear();
+        }
+
         // Check for cached layout. And return it if found.
         if let Some(cached_output) = self.cache.get(
             inputs.known_dimensions,


### PR DESCRIPTION
`TaffyLayout` caches layout based on input dimensions. If a widget in the tree under a `TaffyLayout` requests a layout change, it is only performed on e.g. a subsequent window size change or a tree rebuild.

Note `TaffyLayout` already conditionally clears the cache in the view rebuild, but layout requests made from a child widget currently do not.

Example to reproduce: `TestWidget` renders two rectangles, a green one indicating the currently computed layout, and a yellow one indicating the layout we wish to have. Hovering over the rectangle and scrolling the mouse wheel increases or decreases the widget's desired height. Without this patch, the layout is not recomputed until the window size changes.

```rust
use vello::peniko::{Brush, Color, Stroke};
use xilem::{
    view::{View, ViewMarker},
    widget::Widget,
    App, AppLauncher,
};

struct TestView {}

impl<T, A> View<T, A> for TestView {
    type Element = TestWidget;
    type State = ();

    fn build(&self, cx: &mut xilem::view::Cx) -> (xilem_core::Id, Self::State, Self::Element) {
        let (id, element) = cx.with_new_id(|_cx| TestWidget { height: 20. });
        (id, (), element)
    }
    fn rebuild(
        &self,
        _cx: &mut xilem::view::Cx,
        _prev: &Self,
        _id: &mut xilem_core::Id,
        _state: &mut Self::State,
        _element: &mut Self::Element,
    ) -> xilem::widget::ChangeFlags {
        xilem::widget::ChangeFlags::empty()
    }
    fn message(
        &self,
        _id_path: &[xilem_core::Id],
        _state: &mut Self::State,
        _message: Box<dyn std::any::Any>,
        _app_state: &mut T,
    ) -> xilem_core::MessageResult<A> {
        xilem_core::MessageResult::Nop
    }
}

impl ViewMarker for TestView {}

struct TestWidget {
    height: f64,
}

impl Widget for TestWidget {
    fn update(&mut self, _cx: &mut xilem::widget::UpdateCx) {}

    fn event(&mut self, cx: &mut xilem::widget::EventCx, event: &xilem::widget::Event) {
        if let xilem::widget::Event::MouseWheel(mouse_wheel_event) = event {
            self.height = f64::max(20., self.height + mouse_wheel_event.wheel_delta.y);
            cx.request_layout();
            cx.request_paint();
        }
    }

    fn lifecycle(
        &mut self,
        _cx: &mut xilem::widget::LifeCycleCx,
        _event: &xilem::widget::LifeCycle,
    ) {
    }

    fn layout(
        &mut self,
        cx: &mut xilem::widget::LayoutCx,
        bc: &xilem::widget::BoxConstraints,
    ) -> glazier::kurbo::Size {
        cx.request_paint();
        let size = glazier::kurbo::Size::new(100., self.height);
        dbg!(bc.constrain(size))
    }

    fn paint(&mut self, cx: &mut xilem::widget::PaintCx, builder: &mut vello::SceneBuilder) {
        let stroke = Stroke::new(2.0);

        let mut size = cx.size();
        let rect = size.to_rect();
        let brush = Brush::Solid(Color::YELLOW);
        builder.stroke(
            &stroke,
            vello::kurbo::Affine::IDENTITY,
            &brush,
            None,
            &rect,
        );

        size.height = self.height;
        let rect = size.to_rect();
        let brush = Brush::Solid(Color::GREEN);
        builder.stroke(
            &stroke,
            vello::kurbo::Affine::IDENTITY,
            &brush,
            None,
            &rect,
        );
    }
    fn accessibility(&mut self, _cx: &mut xilem::widget::AccessCx) {}
}

#[cfg(not(feature = "taffy"))]
fn app_logic(_data: &mut AppState) -> impl View<AppState> {
    "Error: this example requires the 'taffy' feature to be enabled"
}

#[cfg(feature = "taffy")]
fn app_logic(_state: &mut ()) -> impl View<()> {
    use taffy::style_helpers::length;
    use xilem::view::{div, flex_column};

    flex_column((
        div(())
            .with_background_color(vello::peniko::Color::RED)
            .with_style(|s| {
                s.size.width = length(200.0);
                s.size.height = length(200.0);
            }),
        TestView {},
        div(())
            .with_background_color(vello::peniko::Color::RED)
            .with_style(|s| {
                s.size.width = length(200.0);
                s.size.height = length(200.0);
            }),
    ))
}

fn main() {
    let app = App::new((), app_logic);
    AppLauncher::new(app).run()
}
```

Before scrolling:
![1](https://github.com/linebender/xilem/assets/9393486/26f0dc25-a432-4edf-92e6-14537f579bd7)
Scroll a bit, the layout does not update:
![2](https://github.com/linebender/xilem/assets/9393486/9f7650a5-1b1d-4cf9-b782-42fd2341f835)
Then resize the window to force a relayout:
![3](https://github.com/linebender/xilem/assets/9393486/65bc7f04-f61e-4315-9ee7-eaa4d6f2300f)
