### PR TITLE
Cleanup the text widgets to not be generic

### DIFF
--- a/crates/masonry/examples/calc.rs
+++ b/crates/masonry/examples/calc.rs
@@ -255,8 +255,8 @@ impl AppDriver for CalcState {
             .get_element()
             .child_mut(1)
             .unwrap()
-            .downcast::<Label<String>>()
-            .set_text((&*self.value).into());
+            .downcast::<Label>()
+            .set_text(&*self.value);
     }
 }
 

--- a/crates/masonry/src/widget/button.rs
+++ b/crates/masonry/src/widget/button.rs
@@ -13,7 +13,7 @@ use crate::paint_scene_helpers::{fill_lin_gradient, stroke, UnitPoint};
 use crate::text2::TextStorage;
 use crate::widget::{Label, WidgetMut, WidgetPod, WidgetRef};
 use crate::{
-    theme, AccessCtx, AccessEvent, BoxConstraints, EventCtx, Insets, LayoutCtx, LifeCycle,
+    theme, AccessCtx, AccessEvent, ArcStr, BoxConstraints, EventCtx, Insets, LayoutCtx, LifeCycle,
     LifeCycleCtx, PaintCtx, PointerEvent, Size, StatusChange, TextEvent, Widget,
 };
 
@@ -25,11 +25,11 @@ const LABEL_INSETS: Insets = Insets::uniform_xy(8., 2.);
 /// A button with a text label.
 ///
 /// Emits [`Action::ButtonPressed`] when pressed.
