### PR TITLE
masonry: Use own `PointerButton` enum

### DIFF
--- a/masonry/src/event.rs
+++ b/masonry/src/event.rs
@@ -11,7 +11,7 @@ use crate::WidgetId;
 use std::{collections::HashSet, path::PathBuf};
 
 use accesskit::{Action, ActionData};
-use winit::event::{Ime, KeyEvent, Modifiers, MouseButton};
+use winit::event::{Ime, KeyEvent, Modifiers};
 use winit::keyboard::ModifiersState;
 
 // TODO - Occluded(bool) event
@@ -30,14 +30,34 @@ pub enum WindowEvent {
     RebuildAccessTree,
 }
 
+/// An indicator of which pointer button was pressed.
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
+#[repr(u8)]
+pub enum PointerButton {
+    /// No mouse button.
+    None,
+    /// Primary button, commonly the left mouse button, touch contact, pen contact.
+    Primary,
+    /// Secondary button, commonly the right mouse button, pen barrel button.
+    Secondary,
+    /// Auxiliary button, commonly the middle mouse button.
+    Auxiliary,
+    /// X1 (back) Mouse.
+    X1,
+    /// X2 (forward) Mouse.
+    X2,
+    /// Other mouse button. This isn't fleshed out yet.
+    Other,
+}
+
 // TODO - How can RenderRoot express "I started a drag-and-drop op"?
 // TODO - Touchpad, Touch, AxisMotion
 // TODO - How to handle CursorEntered?
 // Note to self: Events like "pointerenter", "pointerleave" are handled differently at the Widget level. But that's weird because WidgetPod can distribute them. Need to think about this again.
 #[derive(Debug, Clone)]
 pub enum PointerEvent {
-    PointerDown(MouseButton, PointerState),
-    PointerUp(MouseButton, PointerState),
+    PointerDown(PointerButton, PointerState),
+    PointerUp(PointerButton, PointerState),
     PointerMove(PointerState),
     PointerEnter(PointerState),
     PointerLeave(PointerState),
@@ -72,7 +92,7 @@ pub struct PointerState {
     // pub device_id: DeviceId,
     pub physical_position: PhysicalPosition<f64>,
     pub position: LogicalPosition<f64>,
-    pub buttons: HashSet<MouseButton>,
+    pub buttons: HashSet<PointerButton>,
     pub mods: Modifiers,
     pub count: u8,
     pub focus: bool,

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -13,13 +13,13 @@ use wgpu::{
     BufferDescriptor, BufferUsages, CommandEncoderDescriptor, Extent3d, ImageCopyBuffer,
     TextureDescriptor, TextureFormat, TextureUsages,
 };
-use winit::event::{Ime, MouseButton};
+use winit::event::Ime;
 
 use super::screenshots::get_image_diff;
 use super::snapshot_utils::get_cargo_workspace;
 use crate::action::Action;
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
-use crate::event::{PointerEvent, PointerState, TextEvent, WindowEvent};
+use crate::event::{PointerButton, PointerEvent, PointerState, TextEvent, WindowEvent};
 use crate::event_loop_runner::try_init_tracing;
 use crate::render_root::{RenderRoot, RenderRootSignal, WindowSizePolicy};
 use crate::widget::{WidgetMut, WidgetRef};
@@ -351,13 +351,13 @@ impl TestHarness {
     }
 
     /// Send a MouseDown event to the window.
-    pub fn mouse_button_press(&mut self, button: MouseButton) {
+    pub fn mouse_button_press(&mut self, button: PointerButton) {
         self.mouse_state.buttons.insert(button);
         self.process_pointer_event(PointerEvent::PointerDown(button, self.mouse_state.clone()));
     }
 
     /// Send a MouseUp event to the window.
-    pub fn mouse_button_release(&mut self, button: MouseButton) {
+    pub fn mouse_button_release(&mut self, button: PointerButton) {
         self.mouse_state.buttons.remove(&button);
         self.process_pointer_event(PointerEvent::PointerUp(button, self.mouse_state.clone()));
     }
@@ -379,8 +379,8 @@ impl TestHarness {
         let widget_center = widget_rect.center();
 
         self.mouse_move(widget_center);
-        self.mouse_button_press(MouseButton::Left);
-        self.mouse_button_release(MouseButton::Left);
+        self.mouse_button_press(PointerButton::Primary);
+        self.mouse_button_release(PointerButton::Primary);
     }
 
     /// Use [`mouse_move`](Self::mouse_move) to set the internal mouse pos to the center of the given widget.

--- a/masonry/src/text2/edit.rs
+++ b/masonry/src/text2/edit.rs
@@ -7,11 +7,14 @@ use kurbo::Point;
 use parley::FontContext;
 use vello::Scene;
 use winit::{
-    event::{Ime, MouseButton},
+    event::Ime,
     keyboard::{Key, NamedKey},
 };
 
-use crate::{event::PointerState, Action, EventCtx, Handled, TextEvent};
+use crate::{
+    event::{PointerButton, PointerState},
+    Action, EventCtx, Handled, TextEvent,
+};
 
 use super::{
     offset_for_delete_backwards,
@@ -92,7 +95,7 @@ impl<T: EditableText> TextEditor<T> {
         &mut self,
         origin: Point,
         state: &PointerState,
-        button: MouseButton,
+        button: PointerButton,
     ) -> bool {
         // TODO: If we have a selection and we're hovering over it,
         // implement (optional?) click and drag

--- a/masonry/src/text2/selection.rs
+++ b/masonry/src/text2/selection.rs
@@ -12,10 +12,9 @@ use parley::FontContext;
 use unicode_segmentation::{GraphemeCursor, UnicodeSegmentation};
 use vello::peniko::{Brush, Color};
 use vello::Scene;
-use winit::event::MouseButton;
 use winit::keyboard::NamedKey;
 
-use crate::event::PointerState;
+use crate::event::{PointerButton, PointerState};
 use crate::{Handled, TextEvent};
 
 use super::{TextBrush, TextLayout, TextStorage};
@@ -61,10 +60,10 @@ impl<T: Selectable> TextWithSelection<T> {
         &mut self,
         origin: Point,
         state: &PointerState,
-        button: MouseButton,
+        button: PointerButton,
     ) -> bool {
         // TODO: work out which button is the primary button?
-        if button == MouseButton::Left {
+        if button == PointerButton::Primary {
             self.selecting_with_mouse = true;
             self.needs_selection_update = true;
             // TODO: Much of this juggling seems unnecessary
@@ -90,8 +89,8 @@ impl<T: Selectable> TextWithSelection<T> {
         }
     }
 
-    pub fn pointer_up(&mut self, _origin: Point, _state: &PointerState, button: MouseButton) {
-        if button == MouseButton::Left {
+    pub fn pointer_up(&mut self, _origin: Point, _state: &PointerState, button: PointerButton) {
+        if button == PointerButton::Primary {
             self.selecting_with_mouse = false;
         }
     }

--- a/masonry/src/widget/scroll_bar.rs
+++ b/masonry/src/widget/scroll_bar.rs
@@ -238,10 +238,10 @@ impl Widget for ScrollBar {
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;
-    use winit::event::MouseButton;
 
     use super::*;
     use crate::assert_render_snapshot;
+    use crate::event::PointerButton;
     use crate::testing::{widget_ids, TestHarness, TestWidgetExt};
 
     #[test]
@@ -262,7 +262,7 @@ mod tests {
 
         assert_render_snapshot!(harness, "scrollbar_middle");
 
-        harness.mouse_button_press(MouseButton::Left);
+        harness.mouse_button_press(PointerButton::Primary);
         harness.mouse_move(Point::new(30.0, 150.0));
 
         assert_render_snapshot!(harness, "scrollbar_down");

--- a/masonry/src/widget/split.rs
+++ b/masonry/src/widget/split.rs
@@ -7,9 +7,9 @@ use accesskit::Role;
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, warn, Span};
 use vello::Scene;
-use winit::event::MouseButton;
 
 use crate::dpi::LogicalPosition;
+use crate::event::PointerButton;
 use crate::kurbo::Line;
 use crate::paint_scene_helpers::{fill_color, stroke};
 use crate::widget::flex::Axis;
@@ -372,7 +372,7 @@ impl Widget for Split {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         if self.draggable {
             match event {
-                PointerEvent::PointerDown(MouseButton::Left, state) => {
+                PointerEvent::PointerDown(PointerButton::Primary, state) => {
                     if self.bar_hit_test(ctx.size(), state.position) {
                         ctx.set_handled();
                         ctx.set_active(true);
@@ -391,7 +391,7 @@ impl Widget for Split {
                         }
                     }
                 }
-                PointerEvent::PointerUp(MouseButton::Left, state) => {
+                PointerEvent::PointerUp(PointerButton::Primary, state) => {
                     if ctx.is_active() {
                         ctx.set_handled();
                         ctx.set_active(false);

--- a/masonry/src/widget/tests/status_change.rs
+++ b/masonry/src/widget/tests/status_change.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use assert_matches::assert_matches;
-use winit::event::MouseButton;
 
-use crate::event::{PointerEvent, PointerState};
+use crate::event::{PointerButton, PointerEvent, PointerState};
 use crate::testing::{widget_ids, Record, Recording, TestHarness, TestWidgetExt as _};
 use crate::widget::{Button, Flex, Label, SizedBox};
 use crate::*;
@@ -233,7 +232,7 @@ fn get_pointer_events_while_active() {
     // We press the button
 
     harness.mouse_move_to(button);
-    harness.mouse_button_press(MouseButton::Left);
+    harness.mouse_button_press(PointerButton::Primary);
 
     assert_matches!(
         next_pointer_event(&button_rec),
@@ -277,7 +276,7 @@ fn get_pointer_events_while_active() {
 
     // We release the button
 
-    harness.mouse_button_release(MouseButton::Left);
+    harness.mouse_button_release(PointerButton::Primary);
 
     assert_matches!(
         next_pointer_event(&button_rec),


### PR DESCRIPTION
This brings the `PointerButton` enum from glazier and has all code outside of the winit event loop integration using it.

For now, it has a `todo!()` for the `MouseButton::Other` as it isn't clear what that is for.