### PR TITLE
Add VS Code marker comments to code

### DIFF
--- a/masonry/doc/ARCHITECTURE.md
+++ b/masonry/doc/ARCHITECTURE.md
@@ -166,3 +166,20 @@ The GlobalPassCtx types stores two timer handlers: **timers** and **mock_timer_q
 When a widget calls `request_timer` in a normal running app, a normal timer is requested from the platform. When a widget calls `request_timer` from a simulated app inside a TestHarness, mock_timer_queue is used instead.
 
 All this means you can have timer-based tests without *actually* having to sleep for the duration of the timer.
+
+
+## VS Code markers
+
+Masonry uses VS Code markers to help users browse code with the minimap:
+
+https://code.visualstudio.com/docs/getstarted/userinterface#_minimap
+
+These markers look like this:
+
+```rust
+// --- MARK: MARKER NAME ---
+```
+
+By convention, we write them in all caps with three dashes. Markers don't need to follow strict naming conventions, but their names should be a shorthand for the area of the code they're in. Names should be short enough not to overflow the VS Code minimap.
+
+Small files shouldn't have markers, except for files following a general template (widget implementations, view implementations). Generally files should have between 50 and 200 lines between markers. If a file has any markers, it should have enough split the file into distinct regions.

--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -60,6 +60,7 @@ pub type EventLoop = winit::event_loop::EventLoop<accesskit_winit::Event>;
 /// This *will* be changed to allow custom event types, but is implemented this way for expedience
 pub type EventLoopBuilder = winit::event_loop::EventLoopBuilder<accesskit_winit::Event>;
 
+// --- MARK: RUN ---
 pub fn run(
     // Clearly, this API needs to be refactored, so we don't mind forcing this to be passed in here directly
     // This is passed in mostly to allow configuring the Android app
@@ -184,6 +185,7 @@ impl ApplicationHandler<accesskit_winit::Event> for MainState<'_> {
         }
     }
 
