### PR TITLE
xilem: Add Memoization views (`Memoize` and `Arc<impl View>`)

### DIFF
--- a/xilem/examples/memoization.rs
+++ b/xilem/examples/memoization.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::Arc;
 use xilem::view::{button, flex, memoize};
 use xilem::{AnyMasonryView, MasonryView, Xilem};

--- a/xilem/examples/memoization.rs
+++ b/xilem/examples/memoization.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+use xilem::view::{button, flex, memoize};
+use xilem::{AnyMasonryView, MasonryView, Xilem};
+
+// There are currently two ways to do memoization
+
+fn app_logic(state: &mut AppState) -> impl MasonryView<AppState> {
+    // The following is an example to do memoization with an Arc
+    let increase_button = if let Some(view) = &state.count_view {
+        view.clone()
+    } else {
+        let view = state.make_increase_button();
+        state.count_view = Some(view.clone());
+        view
+    };
+
+    flex((
+        increase_button,
+        // This is the alternative with Memoize
+        // Note how this requires a closure that returns the memoized view, while Arc does not
+        memoize(state.count, |count| {
+            button(
+                format!("decrease the count: {count}"),
+                |data: &mut AppState| {
+                    data.count_view = None;
+                    data.count -= 1;
+                },
+            )
+        }),
+        button("reset", |data: &mut AppState| {
+            if data.count != 0 {
+                data.count_view = None;
+            }
+            data.count = 0;
+        }),
+    ))
+}
+
+struct AppState {
+    count: i32,
+    // When TAITs are stabilized this can be a non-erased concrete type
+    count_view: Option<Arc<dyn AnyMasonryView<AppState>>>,
+}
+
+impl AppState {
+    fn make_increase_button(&self) -> Arc<dyn AnyMasonryView<AppState>> {
+        Arc::new(button(
+            format!("current count is {}", self.count),
+            |state: &mut AppState| {
+                state.count += 1;
+                state.count_view = None;
+            },
+        ))
+    }
+}
+
+fn main() {
+    let data = AppState {
+        count: 0,
+        count_view: None,
+    };
+
+    let app = Xilem::new(data, app_logic);
+    app.run_windowed("Memoization".into()).unwrap();
+}

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -146,7 +146,7 @@ where
         event_loop_runner::run(window_attributes, self.root_widget, self.driver)
     }
 }
-pub trait MasonryView<State, Action = ()>: Send + 'static {
+pub trait MasonryView<State, Action = ()>: Send + Sync + 'static {
     type Element: Widget;
     type ViewState;
 

--- a/xilem/src/view/arc.rs
+++ b/xilem/src/view/arc.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{any::Any, ops::Deref, sync::Arc};
 
 use masonry::widget::WidgetMut;

--- a/xilem/src/view/arc.rs
+++ b/xilem/src/view/arc.rs
@@ -1,0 +1,40 @@
+use std::{any::Any, ops::Deref, sync::Arc};
+
+use masonry::widget::WidgetMut;
+
+use crate::{MasonryView, MessageResult, ViewCx, ViewId};
+
+impl<State: 'static, Action: 'static, V: MasonryView<State, Action>> MasonryView<State, Action>
+    for Arc<V>
+{
+    type ViewState = V::ViewState;
+
+    type Element = V::Element;
+
+    fn build(&self, cx: &mut ViewCx) -> (masonry::WidgetPod<Self::Element>, Self::ViewState) {
+        self.deref().build(cx)
+    }
+
+    fn rebuild(
+        &self,
+        view_state: &mut Self::ViewState,
+        cx: &mut ViewCx,
+        prev: &Self,
+        element: WidgetMut<Self::Element>,
+    ) {
+        if !Arc::ptr_eq(self, prev) {
+            self.deref().rebuild(view_state, cx, prev.deref(), element);
+        }
+    }
+
+    fn message(
+        &self,
+        view_state: &mut Self::ViewState,
+        id_path: &[ViewId],
+        message: Box<dyn Any>,
+        app_state: &mut State,
+    ) -> MessageResult<Action> {
+        self.deref()
+            .message(view_state, id_path, message, app_state)
+    }
+}

