### PR TITLE
xilem_masonry: Add checkbox widget

### DIFF
--- a/crates/xilem_masonry/examples/mason.rs
+++ b/crates/xilem_masonry/examples/mason.rs
@@ -1,7 +1,7 @@
 // On Windows platform, don't show a console when opening the app.
 #![windows_subsystem = "windows"]
 
-use xilem_masonry::view::{button, flex};
+use xilem_masonry::view::{button, checkbox, flex};
 use xilem_masonry::{BoxedMasonryView, MasonryView, Xilem};
 
 fn app_logic(data: &mut AppData) -> impl MasonryView<AppData> {
@@ -20,6 +20,9 @@ fn app_logic(data: &mut AppData) -> impl MasonryView<AppData> {
         .collect::<Vec<_>>();
     flex((
         button(label, |data: &mut AppData| data.count += 1),
+        checkbox("Check me", data.active, |data: &mut AppData, checked| {
+            data.active = checked;
+        }),
         toggleable(data),
         button("Decrement", |data: &mut AppData| data.count -= 1),
         button("Reset", |data: &mut AppData| data.count = 0),

--- a/crates/xilem_masonry/src/view/button.rs
+++ b/crates/xilem_masonry/src/view/button.rs
@@ -56,10 +56,19 @@ where
             id_path.is_empty(),
             "id path should be empty in Button::message"
         );
-        if let Some(masonry::Action::ButtonPressed) = message.downcast_ref() {
-            return MessageResult::Action((self.callback)(app_state));
+        match message.downcast::<masonry::Action>() {
+            Ok(action) => {
+                if let masonry::Action::ButtonPressed = *action {
+                    MessageResult::Action((self.callback)(app_state))
+                } else {
+                    tracing::error!("Wrong action type in Checkbox::message: {action:?}");
+                    MessageResult::Stale(action)
+                }
+            }
+            Err(message) => {
+                tracing::error!("Wrong message type in Checkbox::message");
+                MessageResult::Stale(message)
+            }
         }
-        tracing::error!("Wrong message type in Button::message");
-        MessageResult::Stale(message)
     }
 }

--- a/crates/xilem_masonry/src/view/checkbox.rs
+++ b/crates/xilem_masonry/src/view/checkbox.rs
@@ -69,11 +69,19 @@ where
             id_path.is_empty(),
             "id path should be empty in Checkbox::message"
         );
-        if let Some(masonry::Action::CheckboxChecked(checked)) = message.downcast_ref() {
-            return MessageResult::Action((self.callback)(app_state, *checked))
+        match message.downcast::<masonry::Action>() {
+            Ok(action) => {
+                if let masonry::Action::CheckboxChecked(checked) = *action {
+                    MessageResult::Action((self.callback)(app_state, checked))
+                } else {
+                    tracing::error!("Wrong action type in Checkbox::message: {action:?}");
+                    MessageResult::Stale(action)
+                }
+            }
+            Err(message) => {
+                tracing::error!("Wrong message type in Checkbox::message");
+                MessageResult::Stale(message)
+            }
         }
-        tracing::error!("Wrong message type in Checkbox::message");
-        MessageResult::Stale(message)
     }
-
 }

--- a/crates/xilem_masonry/src/view/checkbox.rs
+++ b/crates/xilem_masonry/src/view/checkbox.rs
@@ -1,0 +1,79 @@
+use masonry::{widget::WidgetMut, ArcStr, WidgetPod};
+
+use crate::{ChangeFlags, MasonryView, MessageResult, ViewCx, ViewId};
+
+pub fn checkbox<F, State, Action>(
+    label: impl Into<ArcStr>,
+    checked: bool,
+    callback: F,
+) -> Checkbox<F>
+where
+    F: Fn(&mut State, bool) -> Action + Send + 'static,
+{
+    Checkbox {
+        label: label.into(),
+        callback,
+        checked,
+    }
+}
+
+pub struct Checkbox<F> {
+    label: ArcStr,
+    checked: bool,
+    callback: F,
+}
+
+impl<F, State, Action> MasonryView<State, Action> for Checkbox<F>
+where
+    F: Fn(&mut State, bool) -> Action + Send + 'static,
+{
+    type Element = masonry::widget::Checkbox;
+    type ViewState = ();
+
+    fn build(&self, cx: &mut ViewCx) -> (WidgetPod<Self::Element>, Self::ViewState) {
+        cx.with_leaf_action_widget(|_| {
+            WidgetPod::new(masonry::widget::Checkbox::new(
+                self.checked,
+                self.label.clone(),
+            ))
+        })
+    }
+
+    fn rebuild(
+        &self,
+        _view_state: &mut Self::ViewState,
+        _cx: &mut ViewCx,
+        prev: &Self,
+        mut element: WidgetMut<Self::Element>,
+    ) -> crate::ChangeFlags {
+        let mut changeflags = ChangeFlags::UNCHANGED;
+        if prev.label != self.label {
+            element.set_text(self.label.clone());
+            changeflags.changed |= ChangeFlags::CHANGED.changed;
+        }
+        if prev.checked != self.checked {
+            element.set_checked(self.checked);
+            changeflags.changed |= ChangeFlags::CHANGED.changed;
+        }
+        changeflags
+    }
+
+    fn message(
+        &self,
+        _view_state: &mut Self::ViewState,
+        id_path: &[ViewId],
+        message: Box<dyn std::any::Any>,
+        app_state: &mut State,
+    ) -> MessageResult<Action> {
+        debug_assert!(
+            id_path.is_empty(),
+            "id path should be empty in Checkbox::message"
+        );
+        if let Some(masonry::Action::CheckboxChecked(checked)) = message.downcast_ref() {
+            return MessageResult::Action((self.callback)(app_state, *checked))
+        }
+        tracing::error!("Wrong message type in Checkbox::message");
+        MessageResult::Stale(message)
+    }
+
+}

--- a/crates/xilem_masonry/src/view/mod.rs
+++ b/crates/xilem_masonry/src/view/mod.rs
@@ -1,5 +1,8 @@
 mod button;
 pub use button::*;
 
+mod checkbox;
+pub use checkbox::*;
+
 mod flex;
 pub use flex::*;


### PR DESCRIPTION
Implements the masonry checkbox as view (and some improvements in `Button::message`)