### PR TITLE
Handle an empty preedit

### DIFF
--- a/masonry/src/event.rs
+++ b/masonry/src/event.rs
@@ -280,7 +280,11 @@ impl TextEvent {
     pub fn short_name(&self) -> &'static str {
         match self {
             TextEvent::KeyboardKey(_, _) => "KeyboardKey",
-            TextEvent::Ime(_) => "Ime",
+            TextEvent::Ime(Ime::Disabled) => "Ime::Disabled",
+            TextEvent::Ime(Ime::Enabled) => "Ime::Enabled",
+            TextEvent::Ime(Ime::Commit(_)) => "Ime::Commit",
+            TextEvent::Ime(Ime::Preedit(s, _)) if s.len() == 0 => "Ime::Preedit(\"\")",
+            TextEvent::Ime(Ime::Preedit(_, _)) => "Ime::Preedit",
             TextEvent::ModifierChange(_) => "ModifierChange",
             TextEvent::FocusChange(_) => "FocusChange",
         }

--- a/masonry/src/event.rs
+++ b/masonry/src/event.rs
@@ -283,7 +283,7 @@ impl TextEvent {
             TextEvent::Ime(Ime::Disabled) => "Ime::Disabled",
             TextEvent::Ime(Ime::Enabled) => "Ime::Enabled",
             TextEvent::Ime(Ime::Commit(_)) => "Ime::Commit",
-            TextEvent::Ime(Ime::Preedit(s, _)) if s.len() == 0 => "Ime::Preedit(\"\")",
+            TextEvent::Ime(Ime::Preedit(s, _)) if s.is_empty() => "Ime::Preedit(\"\")",
             TextEvent::Ime(Ime::Preedit(_, _)) => "Ime::Preedit",
             TextEvent::ModifierChange(_) => "ModifierChange",
             TextEvent::FocusChange(_) => "FocusChange",


### PR DESCRIPTION
Since #314, we request the IME to be positioned every paint cycle. This triggers a new event from the IME, which is a preedit clear. This IME event also breaks text selection, which is why we handle it here.

This is still not the fully correct behaviour, but it does at least make text selection in textboxes work again. We really need to improve our testing story here.

Also give more detail in the short form of IME events; these events all have quite different properties.