### PR TITLE
Disable `clippy::assigning_clones` lint.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ homepage = "https://xilem.dev/"
 
 [workspace.lints]
 clippy.semicolon_if_nothing_returned = "warn"
+# Remove assigning_clones once it's allowed by default in stable Rust
+# https://github.com/rust-lang/rust-clippy/pull/12779
 clippy.assigning_clones = "allow"
 rust.unexpected_cfgs = { level = "warn", check-cfg = ['cfg(FALSE)', 'cfg(tarpaulin_include)'] }
 


### PR DESCRIPTION
Enabling [`assigning_clones`](https://rust-lang.github.io/rust-clippy/master/index.html#/assigning_clones) by default in Rust 1.78 was a mistake which was reversed in a week in [rust-clippy#12779](https://github.com/rust-lang/rust-clippy/pull/12779).

We can disable it locally until the upstream fix arrives to stable Rust.