### PR TITLE
Return the correct accessibility role in DynWidget

### DIFF
--- a/crates/xilem_masonry/src/any_view.rs
+++ b/crates/xilem_masonry/src/any_view.rs
@@ -225,7 +225,7 @@ impl Widget for DynWidget {
     }
 
     fn accessibility_role(&self) -> Role {
-        self.inner.widget().accessibility_role()
+        Role::GenericContainer
     }
 
     fn accessibility(&mut self, ctx: &mut AccessCtx) {


### PR DESCRIPTION
This fixes the problem where the container widget had the same role as its child, leading to, for example, nested buttons in the mason example.