### PR TITLE
Fix peek in `VecSplice`

### DIFF
--- a/crates/xilem_core/src/sequence.rs
+++ b/crates/xilem_core/src/sequence.rs
@@ -91,7 +91,7 @@ macro_rules! generate_viewsequence_trait {
 
             fn mark(&mut self, changeflags: $changeflags, _cx: &mut $cx) -> $changeflags
             {
-                self.peek_mut().map(|pod| pod.mark(changeflags)).unwrap_or_default()
+                self.last_mutated_mut().map(|pod| pod.mark(changeflags)).unwrap_or_default()
             }
 
             fn delete(&mut self, n: usize, _cx: &mut $cx) {

--- a/crates/xilem_core/src/vec_splice.rs
+++ b/crates/xilem_core/src/vec_splice.rs
@@ -51,11 +51,11 @@ impl<'a, 'b, T> VecSplice<'a, 'b, T> {
     }
 
     pub fn peek(&self) -> Option<&T> {
-        self.v.last()
+        self.v.get(self.ix)
     }
 
     pub fn peek_mut(&mut self) -> Option<&mut T> {
-        self.v.last_mut()
+        self.v.get_mut(self.ix)
     }
 
     pub fn len(&self) -> usize {

--- a/crates/xilem_core/src/vec_splice.rs
+++ b/crates/xilem_core/src/vec_splice.rs
@@ -50,12 +50,20 @@ impl<'a, 'b, T> VecSplice<'a, 'b, T> {
         &mut self.v[ix]
     }
 
-    pub fn peek(&self) -> Option<&T> {
-        self.v.get(self.ix)
+    pub fn last_mutated(&self) -> Option<&T> {
+        if self.ix == 0 {
+            None
+        } else {
+            self.v.get(self.ix - 1)
+        }
     }
 
-    pub fn peek_mut(&mut self) -> Option<&mut T> {
-        self.v.get_mut(self.ix)
+    pub fn last_mutated_mut(&mut self) -> Option<&mut T> {
+        if self.ix == 0 {
+            None
+        } else {
+            self.v.get_mut(self.ix - 1)
+        }
     }
 
     pub fn len(&self) -> usize {

--- a/crates/xilem_web/src/elements.rs
+++ b/crates/xilem_web/src/elements.rs
@@ -123,7 +123,7 @@ impl<'a, 'b, 'c> ElementsSplice for ChildrenSplice<'a, 'b, 'c> {
                 self.node_list = Some(self.parent.child_nodes());
                 self.node_list.as_ref().unwrap()
             };
-            let cur_child = self.children.peek_mut().unwrap_throw();
+            let cur_child = self.children.last_mutated_mut().unwrap_throw();
             let old_child = node_list.get(self.child_idx).unwrap_throw();
             self.parent
                 .replace_child(cur_child.0.as_node_ref(), &old_child)

--- a/src/view/tree_structure_tracking.rs
+++ b/src/view/tree_structure_tracking.rs
@@ -38,7 +38,7 @@ impl<'a, 'b> ElementsSplice for TreeStructureSplice<'a, 'b> {
     fn mark(&mut self, changeflags: ChangeFlags, cx: &mut Cx) -> ChangeFlags {
         if changeflags.contains(ChangeFlags::tree_structure()) {
             let current_id = self.current_child_id.take().unwrap();
-            let new_id = self.splice.peek().unwrap().id();
+            let new_id = self.splice.last_mutated().unwrap().id();
             if current_id != new_id {
                 cx.tree_structure
                     .change_child(cx.element_id(), self.splice.len() - 1, new_id);


### PR DESCRIPTION
Fixes #186 

`v` in `VecSplice` can be the original vector, while `ix` is still pointing to the first element, this should fix that. (`peek` and `peek_mut` should point to the current `ix` element)