### PR TITLE
Fix tree-structure tracking in `AnyView` and `ScrollView`

### DIFF
--- a/crates/xilem_core/src/any_view.rs
+++ b/crates/xilem_core/src/any_view.rs
@@ -70,6 +70,7 @@ macro_rules! generate_anyview_trait {
                         <$changeflags>::default()
                     }
                 } else {
+                    cx.delete_descendants();
                     let (new_id, new_state, new_element) = self.build(cx);
                     *id = new_id;
                     *state = Box::new(new_state);

--- a/crates/xilem_web/src/context.rs
+++ b/crates/xilem_web/src/context.rs
@@ -119,6 +119,10 @@ impl Cx {
         (id, state, Pod::new(element))
     }
 
+    /// This currently does nothing, it's only here for compatibility with `AnyView`
+    /// In the future this may track the tree-structure as well as in `xilem`
+    pub fn delete_descendants(&mut self) {}
+
     /// Run some logic within the context of a given Pod,
     ///
     /// This logic is usually `View::rebuild`

--- a/src/view/scroll_view.rs
+++ b/src/view/scroll_view.rs
@@ -44,15 +44,14 @@ impl<T, A, C: View<T, A>> View<T, A> for ScrollView<T, A, C>
 where
     C::Element: 'static,
 {
-    type State = (Id, C::State);
+    type State = C::State;
 
     type Element = crate::widget::ScrollView;
 
     fn build(&self, cx: &mut Cx) -> (Id, Self::State, Self::Element) {
-        let (id, (child_id, child_state, child_element)) =
-            cx.with_new_id(|cx| self.child.build(cx));
+        let (id, child_state, child_element) = cx.with_new_child_pod(|cx| self.child.build(cx));
         let element = crate::widget::ScrollView::new(child_element);
-        (id, (child_id, child_state), element)
+        (id, child_state, element)
     }
 
     fn rebuild(
@@ -63,10 +62,8 @@ where
         state: &mut Self::State,
         element: &mut Self::Element,
     ) -> ChangeFlags {
-        cx.with_id(*id, |cx| {
-            let child_element = element.child_mut().downcast_mut().unwrap();
-            self.child
-                .rebuild(cx, &prev.child, &mut state.0, &mut state.1, child_element)
+        cx.with_pod(element.child_mut(), |el, cx| {
+            self.child.rebuild(cx, &prev.child, id, state, el)
         })
     }
 
@@ -77,12 +74,6 @@ where
         message: Box<dyn Any>,
         app_state: &mut T,
     ) -> MessageResult<A> {
-        match id_path {
-            [child_id, rest_path @ ..] if *child_id == state.0 => {
-                self.child
-                    .message(rest_path, &mut state.1, message, app_state)
-            }
-            _ => MessageResult::Stale(message),
-        }
+        self.child.message(id_path, state, message, app_state)
     }
 }

--- a/src/view/tree_structure_tracking.rs
+++ b/src/view/tree_structure_tracking.rs
@@ -51,7 +51,7 @@ impl<'a, 'b> ElementsSplice for TreeStructureSplice<'a, 'b> {
     fn delete(&mut self, n: usize, cx: &mut Cx) {
         let ix = self.splice.len();
         cx.tree_structure
-            .delete_children(cx.element_id(), ix..ix + n);
+            .delete_descendants(cx.element_id(), ix..ix + n);
         self.splice.delete(n);
     }
 

--- a/src/view/view.rs
+++ b/src/view/view.rs
@@ -153,7 +153,7 @@ impl Cx {
     /// # Panics
     ///
     /// When it's not within a `Pod` context (via `Cx::with_pod` or `Cx::with_new_pod`)
-    /// This should never happen, since the app root already inits `Pod` context
+    /// This should never happen, since the app root already inits a `Pod` context
     pub fn with_new_child_pod<S, E, F>(&mut self, f: F) -> (Id, S, Pod)
     where
         E: Widget + 'static,
@@ -174,7 +174,7 @@ impl Cx {
     /// # Panics
     ///
     /// When it's not within a `Pod` context (via `Cx::with_pod` or `Cx::with_new_pod`)
-    /// This should never happen, since the app root already inits `Pod` context
+    /// This should never happen, since the app root already inits a `Pod` context
     pub fn delete_descendants(&mut self) {
         let cur_pod_id = *self.element_id_path.last().expect(
             "There's supposed to be at least one element id (the root),\

--- a/src/view/view.rs
+++ b/src/view/view.rs
@@ -149,6 +149,11 @@ impl Cx {
 
     /// Same as `Cx::with_new_pod` but additionally it tracks the tree-structure,
     /// i.e. It adds/appends a parent/child relation between the current element and the child pod
+    ///
+    /// # Panics
+    ///
+    /// When it's not within a `Pod` context (via `Cx::with_pod` or `Cx::with_new_pod`)
+    /// This should never happen, since the app root already inits `Pod` context
     pub fn with_new_child_pod<S, E, F>(&mut self, f: F) -> (Id, S, Pod)
     where
         E: Widget + 'static,
@@ -161,6 +166,21 @@ impl Cx {
         let (child_id, child_state, child_pod) = self.with_new_pod(|cx| f(cx));
         self.tree_structure.append_child(cur_pod_id, child_pod.id());
         (child_id, child_state, child_pod)
+    }
+
+    /// Deletes all descendants of the current element
+    /// This currently means only the tree-structure
+    ///
+    /// # Panics
+    ///
+    /// When it's not within a `Pod` context (via `Cx::with_pod` or `Cx::with_new_pod`)
+    /// This should never happen, since the app root already inits `Pod` context
+    pub fn delete_descendants(&mut self) {
+        let cur_pod_id = *self.element_id_path.last().expect(
+            "There's supposed to be at least one element id (the root),\
+             so this should never happen",
+        );
+        self.tree_structure.delete_descendants(cur_pod_id, ..);
     }
 
     pub fn waker(&self) -> Waker {

--- a/src/widget/scroll_view.rs
+++ b/src/widget/scroll_view.rs
@@ -17,7 +17,6 @@
 //! There's a lot more functionality in the Druid version, including
 //! control over scrolling axes, ability to scroll to content, etc.
 
-use crate::id::Id;
 use crate::Axis;
 use vello::kurbo::{Affine, Size, Vec2};
 use vello::peniko::Mix;
@@ -40,11 +39,8 @@ pub struct ScrollView {
 }
 
 impl ScrollView {
-    pub fn new(child: impl Widget + 'static) -> Self {
-        ScrollView {
-            child: Pod::new(child, Id::next()),
-            offset: 0.0,
-        }
+    pub fn new(child: Pod) -> Self {
+        ScrollView { child, offset: 0.0 }
     }
 
     pub fn child_mut(&mut self) -> &mut Pod {

--- a/src/widget/tree_structure.rs
+++ b/src/widget/tree_structure.rs
@@ -162,6 +162,7 @@ mod tests {
         assert_eq!(children, [child1]);
         assert_eq!(tree_structure.parent(child1), Some(parent));
         assert_eq!(tree_structure.parent.len(), 1);
+        assert_eq!(tree_structure.children.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
I just noticed, that the scroll-view wasn't tracking the tree-structure, this should fix that.

Additionally I've removed the new view-id creation, as it isn' t necessary (yet).

~~I think there's a few gotchas here, we have to find more robust solutions in the future, regarding tree-structure tracking (and other lifecycle stuff).
E.g. with this, the relation is leaked when the scroll-view is removed (e.g. because it's encapsulated in an `Box<dyn AnyView>` and there was a type change).
I think we need some kind of lifecycle for cleaning up views/widgets.~~

Within the ViewSequences this is done externally to the view via `ViewSequence::rebuild`.

Edit: This should now be handled within the `AnyView`.

So I think now all cases are handled correctly. 

This actually does a bit more now than just fixing the `ScrollView`: Fixing `AnyView` tree-structure tracking.