### PR TITLE
Generalize `VecSplice` that is used in the ViewSequences as `ElementsSplice` trait and optimize tree-structure diffing in `xilem_web` with it

### DIFF
--- a/crates/xilem_core/src/vec_splice.rs
+++ b/crates/xilem_core/src/vec_splice.rs
@@ -50,6 +50,14 @@ impl<'a, 'b, T> VecSplice<'a, 'b, T> {
         &mut self.v[ix]
     }
 
+    pub fn peek(&self) -> Option<&T> {
+        self.v.last()
+    }
+
+    pub fn peek_mut(&mut self) -> Option<&mut T> {
+        self.v.last_mut()
+    }
+
     pub fn len(&self) -> usize {
         self.ix
     }

--- a/crates/xilem_web/src/lib.rs
+++ b/crates/xilem_web/src/lib.rs
@@ -36,8 +36,8 @@ pub use one_of::{
 pub use optional_action::{Action, OptionalAction};
 pub use pointer::{Pointer, PointerDetails, PointerMsg};
 pub use view::{
-    memoize, static_view, Adapt, AdaptState, AdaptThunk, AnyView, BoxedView, Memoize, MemoizeState,
-    Pod, View, ViewMarker, ViewSequence,
+    memoize, static_view, Adapt, AdaptState, AdaptThunk, AnyView, BoxedView, ElementsSplice,
+    Memoize, MemoizeState, Pod, View, ViewMarker, ViewSequence,
 };
 pub use view_ext::ViewExt;
 

--- a/crates/xilem_web/src/view.rs
+++ b/crates/xilem_web/src/view.rs
@@ -79,13 +79,13 @@ impl Pod {
         self.0.as_any_mut().downcast_mut()
     }
 
-    fn mark(&mut self, flags: ChangeFlags) -> ChangeFlags {
+    pub(crate) fn mark(&mut self, flags: ChangeFlags) -> ChangeFlags {
         flags
     }
 }
 
 xilem_core::generate_view_trait! {View, DomNode, Cx, ChangeFlags;}
-xilem_core::generate_viewsequence_trait! {ViewSequence, View, ViewMarker, DomNode, Cx, ChangeFlags, Pod;}
+xilem_core::generate_viewsequence_trait! {ViewSequence, View, ViewMarker, ElementsSplice, DomNode, Cx, ChangeFlags, Pod;}
 xilem_core::generate_anyview_trait! {AnyView, View, ViewMarker, Cx, ChangeFlags, AnyNode, BoxedView;}
 xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, static_view, memoize;}
 xilem_core::generate_adapt_view! {View, Cx, ChangeFlags;}

