### PR TITLE
Update vello and parley deps...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,24 +4,24 @@ version = 3
 
 [[package]]
 name = "accesskit"
-version = "0.11.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76eb1adf08c5bcaa8490b9851fd53cca27fa9880076f178ea9d29f05196728a8"
+checksum = "6cb10ed32c63247e4e39a8f42e8e30fb9442fbf7878c8e4a9849e7e381619bea"
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04bb4d9e4772fe0d47df57d0d5dbe5d85dd05e2f37ae1ddb6b105e76be58fb00"
+checksum = "8c17cca53c09fbd7288667b22a201274b9becaa27f0b91bf52a526db95de45e6"
 dependencies = [
  "accesskit",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d0acf6acb667c89d3332999b1a5df4edbc8d6113910f392ebb73f2b03bb56"
+checksum = "cd3b6ae1eabbfbced10e840fd3fce8a93ae84f174b3e4ba892ab7bcb42e477a7"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -31,15 +31,15 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.14.3"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eac0a7f2d7cd7a93b938af401d3d8e8b7094217989a7c25c55a953023436e31"
+checksum = "afcae27ec0974fc7c3b0b318783be89fd1b2e66dd702179fe600166a38ff4a0b"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "arrayvec",
  "once_cell",
  "paste",
+ "static_assertions",
  "windows 0.48.0",
 ]
 
@@ -198,7 +198,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "socket2",
+ "socket2 0.4.9",
  "waker-fn",
 ]
 
@@ -738,6 +738,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,11 +789,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "fello"
-version = "0.1.0"
-source = "git+https://github.com/dfrg/fount?rev=dadbcf75695f035ca46766bfd60555d05bd421b1#dadbcf75695f035ca46766bfd60555d05bd421b1"
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
- "read-fonts",
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
 ]
 
 [[package]]
@@ -798,9 +808,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "font-types"
-version = "0.3.4"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6978d65d61022aa249fefdd914dc8215757f617f1a697c496ef6b42013366567"
+checksum = "0bd7f3ea17572640b606b35df42cfb6ecdf003704b062580e59918692190b73d"
 
 [[package]]
 name = "foreign-types"
@@ -851,14 +861,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fount"
-version = "0.1.0"
-source = "git+https://github.com/jneem/fount?rev=361c76fecf813ebc64d2634d3df7bfb6089c6414#361c76fecf813ebc64d2634d3df7bfb6089c6414"
-dependencies = [
- "swash",
 ]
 
 [[package]]
@@ -1003,8 +1005,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1014,9 +1018,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glazier"
 version = "0.1.0"
