### PR TITLE
xilem_web: Remove unused direct dep on `kurbo`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,7 +3859,6 @@ version = "0.1.0"
 dependencies = [
  "bitflags 2.5.0",
  "gloo",
- "kurbo",
  "log",
  "paste",
  "peniko",

--- a/crates/xilem_web/Cargo.toml
+++ b/crates/xilem_web/Cargo.toml
@@ -20,7 +20,6 @@ workspace = true
 
 [dependencies]
 xilem_core.workspace = true
-kurbo.workspace = true
 peniko.workspace = true
 bitflags.workspace = true
 wasm-bindgen = "0.2.92"


### PR DESCRIPTION
This is always used via `peniko`.