--- a/src/view/linear_layout.rs
+++ b/src/view/linear_layout.rs
@@ -70,7 +70,9 @@ impl<T, A, VT: ViewSequence<T, A>> View<T, A> for LinearLayout<T, A, VT> {
 
     fn build(&self, cx: &mut Cx) -> (Id, Self::State, Self::Element) {
         let mut elements = vec![];
-        let (id, state) = cx.with_new_id(|cx| self.children.build(cx, &mut elements));
+        let mut scratch = vec![];
+        let mut splice = VecSplice::new(&mut elements, &mut scratch);
+        let (id, state) = cx.with_new_id(|cx| self.children.build(cx, &mut splice));
         let column = widget::LinearLayout::new(elements, self.spacing, self.axis);
         (id, state, column)
     }

--- a/src/view/list.rs
+++ b/src/view/list.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::view::{Cx, VecSplice, ViewSequence};
-use crate::widget::{ChangeFlags, Pod};
+use crate::view::{Cx, ElementsSplice, ViewSequence};
+use crate::widget::ChangeFlags;
 use crate::MessageResult;
 use std::any::Any;
 use std::marker::PhantomData;
@@ -49,7 +49,7 @@ impl<T, A, VT: ViewSequence<T, A>, F: Fn(usize) -> VT + Send> ViewSequence<T, A>
 {
     type State = ListState<T, A, VT>;
 
-    fn build(&self, cx: &mut Cx, elements: &mut Vec<Pod>) -> Self::State {
+    fn build(&self, cx: &mut Cx, elements: &mut dyn ElementsSplice) -> Self::State {
         let leading = elements.len();
 
         let views =
@@ -72,29 +72,29 @@ impl<T, A, VT: ViewSequence<T, A>, F: Fn(usize) -> VT + Send> ViewSequence<T, A>
         cx: &mut Cx,
         prev: &Self,
         state: &mut Self::State,
-        element: &mut VecSplice<Pod>,
+        elements: &mut dyn ElementsSplice,
     ) -> ChangeFlags {
         // Common length
-        let leading = element.len();
+        let leading = elements.len();
 
         let mut flags = (0..(self.items.min(prev.items)))
             .zip(&mut state.views)
             .fold(ChangeFlags::empty(), |flags, (index, (prev, state))| {
                 let vt = (self.build)(index);
-                let vt_flags = vt.rebuild(cx, prev, state, element);
+                let vt_flags = vt.rebuild(cx, prev, state, elements);
                 *prev = vt;
                 flags | vt_flags
             });
 
         if self.items < prev.items {
             for (prev, state) in state.views.splice(self.items.., []) {
-                element.delete(prev.count(&state));
+                elements.delete(prev.count(&state));
             }
         }
 
         while self.items > state.views.len() {
             let vt = (self.build)(state.views.len());
-            let vt_state = element.as_vec(|vec| vt.build(cx, vec));
+            let vt_state = vt.build(cx, elements);
             state.views.push((vt, vt_state));
         }
 
@@ -104,7 +104,7 @@ impl<T, A, VT: ViewSequence<T, A>, F: Fn(usize) -> VT + Send> ViewSequence<T, A>
             flags |= ChangeFlags::all();
         }
 
-        state.element_count = element.len() - leading;
+        state.element_count = elements.len() - leading;
 
         flags
     }

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -31,7 +31,7 @@ pub use button::button;
 pub use linear_layout::{h_stack, v_stack, LinearLayout};
 pub use list::{list, List};
 pub use switch::switch;
-pub use view::{Adapt, AdaptState, Cx, Memoize, View, ViewMarker, ViewSequence};
+pub use view::{Adapt, AdaptState, Cx, ElementsSplice, Memoize, View, ViewMarker, ViewSequence};
 
 #[cfg(feature = "taffy")]
 mod taffy_layout;

--- a/src/view/taffy_layout.rs
+++ b/src/view/taffy_layout.rs
@@ -103,7 +103,9 @@ impl<T, A, VT: ViewSequence<T, A>> View<T, A> for TaffyLayout<T, A, VT> {
 
     fn build(&self, cx: &mut Cx) -> (Id, Self::State, Self::Element) {
         let mut elements = vec![];
-        let (id, state) = cx.with_new_id(|cx| self.children.build(cx, &mut elements));
+        let mut scratch = vec![];
+        let mut splice = VecSplice::new(&mut elements, &mut scratch);
+        let (id, state) = cx.with_new_id(|cx| self.children.build(cx, &mut splice));
         let column = widget::TaffyLayout::new(elements, self.style.clone(), self.background_color);
         (id, state, column)
     }

--- a/src/view/view.rs
+++ b/src/view/view.rs
@@ -24,7 +24,7 @@ use xilem_core::{Id, IdPath};
 use crate::widget::{AnyWidget, ChangeFlags, Pod, Widget};
 
 xilem_core::generate_view_trait! {View, Widget, Cx, ChangeFlags; : Send}
-xilem_core::generate_viewsequence_trait! {ViewSequence, View, ViewMarker, Widget, Cx, ChangeFlags, Pod; : Send}
+xilem_core::generate_viewsequence_trait! {ViewSequence, View, ViewMarker, ElementsSplice, Widget, Cx, ChangeFlags, Pod; : Send}
 xilem_core::generate_anyview_trait! {AnyView, View, ViewMarker, Cx, ChangeFlags, AnyWidget, BoxedView; + Send}
 xilem_core::generate_memoize_view! {Memoize, MemoizeState, View, ViewMarker, Cx, ChangeFlags, s, memoize; + Send}
 xilem_core::generate_adapt_view! {View, Cx, ChangeFlags; + Send}


### PR DESCRIPTION
This slightly changes the `ViewSequence` trait to take a trait `dyn ElementsSplice` instead of the `VecSplice`. Functionally (in xilem) this should result in the same. But it has the advantage to track diffing more precisely in `ViewSequence`s.
This is used in `xilem_web` to only update elements that actually have changed (instead of removing all elements and adding the rebuilt elements again).