-source = "git+https://github.com/linebender/glazier?rev=19a01ba8a97f15bf499ac64e6ea9690d7390deb5#19a01ba8a97f15bf499ac64e6ea9690d7390deb5"
+source = "git+https://github.com/linebender/glazier?rev=ec7e0c5fafd5c106c4c67831bc829572958c671c#ec7e0c5fafd5c106c4c67831bc829572958c671c"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -1033,7 +1048,7 @@ dependencies = [
  "instant",
  "js-sys",
  "keyboard-types",
- "kurbo 0.9.5",
+ "kurbo 0.10.4",
  "lazy_static",
  "memchr",
  "nix 0.25.1",
@@ -1105,14 +1120,23 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0fe580e4b60a8ab24a868bc08e2f03cbcb20d3d676601fa909386713333728"
+checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
 dependencies = [
  "js-sys",
  "slotmap",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
+dependencies = [
+ "gl_generator",
 ]
 
 [[package]]
@@ -1136,15 +1160,16 @@ dependencies = [
 
 [[package]]
 name = "gpu-allocator"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce95f9e2e11c2c6fadfce42b5af60005db06576f231f5c92550fdded43c423e8"
+checksum = "40fe17c8a05d60c38c0a4e5a3c802f2f1ceb66b76c67d96ffb34bef0475a7fad"
 dependencies = [
  "backtrace",
  "log",
+ "presser",
  "thiserror",
  "winapi",
- "windows 0.44.0",
+ "windows 0.51.1",
 ]
 
 [[package]]
@@ -1155,7 +1180,7 @@ checksum = "0b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a"
 dependencies = [
  "bitflags 1.3.2",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1191,6 +1216,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hassle-rs"
@@ -1257,7 +1288,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1321,14 +1362,20 @@ dependencies = [
 
 [[package]]
 name = "khronos-egl"
-version = "4.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.0",
  "pkg-config",
 ]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kurbo"
@@ -1372,9 +1419,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libloading"
@@ -1475,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623b5e6cefd76e58f774bd3cc0c6f5c7615c58c03a97815245a25c3c9bdee318"
+checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
 dependencies = [
  "bitflags 2.3.3",
  "block",
@@ -1505,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "wasi",
@@ -1516,15 +1563,15 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.13.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ceaaa4eedaece7e4ec08c55c640ba03dbb73fb812a6570a59bcf1930d0f70e"
+checksum = "ae585df4b6514cf8842ac0f1ab4992edc975892704835b549cf818dc0191249e"
 dependencies = [
  "bit-set",
  "bitflags 2.3.3",
  "codespan-reporting",
  "hexf-parse",
- "indexmap",
+ "indexmap 2.1.0",
  "log",
  "num-traits",
  "rustc-hash",
@@ -1532,6 +1579,15 @@ dependencies = [
  "termcolor",
  "thiserror",
  "unicode-xid",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1686,15 +1742,15 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "parley"
-version = "0.1.0"
-source = "git+https://github.com/dfrg/parley?rev=2371bf4b702ec91edee2d58ffb2d432539580e1e#2371bf4b702ec91edee2d58ffb2d432539580e1e"
+version = "0.0.1"
+source = "git+https://github.com/dfrg/parley?rev=432b35e4ea097fe4a21c1f4f63d2fd9e741ebf83#432b35e4ea097fe4a21c1f4f63d2fd9e741ebf83"
 dependencies = [
- "fount",
+ "peniko 0.1.0 (git+https://github.com/linebender/peniko?rev=8717635681dedfab3e9f3741fcbc7f3318a82ff0)",
  "swash",
 ]
 
@@ -1722,9 +1778,9 @@ dependencies = [
 [[package]]
 name = "peniko"
 version = "0.1.0"
-source = "git+https://github.com/linebender/peniko?rev=cafdac9a211a0fb2fec5656bd663d1ac770bcc81#cafdac9a211a0fb2fec5656bd663d1ac770bcc81"
+source = "git+https://github.com/linebender/peniko?rev=8717635681dedfab3e9f3741fcbc7f3318a82ff0#8717635681dedfab3e9f3741fcbc7f3318a82ff0"
 dependencies = [
- "kurbo 0.9.5",
+ "kurbo 0.10.4",
  "smallvec",
 ]
 
@@ -1736,9 +1792,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1773,6 +1829,12 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
@@ -1871,9 +1933,9 @@ checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "read-fonts"
-version = "0.10.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d08214643b2df95b0b3955cd9f264bcfab22b73470b83df4992df523b4d6eb"
+checksum = "7555e052e772f964a1c99f1434f6a2c3a47a5f8e4292236921f121a7753cb2b5"
 dependencies = [
  "font-types",
 ]
@@ -2052,6 +2114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "skrifa"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2a68d7915f596ffbf03d30a497a91e951d16b1cb340662ab441c4b58c84e05"
+dependencies = [
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2179,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spirv"
 version = "0.2.0+1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,7 +2232,8 @@ dependencies = [
 [[package]]
 name = "swash"
 version = "0.1.8"
-source = "git+https://github.com/dfrg/swash#56ea551ac49e51580c466f03d6c75252a8c8e700"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7c73c813353c347272919aa1af2885068b05e625e5532b43049e4f641ae77f"
 dependencies = [
  "yazi",
  "zeno",
@@ -2276,11 +2367,11 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -2288,16 +2379,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.5",
  "tokio-macros",
  "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2316,7 +2407,7 @@ version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "toml_datetime",
  "winnow",
 ]
@@ -2452,13 +2543,14 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 [[package]]
 name = "vello"
 version = "0.0.1"
-source = "git+https://github.com/linebender/vello?rev=9d7c4f00d8db420337706771a37937e9025e089c#9d7c4f00d8db420337706771a37937e9025e089c"
+source = "git+https://github.com/linebender/vello?rev=5fc234a3c296eac4c6858403d6b1891150d78866#5fc234a3c296eac4c6858403d6b1891150d78866"
 dependencies = [
  "bytemuck",
- "fello",
  "futures-intrusive",
- "peniko 0.1.0 (git+https://github.com/linebender/peniko?rev=cafdac9a211a0fb2fec5656bd663d1ac770bcc81)",
+ "kurbo 0.10.4",
+ "peniko 0.1.0 (git+https://github.com/linebender/peniko?rev=8717635681dedfab3e9f3741fcbc7f3318a82ff0)",
  "raw-window-handle",
+ "skrifa",
  "vello_encoding",
  "wgpu",
 ]
@@ -2466,12 +2558,12 @@ dependencies = [
 [[package]]
 name = "vello_encoding"
 version = "0.1.0"
-source = "git+https://github.com/linebender/vello?rev=9d7c4f00d8db420337706771a37937e9025e089c#9d7c4f00d8db420337706771a37937e9025e089c"
+source = "git+https://github.com/linebender/vello?rev=5fc234a3c296eac4c6858403d6b1891150d78866#5fc234a3c296eac4c6858403d6b1891150d78866"
 dependencies = [
  "bytemuck",
- "fello",
  "guillotiere",
- "peniko 0.1.0 (git+https://github.com/linebender/peniko?rev=cafdac9a211a0fb2fec5656bd663d1ac770bcc81)",
+ "peniko 0.1.0 (git+https://github.com/linebender/peniko?rev=8717635681dedfab3e9f3741fcbc7f3318a82ff0)",
+ "skrifa",
 ]
 
 [[package]]
@@ -2656,12 +2748,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7472f3b69449a8ae073f6ec41d05b6f846902d92a6c45313c50cb25857b736ce"
+checksum = "30e7d227c9f961f2061c26f4cb0fbd4df0ef37e056edd0931783599d6c94ef24"
 dependencies = [
  "arrayvec",
  "cfg-if",
+ "flume",
  "js-sys",
  "log",
  "naga",
@@ -2680,9 +2773,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecf7454d9386f602f7399225c92dd2fbdcde52c519bc8fb0bd6fbeb388075dc2"
+checksum = "ef91c1d62d1e9e81c79e600131a258edf75c9531cbdbde09c44a011a47312726"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -2703,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6654a13885a17f475e8324efb46dc6986d7aaaa98353330f8de2077b153d0101"
+checksum = "b84ecc802da3eb67b4cf3dd9ea6fe45bbb47ef13e6c49c5c3240868a9cc6cdd9"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -2716,6 +2809,7 @@ dependencies = [
  "core-graphics-types",
  "d3d12",
  "glow",
+ "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
@@ -2728,6 +2822,7 @@ dependencies = [
  "metal",
  "naga",
  "objc",
+ "once_cell",
  "parking_lot",
  "profiling",
  "range-alloc",
@@ -2744,9 +2839,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee64d7398d0c2f9ca48922c902ef69c42d000c759f3db41e355f4a570b052b67"
+checksum = "0d5ed5f0edf0de351fe311c53304986315ce866f394a2e6df0c4b3c70774bcdd"
 dependencies = [
  "bitflags 2.3.3",
  "js-sys",
@@ -2812,22 +2907,32 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-targets 0.48.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -2858,122 +2963,65 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
@@ -3064,6 +3112,12 @@ dependencies = [
  "web-sys",
  "xilem_core",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
 
 [[package]]
 name = "yazi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "parley"
 version = "0.0.1"
-source = "git+https://github.com/dfrg/parley?rev=432b35e4ea097fe4a21c1f4f63d2fd9e741ebf83#432b35e4ea097fe4a21c1f4f63d2fd9e741ebf83"
+source = "git+https://github.com/dfrg/parley?rev=cf41c3ff25ae0c9c48e96b59bc4ee41571a279b9#cf41c3ff25ae0c9c48e96b59bc4ee41571a279b9"
 dependencies = [
  "peniko 0.1.0 (git+https://github.com/linebender/peniko?rev=8717635681dedfab3e9f3741fcbc7f3318a82ff0)",
  "swash",
@@ -2543,7 +2543,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 [[package]]
 name = "vello"
 version = "0.0.1"
-source = "git+https://github.com/linebender/vello?rev=5fc234a3c296eac4c6858403d6b1891150d78866#5fc234a3c296eac4c6858403d6b1891150d78866"
+source = "git+https://github.com/linebender/vello?rev=944ce63d8ff40d01f3dbbb7be096feaf6c3657fa#944ce63d8ff40d01f3dbbb7be096feaf6c3657fa"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
@@ -2558,7 +2558,7 @@ dependencies = [
 [[package]]
 name = "vello_encoding"
 version = "0.1.0"
-source = "git+https://github.com/linebender/vello?rev=5fc234a3c296eac4c6858403d6b1891150d78866#5fc234a3c296eac4c6858403d6b1891150d78866"
+source = "git+https://github.com/linebender/vello?rev=944ce63d8ff40d01f3dbbb7be096feaf6c3657fa#944ce63d8ff40d01f3dbbb7be096feaf6c3657fa"
 dependencies = [
  "bytemuck",
  "guillotiere",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,19 +49,19 @@ taffy = ["dep:taffy"]
 [dependencies]
 xilem_core.workspace = true
 taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "7781c70241f7f572130c13106f2a869a9cf80885", optional = true }
-vello = { git = "https://github.com/linebender/vello", rev = "9d7c4f00d8db420337706771a37937e9025e089c" }
-wgpu = "0.17.0"
-parley = { git = "https://github.com/dfrg/parley", rev = "2371bf4b702ec91edee2d58ffb2d432539580e1e" }
-tokio = { version = "1.21", features = ["full"] }
+vello = { git = "https://github.com/linebender/vello", rev = "5fc234a3c296eac4c6858403d6b1891150d78866" }
+wgpu = "0.18.0"
+parley = { git = "https://github.com/dfrg/parley", rev = "432b35e4ea097fe4a21c1f4f63d2fd9e741ebf83" }
+tokio = { version = "1.35", features = ["full"] }
 futures-task = "0.3"
 bitflags = "2"
 tracing = "0.1.37"
-accesskit = "0.11"
+accesskit = "0.12"
 fnv = "1.0.7"
 
 [dependencies.glazier]
 git = "https://github.com/linebender/glazier"
-rev = "19a01ba8a97f15bf499ac64e6ea9690d7390deb5"
+rev = "ec7e0c5fafd5c106c4c67831bc829572958c671c"
 default-features = false
 features = ["accesskit"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,9 @@ taffy = ["dep:taffy"]
 [dependencies]
 xilem_core.workspace = true
 taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "7781c70241f7f572130c13106f2a869a9cf80885", optional = true }
-vello = { git = "https://github.com/linebender/vello", rev = "5fc234a3c296eac4c6858403d6b1891150d78866" }
+vello = { git = "https://github.com/linebender/vello", rev = "944ce63d8ff40d01f3dbbb7be096feaf6c3657fa" }
 wgpu = "0.18.0"
-parley = { git = "https://github.com/dfrg/parley", rev = "432b35e4ea097fe4a21c1f4f63d2fd9e741ebf83" }
+parley = { git = "https://github.com/dfrg/parley", rev = "cf41c3ff25ae0c9c48e96b59bc4ee41571a279b9" }
 tokio = { version = "1.35", features = ["full"] }
 futures-task = "0.3"
 bitflags = "2"

--- a/src/app.rs
+++ b/src/app.rs
@@ -198,7 +198,11 @@ where
     }
 
     pub fn accessibility(&mut self) -> TreeUpdate {
-        let mut update = TreeUpdate::default();
+        let mut update = TreeUpdate {
+            nodes: vec![],
+            tree: None,
+            focus: accesskit::NodeId(0),
+        };
         self.ensure_root();
         let root_pod = self.root_pod.as_mut().unwrap();
         let mut window_node_builder = accesskit::NodeBuilder::new(accesskit::Role::Window);

--- a/src/app_main.rs
+++ b/src/app_main.rs
@@ -23,7 +23,7 @@ use vello::{
     kurbo::{Affine, Size},
     peniko::Color,
     util::{RenderContext, RenderSurface},
-    RenderParams, Renderer, RendererOptions,
+    AaSupport, RenderParams, Renderer, RendererOptions,
 };
 use vello::{Scene, SceneBuilder};
 
@@ -230,15 +230,21 @@ where
             let queue = &self.render_cx.devices[dev_id].queue;
             let renderer_options = RendererOptions {
                 surface_format: Some(surface.format),
-                timestamp_period: queue.get_timestamp_period(),
+                use_cpu: false,
+                antialiasing_support: AaSupport {
+                    area: true,
+                    msaa8: false,
+                    msaa16: false,
+                },
             };
             let render_params = RenderParams {
                 base_color: Color::BLACK,
                 width,
                 height,
+                antialiasing_method: vello::AaConfig::Area,
             };
             self.renderer
-                .get_or_insert_with(|| Renderer::new(device, &renderer_options).unwrap())
+                .get_or_insert_with(|| Renderer::new(device, renderer_options).unwrap())
                 .render_to_surface(device, queue, &self.scene, &surface_texture, &render_params)
                 .expect("failed to render to surface");
             surface_texture.present();

--- a/src/id.rs
+++ b/src/id.rs
@@ -49,6 +49,6 @@ impl Id {
 
 impl From<Id> for accesskit::NodeId {
     fn from(id: Id) -> accesskit::NodeId {
-        id.to_nonzero_raw().into()
+        accesskit::NodeId(id.to_nonzero_raw().into())
     }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,24 +1,11 @@
 use parley::Layout;
-use vello::kurbo::Affine;
 use vello::{
-    glyph::{fello::raw::FontRef, GlyphContext},
-    peniko::{Brush, Color},
-    *,
+    kurbo::Affine,
+    peniko::{Brush, Fill},
+    SceneBuilder,
 };
 
-#[derive(Clone, PartialEq, Debug)]
-pub struct ParleyBrush(pub Brush);
-
-impl Default for ParleyBrush {
-    fn default() -> ParleyBrush {
-        ParleyBrush(Brush::Solid(Color::rgb8(0, 0, 0)))
-    }
-}
-
-impl parley::style::Brush for ParleyBrush {}
-
-pub fn render_text(builder: &mut SceneBuilder, transform: Affine, layout: &Layout<ParleyBrush>) {
-    let mut gcx = GlyphContext::new();
+pub fn render_text(builder: &mut SceneBuilder, transform: Affine, layout: &Layout<Brush>) {
     for line in layout.lines() {
         for glyph_run in line.glyph_runs() {
             let mut x = glyph_run.offset();
@@ -26,22 +13,32 @@ pub fn render_text(builder: &mut SceneBuilder, transform: Affine, layout: &Layou
             let run = glyph_run.run();
             let font = run.font();
             let font_size = run.font_size();
-            let font_ref = font.as_ref();
-            if let Ok(font_ref) = FontRef::from_index(font_ref.data, font.index()) {
-                let style = glyph_run.style();
-                let vars: [(&str, f32); 0] = [];
-                let mut gp = gcx.new_provider(&font_ref, None, font_size, false, vars);
-                for glyph in glyph_run.glyphs() {
-                    if let Some(fragment) = gp.get(glyph.id, Some(&style.brush.0)) {
+            let font = vello::peniko::Font::new(font.data().0.clone(), font.index());
+            let style = glyph_run.style();
+            let coords = run
+                .normalized_coords()
+                .iter()
+                .map(|coord| vello::skrifa::instance::NormalizedCoord::from_bits(*coord))
+                .collect::<Vec<_>>();
+            builder
+                .draw_glyphs(&font)
+                .brush(&style.brush)
+                .transform(transform)
+                .font_size(font_size)
+                .normalized_coords(&coords)
+                .draw(
+                    Fill::NonZero,
+                    glyph_run.glyphs().map(|glyph| {
                         let gx = x + glyph.x;
                         let gy = y - glyph.y;
-                        let xform = Affine::translate((gx as f64, gy as f64))
-                            * Affine::scale_non_uniform(1.0, -1.0);
-                        builder.append(&fragment, Some(transform * xform));
-                    }
-                    x += glyph.advance;
-                }
-            }
+                        x += glyph.advance;
+                        vello::glyph::Glyph {
+                            id: glyph.id as _,
+                            x: gx,
+                            y: gy,
+                        }
+                    }),
+                );
         }
     }
 }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -21,7 +21,7 @@ use vello::{
     SceneBuilder,
 };
 
-use crate::{text::ParleyBrush, IdPath, Message};
+use crate::{IdPath, Message};
 
 use super::{
     contexts::LifeCycleCx,
@@ -33,7 +33,7 @@ use super::{
 pub struct Button {
     id_path: IdPath,
     label: String,
-    layout: Option<Layout<ParleyBrush>>,
+    layout: Option<Layout<Brush>>,
 }
 
 impl Button {
@@ -96,8 +96,8 @@ impl Widget for Button {
         let mut lcx = parley::LayoutContext::new();
         let mut layout_builder = lcx.ranged_builder(cx.font_cx(), &self.label, 1.0);
 
-        layout_builder.push_default(&parley::style::StyleProperty::Brush(ParleyBrush(
-            Brush::Solid(Color::rgb8(0xf0, 0xf0, 0xea)),
+        layout_builder.push_default(&parley::style::StyleProperty::Brush(Brush::Solid(
+            Color::rgb8(0xf0, 0xf0, 0xea),
         )));
         let mut layout = layout_builder.build();
         // Question for Chad: is this needed?

--- a/src/widget/piet_scene_helpers.rs
+++ b/src/widget/piet_scene_helpers.rs
@@ -1,5 +1,5 @@
-use vello::kurbo::{self, Affine, Rect, Shape};
-use vello::peniko::{BrushRef, Color, ColorStopsSource, Fill, Gradient, Stroke};
+use vello::kurbo::{self, Affine, Rect, Shape, Stroke};
+use vello::peniko::{BrushRef, Color, ColorStopsSource, Fill, Gradient};
 use vello::SceneBuilder;
 
 #[derive(Debug, Clone, Copy)]
@@ -15,7 +15,7 @@ pub fn stroke<'b>(
     stroke_width: f64,
 ) {
     builder.stroke(
-        &Stroke::new(stroke_width as f32),
+        &Stroke::new(stroke_width),
         Affine::IDENTITY,
         brush,
         None,

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -46,9 +46,9 @@ impl TextWidget {
         if self.layout.is_none() {
             let mut lcx = parley::LayoutContext::new();
             let mut layout_builder = lcx.ranged_builder(font_cx, &self.text, 1.0);
-            layout_builder.push_default(&parley::style::StyleProperty::Brush(
-                Brush::Solid(Color::rgb8(255, 255, 255)),
-            ));
+            layout_builder.push_default(&parley::style::StyleProperty::Brush(Brush::Solid(
+                Color::rgb8(255, 255, 255),
+            )));
             self.layout = Some(layout_builder.build());
         }
 

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -20,8 +20,6 @@ use vello::{
     SceneBuilder,
 };
 
-use crate::text::ParleyBrush;
-
 use super::{
     contexts::LifeCycleCx, BoxConstraints, ChangeFlags, Event, EventCx, LayoutCx, LifeCycle,
     PaintCx, UpdateCx, Widget,
@@ -29,7 +27,7 @@ use super::{
 
 pub struct TextWidget {
     text: Cow<'static, str>,
-    layout: Option<Layout<ParleyBrush>>,
+    layout: Option<Layout<Brush>>,
 }
 
 impl TextWidget {
@@ -43,14 +41,14 @@ impl TextWidget {
         ChangeFlags::LAYOUT | ChangeFlags::PAINT
     }
 
-    fn get_layout_mut(&mut self, font_cx: &mut FontContext) -> &mut Layout<ParleyBrush> {
+    fn get_layout_mut(&mut self, font_cx: &mut FontContext) -> &mut Layout<Brush> {
         // Ensure Parley layout is initialised
         if self.layout.is_none() {
             let mut lcx = parley::LayoutContext::new();
             let mut layout_builder = lcx.ranged_builder(font_cx, &self.text, 1.0);
-            layout_builder.push_default(&parley::style::StyleProperty::Brush(ParleyBrush(
+            layout_builder.push_default(&parley::style::StyleProperty::Brush(
                 Brush::Solid(Color::rgb8(255, 255, 255)),
-            )));
+            ));
             self.layout = Some(layout_builder.build());
         }
 


### PR DESCRIPTION
... and everything else, apparently. This pushes the new font code changes through the ecosystem.

Brings everything into sync and should put us in a good place to start releasing.

This works as is but depends on a vello commit that is still under review: linebender/vello#425 should land first and this should be updated with the new git rev before merging.