### PR TITLE
Masonry: Only activate buttons when they are hot

### DIFF
--- a/crates/masonry/src/widget/button.rs
+++ b/crates/masonry/src/widget/button.rs
@@ -82,7 +82,7 @@ impl Widget for Button {
                 }
             }
             PointerEvent::PointerUp(_, _) => {
-                if ctx.is_active() && !ctx.is_disabled() {
+                if ctx.is_active() && ctx.is_hot() && !ctx.is_disabled() {
                     ctx.submit_action(Action::ButtonPressed);
                     ctx.request_paint();
                     trace!("Button {:?} released", ctx.widget_id());

--- a/crates/masonry/src/widget/button.rs
+++ b/crates/masonry/src/widget/button.rs
@@ -89,6 +89,11 @@ impl Widget for Button {
                 }
                 ctx.set_active(false);
             }
+            PointerEvent::PointerLeave(_) => {
+                // If the screen was locked whilst holding down the mouse button, we don't get a `PointerUp`
+                // event, but should no longer be active
+                ctx.set_active(false);
+            }
             _ => (),
         }
         self.label.on_pointer_event(ctx, event);


### PR DESCRIPTION
This matches the behaviour in Xilem classic