### PR TITLE
Update the hot state in `ParentWindowOrigin` as well

### DIFF
--- a/crates/masonry/src/event.rs
+++ b/crates/masonry/src/event.rs
@@ -172,7 +172,9 @@ pub enum InternalLifeCycle {
     RouteDisabledChanged,
 
     /// The parents widget origin in window coordinate space has changed.
-    ParentWindowOrigin,
+    ParentWindowOrigin {
+        mouse_pos: Option<PhysicalPosition<f64>>,
+    },
 }
 
 /// Event indicating status changes within the widget hierarchy.
@@ -293,7 +295,7 @@ impl LifeCycle {
                 InternalLifeCycle::RouteWidgetAdded => "RouteWidgetAdded",
                 InternalLifeCycle::RouteFocusChanged { .. } => "RouteFocusChanged",
                 InternalLifeCycle::RouteDisabledChanged => "RouteDisabledChanged",
-                InternalLifeCycle::ParentWindowOrigin => "ParentWindowOrigin",
+                InternalLifeCycle::ParentWindowOrigin { .. } => "ParentWindowOrigin",
             },
             LifeCycle::WidgetAdded => "WidgetAdded",
             LifeCycle::AnimFrame(_) => "AnimFrame",
@@ -318,7 +320,7 @@ impl InternalLifeCycle {
             InternalLifeCycle::RouteWidgetAdded
             | InternalLifeCycle::RouteFocusChanged { .. }
             | InternalLifeCycle::RouteDisabledChanged => true,
-            InternalLifeCycle::ParentWindowOrigin => false,
+            InternalLifeCycle::ParentWindowOrigin { .. } => false,
         }
     }
 }

--- a/crates/masonry/src/render_root.rs
+++ b/crates/masonry/src/render_root.rs
@@ -335,7 +335,6 @@ impl RenderRoot {
         }
 
         layout_ctx.place_child(&mut self.root, Point::ORIGIN);
-        self.root_lifecycle(LifeCycle::Internal(InternalLifeCycle::ParentWindowOrigin));
         self.post_event_processing(&mut widget_state);
     }
 
@@ -389,7 +388,9 @@ impl RenderRoot {
         }
 
         if self.root.state().needs_window_origin && !self.root.state().needs_layout {
-            let event = LifeCycle::Internal(InternalLifeCycle::ParentWindowOrigin);
+            let event = LifeCycle::Internal(InternalLifeCycle::ParentWindowOrigin {
+                mouse_pos: self.last_mouse_pos,
+            });
             self.root_lifecycle(event);
         }
 

--- a/crates/masonry/src/widget/tests/snapshots/masonry__widget__tests__lifecycle_basic__app_creation.snap
+++ b/crates/masonry/src/widget/tests/snapshots/masonry__widget__tests__lifecycle_basic__app_creation.snap
@@ -1,6 +1,5 @@
 ---
-source: src/widget/tests/lifecycle_basic.rs
-assertion_line: 23
+source: crates/masonry/src/widget/tests/lifecycle_basic.rs
 expression: record
 ---
 [
@@ -15,7 +14,9 @@ expression: record
     ),
     L(
         Internal(
-            ParentWindowOrigin,
+            ParentWindowOrigin {
+                mouse_pos: None,
+            },
         ),
     ),
 ]

--- a/crates/masonry/src/widget/widget_pod.rs
+++ b/crates/masonry/src/widget/widget_pod.rs
@@ -605,9 +605,16 @@ impl<W: Widget> WidgetPod<W> {
                         _ => false,
                     }
                 }
-                InternalLifeCycle::ParentWindowOrigin => {
+                InternalLifeCycle::ParentWindowOrigin { mouse_pos } => {
                     self.state.parent_window_origin = parent_ctx.widget_state.window_origin();
                     self.state.needs_window_origin = false;
+                    let mouse_pos = mouse_pos.map(|pos| PhysicalPosition::new(pos.x, pos.y));
+                    WidgetPod::update_hot_state(
+                        &mut self.inner,
+                        &mut self.state,
+                        parent_ctx.global_state,
+                        mouse_pos,
+                    );
                     // TODO - self.state.is_hidden
                     true
                 }
@@ -626,6 +633,7 @@ impl<W: Widget> WidgetPod<W> {
                 self.state.update_focus_chain = true;
                 self.state.needs_layout = true;
                 self.state.needs_paint = true;
+                self.state.needs_window_origin = true;
 
                 true
             }
@@ -784,7 +792,6 @@ impl<W: Widget> WidgetPod<W> {
         self.check_initialized("layout");
 
         self.state.needs_layout = false;
-        self.state.needs_window_origin = false;
         self.state.is_expecting_place_child_call = true;
         // TODO - Not everything that has been re-laid out needs to be repainted.
         self.state.needs_paint = true;


### PR DESCRIPTION
The exact circumstances in which ParentWindowOrigin need to be sent aren't entirely clear to me so this might need some more careful thought

This does resolve [#masonry > Hot state for new widgets](https://xi.zulipchat.com/#narrow/stream/317477-masonry/topic/Hot.20state.20for.20new.20widgets)
This can be tested in the `mason` example, for example when pressing the `activate` button