### PR TITLE
parley: Use via workspace dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,19 +513,6 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core-graphics"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-graphics-types",
- "foreign-types 0.3.2",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
@@ -533,7 +520,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -550,25 +537,13 @@ dependencies = [
 
 [[package]]
 name = "core-text"
-version = "19.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
-dependencies = [
- "core-foundation",
- "core-graphics 0.22.3",
- "foreign-types 0.3.2",
- "libc",
-]
-
-[[package]]
-name = "core-text"
 version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
 dependencies = [
  "core-foundation",
- "core-graphics 0.23.1",
- "foreign-types 0.5.0",
+ "core-graphics",
+ "foreign-types",
  "libc",
 ]
 
@@ -832,21 +807,12 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -859,12 +825,6 @@ dependencies = [
  "quote",
  "syn 2.0.57",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1471,7 +1431,7 @@ dependencies = [
  "kurbo",
  "once_cell",
  "open",
- "parley 0.0.1 (git+https://github.com/linebender/parley?rev=4f05e183be9b388c6748d3c531c9ac332672fb86)",
+ "parley",
  "pollster",
  "pulldown-cmark",
  "serde",
@@ -1530,7 +1490,7 @@ dependencies = [
  "bitflags 2.5.0",
  "block",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "log",
  "objc",
  "paste",
@@ -1758,40 +1718,13 @@ dependencies = [
 [[package]]
 name = "parley"
 version = "0.0.1"
-source = "git+https://github.com/dfrg/parley?rev=4e6109f2ff5847a72dc77971b6fa0942b8474d88#4e6109f2ff5847a72dc77971b6fa0942b8474d88"
-dependencies = [
- "anyhow",
- "bytemuck",
- "core-foundation",
- "core-foundation-sys",
- "core-text 19.2.0",
- "dwrote",
- "fontconfig-cache-parser",
- "foreign-types 0.3.2",
- "hashbrown",
- "icu_locid",
- "icu_properties",
- "memmap2 0.5.10",
- "peniko",
- "roxmltree",
- "skrifa 0.19.0",
- "smallvec",
- "swash",
- "thiserror",
- "winapi",
- "wio",
-]
-
-[[package]]
-name = "parley"
-version = "0.0.1"
 source = "git+https://github.com/linebender/parley?rev=4f05e183be9b388c6748d3c531c9ac332672fb86#4f05e183be9b388c6748d3c531c9ac332672fb86"
 dependencies = [
  "anyhow",
  "bytemuck",
  "core-foundation",
  "core-foundation-sys",
- "core-text 20.1.0",
+ "core-text",
  "dwrote",
  "fontconfig-cache-parser",
  "hashbrown",
@@ -3295,7 +3228,7 @@ dependencies = [
  "calloop",
  "cfg_aliases",
  "core-foundation",
- "core-graphics 0.23.1",
+ "core-graphics",
  "cursor-icon",
  "icrate",
  "js-sys",
@@ -3400,7 +3333,7 @@ dependencies = [
  "fnv",
  "futures-task",
  "instant",
- "parley 0.0.1 (git+https://github.com/dfrg/parley?rev=4e6109f2ff5847a72dc77971b6fa0942b8474d88)",
+ "parley",
  "taffy",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ xilem_core = { version = "0.1.0", path = "crates/xilem_core" }
 masonry = { version = "0.1.0", path = "crates/masonry" }
 kurbo = "0.11.0"
 winit = { version = "0.29", features = ["rwh_05"] }
+parley = { git = "https://github.com/linebender/parley", rev = "4f05e183be9b388c6748d3c531c9ac332672fb86" }
 vello = { git = "https://github.com/linebender/vello/", rev = "b520a35addfa6bbb37d93491d2b8236528faf3b5" }
 
 [workspace.lints]
@@ -62,7 +63,7 @@ xilem_core.workspace = true
 taffy = { version = "0.4.0", optional = true }
 vello = "0.1.0"
 wgpu = "0.19.3"
-parley = { git = "https://github.com/dfrg/parley", rev = "4e6109f2ff5847a72dc77971b6fa0942b8474d88" }
+parley.workspace = true
 tokio = { version = "1.35", features = ["full"] }
 futures-task = "0.3"
 bitflags = "2"

--- a/crates/masonry/Cargo.toml
+++ b/crates/masonry/Cargo.toml
@@ -32,7 +32,7 @@ vello.workspace = true
 kurbo = "0.11.0"
 futures-intrusive = "0.5.0"
 pollster = "0.3.0"
-parley = { git = "https://github.com/linebender/parley", rev = "4f05e183be9b388c6748d3c531c9ac332672fb86" }
+parley.workspace = true
 wgpu = { version = "0.19.3" }
 swash = "0.1.15"
 winit.workspace = true


### PR DESCRIPTION
This will help us keep everyone using the same version. This also makes both `xilem` and `masonry` use the same version now.