### PR TITLE
Unbreak text rendering

### DIFF
--- a/crates/masonry/src/text_helpers.rs
+++ b/crates/masonry/src/text_helpers.rs
@@ -116,6 +116,6 @@ pub fn render_text(
                     }),
                 );
         }
-        scene.append(scratch_scene, None);
     }
+    scene.append(scratch_scene, None);
 }


### PR DESCRIPTION
Previously, we were rendering the first line `n` times, the second line `n-1` times, etc.

(Because the copy was in the loop)

See [#xilem > ✔ Text rendering when using nested Scenes](https://xi.zulipchat.com/#narrow/stream/197075-gpu/topic/.E2.9C.94.20Text.20rendering.20when.20using.20nested.20Scenes)