### PR TITLE
invert scroll direction on macos

### DIFF
--- a/src/app_main.rs
+++ b/src/app_main.rs
@@ -171,11 +171,11 @@ where
         self.app
             .window_event(Event::MouseWheel(self.main_pointer.wheel(match delta {
                 MouseScrollDelta::LineDelta(x, y) => {
-                    ScrollDelta::Lines(x.trunc() as isize, y.trunc() as isize)
+                    ScrollDelta::Lines(-x.trunc() as isize, -y.trunc() as isize)
                 }
-                MouseScrollDelta::PixelDelta(PhysicalPosition { x, y }) => {
-                    ScrollDelta::Precise(Vec2::new(x, y) * (1.0 / self.window.scale_factor()))
-                }
+                MouseScrollDelta::PixelDelta(PhysicalPosition { x, y }) => ScrollDelta::Precise(
+                    Vec2::new(-x, -y) * (1.0 / self.window.scale_factor()),
+                ),
             })));
         self.window.request_redraw();
     }

--- a/src/app_main.rs
+++ b/src/app_main.rs
@@ -173,9 +173,9 @@ where
                 MouseScrollDelta::LineDelta(x, y) => {
                     ScrollDelta::Lines(-x.trunc() as isize, -y.trunc() as isize)
                 }
-                MouseScrollDelta::PixelDelta(PhysicalPosition { x, y }) => ScrollDelta::Precise(
-                    Vec2::new(-x, -y) * (1.0 / self.window.scale_factor()),
-                ),
+                MouseScrollDelta::PixelDelta(PhysicalPosition { x, y }) => {
+                    ScrollDelta::Precise(Vec2::new(-x, -y) * (1.0 / self.window.scale_factor()))
+                }
             })));
         self.window.request_redraw();
     }

--- a/src/widget/scroll_view.rs
+++ b/src/widget/scroll_view.rs
@@ -95,13 +95,7 @@ impl Widget for ScrollView {
                     None => 0.0,
                 };
 
-                #[cfg(not(target_os = "macos"))]
-                let direction = 1.0;
-
-                #[cfg(target_os = "macos")]
-                let direction = -1.0;
-
-                let new_offset = (self.offset + y_delta * direction).max(0.0).min(max_offset);
+                let new_offset = (self.offset + y_delta).max(0.0).min(dbg!(max_offset));
                 if new_offset != self.offset {
                     self.offset = new_offset;
                     cx.set_handled(true);

--- a/src/widget/scroll_view.rs
+++ b/src/widget/scroll_view.rs
@@ -94,7 +94,14 @@ impl Widget for ScrollView {
                     Some(ScrollDelta::Lines(_, y)) => -y as f64 * LINE_HEIGHT,
                     None => 0.0,
                 };
-                let new_offset = (self.offset + y_delta).max(0.0).min(max_offset);
+
+                #[cfg(not(target_os = "macos"))]
+                let direction = 1.0;
+
+                #[cfg(target_os = "macos")]
+                let direction = -1.0;
+
+                let new_offset = (self.offset + y_delta * direction).max(0.0).min(max_offset);
                 if new_offset != self.offset {
                     self.offset = new_offset;
                     cx.set_handled(true);


### PR DESCRIPTION
The current scroll direction is the opposite of what mac users expect, so this PR inverts it when `target_os = "macos"`.