### PR TITLE
clippy: Configure via `lints` table in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ license = "Apache-2.0"
 xilem_core = { version = "0.1.0", path = "crates/xilem_core" }
 kurbo = "0.11.0"
 
+[workspace.lints]
+clippy.semicolon_if_nothing_returned = "warn"
+
 [package]
 name = "xilem"
 version = "0.1.0"
@@ -38,6 +41,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
 # rustdoc-scrape-examples tracking issue https://github.com/rust-lang/rust/issues/88791
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+
+[lints]
+workspace = true
 
 [features]
 default = ["x11", "taffy"]

--- a/crates/xilem_core/Cargo.toml
+++ b/crates/xilem_core/Cargo.toml
@@ -17,4 +17,7 @@ default-target = "x86_64-pc-windows-msvc"
 # rustdoc-scrape-examples tracking issue https://github.com/rust-lang/rust/issues/88791
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
+[lints]
+workspace = true
+
 [dependencies]

--- a/crates/xilem_web/Cargo.toml
+++ b/crates/xilem_web/Cargo.toml
@@ -17,6 +17,9 @@ default-target = "x86_64-pc-windows-msvc"
 # rustdoc-scrape-examples tracking issue https://github.com/rust-lang/rust/issues/88791
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
+[lints]
+workspace = true
+
 [dependencies]
 xilem_core.workspace = true
 kurbo.workspace = true

--- a/crates/xilem_web/web_examples/counter/Cargo.toml
+++ b/crates/xilem_web/web_examples/counter/Cargo.toml
@@ -5,6 +5,9 @@ publish = false
 license.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 console_error_panic_hook = "0.1"
 wasm-bindgen = "0.2.87"

--- a/crates/xilem_web/web_examples/counter_custom_element/Cargo.toml
+++ b/crates/xilem_web/web_examples/counter_custom_element/Cargo.toml
@@ -5,6 +5,9 @@ publish = false
 license.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 console_error_panic_hook = "0.1"
 wasm-bindgen = "0.2.87"

--- a/crates/xilem_web/web_examples/mathml_svg/Cargo.toml
+++ b/crates/xilem_web/web_examples/mathml_svg/Cargo.toml
@@ -5,6 +5,9 @@ publish = false
 license.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 console_error_panic_hook = "0.1"
 wasm-bindgen = "0.2.87"

--- a/crates/xilem_web/web_examples/svgtoy/Cargo.toml
+++ b/crates/xilem_web/web_examples/svgtoy/Cargo.toml
@@ -5,6 +5,9 @@ publish = false
 license.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 console_error_panic_hook = "0.1"
 wasm-bindgen = "0.2.87"

--- a/crates/xilem_web/web_examples/todomvc/Cargo.toml
+++ b/crates/xilem_web/web_examples/todomvc/Cargo.toml
@@ -5,6 +5,9 @@ publish = false
 license.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 console_error_panic_hook = "0.1.7"
 serde = { version = "1.0.170", features = ["derive"] }


### PR DESCRIPTION
As of Rust 1.74, lints can be configured within the `Cargo.toml` which allows us to not have to configure them in the source code as well as simplifying having a single configuration across an entire workspace.

This is documented at: https://doc.rust-lang.org/nightly/cargo/reference/manifest.html#the-lints-section