### PR TITLE
Make the default label colour white

### DIFF
--- a/crates/xilem_masonry/src/view/label.rs
+++ b/crates/xilem_masonry/src/view/label.rs
@@ -8,7 +8,7 @@ use crate::{Color, MasonryView, MessageResult, TextAlignment, ViewCx, ViewId};
 pub fn label(label: impl Into<ArcStr>) -> Label {
     Label {
         label: label.into(),
-        text_color: Color::BLACK,
+        text_color: Color::WHITE,
         alignment: TextAlignment::default(),
         disabled: false,
     }


### PR DESCRIPTION
We should be following the system theme here, probably.

And doing a lot of other things. But this is a saner default with a black default "background"