### PR TITLE
Update dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -385,7 +385,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -551,7 +551,7 @@ checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 dependencies = [
  "jobserver",
  "libc",
@@ -876,7 +876,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -938,7 +938,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1136,7 +1136,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1204,7 +1204,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1258,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1526,7 +1526,7 @@ checksum = "d2abdd3a62551e8337af119c5899e600ca0c88ec8f23a46c60ba216c803dcf1a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1994,7 +1994,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2164,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peniko"
@@ -2201,7 +2201,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2322,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2490,9 +2490,9 @@ checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -2529,9 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -2584,7 +2584,7 @@ checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2606,7 +2606,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2814,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2831,7 +2831,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2870,22 +2870,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3005,7 +3005,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3055,7 +3055,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3238,7 +3238,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
  "wasm-bindgen-shared",
 ]
 
@@ -3272,7 +3272,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3605,7 +3605,7 @@ checksum = "942ac266be9249c84ca862f0a164a39533dc2f6f33dc98ec89c8da99b82ea0bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3616,7 +3616,7 @@ checksum = "da33557140a288fae4e1d5f8873aaf9eb6613a9cf82c3e070223ff177f598b60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -4062,7 +4062,7 @@ checksum = "9e6936f0cce458098a201c245a11bef556c6a0181129c7034d10d76d1ec3a2b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
  "synstructure",
 ]
 
@@ -4140,22 +4140,22 @@ checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -4175,7 +4175,7 @@ checksum = "e6a647510471d372f2e6c2e6b7219e44d8c574d24fdc11c610a61455782f18c3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
  "synstructure",
 ]
 
@@ -4198,7 +4198,7 @@ checksum = "7b4e5997cbf58990550ef1f0e5124a05e47e1ebd33a84af25739be6031a62c20"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ clippy.semicolon_if_nothing_returned = "warn"
 xilem_core = { version = "0.1.0", path = "crates/xilem_core" }
 masonry = { version = "0.2.0", path = "crates/masonry" }
 vello = "0.1.0"
-wgpu = "0.19.3"
+wgpu = "0.19.4"
 kurbo = "0.11.0"
 parley = "0.1.0"
 peniko = "0.1.0"
@@ -33,8 +33,8 @@ tracing = "0.1.40"
 smallvec = "1.13.2"
 fnv = "1.0.7"
 image = { version = "0.25.1", default-features = false }
-instant = "0.1.6"
-bitflags = "2.0.0"
+instant = "0.1.12"
+bitflags = "2.5.0"
 accesskit = "0.14.0"
 accesskit_winit = "0.20.0"
 
@@ -76,6 +76,6 @@ bitflags.workspace = true
 tracing.workspace = true
 fnv.workspace = true
 instant = { workspace = true, features = ["wasm-bindgen"] }
-tokio = { version = "1.35", features = ["full"] }
-taffy = { version = "0.4.0", optional = true }
+tokio = { version = "1.37", features = ["full"] }
+taffy = { version = "0.4.3", optional = true }
 futures-task = "0.3"

--- a/crates/masonry/Cargo.toml
+++ b/crates/masonry/Cargo.toml
@@ -29,9 +29,9 @@ tracing.workspace = true
 fnv.workspace = true
 instant = { workspace = true, features = ["wasm-bindgen"] }
 image.workspace = true
-once_cell = "1.9.0"
-serde = { version = "1.0.133", features = ["derive"] }
-serde_json = "1.0.74"
+once_cell = "1.19.0"
+serde = { version = "1.0.200", features = ["derive"] }
+serde_json = "1.0.116"
 futures-intrusive = "0.5.0"
 pollster = "0.3.0"
 unicode-segmentation = "1.11.0"
@@ -45,7 +45,7 @@ time = { version = "0.3.36", features = ["macros", "formatting"] }
 [dev-dependencies]
 float-cmp = { version = "0.9.0", features = ["std"], default-features = false }
 image = { workspace = true, features = ["png"] }
