### PR TITLE
Consistently use `ctx` over `cx` in Xilem

### DIFF
--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -10,7 +10,7 @@ pub struct MasonryDriver<State, Logic, View, ViewState> {
     pub(crate) state: State,
     pub(crate) logic: Logic,
     pub(crate) current_view: View,
-    pub(crate) view_cx: ViewCtx,
+    pub(crate) view_ctx: ViewCtx,
     pub(crate) view_state: ViewState,
 }
 
@@ -25,7 +25,7 @@ where
         widget_id: masonry::WidgetId,
         action: masonry::Action,
     ) {
-        if let Some(id_path) = self.view_cx.widget_map.get(&widget_id) {
+        if let Some(id_path) = self.view_ctx.widget_map.get(&widget_id) {
             let message_result = self.current_view.message(
                 &mut self.view_state,
                 id_path.as_slice(),
@@ -48,14 +48,14 @@ where
                 let next_view = (self.logic)(&mut self.state);
                 let mut root = ctx.get_root::<RootWidget<View::Widget>>();
 
-                self.view_cx.view_tree_changed = false;
+                self.view_ctx.view_tree_changed = false;
                 next_view.rebuild(
                     &self.current_view,
                     &mut self.view_state,
-                    &mut self.view_cx,
+                    &mut self.view_ctx,
                     root.get_element(),
                 );
-                if cfg!(debug_assertions) && !self.view_cx.view_tree_changed {
+                if cfg!(debug_assertions) && !self.view_ctx.view_tree_changed {
                     tracing::debug!("Nothing changed as result of action");
                 }
                 self.current_view = next_view;

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -45,15 +45,15 @@ where
 {
     pub fn new(mut state: State, mut logic: Logic) -> Self {
         let first_view = logic(&mut state);
-        let mut view_cx = ViewCtx::default();
-        let (pod, view_state) = first_view.build(&mut view_cx);
+        let mut view_ctx = ViewCtx::default();
+        let (pod, view_state) = first_view.build(&mut view_ctx);
         let root_widget = RootWidget::from_pod(pod.inner);
         Xilem {
             driver: MasonryDriver {
                 current_view: first_view,
                 logic,
                 state,
-                view_cx,
+                view_ctx,
                 view_state,
             },
             root_widget,

--- a/xilem_core/src/views/memoize.rs
+++ b/xilem_core/src/views/memoize.rs
@@ -58,9 +58,9 @@ where
 
     type Element = V::Element;
 
-    fn build(&self, cx: &mut Context) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
         let view = (self.child_cb)(&self.data);
-        let (element, view_state) = view.build(cx);
+        let (element, view_state) = view.build(ctx);
         let memoize_state = MemoizeState {
             view,
             view_state,
@@ -73,12 +73,12 @@ where
         &self,
         prev: &Self,
         view_state: &mut Self::ViewState,
-        cx: &mut Context,
+        ctx: &mut Context,
         element: Mut<'el, Self::Element>,
     ) -> Mut<'el, Self::Element> {
         if core::mem::take(&mut view_state.dirty) || prev.data != self.data {
             let view = (self.child_cb)(&self.data);
-            let el = view.rebuild(&view_state.view, &mut view_state.view_state, cx, element);
+            let el = view.rebuild(&view_state.view, &mut view_state.view_state, ctx, element);
             view_state.view = view;
             el
         } else {

--- a/xilem_core/tests/any_view.rs
+++ b/xilem_core/tests/any_view.rs
@@ -8,12 +8,12 @@ use xilem_core::{AnyView, MessageResult, View};
 mod common;
 use common::*;
 
-type AnyNoopView = dyn AnyView<(), Action, TestCx, TestElement>;
+type AnyNoopView = dyn AnyView<(), Action, TestCtx, TestElement>;
 
 #[test]
 fn messages_to_inner_view() {
     let view: Box<AnyNoopView> = Box::new(OperationView::<0>(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
@@ -25,7 +25,7 @@ fn messages_to_inner_view() {
 #[test]
 fn message_after_rebuild() {
     let view: Box<AnyNoopView> = Box::new(OperationView::<0>(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     let path = element.view_path.clone();
@@ -45,7 +45,7 @@ fn message_after_rebuild() {
 #[test]
 fn no_message_after_stale() {
     let view: Box<AnyNoopView> = Box::new(OperationView::<0>(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     let path = element.view_path.clone();
@@ -69,7 +69,7 @@ fn no_message_after_stale() {
 #[test]
 fn no_message_after_stale_then_same_type() {
     let view: Box<AnyNoopView> = Box::new(OperationView::<0>(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     let path = element.view_path.clone();

--- a/xilem_core/tests/arc.rs
+++ b/xilem_core/tests/arc.rs
@@ -21,7 +21,7 @@ fn record_ops(id: u32) -> OperationView<0> {
 /// The Arc view shouldn't impact the view path
 fn arc_no_path() {
     let view1 = Arc::new(record_ops(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (element, ()) = view1.build(&mut ctx);
     ctx.assert_empty();
     assert!(element.view_path.is_empty());
@@ -30,7 +30,7 @@ fn arc_no_path() {
 #[test]
 fn same_arc_skip_rebuild() {
     let view1 = Arc::new(record_ops(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view1.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
@@ -45,7 +45,7 @@ fn same_arc_skip_rebuild() {
 /// If use a different Arc, a rebuild should happen
 fn new_arc_rebuild() {
     let view1 = Arc::new(record_ops(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view1.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
@@ -63,7 +63,7 @@ fn new_arc_rebuild() {
 /// If use a different Arc, a rebuild should happen
 fn new_arc_rebuild_same_value() {
     let view1 = Arc::new(record_ops(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view1.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
@@ -81,7 +81,7 @@ fn new_arc_rebuild_same_value() {
 /// Arc should successfully allow the child to teardown
 fn arc_passthrough_teardown() {
     let view1 = Arc::new(record_ops(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view1.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
@@ -97,7 +97,7 @@ fn arc_passthrough_teardown() {
 #[test]
 fn arc_passthrough_message() {
     let view1 = Arc::new(record_ops(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (element, mut state) = view1.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
@@ -111,7 +111,7 @@ fn arc_passthrough_message() {
 /// The Box view shouldn't impact the view path
 fn box_no_path() {
     let view1 = Box::new(record_ops(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (element, ()) = view1.build(&mut ctx);
     ctx.assert_empty();
     assert!(element.view_path.is_empty());
@@ -121,7 +121,7 @@ fn box_no_path() {
 /// The Box view should always rebuild
 fn box_passthrough_rebuild() {
     let view1 = Box::new(record_ops(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view1.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
@@ -139,7 +139,7 @@ fn box_passthrough_rebuild() {
 /// The Box view should always rebuild
 fn box_passthrough_rebuild_same_value() {
     let view1 = Box::new(record_ops(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view1.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
@@ -156,7 +156,7 @@ fn box_passthrough_rebuild_same_value() {
 #[test]
 fn box_passthrough_teardown() {
     let view1 = Box::new(record_ops(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view1.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
@@ -172,7 +172,7 @@ fn box_passthrough_teardown() {
 #[test]
 fn box_passthrough_message() {
     let view1 = Box::new(record_ops(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (element, mut state) = view1.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);

--- a/xilem_core/tests/base_sequence.rs
+++ b/xilem_core/tests/base_sequence.rs
@@ -17,7 +17,7 @@ fn record_ops(id: u32) -> OperationView<0> {
 #[test]
 fn one_element_sequence_passthrough() {
     let view = sequence(1, record_ops(0));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(1)]);
@@ -84,7 +84,7 @@ fn one_element_sequence_passthrough() {
 #[test]
 fn option_none_none() {
     let view = sequence(0, None::<OperationView<0>>);
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
@@ -125,7 +125,7 @@ fn option_none_none() {
 #[test]
 fn option_some_some() {
     let view = sequence(1, Some(record_ops(0)));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(1)]);
@@ -185,7 +185,7 @@ fn option_some_some() {
 #[test]
 fn option_none_some() {
     let view = sequence(0, None);
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
@@ -234,7 +234,7 @@ fn option_none_some() {
 #[test]
 fn option_some_none() {
     let view = sequence(1, Some(record_ops(0)));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(1)]);
@@ -285,7 +285,7 @@ fn option_some_none() {
 #[test]
 fn option_message_some() {
     let view = sequence(1, Some(record_ops(0)));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
 
@@ -301,7 +301,7 @@ fn option_message_some() {
 #[test]
 fn option_message_some_some() {
     let view = sequence(0, Some(record_ops(0)));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
 
@@ -320,7 +320,7 @@ fn option_message_some_some() {
 #[test]
 fn option_message_some_none_stale() {
     let view = sequence(0, Some(record_ops(0)));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
 
@@ -339,7 +339,7 @@ fn option_message_some_none_stale() {
 #[test]
 fn option_message_some_none_some_stale() {
     let view = sequence(0, Some(record_ops(0)));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
 

--- a/xilem_core/tests/tuple_sequence.rs
+++ b/xilem_core/tests/tuple_sequence.rs
@@ -12,7 +12,7 @@ fn record_ops(id: u32) -> OperationView<0> {
 #[test]
 fn unit_no_elements() {
     let view = sequence(0, ());
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (element, _state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert!(element.children.unwrap().active.is_empty());
@@ -22,7 +22,7 @@ fn unit_no_elements() {
 #[test]
 fn one_element_passthrough() {
     let view = sequence(1, (record_ops(0),));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(1)]);
@@ -90,7 +90,7 @@ fn one_element_passthrough() {
 #[test]
 fn two_element_passthrough() {
     let view = sequence(2, (record_ops(0), record_ops(1)));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(2)]);
@@ -169,7 +169,7 @@ fn two_element_passthrough() {
 #[test]
 fn two_element_message() {
     let view = sequence(2, (record_ops(0), record_ops(1)));
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(2)]);

--- a/xilem_core/tests/vec_sequence.rs
+++ b/xilem_core/tests/vec_sequence.rs
@@ -12,7 +12,7 @@ fn record_ops(id: u32) -> OperationView<0> {
 #[test]
 fn zero_zero() {
     let view = sequence(0, Vec::<OperationView<0>>::new());
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
@@ -53,7 +53,7 @@ fn zero_zero() {
 #[test]
 fn one_zero() {
     let view = sequence(1, vec![record_ops(0)]);
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(1)]);
@@ -109,7 +109,7 @@ fn one_zero() {
 #[test]
 fn one_two() {
     let view = sequence(1, vec![record_ops(0)]);
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(1)]);
@@ -178,7 +178,7 @@ fn one_two() {
 #[test]
 fn normal_messages() {
     let view = sequence(0, vec![record_ops(0), record_ops(1)]);
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.view_path, &[]);
@@ -210,7 +210,7 @@ fn normal_messages() {
 #[test]
 fn stale_messages() {
     let view = sequence(0, vec![record_ops(0)]);
-    let mut ctx = TestCx::default();
+    let mut ctx = TestCtx::default();
     let (mut element, mut state) = view.build(&mut ctx);
     ctx.assert_empty();
     assert_eq!(element.view_path, &[]);


### PR DESCRIPTION
This was brought up in [#xilem > paper cuts](https://xi.zulipchat.com/#narrow/stream/354396-xilem/topic/paper.20cuts)

The memoize change was a copy-and-paste failure