### PR TITLE
masonry: Remove profile from non-root Cargo.toml.

### DIFF
--- a/crates/masonry/Cargo.toml
+++ b/crates/masonry/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/PoignardAzur/masonry-rs"
 rust-version = "1.75"
 version = "0.1.3"
 
-[profile.dev.package."*"]
-opt-level = 2
-
 [lints]
 workspace = true
 


### PR DESCRIPTION
This is generating a warning every time you build about it being here and that it will be ignored:

```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /.../xilem/crates/masonry/Cargo.toml
workspace: /.../xilem/Cargo.toml
```
