### PR TITLE
masonry: Remove `'static'` bound requirement for `AppDriver`

### DIFF
--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -122,12 +122,7 @@ where
     }
 
     // TODO: Make windows a specific view
-    pub fn run_windowed(self, window_title: String) -> Result<(), EventLoopError>
-    where
-        State: 'static,
-        Logic: 'static,
-        View: 'static,
-    {
+    pub fn run_windowed(self, window_title: String) -> Result<(), EventLoopError> {
         let window_size = LogicalSize::new(600., 800.);
         let window_attributes = Window::default_attributes()
             .with_title(window_title)
@@ -137,12 +132,10 @@ where
     }
 
     // TODO: Make windows into a custom view
-    pub fn run_windowed_in(self, window_attributes: WindowAttributes) -> Result<(), EventLoopError>
-    where
-        State: 'static,
-        Logic: 'static,
-        View: 'static,
-    {
+    pub fn run_windowed_in(
+        self,
+        window_attributes: WindowAttributes,
+    ) -> Result<(), EventLoopError> {
         event_loop_runner::run(window_attributes, self.root_widget, self.driver)
     }
 }


### PR DESCRIPTION
Not sure if the boxing of the `AppDriver` is somehow intended. But in case it's not, we can remove the `'static` bound requirement for that.