### PR TITLE
Update xilem-architecture.svg to have a white background

### DIFF
--- a/docs/assets/xilem-architecture.svg
+++ b/docs/assets/xilem-architecture.svg
@@ -2,6 +2,7 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
+   style="background-color:white"
    width="210mm"
    height="297mm"
    viewBox="0 0 210 297"


### PR DESCRIPTION
The architecture diagram is very hard to read on the dark theme of github

<img width="1312" alt="image" src="https://github.com/linebender/xilem/assets/9047770/90b5d68e-a14e-43ac-a625-c9696540df0c">
