### PR TITLE
Wire up scale factor

### DIFF
--- a/crates/masonry/src/contexts.rs
+++ b/crates/masonry/src/contexts.rs
@@ -631,9 +631,7 @@ impl LayoutCtx<'_> {
         self.widget_state.local_paint_rect =
             self.widget_state.local_paint_rect.union(child.paint_rect());
 
-        let mouse_pos = self
-            .mouse_pos
-            .map(|pos| LogicalPosition::new(pos.x, pos.y));
+        let mouse_pos = self.mouse_pos.map(|pos| LogicalPosition::new(pos.x, pos.y));
         // if the widget has moved, it may have moved under the mouse, in which
         // case we need to handle that.
         if WidgetPod::update_hot_state(

--- a/crates/masonry/src/contexts.rs
+++ b/crates/masonry/src/contexts.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use parley::FontContext;
 use tracing::{trace, warn};
-use winit::dpi::PhysicalPosition;
+use winit::dpi::LogicalPosition;
 use winit::window::CursorIcon;
 
 use crate::action::Action;
@@ -633,7 +633,7 @@ impl LayoutCtx<'_> {
 
         let mouse_pos = self
             .mouse_pos
-            .map(|pos| PhysicalPosition::new(pos.x, pos.y));
+            .map(|pos| LogicalPosition::new(pos.x, pos.y));
         // if the widget has moved, it may have moved under the mouse, in which
         // case we need to handle that.
         if WidgetPod::update_hot_state(

--- a/crates/masonry/src/event.rs
+++ b/crates/masonry/src/event.rs
@@ -10,7 +10,7 @@ use crate::WidgetId;
 
 use std::{collections::HashSet, path::PathBuf};
 
-use winit::dpi::{PhysicalPosition, PhysicalSize};
+use winit::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use winit::event::{Ime, KeyEvent, Modifiers, MouseButton};
 use winit::keyboard::ModifiersState;
 
@@ -40,7 +40,7 @@ pub enum PointerEvent {
     PointerMove(PointerState),
     PointerEnter(PointerState),
     PointerLeave(PointerState),
-    MouseWheel(PhysicalPosition<f64>, PointerState),
+    MouseWheel(LogicalPosition<f64>, PointerState),
     HoverFile(PathBuf, PointerState),
     DropFile(PathBuf, PointerState),
     HoverFileCancel(PointerState),
@@ -61,7 +61,8 @@ pub enum TextEvent {
 pub struct PointerState {
     // TODO
     // pub device_id: DeviceId,
-    pub position: PhysicalPosition<f64>,
+    pub physical_position: PhysicalPosition<f64>,
+    pub position: LogicalPosition<f64>,
     pub buttons: HashSet<MouseButton>,
     pub mods: Modifiers,
     pub count: u8,
@@ -173,7 +174,7 @@ pub enum InternalLifeCycle {
 
     /// The parents widget origin in window coordinate space has changed.
     ParentWindowOrigin {
-        mouse_pos: Option<PhysicalPosition<f64>>,
+        mouse_pos: Option<LogicalPosition<f64>>,
     },
 }
 
@@ -256,7 +257,8 @@ impl PointerState {
         let device_id = unsafe { DeviceId::dummy() };
 
         PointerState {
-            position: PhysicalPosition::new(0.0, 0.0),
+            physical_position: PhysicalPosition::new(0.0, 0.0),
+            position: LogicalPosition::new(0.0, 0.0),
             buttons: Default::default(),
             mods: Default::default(),
             count: 0,

--- a/crates/masonry/src/event_loop_runner.rs
+++ b/crates/masonry/src/event_loop_runner.rs
@@ -2,8 +2,8 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use tracing::warn;
-use vello::util::{RenderContext, RenderSurface};
 use vello::kurbo::Affine;
+use vello::util::{RenderContext, RenderSurface};
 use vello::{peniko::Color, AaSupport, RenderParams, Renderer, RendererOptions, Scene};
 use wgpu::PresentMode;
 use winit::application::ApplicationHandler;
@@ -104,8 +104,12 @@ impl ApplicationHandler for MainState<'_> {
             },
             WinitWindowEvent::MouseWheel { delta, .. } => {
                 let delta = match delta {
-                    winit::event::MouseScrollDelta::LineDelta(x, y) => LogicalPosition::new(x as f64, y as f64),
-                    winit::event::MouseScrollDelta::PixelDelta(delta) => delta.to_logical(self.window.scale_factor()),
+                    winit::event::MouseScrollDelta::LineDelta(x, y) => {
+                        LogicalPosition::new(x as f64, y as f64)
+                    }
+                    winit::event::MouseScrollDelta::PixelDelta(delta) => {
+                        delta.to_logical(self.window.scale_factor())
+                    }
                 };
                 self.render_root
                     .handle_pointer_event(PointerEvent::MouseWheel(

--- a/crates/masonry/src/render_root.rs
+++ b/crates/masonry/src/render_root.rs
@@ -7,7 +7,7 @@ use parley::FontContext;
 use tracing::{info_span, warn};
 use vello::peniko::{Color, Fill};
 use vello::Scene;
-use winit::dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
+use winit::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use winit::keyboard::{KeyCode, PhysicalKey};
 use winit::window::CursorIcon;
 
@@ -30,7 +30,7 @@ pub struct RenderRoot {
     pub(crate) scale_factor: f64,
     /// Is `Some` if the most recently displayed frame was an animation frame.
     pub(crate) last_anim: Option<Instant>,
-    pub(crate) last_mouse_pos: Option<PhysicalPosition<f64>>,
+    pub(crate) last_mouse_pos: Option<LogicalPosition<f64>>,
     pub(crate) cursor_icon: CursorIcon,
     pub(crate) state: RenderRootState,
 }
@@ -77,12 +77,12 @@ pub enum RenderRootSignal {
 }
 
 impl RenderRoot {
-    pub fn new(root_widget: impl Widget, size_policy: WindowSizePolicy) -> Self {
+    pub fn new(root_widget: impl Widget, size_policy: WindowSizePolicy, scale_factor: f64) -> Self {
         let mut root = RenderRoot {
             root: WidgetPod::new(root_widget).boxed(),
             size_policy,
             size: PhysicalSize::new(0, 0),
-            scale_factor: 1.0,
+            scale_factor,
             last_anim: None,
             last_mouse_pos: None,
             cursor_icon: CursorIcon::Default,

--- a/crates/masonry/src/testing/harness.rs
+++ b/crates/masonry/src/testing/harness.rs
@@ -14,7 +14,7 @@ use wgpu::{
     BufferDescriptor, BufferUsages, CommandEncoderDescriptor, Extent3d, ImageCopyBuffer,
     TextureDescriptor, TextureFormat, TextureUsages,
 };
-use winit::dpi::{PhysicalPosition, PhysicalSize};
+use winit::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use winit::event::{Ime, MouseButton};
 
 use super::screenshots::get_image_diff;
@@ -175,7 +175,7 @@ impl TestHarness {
         let window_size = PhysicalSize::new(window_size.width as _, window_size.height as _);
 
         let mut harness = TestHarness {
-            render_root: RenderRoot::new(root_widget, WindowSizePolicy::User),
+            render_root: RenderRoot::new(root_widget, WindowSizePolicy::User, 1.0),
             mouse_state,
             window_size,
             background_color,
@@ -333,7 +333,10 @@ impl TestHarness {
         // FIXME - Account for scaling
         let pos = pos.into();
         let pos = PhysicalPosition::new(pos.x, pos.y);
-        self.mouse_state.position = dbg!(pos);
+        self.mouse_state.physical_position = dbg!(pos);
+        // TODO: may want to support testing with non-unity scale factors.
+        let scale_factor = 1.0;
+        self.mouse_state.position = pos.to_logical(scale_factor);
 
         self.process_pointer_event(PointerEvent::PointerMove(self.mouse_state.clone()));
     }
@@ -352,7 +355,7 @@ impl TestHarness {
 
     /// Send a Wheel event to the window
     pub fn mouse_wheel(&mut self, wheel_delta: Vec2) {
-        let pixel_delta = PhysicalPosition::new(wheel_delta.x, wheel_delta.y);
+        let pixel_delta = LogicalPosition::new(wheel_delta.x, wheel_delta.y);
         self.process_pointer_event(PointerEvent::MouseWheel(
             pixel_delta,
             self.mouse_state.clone(),

--- a/crates/masonry/src/widget/split.rs
+++ b/crates/masonry/src/widget/split.rs
@@ -7,7 +7,7 @@
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, warn, Span};
 use vello::Scene;
-use winit::dpi::PhysicalPosition;
+use winit::dpi::LogicalPosition;
 use winit::event::MouseButton;
 use winit::window::CursorIcon;
 
@@ -196,7 +196,7 @@ impl Split {
     }
 
     /// Returns true if the provided mouse position is inside the splitter bar area.
-    fn bar_hit_test(&self, size: Size, mouse_pos: PhysicalPosition<f64>) -> bool {
+    fn bar_hit_test(&self, size: Size, mouse_pos: LogicalPosition<f64>) -> bool {
         let (edge1, edge2) = self.bar_edges(size);
         match self.split_axis {
             Axis::Horizontal => mouse_pos.x >= edge1 && mouse_pos.x <= edge2,

--- a/crates/masonry/src/widget/widget_pod.rs
+++ b/crates/masonry/src/widget/widget_pod.rs
@@ -4,7 +4,7 @@
 
 use tracing::{info_span, trace, warn};
 use vello::Scene;
-use winit::dpi::PhysicalPosition;
+use winit::dpi::LogicalPosition;
 
 use crate::event::{PointerEvent, TextEvent};
 use crate::kurbo::{Affine, Insets, Point, Rect, Shape, Size};
@@ -232,7 +232,7 @@ impl<W: Widget> WidgetPod<W> {
         inner: &mut W,
         inner_state: &mut WidgetState,
         global_state: &mut RenderRootState,
-        mouse_pos: Option<PhysicalPosition<f64>>,
+        mouse_pos: Option<LogicalPosition<f64>>,
     ) -> bool {
         let rect = inner_state.layout_rect() + inner_state.parent_window_origin.to_vec2();
         let had_hot = inner_state.is_hot;
@@ -608,7 +608,7 @@ impl<W: Widget> WidgetPod<W> {
                 InternalLifeCycle::ParentWindowOrigin { mouse_pos } => {
                     self.state.parent_window_origin = parent_ctx.widget_state.window_origin();
                     self.state.needs_window_origin = false;
-                    let mouse_pos = mouse_pos.map(|pos| PhysicalPosition::new(pos.x, pos.y));
+                    let mouse_pos = mouse_pos.map(|pos| LogicalPosition::new(pos.x, pos.y));
                     WidgetPod::update_hot_state(
                         &mut self.inner,
                         &mut self.state,

--- a/src/app_main.rs
+++ b/src/app_main.rs
@@ -23,7 +23,6 @@ use vello::{
 use wgpu::PresentMode;
 use winit::{
     application::ApplicationHandler,
-    dpi::PhysicalPosition,
     event::{ElementState, Modifiers, MouseButton, MouseScrollDelta, WindowEvent},
     event_loop::{ActiveEventLoop, ControlFlow, EventLoop},
     window::{Window, WindowId},

--- a/src/app_main.rs
+++ b/src/app_main.rs
@@ -181,8 +181,9 @@ impl<'a, T: Send + 'static, V: View<T> + 'static> MainState<'a, T, V> {
                 MouseScrollDelta::LineDelta(x, y) => {
                     ScrollDelta::Lines(x.trunc() as isize, y.trunc() as isize)
                 }
-                MouseScrollDelta::PixelDelta(PhysicalPosition { x, y }) => {
-                    ScrollDelta::Precise(Vec2::new(x, y) * (1.0 / self.window.scale_factor()))
+                MouseScrollDelta::PixelDelta(position) => {
+                    let logical_pos = position.to_logical(self.window.scale_factor());
+                    ScrollDelta::Precise(Vec2::new(logical_pos.x, logical_pos.y))
                 }
             })));
         self.window.request_redraw();

--- a/src/widget/raw_event.rs
+++ b/src/widget/raw_event.rs
@@ -49,7 +49,7 @@ pub struct MouseEvent {
 /// > Positive values indicate that the content that is being scrolled should move
 /// > right and down (revealing more content left and up).
 ///
-/// The choice to follow this has not been reasoned, but is based on expediance
+/// The choice to follow this has not been reasoned, but is based on expedience.
 pub enum ScrollDelta {
     Precise(Vec2),
     Lines(isize, isize),


### PR DESCRIPTION
Generally prefer use of LogicalPosition to PhysicalPosition for layout, events, etc. Use scale factor to convert to logical position. Apply scale factor as final transform before Vello rendering.

This PR also makes physical_position available in PointerState.

There is a TODO for handling WindowEvent::Rescale, which remains and is not addressed. It should be at some future point.