### PR TITLE
Prepare `Cargo.toml` files for release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "masonry"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "assert_matches",
  "float-cmp",
@@ -3142,6 +3142,17 @@ checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 name = "xilem"
 version = "0.1.0"
 dependencies = [
+ "masonry",
+ "smallvec",
+ "tracing",
+ "vello",
+ "winit",
+]
+
+[[package]]
+name = "xilem_classic"
+version = "0.1.0"
+dependencies = [
  "bitflags 2.5.0",
  "fnv",
  "futures-task",
@@ -3159,17 +3170,6 @@ dependencies = [
 [[package]]
 name = "xilem_core"
 version = "0.1.0"
-
-[[package]]
-name = "xilem_masonry"
-version = "0.1.0"
-dependencies = [
- "masonry",
- "smallvec",
- "tracing",
- "vello",
- "winit",
-]
 
 [[package]]
 name = "xilem_web"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,38 +13,43 @@ members = [
 
 [workspace.package]
 edition = "2021"
-homepage = "https://xilem.dev/"
-repository = "https://github.com/linebender/xilem"
 license = "Apache-2.0"
-
-[workspace.dependencies]
-xilem_core = { version = "0.1.0", path = "crates/xilem_core" }
-masonry = { version = "0.1.0", path = "crates/masonry" }
-kurbo = "0.11.0"
-winit = "0.30"
-parley = "0.1.0"
-vello = "0.1.0"
+repository = "https://github.com/linebender/xilem"
+homepage = "https://xilem.dev/"
 
 [workspace.lints]
 clippy.semicolon_if_nothing_returned = "warn"
 
+[workspace.dependencies]
+xilem_core = { version = "0.1.0", path = "crates/xilem_core" }
+masonry = { version = "0.2.0", path = "crates/masonry" }
+vello = "0.1.0"
+wgpu = "0.19.3"
+kurbo = "0.11.0"
+parley = "0.1.0"
+peniko = "0.1.0"
+winit = "0.30.0"
+tracing = "0.1.40"
+smallvec = "1.13.2"
+fnv = "1.0.7"
+instant = "0.1.6"
+bitflags = "2.0.0"
+
 [package]
-name = "xilem"
+name = "xilem_classic"
 version = "0.1.0"
 description = "A next-generation cross-platform Rust UI framework."
 keywords = ["gui", "ui", "native", "gpu", "performance"]
 categories = ["gui", "graphics", "internationalization", "accessibility"]
 exclude = ["/.github/"]
-publish = false                                                           # Until it's ready
-license.workspace = true
+publish = false # Classic Xilem is not for publishing
 edition.workspace = true
-homepage.workspace = true
+license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-default-target = "x86_64-pc-windows-msvc"
 # rustdoc-scrape-examples tracking issue https://github.com/rust-lang/rust/issues/88791
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
@@ -60,14 +65,14 @@ taffy = ["dep:taffy"]
 
 [dependencies]
 xilem_core.workspace = true
-taffy = { version = "0.4.0", optional = true }
 vello.workspace = true
-wgpu = "0.19.3"
+wgpu.workspace = true
 parley.workspace = true
-tokio = { version = "1.35", features = ["full"] }
-futures-task = "0.3"
-bitflags = "2"
-tracing = "0.1.37"
-fnv = "1.0.7"
-instant = { version = "0.1.6", features = ["wasm-bindgen"] }
 winit.workspace = true
+bitflags.workspace = true
+tracing.workspace = true
+fnv.workspace = true
+instant = { workspace = true, features = ["wasm-bindgen"] }
+tokio = { version = "1.35", features = ["full"] }
+taffy = { version = "0.4.0", optional = true }
+futures-task = "0.3"

--- a/crates/masonry/Cargo.toml
+++ b/crates/masonry/Cargo.toml
@@ -1,35 +1,38 @@
 [package]
-categories = ["gui"]
-description = "Data-oriented Rust UI design toolkit."
-edition = "2021"
-keywords = ["gui", "ui", "toolkit"]
-license.workspace = true
 name = "masonry"
-readme = "README.md"
+version = "0.2.0"
+description = "Data-oriented Rust UI design toolkit."
+keywords = ["gui", "ui", "toolkit"]
+categories = ["gui", "internationalization", "accessibility"]
+edition.workspace = true
+license.workspace = true
 repository.workspace = true
-rust-version = "1.75"
-version = "0.1.3"
+homepage.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+# rustdoc-scrape-examples tracking issue https://github.com/rust-lang/rust/issues/88791
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [lints]
 workspace = true
 
-# NOTE: Make sure to keep wgpu version in sync with the version badge in README.md
 [dependencies]
-fnv = "1.0.7"
-instant = { version = "0.1.6", features = ["wasm-bindgen"] }
-smallvec = "1.6.1"
-tracing = "0.1.29"
+vello.workspace = true
+wgpu.workspace = true
+kurbo.workspace = true
+parley.workspace = true
+winit.workspace = true
+smallvec.workspace = true
+tracing.workspace = true
+fnv.workspace = true
+instant = { workspace = true, features = ["wasm-bindgen"] }
 image = "0.24.0"
 once_cell = "1.9.0"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
-vello.workspace = true
-kurbo = "0.11.0"
 futures-intrusive = "0.5.0"
 pollster = "0.3.0"
-parley.workspace = true
-wgpu = { version = "0.19.3" }
-winit.workspace = true
 unicode-segmentation = "1.11.0"
 # TODO: Is this still the most up-to-date crate for this?
 xi-unicode = "0.3.0"

--- a/crates/xilem_core/Cargo.toml
+++ b/crates/xilem_core/Cargo.toml
@@ -5,15 +5,13 @@ description = "Common core of the Xilem Rust UI framework."
 keywords = ["xilem", "ui", "reactive", "performance"]
 categories = ["gui"]
 publish = false # Until it's ready
-license.workspace = true
 edition.workspace = true
-homepage.workspace = true
+license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-default-target = "x86_64-pc-windows-msvc"
 # rustdoc-scrape-examples tracking issue https://github.com/rust-lang/rust/issues/88791
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 

--- a/crates/xilem_masonry/Cargo.toml
+++ b/crates/xilem_masonry/Cargo.toml
@@ -1,19 +1,25 @@
 [package]
-name = "xilem_masonry"
+name = "xilem"
 version = "0.1.0"
+description = "A next-generation cross-platform Rust UI framework."
+keywords = ["gui", "ui", "native", "gpu", "performance"]
+categories = ["gui", "graphics", "internationalization", "accessibility"]
 edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.docs.rs]
+all-features = true
+# rustdoc-scrape-examples tracking issue https://github.com/rust-lang/rust/issues/88791
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+
+[lints]
+workspace = true
 
 [dependencies]
 masonry.workspace = true
 winit.workspace = true
-tracing = "0.1.40"
+tracing.workspace = true
 vello.workspace = true
-smallvec = "1.13.2"
-
-[lints]
-workspace = true
+smallvec.workspace = true

--- a/crates/xilem_masonry/examples/mason.rs
+++ b/crates/xilem_masonry/examples/mason.rs
@@ -4,8 +4,8 @@
 // On Windows platform, don't show a console when opening the app.
 #![windows_subsystem = "windows"]
 
-use xilem_masonry::view::{button, checkbox, flex, label, prose, textbox};
-use xilem_masonry::{Axis, BoxedMasonryView, Color, MasonryView, TextAlignment, Xilem};
+use xilem::view::{button, checkbox, flex, label, prose, textbox};
+use xilem::{Axis, BoxedMasonryView, Color, MasonryView, TextAlignment, Xilem};
 
 const LOREM: &str = r"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi cursus mi sed euismod euismod. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam placerat efficitur tellus at semper. Morbi ac risus magna. Donec ut cursus ex. Etiam quis posuere tellus. Mauris posuere dui et turpis mollis, vitae luctus tellus consectetur. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eu facilisis nisl.
 

--- a/crates/xilem_web/Cargo.toml
+++ b/crates/xilem_web/Cargo.toml
@@ -5,15 +5,13 @@ description = "HTML DOM frontend for the Xilem Rust UI framework."
 keywords = ["xilem", "html", "dom", "web", "ui"]
 categories = ["gui", "web-programming"]
 publish = false # Until it's ready
-license.workspace = true
 edition.workspace = true
-homepage.workspace = true
+license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-default-target = "x86_64-pc-windows-msvc"
 # rustdoc-scrape-examples tracking issue https://github.com/rust-lang/rust/issues/88791
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
@@ -23,12 +21,12 @@ workspace = true
 [dependencies]
 xilem_core.workspace = true
 kurbo.workspace = true
-bitflags = "2"
+peniko.workspace = true
+bitflags.workspace = true
 wasm-bindgen = "0.2.87"
-paste = "1"
+paste = "1.0.0"
 log = "0.4.19"
 gloo = { version = "0.11.0", default-features = false, features = ["events"] }
-peniko = "0.1.0"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/examples/hello_xilem.rs
+++ b/examples/hello_xilem.rs
@@ -1,8 +1,8 @@
 // Copyright 2022 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use xilem::view::{button, h_stack, switch, v_stack};
-use xilem::{view::View, App, AppLauncher};
+use xilem_classic::view::{button, h_stack, switch, v_stack};
+use xilem_classic::{view::View, App, AppLauncher};
 
 fn app_logic(data: &mut AppData) -> impl View<AppData> {
     // here's some logic, deriving state for the view from our state

--- a/examples/taffy.rs
+++ b/examples/taffy.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use xilem::{view::View, App, AppLauncher};
+use xilem_classic::{view::View, App, AppLauncher};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct AppState {
@@ -24,7 +24,7 @@ fn app_logic(state: &mut AppState) -> impl View<AppState> {
     use taffy::style::{AlignItems, FlexWrap, JustifyContent};
     use taffy::style_helpers::length;
     use vello::peniko::Color;
-    use xilem::view::{button, div, flex_column, flex_row, scroll_view};
+    use xilem_classic::view::{button, div, flex_column, flex_row, scroll_view};
 
     const COLORS: [Color; 4] = [
         Color::LIGHT_GREEN,


### PR DESCRIPTION
* Rename classic `xilem` to `xilem_classic` and the new `xilem_masonry` to `xilem`.
  No directory structure changes yet to avoid merge conflicts before RustNL.
* Base common dependencies on workspace dependencies.
* Bump `masonry` version to `0.2.0`.
* Remove some legacy docs.rs configuration inherited from Druid/Glazier that is no longer needed.
* Unify ordering of properties.