### PR TITLE
Add rustfmt config

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,6 @@
 # See https://rust-lang.github.io/rustfmt for more information
 
-# Git can handle translation with Windows newlines, but if you have
-# configured git correctly, which is not the default on windows
+# Ensure lines end with \n even if the git configuration core.autocrlf is not set to true
 newline_style = "Unix"
 
 # `Foobar { foo, bar }` is more readable than `Foo { foo: foo, bar: bar }`

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,14 @@
+# See https://github.com/rust-lang/rustfmt for more information
+
+# `Foobar { foo, bar }` is more readable than `Foo { foo: foo, bar: bar }`
+use_field_init_shorthand = true
+
+# Forces let else blocks to always be their own line(s)
+single_line_let_else_max_width = 0
+
+# Subjectively, this combo improves readability on imports. The full prefix is always
+# visible right after `use`, and different types of imports are grouped together in
+# a predictable way (first std, then other crates, then local imports).
+# (These options are still unstable and thus commented out)
+# imports_granularity = "Module"
+# group_imports = "StdExternalCrate"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,7 @@
 # See https://rust-lang.github.io/rustfmt for more information
 
-
+# Git can handle translation with Windows newlines, but if you have
+# configured git correctly, which is not the default on windows
 newline_style = "Unix"
 
 # `Foobar { foo, bar }` is more readable than `Foo { foo: foo, bar: bar }`

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,7 @@
-# See https://github.com/rust-lang/rustfmt for more information
+# See https://rust-lang.github.io/rustfmt for more information
+
+
+newline_style = "Unix"
 
 # `Foobar { foo, bar }` is more readable than `Foo { foo: foo, bar: bar }`
 use_field_init_shorthand = true


### PR DESCRIPTION
These standardized options can make code a little nicer. Right now they don't change anything, though they include an implicit commitment to adopt the # `imports_granularity = "Module"` and `group_imports = "StdExternalCrate"` settings.

While these settings are unstable, we can apply them with rustfmt nightly without actually committing to using nightly in CI. We should progressively move parts of the codebase towards that format in future PRs.