### PR TITLE
masonry: Avoid reconstructing LogicalPosition.

### DIFF
--- a/masonry/src/widget/widget_pod.rs
+++ b/masonry/src/widget/widget_pod.rs
@@ -655,12 +655,11 @@ impl<W: Widget> WidgetPod<W> {
                 InternalLifeCycle::ParentWindowOrigin { mouse_pos } => {
                     self.state.parent_window_origin = parent_ctx.widget_state.window_origin();
                     self.state.needs_window_origin = false;
-                    let mouse_pos = mouse_pos.map(|pos| LogicalPosition::new(pos.x, pos.y));
                     WidgetPod::update_hot_state(
                         &mut self.inner,
                         &mut self.state,
                         parent_ctx.global_state,
-                        mouse_pos,
+                        *mouse_pos,
                     );
                     // TODO - self.state.is_hidden
                     true


### PR DESCRIPTION
In the call to updating the hot state from the widget pod, the `mouse_pos` is already of the right type, so it doesn't need to try to reconstruct itself as the right type.

This is different from another call site (in `contexts.rs`) where the `mouse_pos` is an `Option<Point>` and so it does need reconstructing.