### PR TITLE
lints: Suppress some check-cfg warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ homepage = "https://xilem.dev/"
 
 [workspace.lints]
 clippy.semicolon_if_nothing_returned = "warn"
+rust.unexpected_cfgs = { level = "warn", check-cfg = ['cfg(FALSE)', 'cfg(tarpaulin_include)'] }
 
 [workspace.dependencies]
 xilem_core = { version = "0.1.0", path = "xilem_core" }


### PR DESCRIPTION
The current nightly issues warnings for unknown cfgs, so we need to suppress some of these for now.

Even though these are only needed for `masonry`, we put them in the workspace configuration due to limitations in how the lints table is configured and overridden in current versions of Cargo.