### PR TITLE
masonry: Use Kurbo via Vello.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,7 +1878,6 @@ dependencies = [
  "futures-intrusive",
  "image",
  "insta",
- "kurbo",
  "nv-flip",
  "once_cell",
  "parley",

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -22,7 +22,6 @@ workspace = true
 [dependencies]
 vello.workspace = true
 wgpu.workspace = true
-kurbo.workspace = true
 parley.workspace = true
 winit.workspace = true
 smallvec.workspace = true

--- a/masonry/examples/custom_widget.rs
+++ b/masonry/examples/custom_widget.rs
@@ -8,9 +8,8 @@
 #![windows_subsystem = "windows"]
 
 use accesskit::Role;
-use kurbo::Stroke;
 use masonry::app_driver::{AppDriver, DriverCtx};
-use masonry::kurbo::BezPath;
+use masonry::kurbo::{BezPath, Stroke};
 use masonry::widget::{FillStrat, RootWidget};
 use masonry::{
     AccessCtx, AccessEvent, Action, Affine, BoxConstraints, Color, EventCtx, LayoutCtx, LifeCycle,

--- a/masonry/src/box_constraints.rs
+++ b/masonry/src/box_constraints.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::kurbo::Size;
+use vello::kurbo::Size;
 
 /// Constraints for layout.
 ///

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -97,9 +97,9 @@
 
 pub use cursor_icon::{CursorIcon, ParseError as CursorIconParseError};
 pub use dpi;
-pub use kurbo;
 pub use parley;
 pub use vello;
+pub use vello::kurbo;
 
 #[macro_use]
 mod util;

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -4,10 +4,10 @@
 use std::collections::VecDeque;
 
 use accesskit::{ActionRequest, NodeBuilder, Tree, TreeUpdate};
-use kurbo::Affine;
 use parley::fontique::{self, Collection, CollectionOptions};
 use parley::{FontContext, LayoutContext};
 use tracing::{debug, info_span, warn};
+use vello::kurbo::{self, Affine, Point};
 use vello::peniko::{Color, Fill};
 use vello::Scene;
 
@@ -20,7 +20,6 @@ use crate::contexts::{LayoutCtx, LifeCycleCtx, PaintCtx};
 use crate::debug_logger::DebugLogger;
 use crate::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use crate::event::{PointerEvent, TextEvent, WindowEvent};
-use crate::kurbo::Point;
 use crate::passes::event::{root_on_access_event, root_on_pointer_event, root_on_text_event};
 use crate::passes::mutate::{mutate_widget, run_mutate_pass};
 use crate::passes::update::run_update_pointer_pass;

--- a/masonry/src/text/edit.rs
+++ b/masonry/src/text/edit.rs
@@ -3,8 +3,8 @@
 
 use std::ops::{Deref, DerefMut, Range};
 
-use kurbo::Point;
 use parley::{FontContext, LayoutContext};
+use vello::kurbo::Point;
 use vello::Scene;
 use winit::{
     event::Ime,

--- a/masonry/src/text/layout.rs
+++ b/masonry/src/text/layout.rs
@@ -5,12 +5,12 @@
 
 use std::rc::Rc;
 
-use kurbo::{Affine, Line, Point, Rect, Size};
 use parley::context::RangedBuilder;
 use parley::fontique::{Style, Weight};
 use parley::layout::{Alignment, Cursor};
 use parley::style::{Brush as BrushTrait, FontFamily, FontStack, GenericFamily, StyleProperty};
 use parley::{FontContext, Layout, LayoutContext};
+use vello::kurbo::{Affine, Line, Point, Rect, Size};
 use vello::peniko::{self, Color, Gradient};
 use vello::Scene;
 

--- a/masonry/src/text/selection.rs
+++ b/masonry/src/text/selection.rs
@@ -6,10 +6,10 @@
 use std::borrow::Cow;
 use std::ops::{Deref, DerefMut, Range};
 
-use kurbo::{Affine, Line, Point, Stroke};
 use parley::context::RangedBuilder;
 use parley::{FontContext, LayoutContext};
 use unicode_segmentation::{GraphemeCursor, UnicodeSegmentation};
+use vello::kurbo::{Affine, Line, Point, Stroke};
 use vello::peniko::{Brush, Color};
 use vello::Scene;
 use winit::keyboard::NamedKey;

--- a/masonry/src/text_helpers.rs
+++ b/masonry/src/text_helpers.rs
@@ -3,9 +3,12 @@
 
 //! Helper functions for working with text in Masonry.
 
-use kurbo::{Line, Rect, Stroke};
 use parley::Layout;
-use vello::{kurbo::Affine, peniko::Fill, Scene};
+use vello::{
+    kurbo::{Affine, Line, Rect, Stroke},
+    peniko::Fill,
+    Scene,
+};
 
 use crate::{text::TextBrush, WidgetId};
 

--- a/masonry/src/widget/checkbox.rs
+++ b/masonry/src/widget/checkbox.rs
@@ -4,13 +4,12 @@
 //! A checkbox widget.
 
 use accesskit::{DefaultActionVerb, Role, Toggled};
-use kurbo::{Affine, Stroke};
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, Span};
+use vello::kurbo::{Affine, BezPath, Cap, Join, Size, Stroke};
 use vello::Scene;
 
 use crate::action::Action;
-use crate::kurbo::{BezPath, Cap, Join, Size};
 use crate::paint_scene_helpers::{fill_lin_gradient, stroke, UnitPoint};
 use crate::text::TextStorage;
 use crate::widget::{Label, WidgetMut};

--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -4,13 +4,11 @@
 //! A widget that arranges its children in a one-dimensional array.
 
 use accesskit::Role;
-use kurbo::{Affine, Stroke};
 use smallvec::SmallVec;
 use tracing::{trace, trace_span, Span};
+use vello::kurbo::{common::FloatExt, Affine, Line, Stroke, Vec2};
 use vello::Scene;
 
-use crate::kurbo::common::FloatExt;
-use crate::kurbo::{Line, Vec2};
 use crate::theme::get_debug_color;
 use crate::widget::WidgetMut;
 use crate::{

--- a/masonry/src/widget/image.rs
+++ b/masonry/src/widget/image.rs
@@ -5,9 +5,9 @@
 //! Please consider using SVG and the SVG widget as it scales much better.
 
 use accesskit::Role;
-use kurbo::Affine;
 use smallvec::SmallVec;
 use tracing::{trace, trace_span, Span};
+use vello::kurbo::Affine;
 use vello::peniko::{BlendMode, Image as ImageBuf};
 use vello::Scene;
 

--- a/masonry/src/widget/label.rs
+++ b/masonry/src/widget/label.rs
@@ -4,11 +4,11 @@
 //! A label widget.
 
 use accesskit::Role;
-use kurbo::{Affine, Point, Size};
 use parley::layout::Alignment;
 use parley::style::{FontFamily, FontStack};
 use smallvec::SmallVec;
 use tracing::{trace, trace_span, Span};
+use vello::kurbo::{Affine, Point, Size};
 use vello::peniko::BlendMode;
 use vello::Scene;
 

--- a/masonry/src/widget/portal.rs
+++ b/masonry/src/widget/portal.rs
@@ -6,13 +6,12 @@
 use std::ops::Range;
 
 use accesskit::Role;
-use kurbo::Affine;
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace_span, Span};
+use vello::kurbo::{Affine, Point, Rect, Size, Vec2};
 use vello::peniko::BlendMode;
 use vello::Scene;
 
-use crate::kurbo::{Point, Rect, Size, Vec2};
 use crate::widget::{Axis, ScrollBar, WidgetMut};
 use crate::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -2,14 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use accesskit::Role;
-use kurbo::{Affine, Point, Size};
 use parley::{
     layout::Alignment,
     style::{FontFamily, FontStack},
 };
 use smallvec::SmallVec;
 use tracing::{trace, trace_span, Span};
-use vello::{peniko::BlendMode, Scene};
+use vello::{
+    kurbo::{Affine, Point, Size},
+    peniko::BlendMode,
+    Scene,
+};
 
 use crate::widget::{LineBreaking, WidgetMut};
 use crate::{

--- a/masonry/src/widget/root_widget.rs
+++ b/masonry/src/widget/root_widget.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use accesskit::Role;
-use kurbo::Point;
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace_span, Span};
+use vello::kurbo::Point;
 use vello::Scene;
 
 use crate::widget::{WidgetMut, WidgetPod};

--- a/masonry/src/widget/scroll_bar.rs
+++ b/masonry/src/widget/scroll_bar.rs
@@ -6,10 +6,10 @@
 use accesskit::Role;
 use smallvec::SmallVec;
 use tracing::{trace_span, Span};
+use vello::kurbo::Rect;
 use vello::Scene;
 
 use super::Axis;
-use crate::kurbo::Rect;
 use crate::paint_scene_helpers::{fill_color, stroke};
 use crate::widget::WidgetMut;
 use crate::{

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -4,13 +4,12 @@
 //! A widget with predefined size.
 
 use accesskit::Role;
-use kurbo::Affine;
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, warn, Span};
+use vello::kurbo::{Affine, RoundedRectRadii};
 use vello::peniko::{BlendMode, Color, Fill, Gradient};
 use vello::Scene;
 
-use crate::kurbo::RoundedRectRadii;
 use crate::paint_scene_helpers::{fill_color, stroke};
 use crate::widget::{WidgetMut, WidgetPod};
 use crate::{

--- a/masonry/src/widget/spinner.rs
+++ b/masonry/src/widget/spinner.rs
@@ -6,12 +6,11 @@
 use std::f64::consts::PI;
 
 use accesskit::Role;
-use kurbo::{Affine, Cap, Stroke};
 use smallvec::SmallVec;
 use tracing::{trace, trace_span, Span};
+use vello::kurbo::{Affine, Cap, Line, Stroke};
 use vello::Scene;
 
-use crate::kurbo::Line;
 use crate::widget::WidgetMut;
 use crate::{
     theme, AccessCtx, AccessEvent, BoxConstraints, Color, EventCtx, LayoutCtx, LifeCycle,

--- a/masonry/src/widget/tests/layout.rs
+++ b/masonry/src/widget/tests/layout.rs
@@ -3,7 +3,8 @@
 
 //! Tests related to layout.
 
-use crate::kurbo::{Insets, Size};
+use vello::kurbo::{Insets, Size};
+
 use crate::testing::{widget_ids, ModularWidget, TestHarness, TestWidgetExt};
 use crate::widget::{Flex, SizedBox};
 

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use accesskit::Role;
-use kurbo::{Affine, Point, Size, Stroke};
 use parley::{
     layout::Alignment,
     style::{FontFamily, FontStack},
@@ -10,6 +9,7 @@ use parley::{
 use smallvec::SmallVec;
 use tracing::{trace, trace_span, Span};
 use vello::{
+    kurbo::{Affine, Point, Size, Stroke},
     peniko::{BlendMode, Color},
     Scene,
 };

--- a/masonry/src/widget/widget_pod.rs
+++ b/masonry/src/widget/widget_pod.rs
@@ -4,9 +4,9 @@
 use accesskit::{NodeBuilder, NodeId};
 use smallvec::SmallVec;
 use tracing::{info_span, trace, warn};
+use vello::kurbo::{Affine, Rect, Size};
 use vello::Scene;
 
-use crate::kurbo::{Affine, Rect, Size};
 use crate::paint_scene_helpers::stroke;
 use crate::theme::get_debug_color;
 use crate::tree_arena::ArenaRefChildren;

--- a/masonry/src/widget/widget_ref.rs
+++ b/masonry/src/widget/widget_ref.rs
@@ -4,8 +4,8 @@
 use std::ops::Deref;
 
 use smallvec::SmallVec;
+use vello::kurbo::Point;
 
-use crate::kurbo::Point;
 use crate::tree_arena::ArenaRefChildren;
 use crate::{Widget, WidgetId, WidgetState};
 

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -4,9 +4,9 @@
 #![cfg(not(tarpaulin_include))]
 
 use std::sync::atomic::{AtomicBool, Ordering};
+use vello::kurbo::{Insets, Point, Rect, Size};
 
 use crate::bloom::Bloom;
-use crate::kurbo::{Insets, Point, Rect, Size};
 use crate::text_helpers::TextFieldRegistration;
 use crate::{CursorIcon, WidgetId};
 


### PR DESCRIPTION
Rather than have to keep a dependency on `kurbo` at the correct version, always use it via `vello`.

This makes this match how `peniko` is already used within `masonry`.