+    // --- MARK: WINDOW_EVENT ---
     fn window_event(&mut self, event_loop: &ActiveEventLoop, _: WindowId, event: WinitWindowEvent) {
         let WindowState::Rendering {
             window,
@@ -330,6 +332,7 @@ impl ApplicationHandler<accesskit_winit::Event> for MainState<'_> {
         self.handle_signals(event_loop);
     }
 
+    // --- MARK: USER_EVENT ---
     fn user_event(&mut self, event_loop: &ActiveEventLoop, event: accesskit_winit::Event) {
         match event.window_event {
             // Note that this event can be called at any time, even multiple times if
@@ -349,6 +352,7 @@ impl ApplicationHandler<accesskit_winit::Event> for MainState<'_> {
 }
 
 impl MainState<'_> {
+    // --- MARK: RENDER ---
     fn render(&mut self, scene: Scene) {
         let WindowState::Rendering {
             window, surface, ..
@@ -406,6 +410,7 @@ impl MainState<'_> {
         device.poll(wgpu::Maintain::Wait);
     }
 
+    // --- MARK: SIGNALS ---
     fn handle_signals(&mut self, _event_loop: &ActiveEventLoop) {
         let WindowState::Rendering { window, .. } = &mut self.window else {
             tracing::warn!("Tried to handle a signal whilst suspended or before window created");
@@ -469,6 +474,7 @@ impl MainState<'_> {
     }
 }
 
+// --- MARK: TRACING ---
 pub(crate) fn try_init_tracing() -> Result<(), SetGlobalDefaultError> {
     #[cfg(not(target_arch = "wasm32"))]
     {

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -114,6 +114,7 @@ impl RenderRoot {
         root
     }
 
+    // --- MARK: WINDOW_EVENT ---
     pub fn handle_window_event(&mut self, event: WindowEvent) -> Handled {
         match event {
             WindowEvent::Rescale(scale_factor) => {
@@ -159,6 +160,7 @@ impl RenderRoot {
         }
     }
 
+    // --- MARK: PUB FUNCTIONS---
     pub fn handle_pointer_event(&mut self, event: PointerEvent) -> Handled {
         self.root_on_pointer_event(event)
     }
@@ -203,6 +205,7 @@ impl RenderRoot {
         self.cursor_icon
     }
 
+    // --- MARK: EDIT ROOT---
     pub fn edit_root_widget<R>(
         &mut self,
         f: impl FnOnce(WidgetMut<'_, Box<dyn Widget>>) -> R,
@@ -228,6 +231,7 @@ impl RenderRoot {
         res
     }
 
+    // --- MARK: POINTER_EVENT  ---
     fn root_on_pointer_event(&mut self, event: PointerEvent) -> Handled {
         let mut widget_state =
             WidgetState::new(self.root.id(), Some(self.get_kurbo_size()), "<root>");
@@ -276,6 +280,7 @@ impl RenderRoot {
         handled
     }
 
+    // --- MARK: TEXT_EVENT---
     fn root_on_text_event(&mut self, event: TextEvent) -> Handled {
         let mut widget_state =
             WidgetState::new(self.root.id(), Some(self.get_kurbo_size()), "<root>");
@@ -318,6 +323,7 @@ impl RenderRoot {
         handled
     }
 
+    // --- MARK: ACCESS_EVENT ---
     pub fn root_on_access_event(&mut self, event: ActionRequest) {
         let mut widget_state =
             WidgetState::new(self.root.id(), Some(self.get_kurbo_size()), "<root>");
@@ -353,6 +359,7 @@ impl RenderRoot {
         self.root.as_dyn().debug_validate(false);
     }
 
+    // --- MARK: LIFECYCLE ---
     fn root_lifecycle(&mut self, event: LifeCycle) {
         let mut widget_state =
             WidgetState::new(self.root.id(), Some(self.get_kurbo_size()), "<root>");
@@ -376,6 +383,7 @@ impl RenderRoot {
         self.post_event_processing(&mut widget_state);
     }
 
+    // --- MARK: LAYOUT ---
     pub(crate) fn root_layout(&mut self) {
         let mut widget_state =
             WidgetState::new(self.root.id(), Some(self.get_kurbo_size()), "<root>");
@@ -417,6 +425,7 @@ impl RenderRoot {
         self.post_event_processing(&mut widget_state);
     }
 
+    // --- MARK: PAINT ---
     fn root_paint(&mut self) -> Scene {
         // TODO - Handle Xilem's VIEW_CONTEXT_CHANGED
 
@@ -450,6 +459,7 @@ impl RenderRoot {
         scene
     }
 
+    // --- MARK: ACCESSIBILITY ---
     // TODO - Integrate in unit tests?
     fn root_accessibility(&mut self) -> TreeUpdate {
         let mut tree_update = TreeUpdate {
@@ -494,6 +504,7 @@ impl RenderRoot {
         kurbo::Size::new(size.width, size.height)
     }
 
+    // --- MARK: POST-EVENT ---
     fn post_event_processing(&mut self, widget_state: &mut WidgetState) {
         // If children are changed during the handling of an event,
         // we need to send RouteWidgetAdded now, so that they are ready for update/layout.

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -192,6 +192,7 @@ impl TestHarness {
         harness
     }
 
+    // --- MARK: PROCESS EVENTS ---
     // FIXME - The docs for these three functions are copy-pasted. Rewrite them.
 
     /// Send an event to the widget.
@@ -233,6 +234,7 @@ impl TestHarness {
         }
     }
 
+    // --- MARK: RENDER ---
     // TODO - We add way too many dependencies in this code
     // TODO - Should be async?
     /// Create a bitmap (an array of pixels), paint the window and return the bitmap as an 8-bits-per-channel RGB image.
@@ -333,7 +335,7 @@ impl TestHarness {
         RgbaImage::from_vec(width, height, result_unpadded).expect("failed to create image")
     }
 
-    // --- Event helpers ---
+    // --- MARK: EVENT HELPERS ---
 
     /// Move an internal mouse state, and send a MouseMove event to the window.
     pub fn mouse_move(&mut self, pos: impl Into<Point>) {
@@ -424,7 +426,7 @@ impl TestHarness {
         }
     }
 
-    // --- Getters ---
+    // --- MARK: GETTERS ---
 
     /// Return the root widget.
     pub fn root_widget(&self) -> WidgetRef<'_, dyn Widget> {
@@ -495,7 +497,7 @@ impl TestHarness {
         }
     }
 
-    // --- Screenshots ---
+    // --- MARK: SNAPSHOT ---
 
     /// Method used by [`assert_render_snapshot`]. Use the macro instead.
     ///

--- a/masonry/src/widget/align.rs
+++ b/masonry/src/widget/align.rs
@@ -31,6 +31,7 @@ pub struct Align {
     height_factor: Option<f64>,
 }
 
+// --- MARK: BUILDERS ---
 impl Align {
     /// Create widget with alignment.
     ///
@@ -82,6 +83,7 @@ impl Align {
     }
 }
 
+// --- MARK: IMPL WIDGET ---
 impl Widget for Align {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         self.child.on_pointer_event(ctx, event);
@@ -179,6 +181,8 @@ fn log_size_warnings(size: Size) {
     }
 }
 
+// --- MARK: TESTS ---
+// --- MARK: TESTS ---
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widget/button.rs
+++ b/masonry/src/widget/button.rs
@@ -29,6 +29,7 @@ pub struct Button {
     label: WidgetPod<Label>,
 }
 
+// --- MARK: BUILDERS ---
 impl Button {
     /// Create a new button with a text label.
     ///
@@ -61,6 +62,7 @@ impl Button {
     }
 }
 
+// --- MARK: WIDGETMUT ---
 impl WidgetMut<'_, Button> {
     /// Set the text.
     pub fn set_text(&mut self, new_text: impl Into<ArcStr>) {
@@ -72,6 +74,7 @@ impl WidgetMut<'_, Button> {
     }
 }
 
+// --- MARK: IMPL WIDGET ---
 impl Widget for Button {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         match event {
@@ -214,6 +217,7 @@ impl Widget for Button {
     }
 }
 
+// --- MARK: TESTS ---
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widget/checkbox.rs
+++ b/masonry/src/widget/checkbox.rs
@@ -43,6 +43,7 @@ impl Checkbox {
     }
 }
 
+// --- MARK: WIDGETMUT ---
 impl WidgetMut<'_, Checkbox> {
     pub fn set_checked(&mut self, checked: bool) {
         self.widget.checked = checked;
@@ -61,6 +62,7 @@ impl WidgetMut<'_, Checkbox> {
     }
 }
 
+// --- MARK: IMPL WIDGET ---
 impl Widget for Checkbox {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         match event {
@@ -224,6 +226,7 @@ impl Widget for Checkbox {
     }
 }
 
+// --- MARK: TESTS ---
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -93,8 +93,7 @@ pub enum MainAxisAlignment {
     SpaceAround,
 }
 
-// --- Flex impl ---
-
+// --- MARK: IMPL FLEX ---
 impl Flex {
     /// Create a new Flex oriented along the provided axis.
     pub fn for_axis(axis: Axis) -> Self {
@@ -241,8 +240,7 @@ impl Flex {
     }
 }
 
-// --- Mutate live Flex - WidgetMut ---
-
+// --- MARK: WIDGETMUT---
 impl<'a> WidgetMut<'a, Flex> {
     /// Set the flex direction (see [`Axis`]).
     ///
@@ -486,6 +484,7 @@ impl<'a> WidgetMut<'a, Flex> {
     }
 }
 
+// --- MARK: IMPL WIDGET---
 impl Widget for Flex {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         for child in self.children.iter_mut().filter_map(|x| x.widget_mut()) {
@@ -749,8 +748,7 @@ impl Widget for Flex {
     }
 }
 
-// --- Others impls ---
-
+// --- MARK: OTHER IMPLS---
 impl Axis {
     /// Get the axis perpendicular to this one.
     pub fn cross(self) -> Axis {
@@ -1010,6 +1008,7 @@ impl Child {
     }
 }
 
+// --- MARK: TESTS ---
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/masonry/src/widget/image.rs
+++ b/masonry/src/widget/image.rs
@@ -27,6 +27,7 @@ pub struct Image {
     fill: FillStrat,
 }
 
+// --- MARK: BUILDERS ---
 impl Image {
     /// Create an image drawing widget from an image buffer.
     ///
@@ -48,6 +49,7 @@ impl Image {
     }
 }
 
+// --- MARK: WIDGETMUT ---
 impl<'a> WidgetMut<'a, Image> {
     /// Modify the widget's fill strategy.
     #[inline]
@@ -64,6 +66,7 @@ impl<'a> WidgetMut<'a, Image> {
     }
 }
 
+// --- MARK: IMPL WIDGET ---
 impl Widget for Image {
     fn on_pointer_event(&mut self, _ctx: &mut EventCtx, _event: &PointerEvent) {}
 
@@ -123,6 +126,7 @@ impl Widget for Image {
 
 // FIXME - remove cfg?
 #[cfg(not(target_arch = "wasm32"))]
+// --- MARK: TESTS ---
 #[cfg(test)]
 mod tests {
     use vello::peniko::Format;

--- a/masonry/src/widget/label.rs
+++ b/masonry/src/widget/label.rs
@@ -45,6 +45,7 @@ pub struct Label {
     brush: TextBrush,
 }
 
+// --- MARK: BUILDERS ---
 impl Label {
     /// Create a new label.
     pub fn new(text: impl Into<ArcStr>) -> Self {
@@ -95,6 +96,7 @@ impl Label {
     }
 }
 
+// --- MARK: WIDGETMUT ---
 impl WidgetMut<'_, Label> {
     pub fn text(&self) -> &ArcStr {
         self.widget.text_layout.text()
@@ -140,6 +142,7 @@ impl WidgetMut<'_, Label> {
     }
 }
 
+// --- MARK: IMPL WIDGET ---
 impl Widget for Label {
     fn on_pointer_event(&mut self, _ctx: &mut EventCtx, event: &PointerEvent) {
         match event {
@@ -263,6 +266,7 @@ impl Widget for Label {
     }
 }
 
+// --- MARK: TESTS ---
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widget/mod.rs
+++ b/masonry/src/widget/mod.rs
@@ -10,6 +10,7 @@ mod widget_pod;
 mod widget_ref;
 mod widget_state;
 
+// --- MARK: TESTS ---
 #[cfg(test)]
 mod tests;
 

--- a/masonry/src/widget/portal.rs
+++ b/masonry/src/widget/portal.rs
@@ -40,6 +40,7 @@ pub struct Portal<W: Widget> {
     scrollbar_vertical_visible: bool,
 }
 
+// --- MARK: BUILDERS ---
 impl<W: Widget> Portal<W> {
     pub fn new(child: W) -> Self {
         Portal {
@@ -148,6 +149,7 @@ impl<W: Widget> Portal<W> {
     }
 }
 
+// --- MARK: WIDGETMUT ---
 impl<W: Widget> WidgetMut<'_, Portal<W>> {
     pub fn child_mut(&mut self) -> WidgetMut<'_, W> {
         self.ctx.get_mut(&mut self.widget.child)
@@ -235,6 +237,7 @@ impl<W: Widget> WidgetMut<'_, Portal<W>> {
     }
 }
 
+// --- MARK: IMPL WIDGET ---
 impl<W: Widget> Widget for Portal<W> {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         let portal_size = ctx.size();
@@ -422,6 +425,7 @@ impl<W: Widget> Widget for Portal<W> {
     }
 }
 
+// --- MARK: TESTS ---
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -34,6 +34,7 @@ pub struct Prose {
     brush: TextBrush,
 }
 
+// --- MARK: BUILDERS ---
 impl Prose {
     pub fn new(text: impl Into<ArcStr>) -> Self {
         Prose {
@@ -80,6 +81,7 @@ impl Prose {
     }
 }
 
+// --- MARK: WIDGETMUT ---
 impl WidgetMut<'_, Prose> {
     pub fn text(&self) -> &ArcStr {
         self.widget.text_layout.text()
@@ -135,6 +137,7 @@ impl WidgetMut<'_, Prose> {
     }
 }
 
+// --- MARK: IMPL WIDGET ---
 impl Widget for Prose {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         let window_origin = ctx.widget_state.window_origin();

--- a/masonry/src/widget/scroll_bar.rs
+++ b/masonry/src/widget/scroll_bar.rs
@@ -40,6 +40,7 @@ pub struct ScrollBar {
     grab_anchor: Option<f64>,
 }
 
+// --- MARK: BUILDERS ---
 impl ScrollBar {
     pub fn new(axis: Axis, portal_size: f64, content_size: f64) -> Self {
         Self {
@@ -105,6 +106,7 @@ impl ScrollBar {
     }
 }
 
+// --- MARK: WIDGETMUT ---
 impl WidgetMut<'_, ScrollBar> {
     pub fn set_sizes(&mut self, portal_size: f64, content_size: f64) {
         self.widget.portal_size = portal_size;
@@ -124,8 +126,7 @@ impl WidgetMut<'_, ScrollBar> {
     }
 }
 
-// --- TRAIT IMPLS ---
-
+// --- MARK: IMPL WIDGET ---
 impl Widget for ScrollBar {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         match event {
@@ -233,6 +234,7 @@ impl Widget for ScrollBar {
     }
 }
 
+// --- MARK: TESTS ---
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -57,6 +57,7 @@ pub struct SizedBox {
     corner_radius: RoundedRectRadii,
 }
 
+// --- MARK: BUILDERS ---
 impl SizedBox {
     /// Construct container with child, and both width and height not set.
     pub fn new(child: impl Widget) -> Self {
@@ -167,6 +168,7 @@ impl SizedBox {
     // TODO - child()
 }
 
+// --- MARK: WIDGETMUT ---
 impl WidgetMut<'_, SizedBox> {
     pub fn set_child(&mut self, child: impl Widget) {
         self.widget.child = Some(WidgetPod::new(child).boxed());
@@ -247,6 +249,7 @@ impl WidgetMut<'_, SizedBox> {
     }
 }
 
+// --- MARK: INTERNALS ---
 impl SizedBox {
     fn child_constraints(&self, bc: &BoxConstraints) -> BoxConstraints {
         // if we don't have a width/height, we don't change that axis.
@@ -279,6 +282,7 @@ impl SizedBox {
     }
 }
 
+// --- MARK: IMPL WIDGET ---
 impl Widget for SizedBox {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         if let Some(ref mut child) = self.child {
@@ -432,6 +436,7 @@ impl<Painter: FnMut(&mut PaintCtx) + 'static> From<Painter> for BackgroundBrush 
 
 // --- Tests ---
 
+// --- MARK: TESTS ---
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widget/spinner.rs
+++ b/masonry/src/widget/spinner.rs
@@ -30,6 +30,7 @@ pub struct Spinner {
     color: Color,
 }
 
+// --- MARK: BUILDERS ---
 impl Spinner {
     /// Create a spinner widget
     pub fn new() -> Spinner {
@@ -47,6 +48,16 @@ impl Spinner {
     }
 }
 
+impl Default for Spinner {
+    fn default() -> Self {
+        Spinner {
+            t: 0.0,
+            color: theme::TEXT_COLOR,
+        }
+    }
+}
+
+// --- MARK: WIDGETMUT ---
 impl WidgetMut<'_, Spinner> {
     /// Set the spinner's color.
     ///
@@ -59,15 +70,7 @@ impl WidgetMut<'_, Spinner> {
     }
 }
 
-impl Default for Spinner {
-    fn default() -> Self {
-        Spinner {
-            t: 0.0,
-            color: theme::TEXT_COLOR,
-        }
-    }
-}
-
+// --- MARK: IMPL WIDGET ---
 impl Widget for Spinner {
     fn on_pointer_event(&mut self, _ctx: &mut EventCtx, _event: &PointerEvent) {}
 
@@ -152,6 +155,7 @@ impl Widget for Spinner {
     }
 }
 
+// --- MARK: TESTS ---
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/masonry/src/widget/split.rs
+++ b/masonry/src/widget/split.rs
@@ -45,6 +45,7 @@ pub struct Split {
     child2: WidgetPod<Box<dyn Widget>>,
 }
 
+// --- MARK: BUILDERS ---
 impl Split {
     /// Create a new split panel, with the specified axis being split in two.
     ///
@@ -145,7 +146,10 @@ impl Split {
         self.solid = solid;
         self
     }
+}
 
+// --- MARK: INTERNALS ---
+impl Split {
     /// Returns the size of the splitter bar area.
     #[inline]
     fn bar_area(&self) -> f64 {
@@ -291,8 +295,9 @@ impl Split {
     }
 }
 
-// FIXME - Add unit tests for SplitMut
+// FIXME - Add unit tests for WidgetMut<Split>
 
+// --- MARK: WIDGETMUT ---
 impl WidgetMut<'_, Split> {
     /// Set the split point as a fraction of the split axis.
     ///
@@ -362,6 +367,7 @@ impl WidgetMut<'_, Split> {
     }
 }
 
+// --- MARK: IMPL WIDGET ---
 impl Widget for Split {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         if self.draggable {
@@ -582,6 +588,7 @@ impl Widget for Split {
     }
 }
 
+// --- MARK: TESTS ---
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -48,6 +48,7 @@ pub struct Textbox {
     brush: TextBrush,
 }
 
+// --- MARK: BUILDERS ---
 impl Textbox {
     pub fn new(initial_text: impl Into<String>) -> Self {
         Textbox {
@@ -94,6 +95,7 @@ impl Textbox {
     }
 }
 
+// --- MARK: WIDGETMUT ---
 impl WidgetMut<'_, Textbox> {
     pub fn text(&self) -> &str {
         self.widget.editor.text()
@@ -154,6 +156,7 @@ impl WidgetMut<'_, Textbox> {
     }
 }
 
+// --- MARK: IMPL WIDGET ---
 impl Widget for Textbox {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         let window_origin = ctx.widget_state.window_origin();

--- a/masonry/src/widget/widget_pod.rs
+++ b/masonry/src/widget/widget_pod.rs
@@ -33,8 +33,7 @@ pub struct WidgetPod<W> {
     pub(crate) fragment: Scene,
 }
 
-// ---
-
+// --- MARK: GETTERS ---
 impl<W: Widget> WidgetPod<W> {
     /// Create a new widget pod.
     ///
@@ -187,6 +186,17 @@ impl<W: Widget> WidgetPod<W> {
     }
 }
 
+impl<W: Widget + 'static> WidgetPod<W> {
+    /// Box the contained widget.
+    ///
+    /// Convert a `WidgetPod` containing a widget of a specific concrete type
+    /// into a dynamically boxed widget.
+    pub fn boxed(self) -> WidgetPod<Box<dyn Widget>> {
+        WidgetPod::new_with_id(Box::new(self.inner), self.state.id)
+    }
+}
+
+// --- MARK: INTERNALS ---
 impl<W: Widget> WidgetPod<W> {
     // TODO - this is confusing
     #[inline(always)]
@@ -319,20 +329,8 @@ impl<W: Widget> WidgetPod<W> {
     }
 }
 
-impl<W: Widget + 'static> WidgetPod<W> {
-    /// Box the contained widget.
-    ///
-    /// Convert a `WidgetPod` containing a widget of a specific concrete type
-    /// into a dynamically boxed widget.
-    pub fn boxed(self) -> WidgetPod<Box<dyn Widget>> {
-        WidgetPod::new_with_id(Box::new(self.inner), self.state.id)
-    }
-}
-
-// --- TRAIT IMPLS ---
-
 impl<W: Widget> WidgetPod<W> {
-    /// --- ON_EVENT ---
+    /// --- MARK: ON_XXX_EVENT ---
 
     // TODO #5 - Some implicit invariants:
     // - If a Widget gets a keyboard event or an ImeStateChange, then
@@ -551,7 +549,7 @@ impl<W: Widget> WidgetPod<W> {
         parent_ctx.global_state.debug_logger.pop_span();
     }
 
-    // --- LIFECYCLE ---
+    // --- MARK: LIFECYCLE ---
 
     // TODO #5 - Some implicit invariants:
     // - A widget only receives BuildFocusChain if none of its parents are hidden.
@@ -813,7 +811,7 @@ impl<W: Widget> WidgetPod<W> {
         parent_ctx.global_state.debug_logger.pop_span();
     }
 
-    // --- LAYOUT ---
+    // --- MARK: LAYOUT ---
 
     /// Compute layout of a widget.
     ///
@@ -940,7 +938,7 @@ impl<W: Widget> WidgetPod<W> {
         }
     }
 
-    // --- PAINT ---
+    // --- MARK: PAINT ---
 
     /// Paint the widget, translating it by the origin of its layout rectangle.
     ///
@@ -1004,6 +1002,7 @@ impl<W: Widget> WidgetPod<W> {
         stroke(scene, &rect, color, BORDER_WIDTH);
     }
 
+    // --- MARK: ACCESSIBILITY ---
     pub fn accessibility(&mut self, parent_ctx: &mut AccessCtx) {
         let _span = self.inner.make_trace_span().entered();
 

--- a/masonry/src/widget/widget_ref.rs
+++ b/masonry/src/widget/widget_ref.rs
@@ -202,6 +202,7 @@ impl<'w> WidgetRef<'w, dyn Widget> {
     }
 }
 
+// --- MARK: TESTS ---
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;


### PR DESCRIPTION
[VS Code marker comments](https://code.visualstudio.com/docs/editor/custom-layout#_minimap-and-breadcrumbs) are a [new feature](https://code.visualstudio.com/updates/v1_88#_minimap-section-headers) that supposedly help with browsing the code with a minimap. I don't know if other editors have equivalents.

I haven't tested them before, and I don't know whether they actually improve DX, but they're pretty simple and unobstrusive, so I think it'd be worth adding them experimentally and seeing how it goes.