### PR TITLE
masonry: Use workspace lint config.

### DIFF
--- a/crates/masonry/.cargo/config.toml
+++ b/crates/masonry/.cargo/config.toml
@@ -1,9 +1,0 @@
-[target.'cfg(all())']
-# TODO - Replace with Cargo.toml config
-rustflags = [
-    # Global lints/warnings.
-    # We do this here instead of in the crate root because we want to apply
-    # these to example and test targets as well.
-    "-Aclippy::single_match",
-    "-Aclippy::bool_assert_comparison",
-]

--- a/crates/masonry/Cargo.toml
+++ b/crates/masonry/Cargo.toml
@@ -14,6 +14,9 @@ version = "0.1.3"
 [profile.dev.package."*"]
 opt-level = 2
 
+[lints]
+workspace = true
+
 # NOTE: Make sure to keep wgpu version in sync with the version badge in README.md
 [dependencies]
 fnv = "1.0.7"


### PR DESCRIPTION
This replaces the old lint configuration in a cargo config with the workspace lint configuration in the Cargo.toml.

The old lint configuration was for tests, which don't currently trigger those lints, so we don't need to supply this configuration elsewhere. (The library has its own lint configuration that supplements this in `src/lib.rs` which can be improved later.)