### PR TITLE
Add an `AnyViewSequence` which is analogous to the AnyView for ViewSequences

### DIFF
--- a/crates/xilem_html/src/lib.rs
+++ b/crates/xilem_html/src/lib.rs
@@ -33,8 +33,8 @@ pub use one_of::{
 };
 pub use optional_action::{Action, OptionalAction};
 pub use view::{
-    memoize, static_view, Adapt, AdaptState, AdaptThunk, AnyView, Memoize, MemoizeState, Pod, View,
-    ViewMarker, ViewSequence,
+    memoize, static_view, Adapt, AdaptState, AdaptThunk, AnyView, AnyViewSequence, BoxedView,
+    BoxedViewSequence, Memoize, MemoizeState, Pod, View, ViewMarker, ViewSequence,
 };
 pub use view_ext::ViewExt;
 

--- a/crates/xilem_html/src/view.rs
+++ b/crates/xilem_html/src/view.rs
@@ -85,7 +85,7 @@ impl Pod {
 }
 
 xilem_core::generate_view_trait! {View, DomNode, Cx, ChangeFlags;}
-xilem_core::generate_viewsequence_trait! {ViewSequence, View, ViewMarker, DomNode, Cx, ChangeFlags, Pod;}
+xilem_core::generate_viewsequence_trait! {ViewSequence, AnyViewSequence, BoxedViewSequence, View, ViewMarker, DomNode, Cx, ChangeFlags, Pod;();()}
 xilem_core::generate_anyview_trait! {AnyView, View, ViewMarker, Cx, ChangeFlags, AnyNode, BoxedView;}
 xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, static_view, memoize;}
 xilem_core::generate_adapt_view! {View, Cx, ChangeFlags;}

--- a/crates/xilem_svg/src/view.rs
+++ b/crates/xilem_svg/src/view.rs
@@ -73,7 +73,7 @@ impl Pod {
 }
 
 xilem_core::generate_view_trait! {View, DomElement, Cx, ChangeFlags;}
-xilem_core::generate_viewsequence_trait! {ViewSequence, View, ViewMarker, DomElement, Cx, ChangeFlags, Pod;}
+xilem_core::generate_viewsequence_trait! {ViewSequence, AnyViewSequence, BoxedViewSequence, View, ViewMarker, DomElement, Cx, ChangeFlags, Pod;();()}
 xilem_core::generate_anyview_trait! {AnyView, View, ViewMarker, Cx, ChangeFlags, AnyElement, BoxedView;}
 xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, s, memoize;}
 xilem_core::generate_adapt_view! {View, Cx, ChangeFlags;}

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -31,7 +31,10 @@ pub use button::button;
 pub use linear_layout::{h_stack, v_stack, LinearLayout};
 pub use list::{list, List};
 pub use switch::switch;
-pub use view::{Adapt, AdaptState, Cx, Memoize, View, ViewMarker, ViewSequence};
+pub use view::{
+    Adapt, AdaptState, AnyView, AnyViewSequence, BoxedView, BoxedViewSequence, Cx, Memoize, View,
+    ViewMarker, ViewSequence,
+};
 
 #[cfg(feature = "taffy")]
 mod taffy_layout;

--- a/src/view/view.rs
+++ b/src/view/view.rs
@@ -24,7 +24,7 @@ use xilem_core::{Id, IdPath};
 use crate::widget::{AnyWidget, ChangeFlags, Pod, Widget};
 
 xilem_core::generate_view_trait! {View, Widget, Cx, ChangeFlags; : Send}
-xilem_core::generate_viewsequence_trait! {ViewSequence, View, ViewMarker, Widget, Cx, ChangeFlags, Pod; : Send}
+xilem_core::generate_viewsequence_trait! {ViewSequence, AnyViewSequence, BoxedViewSequence, View, ViewMarker, Widget, Cx, ChangeFlags, Pod; (: Send); (+ Send)}
 xilem_core::generate_anyview_trait! {AnyView, View, ViewMarker, Cx, ChangeFlags, AnyWidget, BoxedView; + Send}
 xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, s, memoize; + Send}
 xilem_core::generate_adapt_view! {View, Cx, ChangeFlags; + Send}


### PR DESCRIPTION
This allows for type-erased ViewSequences.

Original Motivation was to check whether this helps with reducing wasm binary size in `xilem_html` (which wasn't really that [successful](https://xi.zulipchat.com/#narrow/stream/354396-xilem/topic/AnyViewSequence), static optimization + compression seems to work quite well at this point). But I think this could be helpful otherwise too, e.g. for recursive ViewSequences (see e.g. [here](https://xi.zulipchat.com/#narrow/stream/354396-xilem/topic/Recursively.20returning.20views)) or cross-language bindings that need type erasure in sequences.