### PR TITLE
masonry: More efficient set of PointerButtons.

### DIFF
--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -369,7 +369,7 @@ impl TestHarness {
 
     /// Send a [`PointerUp`](PointerEvent::PointerUp) event to the window.
     pub fn mouse_button_release(&mut self, button: PointerButton) {
-        self.mouse_state.buttons.remove(&button);
+        self.mouse_state.buttons.remove(button);
         self.process_pointer_event(PointerEvent::PointerUp(button, self.mouse_state.clone()));
     }
 


### PR DESCRIPTION
This brings code over from glazier for a set of PointerButtons that just uses a single value and bit flags rather than a `HashSet`.