### PR TITLE
Properly `deref` the previous view when using `AnyMasonryView`

### DIFF
--- a/crates/xilem_masonry/src/any_view.rs
+++ b/crates/xilem_masonry/src/any_view.rs
@@ -28,15 +28,6 @@ impl<T: 'static, A: 'static> MasonryView<T, A> for BoxedMasonryView<T, A> {
         self.deref().dyn_build(cx)
     }
 
-    fn message(
-        &self,
-        id_path: &[ViewId],
-        message: Box<dyn std::any::Any>,
-        app_state: &mut T,
-    ) -> crate::MessageResult<A> {
-        self.deref().dyn_message(id_path, message, app_state)
-    }
-
     fn rebuild(
         &self,
         cx: &mut ViewCx,
@@ -44,7 +35,16 @@ impl<T: 'static, A: 'static> MasonryView<T, A> for BoxedMasonryView<T, A> {
         // _id: &mut Id,
         element: masonry::widget::WidgetMut<Self::Element>,
     ) -> ChangeFlags {
-        self.deref().dyn_rebuild(cx, prev, element)
+        self.deref().dyn_rebuild(cx, prev.deref(), element)
+    }
+
+    fn message(
+        &self,
+        id_path: &[ViewId],
+        message: Box<dyn std::any::Any>,
+        app_state: &mut T,
+    ) -> crate::MessageResult<A> {
+        self.deref().dyn_message(id_path, message, app_state)
     }
 }
 


### PR DESCRIPTION
Previously, this meant that the previous was actually a `Box<dyn AnyView>`, which implemented `View` and so was being passed as its own `&dyn AnyView` to rebuild.

I also moved `rebuild` and `message` into the correct order.

This partially fixes the `mason` example - pressing the `Unlimited Power` button, it now retains its state.
This would be more impactful for e.g. a text input view, where the widget had internal state.

Pressing activate and deactivate is still broken. See [#masonry > Hot state for new widgets](https://xi.zulipchat.com/#narrow/stream/317477-masonry/topic/Hot.20state.20for.20new.20widgets)