### PR TITLE
Mark pod correctly for view sequence

### DIFF
--- a/crates/xilem_core/src/sequence.rs
+++ b/crates/xilem_core/src/sequence.rs
@@ -173,7 +173,7 @@ macro_rules! generate_viewsequence_trait {
                         el,
                     )
                 });
-                elements.mark(flags, cx)
+                pod.mark(flags)
             }
 
             fn message(


### PR DESCRIPTION
From what I can tell only the last pod in a view sequence was correctly marked when `ChangeFlags::Paint` was requested. This should mark the correct pod and not just the last one.