### PR TITLE
Additional flex view options

### DIFF
--- a/crates/xilem_masonry/examples/flex.rs
+++ b/crates/xilem_masonry/examples/flex.rs
@@ -8,26 +8,15 @@ use xilem::{
     MasonryView, Xilem,
 };
 
-struct AppState {
-    count: u32,
-}
-
-impl AppState {
-    fn decrement(&mut self) {
-        if self.count > 0 {
-            self.count -= 1;
-        };
-    }
-    fn increment(&mut self) {
-        self.count += 1;
-    }
-}
-
-fn app_logic(data: &mut AppState) -> impl MasonryView<AppState> {
+fn app_logic(data: &mut i32) -> impl MasonryView<i32> {
     flex((
-        button("-", AppState::decrement),
-        label(format!("count: {}", data.count)),
-        button("+", AppState::increment),
+        button("-", |data| {
+            *data -= 1;
+        }),
+        label(format!("count: {}", data)),
+        button("+", |data| {
+            *data += 1;
+        }),
     ))
     .direction(xilem::Axis::Horizontal)
     .cross_axis_alignment(CrossAxisAlignment::Center)
@@ -35,8 +24,7 @@ fn app_logic(data: &mut AppState) -> impl MasonryView<AppState> {
 }
 
 fn main() -> Result<(), EventLoopError> {
-    let data = AppState { count: 0 };
-    let app = Xilem::new(data, app_logic);
-    app.run_windowed("Demo".into())?;
+    let app = Xilem::new(0, app_logic);
+    app.run_windowed("Centered Flex".into())?;
     Ok(())
 }

--- a/crates/xilem_masonry/examples/flex.rs
+++ b/crates/xilem_masonry/examples/flex.rs
@@ -1,0 +1,42 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use masonry::widget::{CrossAxisAlignment, MainAxisAlignment};
+use winit::error::EventLoopError;
+use xilem::{
+    view::{button, flex, label},
+    MasonryView, Xilem,
+};
+
+struct AppState {
+    count: u32,
+}
+
+impl AppState {
+    fn decrement(&mut self) {
+        if self.count > 0 {
+            self.count -= 1;
+        };
+    }
+    fn increment(&mut self) {
+        self.count += 1;
+    }
+}
+
+fn app_logic(data: &mut AppState) -> impl MasonryView<AppState> {
+    flex((
+        button("-", AppState::decrement),
+        label(format!("count: {}", data.count)),
+        button("+", AppState::increment),
+    ))
+    .direction(xilem::Axis::Horizontal)
+    .cross_axis_alignment(CrossAxisAlignment::Center)
+    .main_axis_alignment(MainAxisAlignment::Center)
+}
+
+fn main() -> Result<(), EventLoopError> {
+    let data = AppState { count: 0 };
+    let app = Xilem::new(data, app_logic);
+    app.run_windowed("Demo".into())?;
+    Ok(())
+}


### PR DESCRIPTION
Wired up some more existing masonry flex properties so they can be set on the flex view.

I was messing around with a dummy example to try out the v0.1 and noticed I couldn't easily center something because flex was only exposing direction not alignment/cross-alignment. It looked like all the logic already exists in masonry so it was just a matter of wiring it up. This is my first contribution so sorry if I missed some steps.

Sidenote: I didn't see any examples of testing that a view updates the underlying element so I am guessing that is still tbd. If someone has a suggestion for a good way to do that I am happy to try it out.

I'm also not sure what the etiquette is on adding/editing examples so I just included the example I was using to verify it worked but no stress if you want to remove it.