### PR TITLE
fix invalid HTML in examples

### DIFF
--- a/xilem_web/web_examples/counter/index.html
+++ b/xilem_web/web_examples/counter/index.html
@@ -1,4 +1,6 @@
 <!DOCTYPE html>
+<html>
 <title>Pythagorean theorem</title>
 
 <body></body>
+</html>

--- a/xilem_web/web_examples/counter_custom_element/index.html
+++ b/xilem_web/web_examples/counter_custom_element/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html>
 <head>
 <style>
     .gray {
@@ -19,3 +20,4 @@
     <p>This is like the <code>counter</code> example, but does not use the typed 
         elements/events/attrs in <code>xilem_web</code>, instead using strings</p>
 </body>
+</html>

--- a/xilem_web/web_examples/mathml_svg/index.html
+++ b/xilem_web/web_examples/mathml_svg/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html>
 <head>
 <style>
     .gray {
@@ -17,3 +18,4 @@
 </head>
 <body>
 </body>
+</html>

--- a/xilem_web/web_examples/svgtoy/index.html
+++ b/xilem_web/web_examples/svgtoy/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="en">
 <head>
 <style>
     .gray {
@@ -17,3 +18,4 @@
 </head>
 <body>
 </body>
+</html>


### PR DESCRIPTION
For some reason the recent version of Trunk refused to serve some of the examples due to them missing the <html> tags. Adding the tags calms it down and allows it to work again. Trivial change, but would save someone the pain of having to fix examples before running them with trunk serve.