### PR TITLE
deps: Use `raw-window-handle` 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,8 +1418,7 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
- "raw-window-handle 0.5.2",
- "raw-window-handle 0.6.0",
+ "raw-window-handle",
  "thiserror",
 ]
 
@@ -1732,12 +1731,6 @@ name = "range-alloc"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
-
-[[package]]
-name = "raw-window-handle"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "raw-window-handle"
@@ -2389,7 +2382,7 @@ dependencies = [
  "bytemuck",
  "futures-intrusive",
  "peniko",
- "raw-window-handle 0.6.0",
+ "raw-window-handle",
  "skrifa 0.15.5",
  "vello_encoding 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wgpu",
@@ -2404,7 +2397,7 @@ dependencies = [
  "futures-intrusive",
  "log",
  "peniko",
- "raw-window-handle 0.6.0",
+ "raw-window-handle",
  "skrifa 0.19.0",
  "vello_encoding 0.1.0 (git+https://github.com/linebender/vello/?rev=b520a35addfa6bbb37d93491d2b8236528faf3b5)",
  "wgpu",
@@ -2670,7 +2663,7 @@ dependencies = [
  "naga",
  "parking_lot",
  "profiling",
- "raw-window-handle 0.6.0",
+ "raw-window-handle",
  "smallvec",
  "static_assertions",
  "wasm-bindgen",
@@ -2698,7 +2691,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "profiling",
- "raw-window-handle 0.6.0",
+ "raw-window-handle",
  "rustc-hash",
  "smallvec",
  "thiserror",
@@ -2741,7 +2734,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "range-alloc",
- "raw-window-handle 0.6.0",
+ "raw-window-handle",
  "renderdoc-sys",
  "rustc-hash",
  "smallvec",
@@ -3044,8 +3037,7 @@ dependencies = [
  "once_cell",
  "orbclient",
  "percent-encoding",
- "raw-window-handle 0.5.2",
- "raw-window-handle 0.6.0",
+ "raw-window-handle",
  "redox_syscall 0.3.5",
  "rustix",
  "sctk-adwaita",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "Apache-2.0"
 xilem_core = { version = "0.1.0", path = "crates/xilem_core" }
 masonry = { version = "0.1.0", path = "crates/masonry" }
 kurbo = "0.11.0"
-winit = { version = "0.29", features = ["rwh_05"] }
+winit = "0.29"
 parley = { git = "https://github.com/linebender/parley", rev = "9a519ba644eda13783a7326539dd0305dc206ba8" }
 vello = { git = "https://github.com/linebender/vello/", rev = "b520a35addfa6bbb37d93491d2b8236528faf3b5" }
 
@@ -70,4 +70,4 @@ bitflags = "2"
 tracing = "0.1.37"
 fnv = "1.0.7"
 instant = { version = "0.1.6", features = ["wasm-bindgen"] }
-winit = { version = "0.29", features = ["rwh_05"] }
+winit = "0.29"


### PR DESCRIPTION
We don't need to force the usage of 0.5.0.