### PR TITLE
Allow feeding masonry from an externally event loop.

### DIFF
--- a/masonry/src/app_driver.rs
+++ b/masonry/src/app_driver.rs
@@ -8,7 +8,12 @@ use crate::{Action, Widget, WidgetId};
 
 pub struct DriverCtx<'a> {
     // TODO
-    pub(crate) main_root_widget: WidgetMut<'a, Box<dyn Widget>>,
+    // This is exposed publicly for now to let people drive
+    // masonry on their own, but this is not expected to be
+    // stable or even supported. This is for short term
+    // expedience only while better solutions are devised.
+    #[doc(hidden)]
+    pub main_root_widget: WidgetMut<'a, Box<dyn Widget>>,
 }
 
 pub trait AppDriver {

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -119,7 +119,8 @@ pub use action::Action;
 pub use box_constraints::BoxConstraints;
 pub use contexts::{AccessCtx, EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, WidgetCtx};
 pub use event::{
-    AccessEvent, InternalLifeCycle, LifeCycle, PointerEvent, StatusChange, TextEvent, WindowTheme,
+    AccessEvent, InternalLifeCycle, LifeCycle, PointerEvent, PointerState, StatusChange, TextEvent,
+    WindowEvent, WindowTheme,
 };
 pub use kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
 pub use parley::layout::Alignment as TextAlignment;


### PR DESCRIPTION
This allows for running `masonry` with an externally managed event loop for integrating with an application that is already running an event loop.

* Expose `PointerState` to allow creating `PointerEvent`
* Expose `WindowEvent` to allow managing window size and scale factor.
* Make `DriverCtx` usable from outside the crate. While this struct was already `pub`, the sole member of it was not.