-insta = { version = "1.8.0" }
+insta = { version = "1.38.0" }
 assert_matches = "1.5.0"
 tempfile = "3.10.1"
 

--- a/crates/xilem_web/Cargo.toml
+++ b/crates/xilem_web/Cargo.toml
@@ -23,13 +23,13 @@ xilem_core.workspace = true
 kurbo.workspace = true
 peniko.workspace = true
 bitflags.workspace = true
-wasm-bindgen = "0.2.87"
-paste = "1.0.0"
-log = "0.4.19"
+wasm-bindgen = "0.2.92"
+paste = "1.0.15"
+log = "0.4.21"
 gloo = { version = "0.11.0", default-features = false, features = ["events"] }
 
 [dependencies.web-sys]
-version = "0.3.4"
+version = "0.3.69"
 features = [
     "console",
     "CssStyleDeclaration",

--- a/crates/xilem_web/web_examples/counter/Cargo.toml
+++ b/crates/xilem_web/web_examples/counter/Cargo.toml
@@ -10,6 +10,6 @@ workspace = true
 
 [dependencies]
 console_error_panic_hook = "0.1"
-wasm-bindgen = "0.2.87"
-web-sys = "0.3.64"
+wasm-bindgen = "0.2.92"
+web-sys = "0.3.69"
 xilem_web = { path = "../.." }

--- a/crates/xilem_web/web_examples/counter_custom_element/Cargo.toml
+++ b/crates/xilem_web/web_examples/counter_custom_element/Cargo.toml
@@ -10,6 +10,6 @@ workspace = true
 
 [dependencies]
 console_error_panic_hook = "0.1"
-wasm-bindgen = "0.2.87"
-web-sys = "0.3.64"
+wasm-bindgen = "0.2.92"
+web-sys = "0.3.69"
 xilem_web = { path = "../.." }

--- a/crates/xilem_web/web_examples/mathml_svg/Cargo.toml
+++ b/crates/xilem_web/web_examples/mathml_svg/Cargo.toml
@@ -10,6 +10,6 @@ workspace = true
 
 [dependencies]
 console_error_panic_hook = "0.1"
-wasm-bindgen = "0.2.87"
-web-sys = "0.3.64"
+wasm-bindgen = "0.2.92"
+web-sys = "0.3.69"
 xilem_web = { path = "../.." }

--- a/crates/xilem_web/web_examples/svgtoy/Cargo.toml
+++ b/crates/xilem_web/web_examples/svgtoy/Cargo.toml
@@ -10,6 +10,6 @@ workspace = true
 
 [dependencies]
 console_error_panic_hook = "0.1"
-wasm-bindgen = "0.2.87"
-web-sys = "0.3.64"
+wasm-bindgen = "0.2.92"
+web-sys = "0.3.69"
 xilem_web = { path = "../.." }

--- a/crates/xilem_web/web_examples/todomvc/Cargo.toml
+++ b/crates/xilem_web/web_examples/todomvc/Cargo.toml
@@ -10,10 +10,10 @@ workspace = true
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-serde = { version = "1.0.170", features = ["derive"] }
-serde_json = "1.0.100"
-tracing = "0.1.37"
+serde = { version = "1.0.200", features = ["derive"] }
+serde_json = "1.0.116"
+tracing = "0.1.40"
 tracing-wasm = "0.2.1"
-wasm-bindgen = "0.2.87"
-web-sys = { version = "0.3.64", features = ["Storage", "Window"] }
+wasm-bindgen = "0.2.92"
+web-sys = { version = "0.3.69", features = ["Storage", "Window"] }
 xilem_web = { path = "../.." }


### PR DESCRIPTION
These are the results of running

```sh
cargo upgrade --ignore-rust-version
cargo update
```

in preparation for the upcoming release.

These are semver compatible updates.