### PR TITLE
masonry: Disable render tests by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,6 @@ env:
   # come automatically. If the version specified here is no longer the latest stable version,
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
   RUST_STABLE_VER: "1.77" # In quotes because otherwise 1.70 would be interpreted as 1.7
-  # We do not run the masonry snapshot tests, because those require a specific font stack
-  SKIP_RENDER_SNAPSHOTS: 1
-  # We do not run the masonry render tests, because those require Vello rendering to be working
-  # See https://github.com/linebender/vello/pull/439
-  SKIP_RENDER_TESTS: 1
 
 # Rationale
 #

--- a/crates/masonry/src/testing/harness.rs
+++ b/crates/masonry/src/testing/harness.rs
@@ -33,6 +33,11 @@ pub const HARNESS_DEFAULT_SIZE: Size = Size::new(400., 400.);
 /// Default background color for tests.
 pub const HARNESS_DEFAULT_BACKGROUND_COLOR: Color = Color::rgb8(0x29, 0x29, 0x29);
 
+fn check_env_enabled(key: &'static str) -> bool {
+    let val = std::env::var_os(key);
+    val.is_some_and(|it| !it.is_empty())
+}
+
 /// A safe headless environment to test widgets in.
 ///
 /// `TestHarness` is a type that simulates an [`AppRoot`](crate::AppRoot)
@@ -238,7 +243,7 @@ impl TestHarness {
     /// Create a bitmap (an array of pixels), paint the window and return the bitmap as an 8-bits-per-channel RGB image.
     pub fn render(&mut self) -> RgbaImage {
         let (scene, _tree_update) = self.render_root.redraw();
-        if std::env::var("SKIP_RENDER_TESTS").is_ok_and(|it| !it.is_empty()) {
+        if !check_env_enabled("ENABLE_RENDER_TESTS") {
             return RgbaImage::from_pixel(1, 1, Rgba([255, 255, 255, 255]));
         }
         let mut context =
@@ -513,7 +518,7 @@ impl TestHarness {
         test_module_path: &str,
         test_name: &str,
     ) {
-        if option_env!("SKIP_RENDER_SNAPSHOTS").is_some() {
+        if !check_env_enabled("ENABLE_RENDER_SNAPSHOTS") {
             // FIXME - This is a terrible, awful hack.
             // We need a way to skip render snapshots on CI and locally
             // until we can make sure the snapshots render the same on


### PR DESCRIPTION
Set both `ENABLE_RENDER_TESTS=1` and `ENABLE_RENDER_SNAPSHOTS=1` in your environment to run the tests.