### PR TITLE
masonry: Fix non-resetting visual active state when releasing active button outside of its area

### DIFF
--- a/crates/masonry/src/widget/button.rs
+++ b/crates/masonry/src/widget/button.rs
@@ -86,6 +86,9 @@ impl Widget for Button {
                     ctx.request_paint();
                     trace!("Button {:?} released", ctx.widget_id());
                 }
+                if ctx.is_active() && !ctx.is_hot() && !ctx.is_disabled() {
+                    ctx.request_paint();
+                }
                 ctx.set_active(false);
             }
             PointerEvent::PointerLeave(_) => {

--- a/crates/masonry/src/widget/button.rs
+++ b/crates/masonry/src/widget/button.rs
@@ -83,12 +83,9 @@ impl Widget for Button {
             PointerEvent::PointerUp(_, _) => {
                 if ctx.is_active() && ctx.is_hot() && !ctx.is_disabled() {
                     ctx.submit_action(Action::ButtonPressed);
-                    ctx.request_paint();
                     trace!("Button {:?} released", ctx.widget_id());
                 }
-                if ctx.is_active() && !ctx.is_hot() {
-                    ctx.request_paint();
-                }
+                ctx.request_paint();
                 ctx.set_active(false);
             }
             PointerEvent::PointerLeave(_) => {

--- a/crates/masonry/src/widget/button.rs
+++ b/crates/masonry/src/widget/button.rs
@@ -86,7 +86,7 @@ impl Widget for Button {
                     ctx.request_paint();
                     trace!("Button {:?} released", ctx.widget_id());
                 }
-                if ctx.is_active() && !ctx.is_hot() && !ctx.is_disabled() {
+                if ctx.is_active() && !ctx.is_hot() {
                     ctx.request_paint();
                 }
                 ctx.set_active(false);


### PR DESCRIPTION
When pressing the button and releasing it outside of its active area, the visual pressed state (background gradient) stays "pressed". This should fix this.

(Not related to that PR) I'm not sure, if there's a case, where the disabled state could change while pressing the button and trigger a similar behavior.