### PR TITLE
xilem,masonry: Use `dpi` crate directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,7 @@ dependencies = [
  "accesskit_winit",
  "assert_matches",
  "cursor-icon",
+ "dpi",
  "float-cmp",
  "fnv",
  "futures-intrusive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ peniko = "0.1.0"
 winit = "0.30.0"
 tracing = "0.1.40"
 smallvec = "1.13.2"
+dpi = "0.1.1"
 fnv = "1.0.7"
 image = { version = "0.25.1", default-features = false }
 instant = "0.1.12"

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -42,6 +42,7 @@ accesskit.workspace = true
 accesskit_winit.workspace = true
 time = { version = "0.3.36", features = ["macros", "formatting"] }
 cursor-icon = "1.1.0"
+dpi.workspace = true
 
 [dev-dependencies]
 float-cmp = { version = "0.9.0", features = ["std"], default-features = false }

--- a/masonry/examples/calc.rs
+++ b/masonry/examples/calc.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use accesskit::{DefaultActionVerb, Role};
 use masonry::app_driver::{AppDriver, DriverCtx};
+use masonry::dpi::LogicalSize;
 use masonry::widget::{Align, CrossAxisAlignment, Flex, Label, RootWidget, SizedBox, WidgetRef};
 use masonry::{
     AccessCtx, AccessEvent, Action, BoxConstraints, Color, EventCtx, LayoutCtx, LifeCycle,
@@ -20,7 +21,6 @@ use masonry::{
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, Span};
 use vello::Scene;
-use winit::dpi::LogicalSize;
 use winit::window::Window;
 
 #[derive(Clone)]

--- a/masonry/examples/hello_masonry.rs
+++ b/masonry/examples/hello_masonry.rs
@@ -8,10 +8,10 @@
 #![windows_subsystem = "windows"]
 
 use masonry::app_driver::{AppDriver, DriverCtx};
+use masonry::dpi::LogicalSize;
 use masonry::widget::{prelude::*, RootWidget};
 use masonry::widget::{Button, Flex, Label};
 use masonry::Action;
-use winit::dpi::LogicalSize;
 use winit::window::Window;
 
 const VERTICAL_WIDGET_SPACING: f64 = 20.0;

--- a/masonry/examples/simple_image.rs
+++ b/masonry/examples/simple_image.rs
@@ -9,10 +9,10 @@
 #![windows_subsystem = "windows"]
 
 use masonry::app_driver::{AppDriver, DriverCtx};
+use masonry::dpi::LogicalSize;
 use masonry::widget::{FillStrat, Image, RootWidget};
 use masonry::{Action, WidgetId};
 use vello::peniko::{Format, Image as ImageBuf};
-use winit::dpi::LogicalSize;
 use winit::window::Window;
 
 struct Driver;

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -9,9 +9,9 @@ use std::time::Duration;
 use accesskit::{NodeBuilder, TreeUpdate};
 use parley::FontContext;
 use tracing::{trace, warn};
-use winit::dpi::LogicalPosition;
 
 use crate::action::Action;
+use crate::dpi::LogicalPosition;
 use crate::promise::PromiseToken;
 use crate::render_root::{RenderRootSignal, RenderRootState};
 use crate::text_helpers::{ImeChangeSignal, TextFieldRegistration};

--- a/masonry/src/event.rs
+++ b/masonry/src/event.rs
@@ -3,6 +3,7 @@
 
 //! Events.
 
+use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::kurbo::Rect;
 // TODO - See issue #14
 use crate::WidgetId;
@@ -10,7 +11,6 @@ use crate::WidgetId;
 use std::{collections::HashSet, path::PathBuf};
 
 use accesskit::{Action, ActionData};
-use winit::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use winit::event::{Ime, KeyEvent, Modifiers, MouseButton};
 use winit::keyboard::ModifiersState;
 

--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -12,13 +12,13 @@ use vello::util::{RenderContext, RenderSurface};
 use vello::{peniko::Color, AaSupport, RenderParams, Renderer, RendererOptions, Scene};
 use wgpu::PresentMode;
 use winit::application::ApplicationHandler;
-use winit::dpi::LogicalPosition;
 use winit::error::EventLoopError;
 use winit::event::WindowEvent as WinitWindowEvent;
 use winit::event_loop::{ActiveEventLoop, EventLoopProxy};
 use winit::window::{Window, WindowAttributes, WindowId};
 
 use crate::app_driver::{AppDriver, DriverCtx};
+use crate::dpi::LogicalPosition;
 use crate::event::{PointerState, WindowEvent};
 use crate::render_root::{self, RenderRoot, WindowSizePolicy};
 use crate::{PointerEvent, TextEvent, Widget};

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -86,6 +86,7 @@
 // TODO - Add logo
 
 pub use cursor_icon::{CursorIcon, ParseError as CursorIconParseError};
+pub use dpi;
 pub use kurbo;
 pub use parley;
 pub use vello;

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -11,11 +11,11 @@ use parley::FontContext;
 use tracing::{debug, info_span, warn};
 use vello::peniko::{Color, Fill};
 use vello::Scene;
-use winit::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use winit::keyboard::{KeyCode, PhysicalKey};
 
 use crate::contexts::{EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, WidgetCtx, WorkerFn};
 use crate::debug_logger::DebugLogger;
+use crate::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use crate::event::{PointerEvent, TextEvent, WindowEvent};
 use crate::kurbo::Point;
 use crate::widget::{WidgetMut, WidgetState};

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -13,12 +13,12 @@ use wgpu::{
     BufferDescriptor, BufferUsages, CommandEncoderDescriptor, Extent3d, ImageCopyBuffer,
     TextureDescriptor, TextureFormat, TextureUsages,
 };
-use winit::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use winit::event::{Ime, MouseButton};
 
 use super::screenshots::get_image_diff;
 use super::snapshot_utils::get_cargo_workspace;
 use crate::action::Action;
+use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::event::{PointerEvent, PointerState, TextEvent, WindowEvent};
 use crate::event_loop_runner::try_init_tracing;
 use crate::render_root::{RenderRoot, RenderRootSignal, WindowSizePolicy};

--- a/masonry/src/widget/split.rs
+++ b/masonry/src/widget/split.rs
@@ -7,9 +7,9 @@ use accesskit::Role;
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, warn, Span};
 use vello::Scene;
-use winit::dpi::LogicalPosition;
 use winit::event::MouseButton;
 
+use crate::dpi::LogicalPosition;
 use crate::kurbo::Line;
 use crate::paint_scene_helpers::{fill_color, stroke};
 use crate::widget::flex::Axis;

--- a/masonry/src/widget/widget_pod.rs
+++ b/masonry/src/widget/widget_pod.rs
@@ -4,8 +4,8 @@
 use accesskit::{NodeBuilder, NodeId};
 use tracing::{info_span, trace, warn};
 use vello::Scene;
-use winit::dpi::LogicalPosition;
 
+use crate::dpi::LogicalPosition;
 use crate::event::{AccessEvent, PointerEvent, TextEvent};
 use crate::kurbo::{Affine, Insets, Point, Rect, Shape, Size};
 use crate::paint_scene_helpers::stroke;

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -6,13 +6,13 @@ use std::{any::Any, collections::HashMap};
 
 use masonry::{
     app_driver::AppDriver,
+    dpi::LogicalSize,
     event_loop_runner,
     widget::{RootWidget, WidgetMut},
     Widget, WidgetId, WidgetPod,
 };
 pub use masonry::{widget::Axis, Color, TextAlignment};
 use winit::{
-    dpi::LogicalSize,
     error::EventLoopError,
     window::{Window, WindowAttributes},
 };
@@ -27,6 +27,7 @@ pub use id::ViewId;
 pub use sequence::{ElementSplice, ViewSequence};
 pub use vec_splice::VecSplice;
 
+pub use masonry::dpi;
 pub use masonry::event_loop_runner::{EventLoop, EventLoopBuilder};
 
 pub struct Xilem<State, Logic, View>


### PR DESCRIPTION
This removes a class of dependencies from within both `masonry` and `xilem` on the `winit` crate where we can just use `dpi` directly instead.

The `dpi` crate is meant (like `cursor_icon`) to be a shared ecosystem crate rather than only for usage with `winit`.