### PR TITLE
Implement underlining and strikethrough for Masonry

### DIFF
--- a/crates/masonry/src/text_helpers.rs
+++ b/crates/masonry/src/text_helpers.rs
@@ -148,6 +148,39 @@ pub fn render_text(
                     &line,
                 )
             }
+            if let Some(strikethrough) = &style.strikethrough {
+                let strikethrough_brush = match &strikethrough.brush {
+                    TextBrush::Normal(text) => text,
+                    // It doesn't make sense for an underline to have a highlight colour, so we
+                    // just use the text colour for the colour
+                    TextBrush::Highlight { text, .. } => text,
+                };
+                let run_metrics = glyph_run.run().metrics();
+                let offset = match strikethrough.offset {
+                    Some(offset) => offset,
+                    None => run_metrics.strikethrough_offset,
+                };
+                let width = match strikethrough.size {
+                    Some(size) => size,
+                    None => run_metrics.strikethrough_size,
+                };
+                // The `offset` is the distance from the baseline to the *top* of the strikethrough
+                // so we move the line down by half the width
+                // Remember that we are using a y-down coordinate system
+                let y = glyph_run.baseline() - offset + width / 2.;
+
+                let line = Line::new(
+                    (glyph_run.offset() as f64, y as f64),
+                    ((glyph_run.offset() + glyph_run.advance()) as f64, y as f64),
+                );
+                scratch_scene.stroke(
+                    &Stroke::new(width.into()),
+                    transform,
+                    strikethrough_brush,
+                    None,
+                    &line,
+                )
+            }
         }
     }
     scene.append(scratch_scene, None);

--- a/crates/masonry/src/text_helpers.rs
+++ b/crates/masonry/src/text_helpers.rs
@@ -146,7 +146,7 @@ pub fn render_text(
                     underline_brush,
                     None,
                     &line,
-                )
+                );
             }
             if let Some(strikethrough) = &style.strikethrough {
                 let strikethrough_brush = match &strikethrough.brush {
@@ -179,7 +179,7 @@ pub fn render_text(
                     strikethrough_brush,
                     None,
                     &line,
-                )
+                );
             }
         }
     }


### PR DESCRIPTION
This will be needed to follow on from #273 (showing the pre-edit region visually)

![underline on Lorem Ipsum.](https://github.com/linebender/xilem/assets/36049421/eee27c4f-4029-45a1-8a4b-a853a61f5d6b)

and

![stikethrough on Lorem Ipsum](https://github.com/linebender/xilem/assets/36049421/c7a0efdb-3ddf-4bd1-b837-64a0ee538914)

cc @dfrg for awareness, I'm not certain on the maths (but that doesn't need to block merging)