### PR TITLE
Add `View::State` and `IdPath` to `xilem_masonry`

### DIFF
--- a/crates/xilem_masonry/src/any_view.rs
+++ b/crates/xilem_masonry/src/any_view.rs
@@ -19,109 +19,129 @@ use crate::{ChangeFlags, MasonryView, MessageResult, ViewCx, ViewId};
 /// Note that `Option` can also be used for conditionally displaying
 /// views in a [`ViewSequence`](crate::ViewSequence).
 // TODO: Mention `Either` when we have implemented that?
-pub type BoxedMasonryView<T, A = ()> = Box<dyn AnyMasonryView<T, A>>;
+pub type BoxedMasonryView<AppState, Action = ()> = Box<dyn AnyMasonryView<AppState, Action>>;
 
 impl<T: 'static, A: 'static> MasonryView<T, A> for BoxedMasonryView<T, A> {
+    type State = Box<dyn std::any::Any>;
     type Element = DynWidget;
 
-    fn build(&self, cx: &mut ViewCx) -> masonry::WidgetPod<Self::Element> {
+    fn build(&self, cx: &mut ViewCx) -> (ViewId, Self::State, masonry::WidgetPod<Self::Element>) {
         self.deref().dyn_build(cx)
-    }
-
-    fn message(
-        &self,
-        id_path: &[ViewId],
-        message: Box<dyn std::any::Any>,
-        app_state: &mut T,
-    ) -> crate::MessageResult<A> {
-        self.deref().dyn_message(id_path, message, app_state)
     }
 
     fn rebuild(
         &self,
         cx: &mut ViewCx,
         prev: &Self,
-        // _id: &mut Id,
+        id: &mut ViewId,
+        state: &mut Self::State,
         element: masonry::widget::WidgetMut<Self::Element>,
     ) -> ChangeFlags {
-        self.deref().dyn_rebuild(cx, prev, element)
+        self.deref().dyn_rebuild(cx, prev, id, state, element)
+    }
+
+    fn message(
+        &self,
+        id_path: &[ViewId],
+        state: &mut Self::State,
+        message: Box<dyn std::any::Any>,
+        app_state: &mut T,
+    ) -> crate::MessageResult<A> {
+        self.deref().dyn_message(id_path, state, message, app_state)
     }
 }
 
 /// A trait enabling type erasure of views.
-pub trait AnyMasonryView<T, A = ()>: Send {
+pub trait AnyMasonryView<AppState, Action = ()>: Send {
     fn as_any(&self) -> &dyn std::any::Any;
 
-    fn dyn_build(&self, cx: &mut ViewCx) -> WidgetPod<DynWidget>;
+    fn dyn_build(&self, cx: &mut ViewCx) -> (ViewId, Box<dyn std::any::Any>, WidgetPod<DynWidget>);
 
     fn dyn_rebuild(
         &self,
         cx: &mut ViewCx,
-        prev: &dyn AnyMasonryView<T, A>,
+        prev: &dyn AnyMasonryView<AppState, Action>,
+        id: &mut ViewId,
+        state: &mut Box<dyn std::any::Any>,
         element: WidgetMut<DynWidget>,
     ) -> ChangeFlags;
 
     fn dyn_message(
         &self,
         id_path: &[ViewId],
+        state: &mut Box<dyn std::any::Any>,
         message: Box<dyn std::any::Any>,
-        app_state: &mut T,
-    ) -> MessageResult<A>;
+        app_state: &mut AppState,
+    ) -> MessageResult<Action>;
 }
 
-impl<T, A, V: MasonryView<T, A> + 'static> AnyMasonryView<T, A> for V {
+impl<AppState, Action, View> AnyMasonryView<AppState, Action> for View
+where
+    View: MasonryView<AppState, Action> + 'static,
+    View::State: 'static,
+{
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
 
-    fn dyn_build(&self, cx: &mut ViewCx) -> WidgetPod<DynWidget> {
-        let gen_1 = NonZeroU64::new(1).unwrap();
-        let element = cx.with_id(ViewId::for_type::<V>(gen_1), |cx| self.build(cx));
-        WidgetPod::new(DynWidget {
+    fn dyn_build(&self, cx: &mut ViewCx) -> (ViewId, Box<dyn std::any::Any>, WidgetPod<DynWidget>) {
+        let (id, state, element) = self.build(cx);
+        let pod = WidgetPod::new(DynWidget {
             inner: element.boxed(),
-            generation: gen_1.checked_add(1).unwrap(),
-        })
+            generation: NonZeroU64::new(1).unwrap(),
+        });
+
+        (id, Box::new(state), pod)
     }
 
     fn dyn_rebuild(
         &self,
         cx: &mut ViewCx,
-        prev: &dyn AnyMasonryView<T, A>,
+        prev: &dyn AnyMasonryView<AppState, Action>,
+        id: &mut ViewId,
+        state: &mut Box<dyn std::any::Any>,
         mut element: WidgetMut<DynWidget>,
     ) -> ChangeFlags {
         // TODO: Does this need to have a custom view id to enable events sent
         // to an outdated view path to be caught and returned?
         // Should we store this generation in `element`? Seems plausible
         if let Some(prev) = prev.as_any().downcast_ref() {
-            let generation = element.generation();
-            // If we were previously of this type, then do a normal rebuild
-            element.downcast(|element| {
-                if let Some(element) = element {
-                    cx.with_id(ViewId::for_type::<V>(generation), move |cx| {
-                        self.rebuild(cx, prev, element)
-                    })
-                } else {
-                    eprintln!("downcast of element failed in dyn_rebuild");
-                    ChangeFlags::UNCHANGED
-                }
-            })
+            if let Some(state) = state.downcast_mut() {
+                // If we were previously of this type, then do a normal rebuild
+                element.downcast(|element| {
+                    if let Some(element) = element {
+                        self.rebuild(cx, prev, id, state, element)
+                    } else {
+                        tracing::error!("downcast of state failed in dyn_rebuild");
+                        ChangeFlags::UNCHANGED
+                    }
+                })
+            } else {
+                tracing::error!("downcast of element failed in dyn_rebuild");
+                ChangeFlags::UNCHANGED
+            }
         } else {
-            // Otherwise, replace the element
-            let next_gen = element.next_generation();
-            let new_element = cx.with_id(ViewId::for_type::<V>(next_gen), |cx| self.build(cx));
+            let (new_id, new_state, new_element) = self.build(cx);
+            *id = new_id;
+            *state = Box::new(new_state);
             element.replace_inner(new_element.boxed());
-            ChangeFlags::CHANGED
+            ChangeFlags::CHANGED // Tree structure
         }
     }
 
     fn dyn_message(
         &self,
         id_path: &[ViewId],
+        state: &mut Box<dyn std::any::Any>,
         message: Box<dyn std::any::Any>,
-        app_state: &mut T,
-    ) -> MessageResult<A> {
-        // TODO: Validate this id
-        self.message(id_path.split_first().unwrap().1, message, app_state)
+        app_state: &mut AppState,
+    ) -> MessageResult<Action> {
+        if let Some(state) = state.downcast_mut() {
+            self.message(id_path, state, message, app_state)
+        } else {
+            tracing::error!("downcast of state failed in dyn_message");
+            MessageResult::Stale(message)
+        }
     }
 }
 

--- a/crates/xilem_masonry/src/id.rs
+++ b/crates/xilem_masonry/src/id.rs
@@ -1,26 +1,29 @@
 use std::{fmt::Debug, num::NonZeroU64};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ViewId {
-    routing_id: NonZeroU64,
+    id: NonZeroU64,
     debug: &'static str,
 }
 
 impl ViewId {
-    pub fn for_type<T: 'static>(raw: NonZeroU64) -> Self {
+    pub fn next_with_type<T: 'static>() -> Self {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+        // Note: we can make the safety argument for the unchecked version.
         Self {
+            id: (NonZeroU64::new(ID_COUNTER.fetch_add(1, Ordering::Relaxed)).unwrap()),
             debug: std::any::type_name::<T>(),
-            routing_id: raw,
         }
     }
 
-    pub fn routing_id(self) -> NonZeroU64 {
-        self.routing_id
+    pub fn id(self) -> NonZeroU64 {
+        self.id
     }
 }
 
 impl Debug for ViewId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}@[{}]", self.routing_id, self.debug)
+        write!(f, "{}@[{}]", self.id, self.debug)
     }
 }


### PR DESCRIPTION
Draft, to avoid (further) duplicate work.

Basically adds `View::State` back to `xilem_masonry` and the id path, similar to how it was done before (i.e. distinct ids, which may be relevant for a robust async context).

This is not yet 100% done (issues with changing `AnyView` currently).

Also renames the generic params `State` and `T` to `AppState` for clear distinction to `View::State`