### PR TITLE
xilem_masonry: Robust generational indexing for `ViewSequence`

### DIFF
--- a/crates/xilem_masonry/examples/mason.rs
+++ b/crates/xilem_masonry/examples/mason.rs
@@ -38,7 +38,7 @@ fn toggleable(data: &mut AppData) -> impl MasonryView<AppData> {
             }),
         )))
     } else {
-        Box::new(button("Activate", |data: &mut AppData| data.active = true))
+        Box::new(button("Activate", |data: &mut AppData| data.active = false))
     };
     inner_view
 }

--- a/crates/xilem_masonry/examples/mason.rs
+++ b/crates/xilem_masonry/examples/mason.rs
@@ -38,7 +38,7 @@ fn toggleable(data: &mut AppData) -> impl MasonryView<AppData> {
             }),
         )))
     } else {
-        Box::new(button("Activate", |data: &mut AppData| data.active = false))
+        Box::new(button("Activate", |data: &mut AppData| data.active = true))
     };
     inner_view
 }

--- a/crates/xilem_masonry/src/any_view.rs
+++ b/crates/xilem_masonry/src/any_view.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, num::NonZeroU64, ops::Deref};
+use std::{any::Any, ops::Deref};
 
 use masonry::{
     declare_widget,
@@ -23,10 +23,21 @@ pub type BoxedMasonryView<T, A = ()> = Box<dyn AnyMasonryView<T, A>>;
 
 impl<T: 'static, A: 'static> MasonryView<T, A> for BoxedMasonryView<T, A> {
     type Element = DynWidget;
-    type ViewState = Box<dyn Any>;
+    type ViewState = AnyViewState;
 
     fn build(&self, cx: &mut ViewCx) -> (masonry::WidgetPod<Self::Element>, Self::ViewState) {
         self.deref().dyn_build(cx)
+    }
+
+    fn message(
+        &self,
+        view_state: &mut Self::ViewState,
+        id_path: &[ViewId],
+        message: Box<dyn std::any::Any>,
+        app_state: &mut T,
+    ) -> crate::MessageResult<A> {
+        self.deref()
+            .dyn_message(view_state, id_path, message, app_state)
     }
 
     fn rebuild(
@@ -37,28 +48,24 @@ impl<T: 'static, A: 'static> MasonryView<T, A> for BoxedMasonryView<T, A> {
         // _id: &mut Id,
         element: masonry::widget::WidgetMut<Self::Element>,
     ) -> ChangeFlags {
-        self.deref().dyn_rebuild(cx, prev.deref(), element)
+        self.deref().dyn_rebuild(view_state, cx, prev.deref(), element)
     }
+}
 
-    fn message(
-        &self,
-        view_state: &mut Self::ViewState,
-        id_path: &[ViewId],
-        message: Box<dyn std::any::Any>,
-        app_state: &mut T,
-    ) -> crate::MessageResult<A> {
-        self.deref().dyn_message(id_path, message, app_state)
-    }
+pub struct AnyViewState {
+    inner_state: Box<dyn Any>,
+    generation: u64,
 }
 
 /// A trait enabling type erasure of views.
 pub trait AnyMasonryView<T, A = ()>: Send {
     fn as_any(&self) -> &dyn std::any::Any;
 
-    fn dyn_build(&self, cx: &mut ViewCx) -> (WidgetPod<DynWidget>, Box<dyn std::any::Any>);
+    fn dyn_build(&self, cx: &mut ViewCx) -> (WidgetPod<DynWidget>, AnyViewState);
 
     fn dyn_rebuild(
         &self,
+        dyn_state: &mut AnyViewState,
         cx: &mut ViewCx,
         prev: &dyn AnyMasonryView<T, A>,
         element: WidgetMut<DynWidget>,
@@ -66,6 +73,7 @@ pub trait AnyMasonryView<T, A = ()>: Send {
 
     fn dyn_message(
         &self,
+        dyn_state: &mut AnyViewState,
         id_path: &[ViewId],
         message: Box<dyn std::any::Any>,
         app_state: &mut T,
@@ -80,20 +88,24 @@ where
         self
     }
 
-    fn dyn_build(&self, cx: &mut ViewCx) -> (masonry::WidgetPod<DynWidget>, Box<dyn Any>) {
-        let gen_1 = NonZeroU64::new(1).unwrap();
-        let (element, view_state) = cx.with_id(ViewId::for_type::<V>(gen_1), |cx| self.build(cx));
+    fn dyn_build(&self, cx: &mut ViewCx) -> (masonry::WidgetPod<DynWidget>, AnyViewState) {
+        let generation = 0;
+        let (element, view_state) =
+            cx.with_id(ViewId::for_type::<V>(generation), |cx| self.build(cx));
         (
             WidgetPod::new(DynWidget {
                 inner: element.boxed(),
-                generation: gen_1.checked_add(1).unwrap(),
             }),
-            Box::new(view_state),
+            AnyViewState {
+                inner_state: Box::new(view_state),
+                generation,
+            },
         )
     }
 
     fn dyn_rebuild(
         &self,
+        dyn_state: &mut AnyViewState,
         cx: &mut ViewCx,
         prev: &dyn AnyMasonryView<T, A>,
         mut element: WidgetMut<DynWidget>,
@@ -102,13 +114,17 @@ where
         // to an outdated view path to be caught and returned?
         // Should we store this generation in `element`? Seems plausible
         if let Some(prev) = prev.as_any().downcast_ref() {
-            let generation = element.generation();
             // If we were previously of this type, then do a normal rebuild
             element.downcast(|element| {
                 if let Some(element) = element {
-                    cx.with_id(ViewId::for_type::<V>(generation), move |cx| {
-                        self.rebuild(todo!("DJMcNab"), cx, prev, element)
-                    })
+                    if let Some(state) = dyn_state.inner_state.downcast_mut() {
+                        cx.with_id(ViewId::for_type::<V>(dyn_state.generation), move |cx| {
+                            self.rebuild(state, cx, prev, element)
+                        })
+                    } else {
+                        tracing::error!("Unexpected element state type");
+                        ChangeFlags::UNCHANGED
+                    }
                 } else {
                     eprintln!("downcast of element failed in dyn_rebuild");
                     ChangeFlags::UNCHANGED
@@ -116,9 +132,17 @@ where
             })
         } else {
             // Otherwise, replace the element
-            let next_gen = element.next_generation();
-            let (new_element, view_state) =
-                cx.with_id(ViewId::for_type::<V>(next_gen), |cx| self.build(cx));
+
+            // Increase the generation, because the underlying widget has been swapped out.
+            // We increase this in the new
+            // Overflow condition: Impossible to overflow, as u64 only ever incremented by 1
+            // and starting at 0
+            dyn_state.generation = dyn_state.generation.wrapping_add(1);
+            let (new_element, view_state) = cx
+                .with_id(ViewId::for_type::<V>(dyn_state.generation), |cx| {
+                    self.build(cx)
+                });
+            dyn_state.inner_state = Box::new(view_state);
             element.replace_inner(new_element.boxed());
             ChangeFlags::CHANGED
         }
@@ -126,17 +150,23 @@ where
 
     fn dyn_message(
         &self,
+        dyn_state: &mut AnyViewState,
         id_path: &[ViewId],
         message: Box<dyn std::any::Any>,
         app_state: &mut T,
     ) -> MessageResult<A> {
-        // TODO: Validate this id
-        self.message(
-            todo!("DJMcNab"),
-            id_path.split_first().unwrap().1,
-            message,
-            app_state,
-        )
+        let (start, rest) = id_path
+            .split_first()
+            .expect("Id path has elements for AnyView");
+        if start.routing_id() != dyn_state.generation {
+            return MessageResult::Stale(message);
+        }
+        if let Some(view_state) = dyn_state.inner_state.downcast_mut() {
+            self.message(view_state, rest, message, app_state)
+        } else {
+            // Possibly softer failure?
+            panic!("downcast error in dyn_message");
+        }
     }
 }
 
@@ -145,9 +175,6 @@ where
 /// `WidgetPod<Box<dyn Widget>>` doesn't expose this possibility.
 pub struct DynWidget {
     inner: WidgetPod<Box<dyn Widget>>,
-    // This might be a layer break?
-    /// The generation of the inner widget, increases whenever the contained widget is replaced
-    generation: NonZeroU64,
 }
 
 /// Forward all events to the child widget.
@@ -186,19 +213,8 @@ impl Widget for DynWidget {
 
 declare_widget!(DynWidgetMut, DynWidget);
 
-impl DynWidget {
-    pub fn generation(&self) -> NonZeroU64 {
-        self.generation
-    }
-
-    pub fn next_generation(&self) -> NonZeroU64 {
-        self.generation.checked_add(1).unwrap()
-    }
-}
-
 impl DynWidgetMut<'_> {
     pub(crate) fn replace_inner(&mut self, widget: WidgetPod<Box<dyn Widget>>) {
-        self.widget.generation = self.next_generation();
         self.widget.inner = widget;
         self.ctx.children_changed();
     }

--- a/crates/xilem_masonry/src/any_view.rs
+++ b/crates/xilem_masonry/src/any_view.rs
@@ -110,9 +110,6 @@ where
         prev: &dyn AnyMasonryView<T, A>,
         mut element: WidgetMut<DynWidget>,
     ) -> ChangeFlags {
-        // TODO: Does this need to have a custom view id to enable events sent
-        // to an outdated view path to be caught and returned?
-        // Should we store this generation in `element`? Seems plausible
         if let Some(prev) = prev.as_any().downcast_ref() {
             // If we were previously of this type, then do a normal rebuild
             element.downcast(|element| {
@@ -131,12 +128,11 @@ where
                 }
             })
         } else {
-            // Otherwise, replace the element
+            // Otherwise, replace the element.
 
             // Increase the generation, because the underlying widget has been swapped out.
-            // We increase this in the new
             // Overflow condition: Impossible to overflow, as u64 only ever incremented by 1
-            // and starting at 0
+            // and starting at 0.
             dyn_state.generation = dyn_state.generation.wrapping_add(1);
             let (new_element, view_state) = cx
                 .with_id(ViewId::for_type::<V>(dyn_state.generation), |cx| {

--- a/crates/xilem_masonry/src/any_view.rs
+++ b/crates/xilem_masonry/src/any_view.rs
@@ -45,7 +45,6 @@ impl<T: 'static, A: 'static> MasonryView<T, A> for BoxedMasonryView<T, A> {
         view_state: &mut Self::ViewState,
         cx: &mut ViewCx,
         prev: &Self,
-        // _id: &mut Id,
         element: masonry::widget::WidgetMut<Self::Element>,
     ) -> ChangeFlags {
         self.deref().dyn_rebuild(view_state, cx, prev.deref(), element)

--- a/crates/xilem_masonry/src/any_view.rs
+++ b/crates/xilem_masonry/src/any_view.rs
@@ -47,7 +47,8 @@ impl<T: 'static, A: 'static> MasonryView<T, A> for BoxedMasonryView<T, A> {
         prev: &Self,
         element: masonry::widget::WidgetMut<Self::Element>,
     ) -> ChangeFlags {
-        self.deref().dyn_rebuild(view_state, cx, prev.deref(), element)
+        self.deref()
+            .dyn_rebuild(view_state, cx, prev.deref(), element)
     }
 }
 

--- a/crates/xilem_masonry/src/any_view.rs
+++ b/crates/xilem_masonry/src/any_view.rs
@@ -31,6 +31,7 @@ impl<T: 'static, A: 'static> MasonryView<T, A> for BoxedMasonryView<T, A> {
 
     fn rebuild(
         &self,
+        view_state: &mut Self::ViewState,
         cx: &mut ViewCx,
         prev: &Self,
         // _id: &mut Id,
@@ -41,6 +42,7 @@ impl<T: 'static, A: 'static> MasonryView<T, A> for BoxedMasonryView<T, A> {
 
     fn message(
         &self,
+        view_state: &mut Self::ViewState,
         id_path: &[ViewId],
         message: Box<dyn std::any::Any>,
         app_state: &mut T,
@@ -105,7 +107,7 @@ where
             element.downcast(|element| {
                 if let Some(element) = element {
                     cx.with_id(ViewId::for_type::<V>(generation), move |cx| {
-                        self.rebuild(cx, prev, element)
+                        self.rebuild(todo!("DJMcNab"), cx, prev, element)
                     })
                 } else {
                     eprintln!("downcast of element failed in dyn_rebuild");
@@ -129,7 +131,12 @@ where
         app_state: &mut T,
     ) -> MessageResult<A> {
         // TODO: Validate this id
-        self.message(id_path.split_first().unwrap().1, message, app_state)
+        self.message(
+            todo!("DJMcNab"),
+            id_path.split_first().unwrap().1,
+            message,
+            app_state,
+        )
     }
 }
 

--- a/crates/xilem_masonry/src/id.rs
+++ b/crates/xilem_masonry/src/id.rs
@@ -1,20 +1,21 @@
-use std::{fmt::Debug, num::NonZeroU64};
+use std::fmt::Debug;
 
 #[derive(Copy, Clone)]
 pub struct ViewId {
-    routing_id: NonZeroU64,
+    // TODO: This used to be NonZeroU64, but that wasn't really being used
+    routing_id: u64,
     debug: &'static str,
 }
 
 impl ViewId {
-    pub fn for_type<T: 'static>(raw: NonZeroU64) -> Self {
+    pub fn for_type<T: 'static>(raw: u64) -> Self {
         Self {
             debug: std::any::type_name::<T>(),
             routing_id: raw,
         }
     }
 
-    pub fn routing_id(self) -> NonZeroU64 {
+    pub fn routing_id(self) -> u64 {
         self.routing_id
     }
 }

--- a/crates/xilem_masonry/src/view/button.rs
+++ b/crates/xilem_masonry/src/view/button.rs
@@ -22,9 +22,12 @@ where
     F: Fn(&mut State) -> Action + Send + 'static,
 {
     type Element = masonry::widget::Button;
+    type ViewState = ();
 
-    fn build(&self, cx: &mut ViewCx) -> WidgetPod<Self::Element> {
-        cx.with_action_widget(|_| WidgetPod::new(masonry::widget::Button::new(self.label.clone())))
+    fn build(&self, cx: &mut ViewCx) -> (WidgetPod<Self::Element>, Self::ViewState) {
+        cx.with_leaf_action_widget(|_| {
+            WidgetPod::new(masonry::widget::Button::new(self.label.clone()))
+        })
     }
     fn message(
         &self,

--- a/crates/xilem_masonry/src/view/button.rs
+++ b/crates/xilem_masonry/src/view/button.rs
@@ -31,6 +31,7 @@ where
     }
     fn message(
         &self,
+        _view_state: &mut Self::ViewState,
         _id_path: &[ViewId],
         // TODO: Ensure is masonry button pressed action?
         _message: Box<dyn std::any::Any>,
@@ -40,9 +41,9 @@ where
     }
     fn rebuild(
         &self,
+        _view_state: &mut Self::ViewState,
         _cx: &mut ViewCx,
         prev: &Self,
-        // _id: &mut Id,
         mut element: WidgetMut<Self::Element>,
     ) -> crate::ChangeFlags {
         if prev.label != self.label {

--- a/crates/xilem_masonry/src/view/flex.rs
+++ b/crates/xilem_masonry/src/view/flex.rs
@@ -25,7 +25,7 @@ where
     Seq: ViewSequence<State, Action, Marker>,
 {
     type Element = widget::Flex;
-    type ViewState = Seq::ViewState;
+    type ViewState = Seq::SeqState;
 
     fn build(
         &self,
@@ -49,22 +49,26 @@ where
 
     fn message(
         &self,
+        view_state: &mut Self::ViewState,
         id_path: &[crate::ViewId],
         message: Box<dyn std::any::Any>,
         app_state: &mut State,
     ) -> crate::MessageResult<Action> {
-        self.sequence.message(id_path, message, app_state)
+        self.sequence
+            .message(view_state, id_path, message, app_state)
     }
 
     fn rebuild(
         &self,
+        view_state: &mut Self::ViewState,
         cx: &mut crate::ViewCx,
         prev: &Self,
         // _id: &mut Id,
         element: widget::WidgetMut<Self::Element>,
     ) -> crate::ChangeFlags {
         let mut splice = FlexSplice { ix: 0, element };
-        self.sequence.rebuild(cx, &prev.sequence, &mut splice)
+        self.sequence
+            .rebuild(view_state, cx, &prev.sequence, &mut splice)
     }
 }
 

--- a/crates/xilem_masonry/src/view/flex.rs
+++ b/crates/xilem_masonry/src/view/flex.rs
@@ -63,7 +63,6 @@ where
         view_state: &mut Self::ViewState,
         cx: &mut crate::ViewCx,
         prev: &Self,
-        // _id: &mut Id,
         element: widget::WidgetMut<Self::Element>,
     ) -> crate::ChangeFlags {
         let mut splice = FlexSplice { ix: 0, element };

--- a/crates/xilem_masonry/src/view/flex.rs
+++ b/crates/xilem_masonry/src/view/flex.rs
@@ -25,12 +25,16 @@ where
     Seq: ViewSequence<State, Action, Marker>,
 {
     type Element = widget::Flex;
+    type ViewState = Seq::ViewState;
 
-    fn build(&self, cx: &mut crate::ViewCx) -> masonry::WidgetPod<Self::Element> {
+    fn build(
+        &self,
+        cx: &mut crate::ViewCx,
+    ) -> (masonry::WidgetPod<Self::Element>, Self::ViewState) {
         let mut elements = Vec::new();
         let mut scratch = Vec::new();
         let mut splice = VecSplice::new(&mut elements, &mut scratch);
-        self.sequence.build(cx, &mut splice);
+        let seq_state = self.sequence.build(cx, &mut splice);
         let mut view = widget::Flex::column();
         debug_assert!(
             scratch.is_empty(),
@@ -40,7 +44,7 @@ where
         for item in elements.drain(..) {
             view = view.with_child_pod(item).with_default_spacer();
         }
-        WidgetPod::new(view)
+        (WidgetPod::new(view), seq_state)
     }
 
     fn message(


### PR DESCRIPTION
Alternative to #218

The version of viewsequence added in #205 is robust for all properties supported in that version. However, it would be incompatible with future expansions to the Xilem model, in particular async wiring.

In this PR, I propose a system to resolve this, which uses generational indexes in the view id path (for the items where this is relevant).

Some other historical record: #9

This brings back the `View::State` associated type (renamed to `ViewState` and `SeqState` depending on the trait), in order to perform this wiring.