### PR TITLE
Fix incorrect handling of the margin in textbox selection

### DIFF
--- a/crates/masonry/src/widget/textbox.rs
+++ b/crates/masonry/src/widget/textbox.rs
@@ -24,7 +24,10 @@ use super::{LineBreaking, WidgetMut, WidgetRef};
 
 const TEXTBOX_PADDING: f64 = 3.0;
 /// HACK: A "margin" which is placed around the outside of all textboxes, ensuring that
-/// they do not fill the entire width of the window
+/// they do not fill the entire width of the window.
+///
+/// This is added by making the width of the textbox be (twice) this amount less than
+/// the space available, which is absolutely horrible.
 ///
 /// In theory, this should be proper margin/padding in the parent widget, but that hasn't been
 /// designed.
@@ -154,7 +157,7 @@ impl Widget for Textbox {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         let window_origin = ctx.widget_state.window_origin();
         let inner_origin = Point::new(
-            window_origin.x + TEXTBOX_PADDING + TEXTBOX_MARGIN,
+            window_origin.x + TEXTBOX_PADDING,
             window_origin.y + TEXTBOX_PADDING,
         );
         match event {


### PR DESCRIPTION
Previously, click-and-drag selection in the textbox would select the wrong characters (among other issues with clicking)