### PR TITLE
`masonry`: Use `cursor_icon` crate directly.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,6 +1722,7 @@ dependencies = [
  "accesskit",
  "accesskit_winit",
  "assert_matches",
+ "cursor-icon",
  "float-cmp",
  "fnv",
  "futures-intrusive",

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -41,6 +41,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "time"] }
 accesskit.workspace = true
 accesskit_winit.workspace = true
 time = { version = "0.3.36", features = ["macros", "formatting"] }
+cursor-icon = "1.1.0"
 
 [dev-dependencies]
 float-cmp = { version = "0.9.0", features = ["std"], default-features = false }

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -10,14 +10,13 @@ use accesskit::{NodeBuilder, TreeUpdate};
 use parley::FontContext;
 use tracing::{trace, warn};
 use winit::dpi::LogicalPosition;
-use winit::window::CursorIcon;
 
 use crate::action::Action;
 use crate::promise::PromiseToken;
 use crate::render_root::{RenderRootSignal, RenderRootState};
 use crate::text_helpers::{ImeChangeSignal, TextFieldRegistration};
 use crate::widget::{CursorChange, WidgetMut, WidgetState};
-use crate::{Insets, Point, Rect, Size, Widget, WidgetId, WidgetPod};
+use crate::{CursorIcon, Insets, Point, Rect, Size, Widget, WidgetId, WidgetPod};
 
 /// A macro for implementing methods on multiple contexts.
 ///

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -85,6 +85,7 @@
 
 // TODO - Add logo
 
+pub use cursor_icon::{CursorIcon, ParseError as CursorIconParseError};
 pub use kurbo;
 pub use parley;
 pub use vello;

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -13,7 +13,6 @@ use vello::peniko::{Color, Fill};
 use vello::Scene;
 use winit::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use winit::keyboard::{KeyCode, PhysicalKey};
-use winit::window::CursorIcon;
 
 use crate::contexts::{EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, WidgetCtx, WorkerFn};
 use crate::debug_logger::DebugLogger;
@@ -21,8 +20,8 @@ use crate::event::{PointerEvent, TextEvent, WindowEvent};
 use crate::kurbo::Point;
 use crate::widget::{WidgetMut, WidgetState};
 use crate::{
-    AccessCtx, AccessEvent, Action, BoxConstraints, Handled, InternalLifeCycle, LifeCycle, Widget,
-    WidgetId, WidgetPod,
+    AccessCtx, AccessEvent, Action, BoxConstraints, CursorIcon, Handled, InternalLifeCycle,
+    LifeCycle, Widget, WidgetId, WidgetPod,
 };
 
 // TODO - Remove pub(crate)

--- a/masonry/src/widget/mod.rs
+++ b/masonry/src/widget/mod.rs
@@ -28,6 +28,8 @@ mod spinner;
 mod split;
 mod textbox;
 
+use crate::CursorIcon;
+
 pub use self::image::Image;
 pub use align::Align;
 pub use button::Button;
@@ -50,7 +52,6 @@ pub use widget_state::WidgetState;
 pub use sized_box::BackgroundBrush;
 #[doc(hidden)]
 pub use widget::{Widget, WidgetId};
-use winit::window::CursorIcon;
 
 /// The possible cursor states for a widget.
 #[derive(Clone, Debug)]

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -14,8 +14,8 @@ use vello::{peniko::BlendMode, Scene};
 use crate::{
     text2::{TextBrush, TextStorage, TextWithSelection},
     widget::label::LABEL_X_PADDING,
-    AccessCtx, AccessEvent, ArcStr, BoxConstraints, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
-    PaintCtx, PointerEvent, StatusChange, TextEvent, Widget,
+    AccessCtx, AccessEvent, ArcStr, BoxConstraints, CursorIcon, EventCtx, LayoutCtx, LifeCycle,
+    LifeCycleCtx, PaintCtx, PointerEvent, StatusChange, TextEvent, Widget,
 };
 
 use super::{LineBreaking, WidgetMut, WidgetRef};
@@ -155,7 +155,7 @@ impl Widget for Prose {
             PointerEvent::PointerMove(state) => {
                 if !ctx.is_disabled() {
                     // TODO: Set cursor if over link
-                    ctx.set_cursor(&winit::window::CursorIcon::Text);
+                    ctx.set_cursor(&CursorIcon::Text);
                     if ctx.is_active() && self.text_layout.pointer_move(inner_origin, state) {
                         // We might have changed text colours, so we need to re-request a layout
                         ctx.request_layout();

--- a/masonry/src/widget/split.rs
+++ b/masonry/src/widget/split.rs
@@ -9,15 +9,15 @@ use tracing::{trace, trace_span, warn, Span};
 use vello::Scene;
 use winit::dpi::LogicalPosition;
 use winit::event::MouseButton;
-use winit::window::CursorIcon;
 
 use crate::kurbo::Line;
 use crate::paint_scene_helpers::{fill_color, stroke};
 use crate::widget::flex::Axis;
 use crate::widget::{WidgetMut, WidgetPod, WidgetRef};
 use crate::{
-    theme, AccessCtx, AccessEvent, BoxConstraints, Color, EventCtx, LayoutCtx, LifeCycle,
-    LifeCycleCtx, PaintCtx, Point, PointerEvent, Rect, Size, StatusChange, TextEvent, Widget,
+    theme, AccessCtx, AccessEvent, BoxConstraints, Color, CursorIcon, EventCtx, LayoutCtx,
+    LifeCycle, LifeCycleCtx, PaintCtx, Point, PointerEvent, Rect, Size, StatusChange, TextEvent,
+    Widget,
 };
 
 // TODO - Have child widget type as generic argument

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -16,8 +16,8 @@ use vello::{
 
 use crate::{
     text2::{TextBrush, TextEditor, TextStorage, TextWithSelection},
-    AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    PointerEvent, StatusChange, TextEvent, Widget,
+    AccessCtx, AccessEvent, BoxConstraints, CursorIcon, EventCtx, LayoutCtx, LifeCycle,
+    LifeCycleCtx, PaintCtx, PointerEvent, StatusChange, TextEvent, Widget,
 };
 
 use super::{LineBreaking, WidgetMut, WidgetRef};
@@ -177,7 +177,7 @@ impl Widget for Textbox {
             PointerEvent::PointerMove(state) => {
                 if !ctx.is_disabled() {
                     // TODO: Set cursor if over link
-                    ctx.set_cursor(&winit::window::CursorIcon::Text);
+                    ctx.set_cursor(&CursorIcon::Text);
                     if ctx.is_active() && self.editor.pointer_move(inner_origin, state) {
                         // We might have changed text colours, so we need to re-request a layout
                         ctx.request_layout();

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -5,13 +5,11 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use winit::window::CursorIcon;
-
 use crate::bloom::Bloom;
 use crate::kurbo::{Insets, Point, Rect, Size};
 use crate::text_helpers::TextFieldRegistration;
 use crate::widget::CursorChange;
-use crate::WidgetId;
+use crate::{CursorIcon, WidgetId};
 
 // FIXME #5 - Make a note documenting this: the only way to get a &mut WidgetState should be in a pass.
 // A pass should reborrow the parent widget state (to avoid crossing wires) and call merge_up at


### PR DESCRIPTION
`cursor_icon` is a crate that is used by `winit` to provide its `CursorIcon` type separately from the `winit` crate.

This re-exports the `CursorIcon` from `masonry` and then uses that rather than via `winit::window::CursorIcon`, allowing the use of the `CursorIcon` without having to independently discover its provenance.

This is also one step towards not requiring `winit` within the `masonry` internals apart from the actual window / event loop management.