--- a/xilem/src/view/button.rs
+++ b/xilem/src/view/button.rs
@@ -22,7 +22,7 @@ pub struct Button<F> {
 
 impl<F, State, Action> MasonryView<State, Action> for Button<F>
 where
-    F: Fn(&mut State) -> Action + Send + 'static,
+    F: Fn(&mut State) -> Action + Send + Sync + 'static,
 {
     type Element = masonry::widget::Button;
     type ViewState = ();

--- a/xilem/src/view/checkbox.rs
+++ b/xilem/src/view/checkbox.rs
@@ -28,7 +28,7 @@ pub struct Checkbox<F> {
 
 impl<F, State, Action> MasonryView<State, Action> for Checkbox<F>
 where
-    F: Fn(&mut State, bool) -> Action + Send + 'static,
+    F: Fn(&mut State, bool) -> Action + Send + Sync + 'static,
 {
     type Element = masonry::widget::Checkbox;
     type ViewState = ();

--- a/xilem/src/view/flex.rs
+++ b/xilem/src/view/flex.rs
@@ -52,7 +52,7 @@ impl<VT, Marker> Flex<VT, Marker> {
     }
 }
 
-impl<State, Action, Marker: 'static, Seq> MasonryView<State, Action> for Flex<Seq, Marker>
+impl<State, Action, Marker: 'static, Seq: Sync> MasonryView<State, Action> for Flex<Seq, Marker>
 where
     Seq: ViewSequence<State, Action, Marker>,
 {

--- a/xilem/src/view/memoize.rs
+++ b/xilem/src/view/memoize.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use std::any::Any;
 
 use masonry::{widget::WidgetMut, WidgetPod};

--- a/xilem/src/view/memoize.rs
+++ b/xilem/src/view/memoize.rs
@@ -1,0 +1,101 @@
+use std::any::Any;
+
+use masonry::{widget::WidgetMut, WidgetPod};
+
+use crate::{MasonryView, MessageResult, ViewCx, ViewId};
+
+pub struct Memoize<D, F> {
+    data: D,
+    child_cb: F,
+}
+
+pub struct MemoizeState<T, A, V: MasonryView<T, A>> {
+    view: V,
+    view_state: V::ViewState,
+    dirty: bool,
+}
+
+impl<D, V, F> Memoize<D, F>
+where
+    F: Fn(&D) -> V,
+{
+    pub fn new(data: D, child_cb: F) -> Self {
+        Memoize { data, child_cb }
+    }
+}
+
+impl<State, Action, D, V, F> MasonryView<State, Action> for Memoize<D, F>
+where
+    D: PartialEq + Send + Sync + 'static,
+    V: MasonryView<State, Action>,
+    F: Fn(&D) -> V + Send + Sync + 'static,
+{
+    type ViewState = MemoizeState<State, Action, V>;
+
+    type Element = V::Element;
+
+    fn build(&self, cx: &mut ViewCx) -> (WidgetPod<Self::Element>, Self::ViewState) {
+        assert!(
+            std::mem::size_of::<F>() == 0,
+            "The callback is not allowed to be a function pointer or a closure capturing context"
+        );
+        let view = (self.child_cb)(&self.data);
+        let (element, view_state) = view.build(cx);
+        let memoize_state = MemoizeState {
+            view,
+            view_state,
+            dirty: false,
+        };
+        (element, memoize_state)
+    }
+
+    fn rebuild(
+        &self,
+        view_state: &mut Self::ViewState,
+        cx: &mut ViewCx,
+        prev: &Self,
+        element: WidgetMut<Self::Element>,
+    ) {
+        if std::mem::take(&mut view_state.dirty) || prev.data != self.data {
+            let view = (self.child_cb)(&self.data);
+            view.rebuild(&mut view_state.view_state, cx, &view_state.view, element);
+            view_state.view = view;
+        }
+    }
+
+    fn message(
+        &self,
+        view_state: &mut Self::ViewState,
+        id_path: &[ViewId],
+        message: Box<dyn Any>,
+        app_state: &mut State,
+    ) -> MessageResult<Action> {
+        let r = view_state
+            .view
+            .message(&mut view_state.view_state, id_path, message, app_state);
+        if matches!(r, MessageResult::RequestRebuild) {
+            view_state.dirty = true;
+        }
+        r
+    }
+}
+
+/// A static view, all of the content of the `view` should be constant, as this function is only run once
+pub fn static_view<V, F>(view: F) -> Memoize<(), impl Fn(&()) -> V>
+where
+    F: Fn() -> V + Send + 'static,
+{
+    assert!(
+        std::mem::size_of::<F>() == 0,
+        "The callback is not allowed to be a function pointer or a closure capturing context"
+    );
+    Memoize::new((), move |_: &()| view())
+}
+
+/// Memoize the view, until the `data` changes (in which case `view` is called again)
+pub fn memoize<D, V, F>(data: D, view: F) -> Memoize<D, F>
+where
+    F: Fn(&D) -> V + Send,
+{
+    Memoize::new(data, view)
+}

--- a/xilem/src/view/memoize.rs
+++ b/xilem/src/view/memoize.rs
@@ -25,7 +25,13 @@ where
     const ASSERT_CONTEXTLESS_FN: () = {
         assert!(
             std::mem::size_of::<F>() == 0,
-            "The callback is not allowed to be a function pointer or a closure capturing context"
+            "
+It's not possible to use function pointers or captured context in closures,
+as this potentially messes up the logic of memoize or produces unwanted effects.
+
+For example a different kind of view could be instantiated with a different callback, while the old one is still memoized, but it's not updated then.
+It's not possible in Rust currently to check whether the (content of the) callback has changed with the `Fn` trait, which would make this otherwise possible.
+"
         );
     };
 

--- a/xilem/src/view/mod.rs
+++ b/xilem/src/view/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+mod arc;
+
 mod button;
 pub use button::*;
 
@@ -12,6 +14,9 @@ pub use flex::*;
 
 mod label;
 pub use label::*;
+
+mod memoize;
+pub use memoize::*;
 
 mod prose;
 pub use prose::*;

--- a/xilem/src/view/textbox.rs
+++ b/xilem/src/view/textbox.rs
@@ -9,11 +9,11 @@ use crate::{Color, MasonryView, MessageResult, TextAlignment, ViewCx, ViewId};
 // is that if the user forgets to hook up the modify the state's contents in the callback,
 // the textbox will always be reset to the initial state. This will be very annoying for the user.
 
-type Callback<State, Action> = Box<dyn Fn(&mut State, String) -> Action + Send + 'static>;
+type Callback<State, Action> = Box<dyn Fn(&mut State, String) -> Action + Send + Sync + 'static>;
 
 pub fn textbox<F, State, Action>(contents: String, on_changed: F) -> Textbox<State, Action>
 where
-    F: Fn(&mut State, String) -> Action + Send + 'static,
+    F: Fn(&mut State, String) -> Action + Send + Sync + 'static,
 {
     // TODO: Allow setting a placeholder
     Textbox {
@@ -55,7 +55,7 @@ impl<State, Action> Textbox<State, Action> {
 
     pub fn on_enter<F>(mut self, on_enter: F) -> Self
     where
-        F: Fn(&mut State, String) -> Action + Send + 'static,
+        F: Fn(&mut State, String) -> Action + Send + Sync + 'static,
     {
         self.on_enter = Some(Box::new(on_enter));
         self


### PR DESCRIPTION
This ports the `Memoize` view from old xilem, slightly enhances it, by checking whether the given view callback is a non-capturing closure and not a function pointer (by asserting `std::mem::size_of::<F>() == 0`)

It also ports the `Arc<impl View>` and `Arc<dyn AnyMasonryView>` from #164 including the example there to show how these two forms of memoization can be used.