### PR TITLE
Check for typos in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,11 @@ jobs:
         # We currently skip checking masonry's docs
         run: cargo doc --workspace --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples --exclude masonry
 
+  # If this fails, consider changing your text or adding something to .typos.toml
   typos:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.21.0
+
+      - name: check typos
+        uses: crate-ci/typos@v1.21.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,10 @@ jobs:
       - name: cargo doc
         # We currently skip checking masonry's docs
         run: cargo doc --workspace --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples --exclude masonry
+
+  typos:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@v1.21.0

--- a/.typos.toml
+++ b/.typos.toml
@@ -3,7 +3,12 @@
 
 [default]
 extend-ignore-re = [
+    # Matches lorem ipsum text.
+    # In general, regexes are only matched until the end of a line by typos,
+    # and the repeated matcher at the end of both of these also ensures that
+    # matching ends at quotes or symbols commonly used to terminate comments.
     "Lorem ipsum [a-zA-Z .,]*",
+    "Phasellus in viverra dolor [a-zA-Z .,]*",
 ]
 
 # Corrections take the form of a key/value pair. The key is the incorrect word

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,13 +1,22 @@
+# See the configuration reference at
+# https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
 [default]
 extend-ignore-re = [
     "Lorem ipsum [a-zA-Z .,]*",
 ]
 
+# Corrections take the form of a key/value pair. The key is the incorrect word
+# and the value is the correct word. If the key and value are the same, the
+# word is treated as always correct. If the value is an empty string, the word
+# is treated as always incorrect.
+
 [default.extend-identifiers]
 FillStrat = "FillStrat" # short for strategy
 
+# Case insensitive
 [default.extend-words]
-seeked = "seeked" # FIXME?
+seeked = "seeked" # Part of the HTML standard
 
 [files]
 extend-exclude = [

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,15 @@
+[default]
+extend-ignore-re = [
+    "Lorem ipsum [a-zA-Z .,]*",
+]
+
+[default.extend-identifiers]
+FillStrat = "FillStrat" # short for strategy
+
+[default.extend-words]
+seeked = "seeked" # FIXME?
+
+[files]
+extend-exclude = [
+    "masonry/resources/i18n"
+]


### PR DESCRIPTION
Currently, the only legit typo being found is `seeked` but I'm not sure what to do about that.

Would be nice to check for new typos in CI anyways, right?