### PR TITLE
masonry: Use `web-time` instead of `instant`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,9 +1534,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1729,7 +1726,6 @@ dependencies = [
  "futures-intrusive",
  "image",
  "insta",
- "instant",
  "kurbo",
  "once_cell",
  "parley",
@@ -1743,6 +1739,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-segmentation",
  "vello",
+ "web-time",
  "wgpu",
  "winit",
  "xi-unicode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ smallvec = "1.13.2"
 dpi = "0.1.1"
 fnv = "1.0.7"
 image = { version = "0.25.1", default-features = false }
-instant = "0.1.12"
+web-time = "1.1.0"
 bitflags = "2.5.0"
 accesskit = "0.14.0"
 accesskit_winit = "0.20.0"

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -27,7 +27,6 @@ winit.workspace = true
 smallvec.workspace = true
 tracing.workspace = true
 fnv.workspace = true
-instant = { workspace = true, features = ["wasm-bindgen"] }
 image.workspace = true
 once_cell = "1.19.0"
 serde = { version = "1.0.200", features = ["derive"] }
@@ -43,6 +42,9 @@ accesskit_winit.workspace = true
 time = { version = "0.3.36", features = ["macros", "formatting"] }
 cursor-icon = "1.1.0"
 dpi.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-time.workspace = true
 
 [dev-dependencies]
 float-cmp = { version = "0.9.0", features = ["std"], default-features = false }

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -4,14 +4,17 @@
 use std::collections::VecDeque;
 
 use accesskit::{ActionRequest, NodeBuilder, Tree, TreeUpdate};
-// Automatically defaults to std::time::Instant on non Wasm platforms
-use instant::Instant;
 use kurbo::Affine;
 use parley::FontContext;
 use tracing::{debug, info_span, warn};
 use vello::peniko::{Color, Fill};
 use vello::Scene;
 use winit::keyboard::{KeyCode, PhysicalKey};
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 use crate::contexts::{EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, WidgetCtx, WorkerFn};
 use crate::debug_logger::DebugLogger;

--- a/masonry/src/widget/spinner.rs
+++ b/masonry/src/widget/spinner.rs
@@ -157,7 +157,7 @@ mod tests {
     use super::*;
     use crate::assert_render_snapshot;
     use crate::testing::TestHarness;
-    //use instant::Duration;
+    //use {std::time,web_time}::Duration;
 
     #[test]
     fn simple_spinner() {


### PR DESCRIPTION
Recently, `instant` has been marked as unmaintained by the maintainer. A suggested replacement is `web-time`, which is used by `winit` and is already in our dependency tree.