### PR TITLE
xilem_masonry: Fix Flex splice (increment ix by 2 because of spacer widget)

### DIFF
--- a/crates/xilem_masonry/src/view/flex.rs
+++ b/crates/xilem_masonry/src/view/flex.rs
@@ -100,7 +100,7 @@ impl ElementSplice for FlexSplice<'_> {
     fn push(&mut self, element: WidgetPod<Box<dyn masonry::Widget>>) {
         self.element.insert_child_pod(self.ix, element);
         self.element.insert_default_spacer(self.ix);
-        self.ix += 1;
+        self.ix += 2;
     }
 
     fn mutate(&mut self) -> WidgetMut<Box<dyn Widget>> {
@@ -142,6 +142,6 @@ impl ElementSplice for FlexSplice<'_> {
     }
 
     fn len(&self) -> usize {
-        self.ix
+        self.ix / 2
     }
 }


### PR DESCRIPTION
While adding filters to the TodoMVC example, I produced a crash. Which seems to originate because there was a spacer added, which also increments the underlying element child count.
So in case we want to have that spacer, we need to increment by 2 instead...

(Since `mutate` and `delete` skip spacers, because `child_mut` returns none, and the index is only incremented for concrete children it's not necessary to change the index incrementation code there)