-pub struct Button<T: TextStorage> {
-    label: WidgetPod<Label<T>>,
+pub struct Button {
+    label: WidgetPod<Label>,
 }
 
-impl<T: TextStorage> Button<T> {
+impl Button {
     /// Create a new button with a text label.
     ///
     /// # Examples
@@ -39,7 +39,7 @@ impl<T: TextStorage> Button<T> {
     ///
     /// let button = Button::new("Increment");
     /// ```
-    pub fn new(text: T) -> Button<T> {
+    pub fn new(text: impl Into<ArcStr>) -> Button {
         Button::from_label(Label::new(text))
     }
 
@@ -54,25 +54,25 @@ impl<T: TextStorage> Button<T> {
     /// let label = Label::new("Increment").with_text_brush(Color::rgb(0.5, 0.5, 0.5));
     /// let button = Button::from_label(label);
     /// ```
-    pub fn from_label(label: Label<T>) -> Button<T> {
+    pub fn from_label(label: Label) -> Button {
         Button {
             label: WidgetPod::new(label),
         }
     }
 }
 
-impl<T: TextStorage> WidgetMut<'_, Button<T>> {
+impl WidgetMut<'_, Button> {
     /// Set the text.
-    pub fn set_text(&mut self, new_text: T) {
+    pub fn set_text(&mut self, new_text: impl Into<ArcStr>) {
         self.label_mut().set_text(new_text);
     }
 
-    pub fn label_mut(&mut self) -> WidgetMut<'_, Label<T>> {
+    pub fn label_mut(&mut self) -> WidgetMut<'_, Label> {
         self.ctx.get_mut(&mut self.widget.label)
     }
 }
 
-impl<T: TextStorage> Widget for Button<T> {
+impl Widget for Button {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         match event {
             PointerEvent::PointerDown(_, _) => {
@@ -261,7 +261,7 @@ mod tests {
             let mut harness = TestHarness::create_with_size(button, Size::new(50.0, 50.0));
 
             harness.edit_root_widget(|mut button| {
-                let mut button = button.downcast::<Button<&'static str>>();
+                let mut button = button.downcast::<Button>();
                 button.set_text("The quick brown fox jumps over the lazy dog");
 
                 let mut label = button.label_mut();

--- a/crates/masonry/src/widget/checkbox.rs
+++ b/crates/masonry/src/widget/checkbox.rs
@@ -20,14 +20,14 @@ use crate::{
 };
 
 /// A checkbox that can be toggled.
-pub struct Checkbox<T: TextStorage = ArcStr> {
+pub struct Checkbox {
     checked: bool,
-    label: WidgetPod<Label<T>>,
+    label: WidgetPod<Label>,
 }
 
-impl<T: TextStorage> Checkbox<T> {
+impl Checkbox {
     /// Create a new `Checkbox` with a text label.
-    pub fn new(checked: bool, text: T) -> Checkbox<T> {
+    pub fn new(checked: bool, text: impl Into<ArcStr>) -> Checkbox {
         Checkbox {
             checked,
             label: WidgetPod::new(Label::new(text)),
@@ -35,7 +35,7 @@ impl<T: TextStorage> Checkbox<T> {
     }
 
     /// Create a new `Checkbox` with the given label.
-    pub fn from_label(checked: bool, label: Label<T>) -> Checkbox<T> {
+    pub fn from_label(checked: bool, label: Label) -> Checkbox {
         Checkbox {
             checked,
             label: WidgetPod::new(label),
@@ -43,23 +43,25 @@ impl<T: TextStorage> Checkbox<T> {
     }
 }
 
-impl<T: TextStorage> WidgetMut<'_, Checkbox<T>> {
+impl WidgetMut<'_, Checkbox> {
     pub fn set_checked(&mut self, checked: bool) {
         self.widget.checked = checked;
         self.ctx.request_paint();
     }
 
     /// Set the text.
-    pub fn set_text(&mut self, new_text: T) {
+    ///
+    /// We enforce this to be an `ArcStr` to make the allocation explicit.
+    pub fn set_text(&mut self, new_text: ArcStr) {
         self.label_mut().set_text(new_text);
     }
 
-    pub fn label_mut(&mut self) -> WidgetMut<'_, Label<T>> {
+    pub fn label_mut(&mut self) -> WidgetMut<'_, Label> {
         self.ctx.get_mut(&mut self.widget.label)
     }
 }
 
-impl<T: TextStorage> Widget for Checkbox<T> {
+impl Widget for Checkbox {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         match event {
             PointerEvent::PointerDown(_, _) => {
@@ -280,9 +282,9 @@ mod tests {
             let mut harness = TestHarness::create_with_size(checkbox, Size::new(50.0, 50.0));
 
             harness.edit_root_widget(|mut checkbox| {
-                let mut checkbox = checkbox.downcast::<Checkbox<&'static str>>();
+                let mut checkbox = checkbox.downcast::<Checkbox>();
                 checkbox.set_checked(true);
-                checkbox.set_text("The quick brown fox jumps over the lazy dog");
+                checkbox.set_text(ArcStr::from("The quick brown fox jumps over the lazy dog"));
 
                 let mut label = checkbox.label_mut();
                 label.set_text_brush(PRIMARY_LIGHT);

--- a/crates/masonry/src/widget/flex.rs
+++ b/crates/masonry/src/widget/flex.rs
@@ -1392,7 +1392,7 @@ mod tests {
             let mut child = flex.child_mut(1).unwrap();
             assert_eq!(
                 child
-                    .try_downcast::<Label<&'static str>>()
+                    .try_downcast::<Label>()
                     .unwrap()
                     .widget
                     .text()

--- a/crates/masonry/src/widget/widget_ref.rs
+++ b/crates/masonry/src/widget/widget_ref.rs
@@ -216,9 +216,9 @@ mod tests {
         let label = WidgetPod::new(Label::new("Hello"));
         let dyn_widget: WidgetRef<dyn Widget> = label.as_dyn();
 
-        let label = dyn_widget.downcast::<Label<&'static str>>();
+        let label = dyn_widget.downcast::<Label>();
         assert_matches!(label, Some(_));
-        let label = dyn_widget.downcast::<Button<&'static str>>();
+        let label = dyn_widget.downcast::<Button>();
         assert_matches!(label, None);
     }
 
@@ -229,17 +229,7 @@ mod tests {
 
         let harness = TestHarness::create(label);
 
-        assert_matches!(
-            harness
-                .get_widget(label_id)
-                .downcast::<Label<&'static str>>(),
-            Some(_)
-        );
-        assert_matches!(
-            harness
-                .get_widget(label_id)
-                .downcast::<Button<&'static str>>(),
-            None
-        );
+        assert_matches!(harness.get_widget(label_id).downcast::<Label>(), Some(_));
+        assert_matches!(harness.get_widget(label_id).downcast::<Button>(), None);
     }
 }

--- a/crates/xilem_masonry/src/view/button.rs
+++ b/crates/xilem_masonry/src/view/button.rs
@@ -24,7 +24,7 @@ impl<F, State, Action> MasonryView<State, Action> for Button<F>
 where
     F: Fn(&mut State) -> Action + Send + 'static,
 {
-    type Element = masonry::widget::Button<ArcStr>;
+    type Element = masonry::widget::Button;
     type ViewState = ();
 
     fn build(&self, cx: &mut ViewCx) -> (WidgetPod<Self::Element>, Self::ViewState) {

--- a/crates/xilem_masonry/src/view/label.rs
+++ b/crates/xilem_masonry/src/view/label.rs
@@ -40,7 +40,7 @@ impl Label {
 }
 
 impl<State, Action> MasonryView<State, Action> for Label {
-    type Element = masonry::widget::Label<ArcStr>;
+    type Element = masonry::widget::Label;
     type ViewState = ();
 
     fn build(&self, _cx: &mut ViewCx) -> (WidgetPod<Self::Element>, Self::ViewState) {

--- a/crates/xilem_masonry/src/view/prose.rs
+++ b/crates/xilem_masonry/src/view/prose.rs
@@ -41,7 +41,7 @@ impl Prose {
 }
 
 impl<State, Action> MasonryView<State, Action> for Prose {
-    type Element = masonry::widget::Prose<ArcStr>;
+    type Element = masonry::widget::Prose;
     type ViewState = ();
 
     fn build(&self, _cx: &mut ViewCx) -> (WidgetPod<Self::Element>, Self::ViewState) {

--- a/crates/xilem_masonry/src/view/textbox.rs
+++ b/crates/xilem_masonry/src/view/textbox.rs
@@ -63,7 +63,7 @@ impl<State, Action> Textbox<State, Action> {
 }
 
 impl<State: 'static, Action: 'static> MasonryView<State, Action> for Textbox<State, Action> {
-    type Element = masonry::widget::Textbox<String>;
+    type Element = masonry::widget::Textbox;
     type ViewState = ();
 
     fn build(&self, cx: &mut ViewCx) -> (WidgetPod<Self::Element>, Self::ViewState) {
@@ -89,9 +89,9 @@ impl<State: 'static, Action: 'static> MasonryView<State, Action> for Textbox<Sta
         // instead, we compare directly to the element's text. This is to handle
         // cases like "Previous data says contents is 'fooba', user presses 'r',
         // now data and contents are both 'foobar' but previous data is 'fooba'"
-        // withou calling `set_text`.
-        if self.contents != element.text().as_str() {
-            element.set_text(self.contents.clone());
+        // without calling `set_text`.
+        if self.contents != element.text() {
+            element.reset_text(self.contents.clone());
             changeflags.changed |= ChangeFlags::CHANGED.changed;
         }
 


### PR DESCRIPTION
This is fallout from #241. As discussed on Zulip, using different underlying text types here is a very advanced feature, which will not be needed by any real consumers. It also creates some footguns

Probably conflicts with #257, so that should land first