### PR TITLE
xilem_web: Support arrays (`impl IntoClasses for [impl IntoClasses; N]`) as classes

### DIFF
--- a/crates/xilem_web/src/class.rs
+++ b/crates/xilem_web/src/class.rs
@@ -52,6 +52,14 @@ where
     }
 }
 
+impl<T: IntoClasses, const N: usize> IntoClasses for [T; N] {
+    fn into_classes(self, classes: &mut Vec<Cow<'static, str>>) {
+        for itm in self {
+            itm.into_classes(classes);
+        }
+    }
+}
+
 macro_rules! impl_tuple_intoclasses {
     ($($name:ident : $type:ident),* $(,)?) => {
         impl<$($type),*> IntoClasses for ($($type,)*)


### PR DESCRIPTION
Should allow `el.class(["class1", "class2"])`, as something like `el.class("class1 class2")` doesn't seem to be allowed (probably worth adding more documentation at some time soon).