### PR TITLE
Port `Adapt` from old `xilem_core`

### DIFF
--- a/xilem/examples/components.rs
+++ b/xilem/examples/components.rs
@@ -1,0 +1,47 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Modularizing state can be done with `map_state` which maps a subset of the state from the parent view state
+
+use masonry::widget::MainAxisAlignment;
+use winit::error::EventLoopError;
+use xilem::{
+    core::map_state,
+    view::{button, flex, label},
+    EventLoop, WidgetView, Xilem,
+};
+
+#[derive(Default)]
+struct AppState {
+    modularized_count: i32,
+    global_count: i32,
+}
+
+fn modularized_counter(count: &mut i32) -> impl WidgetView<i32> {
+    flex((
+        label(format!("modularized count: {count}")),
+        button("+", |count| *count += 1),
+        button("-", |count| *count -= 1),
+    ))
+}
+
+fn app_logic(state: &mut AppState) -> impl WidgetView<AppState> {
+    flex((
+        map_state(
+            modularized_counter(&mut state.modularized_count),
+            |state: &mut AppState| &mut state.modularized_count,
+        ),
+        button(
+            format!("clicked {} times", state.global_count),
+            |state: &mut AppState| state.global_count += 1,
+        ),
+    ))
+    .direction(xilem::Axis::Horizontal)
+    .main_axis_alignment(MainAxisAlignment::Center)
+}
+
+fn main() -> Result<(), EventLoopError> {
+    let app = Xilem::new(AppState::default(), app_logic);
+    app.run_windowed(EventLoop::with_user_event(), "Components".into())?;
+    Ok(())
+}

--- a/xilem/examples/elm.rs
+++ b/xilem/examples/elm.rs
@@ -1,6 +1,10 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//! Xilem supports several patterns for creating modular components.
+//! You can also emulate the elm architecture for a subset of your app.
+//! Though usually it's more idiomatic to update state directly within event callbacks, as seen in the `direct_counter` view.
+
 use masonry::widget::{CrossAxisAlignment, MainAxisAlignment};
 use winit::error::EventLoopError;
 use xilem::{
@@ -17,9 +21,9 @@ struct AppState {
 }
 
 // `map_state()` maps a subset of the state from the parent, such that views can be modularized by state
-fn map_state_view(count: &mut i32) -> impl WidgetView<i32> {
+fn direct_counter(count: &mut i32) -> impl WidgetView<i32> {
     flex((
-        label(format!("adapt state count: {}", count)),
+        label(format!("direct count: {count}")),
         button("+", |count| *count += 1),
         button("-", |count| *count -= 1),
     ))
@@ -32,9 +36,9 @@ enum CountMessage {
 
 // `map_action()` is basically how elm works, i.e. provide a message that the parent view has to handle to update the state.
 // In this case the parent adjusts the count that is given to this view according to the message
-fn map_action_view<T>(count: i32) -> impl WidgetView<T, CountMessage> {
+fn elm_counter<T>(count: i32) -> impl WidgetView<T, CountMessage> {
     flex((
-        label(format!("adapt state count: {}", count)),
+        label(format!("elm count: {count}")),
         button("+", |_| CountMessage::Increment),
         button("-", |_| CountMessage::Decrement),
     ))
@@ -48,10 +52,10 @@ enum AdaptMessage {
 
 // `adapt()` is the most flexible but also most verbose way to modularize the views by state and action,
 // This is basically a combination of the two ways above, but it also allows to change the `MessageResult` for the parent view
-fn adapt_view(count: i32) -> impl WidgetView<i32, AdaptMessage> {
+fn adapt_counter(count: i32) -> impl WidgetView<i32, AdaptMessage> {
     flex((
         flex((
-            label(format!("adapt count: {}", count)),
+            label(format!("adapt count: {count}")),
             button("+", |count| {
                 *count += 1;
                 AdaptMessage::Changed
@@ -74,18 +78,18 @@ fn adapt_view(count: i32) -> impl WidgetView<i32, AdaptMessage> {
 fn app_logic(state: &mut AppState) -> impl WidgetView<AppState> {
     flex((
         map_state(
-            map_state_view(&mut state.map_state_count),
+            direct_counter(&mut state.map_state_count),
             |state: &mut AppState| &mut state.map_state_count,
         ),
         map_action(
-            map_action_view(state.map_action_count),
+            elm_counter(state.map_action_count),
             |state: &mut AppState, message| match message {
                 CountMessage::Increment => state.map_action_count += 1,
                 CountMessage::Decrement => state.map_action_count -= 1,
             },
         ),
         adapt(
-            adapt_view(state.adapt_count),
+            adapt_counter(state.adapt_count),
             |state: &mut AppState, thunk| match thunk.call(&mut state.adapt_count) {
                 MessageResult::Action(AdaptMessage::Reset) => {
                     state.adapt_count = 0;

--- a/xilem/examples/elm.rs
+++ b/xilem/examples/elm.rs
@@ -1,0 +1,110 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use masonry::widget::{CrossAxisAlignment, MainAxisAlignment};
+use winit::error::EventLoopError;
+use xilem::{
+    view::{button, flex, label},
+    EventLoop, WidgetView, Xilem,
+};
+use xilem_core::{adapt, map_action, map_state, MessageResult};
+
+#[derive(Default)]
+struct AppState {
+    adapt_count: i32,
+    map_state_count: i32,
+    map_action_count: i32,
+}
+
+// `map_state()` maps a subset of the state from the parent, such that views can be modularized by state
+fn map_state_view(count: &mut i32) -> impl WidgetView<i32> {
+    flex((
+        label(format!("adapt state count: {}", count)),
+        button("+", |count| *count += 1),
+        button("-", |count| *count -= 1),
+    ))
+}
+
+enum CountMessage {
+    Increment,
+    Decrement,
+}
+
+// `map_action()` is basically how elm works, i.e. provide a message that the parent view has to handle to update the state.
+// In this case the parent adjusts the count that is given to this view according to the message
+fn map_action_view<T>(count: i32) -> impl WidgetView<T, CountMessage> {
+    flex((
+        label(format!("adapt state count: {}", count)),
+        button("+", |_| CountMessage::Increment),
+        button("-", |_| CountMessage::Decrement),
+    ))
+}
+
+enum AdaptMessage {
+    Changed,
+    Reset,
+    Nop,
+}
+
+// `adapt()` is the most flexible but also most verbose way to modularize the views by state and action,
+// This is basically a combination of the two ways above, but it also allows to change the `MessageResult` for the parent view
+fn adapt_view(count: i32) -> impl WidgetView<i32, AdaptMessage> {
+    flex((
+        flex((
+            label(format!("adapt count: {}", count)),
+            button("+", |count| {
+                *count += 1;
+                AdaptMessage::Changed
+            }),
+            button("-", |count| {
+                *count -= 1;
+                AdaptMessage::Changed
+            }),
+        )),
+        flex((
+            button("reset all", |_| AdaptMessage::Reset),
+            button("do nothing (and don't rebuild the view tree)", |_| {
+                AdaptMessage::Nop
+            }),
+        )),
+    ))
+    .direction(xilem::Axis::Horizontal)
+}
+
+fn app_logic(state: &mut AppState) -> impl WidgetView<AppState> {
+    flex((
+        map_state(
+            map_state_view(&mut state.map_state_count),
+            |state: &mut AppState| &mut state.map_state_count,
+        ),
+        map_action(
+            map_action_view(state.map_action_count),
+            |state: &mut AppState, message| match message {
+                CountMessage::Increment => state.map_action_count += 1,
+                CountMessage::Decrement => state.map_action_count -= 1,
+            },
+        ),
+        adapt(
+            adapt_view(state.adapt_count),
+            |state: &mut AppState, thunk| match thunk.call(&mut state.adapt_count) {
+                MessageResult::Action(AdaptMessage::Reset) => {
+                    state.adapt_count = 0;
+                    state.map_state_count = 0;
+                    state.map_action_count = 0;
+                    MessageResult::Action(())
+                }
+                MessageResult::Action(AdaptMessage::Nop) => MessageResult::Nop, // nothing changed, don't rebuild view tree
+                message_result => message_result.map(|_| ()), // just convert the result to `MessageResult<()>`
+            },
+        ),
+    ))
+    .direction(xilem::Axis::Horizontal)
+    .cross_axis_alignment(CrossAxisAlignment::Center)
+    .main_axis_alignment(MainAxisAlignment::Center)
+}
+
+fn main() -> Result<(), EventLoopError> {
+    let app = Xilem::new(AppState::default(), app_logic);
+    app.run_windowed(EventLoop::with_user_event(), "Centered Flex".into())?;
+    Ok(())
+}

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -33,7 +33,7 @@ mod view;
 pub use view::{View, ViewId, ViewPathTracker};
 
 mod views;
-pub use views::{memoize, Memoize};
+pub use views::{memoize, Adapt, AdaptThunk, Memoize};
 
 mod message;
 pub use message::{DynMessage, Message, MessageResult};

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -33,7 +33,9 @@ mod view;
 pub use view::{View, ViewId, ViewPathTracker};
 
 mod views;
-pub use views::{memoize, Adapt, AdaptThunk, Memoize};
+pub use views::{
+    adapt, map_action, map_state, memoize, Adapt, AdaptThunk, MapAction, MapState, Memoize,
+};
 
 mod message;
 pub use message::{DynMessage, Message, MessageResult};

--- a/xilem_core/src/message.rs
+++ b/xilem_core/src/message.rs
@@ -28,6 +28,18 @@ pub enum MessageResult<Action> {
     Stale(DynMessage),
 }
 
+impl<A> MessageResult<A> {
+    /// Maps the action type `A` to `B`, i.e. [`MessageResult<A>`] to [`MessageResult<B>`]
+    pub fn map<B>(self, f: impl FnOnce(A) -> B) -> MessageResult<B> {
+        match self {
+            MessageResult::Action(a) => MessageResult::Action(f(a)),
+            MessageResult::RequestRebuild => MessageResult::RequestRebuild,
+            MessageResult::Stale(event) => MessageResult::Stale(event),
+            MessageResult::Nop => MessageResult::Nop,
+        }
+    }
+}
+
 /// A dynamically typed message for the [`View`] trait.
 ///
 /// Mostly equivalent to `Box<dyn Any>`, but with support for debug printing.

--- a/xilem_core/src/views/adapt.rs
+++ b/xilem_core/src/views/adapt.rs
@@ -1,3 +1,6 @@
+// Copyright 2023 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use core::marker::PhantomData;
 
 use crate::{DynMessage, MessageResult, Mut, View, ViewId, ViewPathTracker};

--- a/xilem_core/src/views/adapt.rs
+++ b/xilem_core/src/views/adapt.rs
@@ -1,0 +1,186 @@
+use core::marker::PhantomData;
+
+use crate::{DynMessage, MessageResult, Mut, View, ViewId, ViewPathTracker};
+
+/// A view that wraps a child view and modifies the state that callbacks have access to.
+///
+/// # Examples
+///
+/// Suppose you have an outer type that looks like
+///
+/// ```ignore
+/// struct State {
+///     todos: Vec<Todo>
+/// }
+/// ```
+///
+/// and an inner type/view that looks like
+///
+/// ```ignore
+/// struct Todo {
+///     label: String
+/// }
+///
+/// struct TodoView {
+///     label: String
+/// }
+///
+/// enum TodoAction {
+///     Delete
+/// }
+///
+/// impl View<Todo, TodoAction, ViewCtx> for TodoView {
+///     // ...
+/// }
+/// ```
+///
+/// then your top-level action (`()`) and state type (`State`) don't match `TodoView`'s.
+/// You can use the `Adapt` view to mediate between them:
+///
+/// ```ignore
+/// state
+///     .todos
+///     .enumerate()
+///     .map(|(idx, todo)| {
+///         Adapt::new(
+///             move |data: &mut AppState, thunk| {
+///                 if let MessageResult::Action(action) = thunk.call(&mut data.todos[idx]) {
+///                     match action {
+///                         TodoAction::Delete => data.todos.remove(idx),
+///                     }
+///                 }
+///                 MessageResult::Nop
+///             },
+///             TodoView { label: todo.label }
+///         )
+///     })
+/// ```
+pub struct Adapt<
+    ParentState,
+    ParentAction,
+    ChildState,
+    ChildAction,
+    Context,
+    V,
+    F = fn(
+        &mut ParentState,
+        AdaptThunk<ChildState, ChildAction, Context, V>,
+    ) -> MessageResult<ParentAction>,
+> where
+    Context: ViewPathTracker,
+{
+    f: F,
+    child: V,
+    #[allow(clippy::type_complexity)]
+    phantom: PhantomData<fn() -> (ParentState, ParentAction, ChildState, ChildAction, Context)>,
+}
+
+/// A "thunk" which dispatches an message to an adapt node's child.
+///
+/// The closure passed to [`Adapt`] should call this thunk with the child's
+/// app state.
+pub struct AdaptThunk<'a, ChildState, ChildAction, Context, V>
+where
+    Context: ViewPathTracker,
+    V: View<ChildState, ChildAction, Context>,
+{
+    child: &'a V,
+    view_state: &'a mut V::ViewState,
+    id_path: &'a [ViewId],
+    message: DynMessage,
+}
+
+impl<ParentState, ParentAction, ChildState, ChildAction, Context, ChildView, ProxyFn>
+    Adapt<ParentState, ParentAction, ChildState, ChildAction, Context, ChildView, ProxyFn>
+where
+    Context: ViewPathTracker,
+    ChildView: View<ChildState, ChildAction, Context>,
+    ProxyFn: Fn(
+        &mut ParentState,
+        AdaptThunk<ChildState, ChildAction, Context, ChildView>,
+    ) -> MessageResult<ParentAction>,
+{
+    /// Creates a new [`Adapt<ParentState, ParentAction, ChildState, ChildAction, Context, V, F>`].
+    pub fn new(f: ProxyFn, child: ChildView) -> Self {
+        Adapt {
+            f,
+            child,
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl<'a, ChildState, ChildAction, Context, ChildView>
+    AdaptThunk<'a, ChildState, ChildAction, Context, ChildView>
+where
+    Context: ViewPathTracker,
+    ChildView: View<ChildState, ChildAction, Context>,
+{
+    /// Proxies messages from the parent [`View<ParentState, ParentAction, Context>`] to the child [`View<ChildState, ChildAction, Context>`]
+    ///
+    /// When the `Action` types differ the `MessageResult` returned by this method has to be converted to [`MessageResult<ParentAction>`]
+    pub fn call(self, app_state: &mut ChildState) -> MessageResult<ChildAction> {
+        self.child
+            .message(self.view_state, self.id_path, self.message, app_state)
+    }
+}
+
+impl<ParentState, ParentAction, ChildState, ChildAction, Context, V, F>
+    View<ParentState, ParentAction, Context>
+    for Adapt<ParentState, ParentAction, ChildState, ChildAction, Context, V, F>
+where
+    ChildState: 'static,
+    ChildAction: 'static,
+    ParentState: 'static,
+    ParentAction: 'static,
+    Context: ViewPathTracker + 'static,
+    V: View<ChildState, ChildAction, Context>,
+    F: Fn(
+            &mut ParentState,
+            AdaptThunk<ChildState, ChildAction, Context, V>,
+        ) -> MessageResult<ParentAction>
+        + 'static,
+{
+    type ViewState = V::ViewState;
+
+    type Element = V::Element;
+
+    fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
+        self.child.build(ctx)
+    }
+
+    fn rebuild<'el>(
+        &self,
+        prev: &Self,
+        view_state: &mut Self::ViewState,
+        ctx: &mut Context,
+        element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
+        self.child.rebuild(&prev.child, view_state, ctx, element)
+    }
+
+    fn teardown(
+        &self,
+        view_state: &mut Self::ViewState,
+        ctx: &mut Context,
+        element: Mut<'_, Self::Element>,
+    ) {
+        self.child.teardown(view_state, ctx, element);
+    }
+
+    fn message(
+        &self,
+        view_state: &mut Self::ViewState,
+        id_path: &[ViewId],
+        message: crate::DynMessage,
+        app_state: &mut ParentState,
+    ) -> MessageResult<ParentAction> {
+        let thunk = AdaptThunk {
+            child: &self.child,
+            view_state,
+            id_path,
+            message,
+        };
+        (self.f)(app_state, thunk)
+    }
+}

--- a/xilem_core/src/views/adapt.rs
+++ b/xilem_core/src/views/adapt.rs
@@ -6,13 +6,49 @@ use core::marker::PhantomData;
 use crate::{DynMessage, MessageResult, Mut, View, ViewId, ViewPathTracker};
 
 /// A view that wraps a child view and modifies the state that callbacks have access to.
+pub struct Adapt<
+    ParentState,
+    ParentAction,
+    ChildState,
+    ChildAction,
+    Context,
+    ChildView,
+    ProxyFn = fn(
+        &mut ParentState,
+        AdaptThunk<ChildState, ChildAction, Context, ChildView>,
+    ) -> MessageResult<ParentAction>,
+> where
+    Context: ViewPathTracker,
+{
+    proxy_fn: ProxyFn,
+    child: ChildView,
+    #[allow(clippy::type_complexity)]
+    phantom: PhantomData<fn() -> (ParentState, ParentAction, ChildState, ChildAction, Context)>,
+}
+
+/// A "thunk" which dispatches an message to an adapt node's child.
+///
+/// The closure passed to [`Adapt`] should call this thunk with the child's
+/// app state.
+pub struct AdaptThunk<'a, ChildState, ChildAction, Context, ChildView>
+where
+    Context: ViewPathTracker,
+    ChildView: View<ChildState, ChildAction, Context>,
+{
+    child: &'a ChildView,
+    view_state: &'a mut ChildView::ViewState,
+    id_path: &'a [ViewId],
+    message: DynMessage,
+}
+
+/// A view that wraps a child view and modifies the state that callbacks have access to.
 ///
 /// # Examples
 ///
 /// Suppose you have an outer type that looks like
 ///
 /// ```ignore
-/// struct State {
+/// struct TodoList {
 ///     todos: Vec<Todo>
 /// }
 /// ```
@@ -32,84 +68,48 @@ use crate::{DynMessage, MessageResult, Mut, View, ViewId, ViewPathTracker};
 ///     Delete
 /// }
 ///
-/// impl View<Todo, TodoAction, ViewCtx> for TodoView {
+/// impl<ViewCtx> View<Todo, TodoAction, ViewCtx> for TodoView {
 ///     // ...
 /// }
 /// ```
 ///
-/// then your top-level action (`()`) and state type (`State`) don't match `TodoView`'s.
+/// then your top-level action (`()`) and state type (`TodoList`) don't match `TodoView`'s.
 /// You can use the `Adapt` view to mediate between them:
 ///
 /// ```ignore
 /// state
 ///     .todos
 ///     .enumerate()
-///     .map(|(idx, todo)| {
-///         Adapt::new(
-///             move |data: &mut AppState, thunk| {
-///                 if let MessageResult::Action(action) = thunk.call(&mut data.todos[idx]) {
-///                     match action {
-///                         TodoAction::Delete => data.todos.remove(idx),
-///                     }
-///                 }
-///                 MessageResult::Nop
-///             },
-///             TodoView { label: todo.label }
-///         )
-///     })
+///     .map(|(idx, todo)| adapt(
+///         TodoView { label: todo.label },
+///         |data: &mut AppState, thunk| {
+///             thunk.call(&mut data.todos[idx]).map(|action| match action {
+///                 TodoAction::Delete => data.todos.remove(idx),
+///             })
+///         })
+///     )
 /// ```
-pub struct Adapt<
-    ParentState,
-    ParentAction,
-    ChildState,
-    ChildAction,
-    Context,
-    V,
-    F = fn(
-        &mut ParentState,
-        AdaptThunk<ChildState, ChildAction, Context, V>,
-    ) -> MessageResult<ParentAction>,
-> where
-    Context: ViewPathTracker,
-{
-    f: F,
-    child: V,
-    #[allow(clippy::type_complexity)]
-    phantom: PhantomData<fn() -> (ParentState, ParentAction, ChildState, ChildAction, Context)>,
-}
-
-/// A "thunk" which dispatches an message to an adapt node's child.
-///
-/// The closure passed to [`Adapt`] should call this thunk with the child's
-/// app state.
-pub struct AdaptThunk<'a, ChildState, ChildAction, Context, V>
+pub fn adapt<ParentState, ParentAction, ChildState, ChildAction, Context, ChildView, ProxyFn>(
+    child: ChildView,
+    proxy_fn: ProxyFn,
+) -> Adapt<ParentState, ParentAction, ChildState, ChildAction, Context, ChildView, ProxyFn>
 where
-    Context: ViewPathTracker,
-    V: View<ChildState, ChildAction, Context>,
-{
-    child: &'a V,
-    view_state: &'a mut V::ViewState,
-    id_path: &'a [ViewId],
-    message: DynMessage,
-}
-
-impl<ParentState, ParentAction, ChildState, ChildAction, Context, ChildView, ProxyFn>
-    Adapt<ParentState, ParentAction, ChildState, ChildAction, Context, ChildView, ProxyFn>
-where
-    Context: ViewPathTracker,
+    ChildState: 'static,
+    ChildAction: 'static,
+    ParentState: 'static,
+    ParentAction: 'static,
+    Context: ViewPathTracker + 'static,
     ChildView: View<ChildState, ChildAction, Context>,
     ProxyFn: Fn(
-        &mut ParentState,
-        AdaptThunk<ChildState, ChildAction, Context, ChildView>,
-    ) -> MessageResult<ParentAction>,
+            &mut ParentState,
+            AdaptThunk<ChildState, ChildAction, Context, ChildView>,
+        ) -> MessageResult<ParentAction>
+        + 'static,
 {
-    /// Creates a new [`Adapt<ParentState, ParentAction, ChildState, ChildAction, Context, V, F>`].
-    pub fn new(f: ProxyFn, child: ChildView) -> Self {
-        Adapt {
-            f,
-            child,
-            phantom: Default::default(),
-        }
+    Adapt {
+        proxy_fn,
+        child,
+        phantom: Default::default(),
     }
 }
 
@@ -184,6 +184,6 @@ where
             id_path,
             message,
         };
-        (self.f)(app_state, thunk)
+        (self.proxy_fn)(app_state, thunk)
     }
 }

--- a/xilem_core/src/views/map_action.rs
+++ b/xilem_core/src/views/map_action.rs
@@ -1,0 +1,118 @@
+use core::marker::PhantomData;
+
+use crate::{DynMessage, Mut, View, ViewId, ViewPathTracker};
+
+/// A view that maps a child [`View<State,ChildAction,_>`] to [`View<State,ParentAction,_>`] while providing mutable access to `State` in the map function.
+///
+/// This is very similar to the Elm architecture, where the parent view can update state based on the action message from the child view.
+pub struct MapAction<
+    State,
+    ParentAction,
+    ChildAction,
+    V,
+    F = fn(&mut State, ChildAction) -> ParentAction,
+> {
+    map_fn: F,
+    child: V,
+    #[allow(clippy::type_complexity)]
+    phantom: PhantomData<fn() -> (State, ParentAction, ChildAction)>,
+}
+
+/// A view that maps a child [`View<State,ChildAction,_>`] to [`View<State,ParentAction,_>`] while providing mutable access to `State` in the map function.
+///
+/// This is very similar to the Elm architecture, where the parent view can update state based on the action message from the child view.
+///
+/// # Examples
+///
+/// (From the Xilem implementation)
+///
+/// ```ignore
+/// enum CountMessage {
+///     Increment,
+///     Decrement,
+/// }
+///
+/// fn count_view<T>(count: i32) -> impl WidgetView<T, CountMessage> {
+///     flex((
+///         label(format!("count: {}", count)),
+///         button("+", |_| CountMessage::Increment),
+///         button("-", |_| CountMessage::Decrement),
+///     ))
+/// }
+///
+/// fn main() -> Result<(), EventLoopError> {
+///     Xilem::new(0, |count| {
+///         map_action(count_view(*count), |count, message| match message {
+///             CountMessage::Increment => *count += 1,
+///             CountMessage::Decrement => *count -= 1,
+///         })
+///     })
+///     .run_windowed(EventLoop::with_user_event(), "Map action example".into())?;
+///     Ok(())
+/// }
+/// ```
+pub fn map_action<State, ParentAction, ChildAction, Context: ViewPathTracker, V, F>(
+    view: V,
+    map_fn: F,
+) -> MapAction<State, ParentAction, ChildAction, V, F>
+where
+    State: 'static,
+    ParentAction: 'static,
+    ChildAction: 'static,
+    V: View<State, ChildAction, Context>,
+    F: Fn(&mut State, ChildAction) -> ParentAction + 'static,
+{
+    MapAction {
+        map_fn,
+        child: view,
+        phantom: PhantomData,
+    }
+}
+
+impl<State, ParentAction, ChildAction, Context: ViewPathTracker, V, F>
+    View<State, ParentAction, Context> for MapAction<State, ParentAction, ChildAction, V, F>
+where
+    State: 'static,
+    ParentAction: 'static,
+    ChildAction: 'static,
+    V: View<State, ChildAction, Context>,
+    F: Fn(&mut State, ChildAction) -> ParentAction + 'static,
+{
+    type ViewState = V::ViewState;
+    type Element = V::Element;
+
+    fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
+        self.child.build(ctx)
+    }
+
+    fn rebuild<'el>(
+        &self,
+        prev: &Self,
+        view_state: &mut Self::ViewState,
+        ctx: &mut Context,
+        element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
+        self.child.rebuild(&prev.child, view_state, ctx, element)
+    }
+
+    fn teardown(
+        &self,
+        view_state: &mut Self::ViewState,
+        ctx: &mut Context,
+        element: Mut<'_, Self::Element>,
+    ) {
+        self.child.teardown(view_state, ctx, element);
+    }
+
+    fn message(
+        &self,
+        view_state: &mut Self::ViewState,
+        id_path: &[ViewId],
+        message: DynMessage,
+        app_state: &mut State,
+    ) -> crate::MessageResult<ParentAction> {
+        self.child
+            .message(view_state, id_path, message, app_state)
+            .map(|action| (self.map_fn)(app_state, action))
+    }
+}

--- a/xilem_core/src/views/map_action.rs
+++ b/xilem_core/src/views/map_action.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use core::marker::PhantomData;
 
 use crate::{DynMessage, Mut, View, ViewId, ViewPathTracker};

--- a/xilem_core/src/views/map_action.rs
+++ b/xilem_core/src/views/map_action.rs
@@ -43,15 +43,11 @@ pub struct MapAction<
 ///     ))
 /// }
 ///
-/// fn main() -> Result<(), EventLoopError> {
-///     Xilem::new(0, |count| {
-///         map_action(count_view(*count), |count, message| match message {
-///             CountMessage::Increment => *count += 1,
-///             CountMessage::Decrement => *count -= 1,
-///         })
+/// fn app_logic(count: &mut i32) -> impl WidgetView<i32> {
+///     map_action(count_view(*count), |count, message| match message {
+///         CountMessage::Increment => *count += 1,
+///         CountMessage::Decrement => *count -= 1,
 ///     })
-///     .run_windowed(EventLoop::with_user_event(), "Map action example".into())?;
-///     Ok(())
 /// }
 /// ```
 pub fn map_action<State, ParentAction, ChildAction, Context: ViewPathTracker, V, F>(

--- a/xilem_core/src/views/map_state.rs
+++ b/xilem_core/src/views/map_state.rs
@@ -35,12 +35,8 @@ pub struct MapState<ParentState, ChildState, V, F = fn(&mut ParentState) -> &mut
 ///     ))
 /// }
 ///
-/// fn main() -> Result<(), EventLoopError> {
-///     Xilem::new(AppState::default(), |state| {
-///         map_state(count_view(state.count), |state: &mut AppState|  &mut state.count)
-///     })
-///     .run_windowed(EventLoop::with_user_event(), "Map action example".into())?;
-///     Ok(())
+/// fn app_logic(state: &mut AppState) -> impl WidgetView<AppState> {
+///     map_state(count_view(state.count), |state: &mut AppState|  &mut state.count)
 /// }
 /// ```
 pub fn map_state<ParentState, ChildState, Action, Context: ViewPathTracker, V, F>(

--- a/xilem_core/src/views/map_state.rs
+++ b/xilem_core/src/views/map_state.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use core::marker::PhantomData;
 
 use crate::{DynMessage, MessageResult, Mut, View, ViewId, ViewPathTracker};

--- a/xilem_core/src/views/map_state.rs
+++ b/xilem_core/src/views/map_state.rs
@@ -1,0 +1,104 @@
+use core::marker::PhantomData;
+
+use crate::{DynMessage, MessageResult, Mut, View, ViewId, ViewPathTracker};
+
+/// A view that "extracts" state from a [`View<ParentState,_,_>`] to [`View<ChildState,_,_>`].
+/// This allows modularization of views based on their state.
+pub struct MapState<ParentState, ChildState, V, F = fn(&mut ParentState) -> &mut ChildState> {
+    f: F,
+    child: V,
+    phantom: PhantomData<fn() -> (ParentState, ChildState)>,
+}
+
+/// A view that "extracts" state from a [`View<ParentState,_,_>`] to [`View<ChildState,_,_>`].
+/// This allows modularization of views based on their state.
+///
+/// # Examples
+///
+/// (From the Xilem implementation)
+///
+/// ```ignore
+/// #[derive(Default)]
+/// struct AppState {
+///     count: i32,
+///     other: i32,
+/// }
+/// 
+/// fn count_view(count: i32) -> impl WidgetView<i32> {
+///     flex((
+///         label(format!("count: {}", count)),
+///         button("+", |count| *count += 1),
+///         button("-", |count| *count -= 1),
+///     ))
+/// }
+/// 
+/// fn main() -> Result<(), EventLoopError> {
+///     Xilem::new(AppState::default(), |state| {
+///         map_state(count_view(state.count), |state: &mut AppState|  &mut state.count)
+///     })
+///     .run_windowed(EventLoop::with_user_event(), "Map action example".into())?;
+///     Ok(())
+/// }
+/// ```
+pub fn map_state<ParentState, ChildState, Action, Context: ViewPathTracker, V, F>(
+    view: V,
+    f: F,
+) -> MapState<ParentState, ChildState, V, F>
+where
+    ParentState: 'static,
+    ChildState: 'static,
+    V: View<ChildState, Action, Context>,
+    F: Fn(&mut ParentState) -> &mut ChildState + 'static,
+{
+    MapState {
+        f,
+        child: view,
+        phantom: PhantomData,
+    }
+}
+
+impl<ParentState, ChildState, Action, Context: ViewPathTracker, V, F>
+    View<ParentState, Action, Context> for MapState<ParentState, ChildState, V, F>
+where
+    ParentState: 'static,
+    ChildState: 'static,
+    V: View<ChildState, Action, Context>,
+    F: Fn(&mut ParentState) -> &mut ChildState + 'static,
+{
+    type ViewState = V::ViewState;
+    type Element = V::Element;
+
+    fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
+        self.child.build(ctx)
+    }
+
+    fn rebuild<'el>(
+        &self,
+        prev: &Self,
+        view_state: &mut Self::ViewState,
+        ctx: &mut Context,
+        element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
+        self.child.rebuild(&prev.child, view_state, ctx, element)
+    }
+
+    fn teardown(
+        &self,
+        view_state: &mut Self::ViewState,
+        ctx: &mut Context,
+        element: Mut<'_, Self::Element>,
+    ) {
+        self.child.teardown(view_state, ctx, element);
+    }
+
+    fn message(
+        &self,
+        view_state: &mut Self::ViewState,
+        id_path: &[ViewId],
+        message: DynMessage,
+        app_state: &mut ParentState,
+    ) -> MessageResult<Action> {
+        self.child
+            .message(view_state, id_path, message, (self.f)(app_state))
+    }
+}

--- a/xilem_core/src/views/map_state.rs
+++ b/xilem_core/src/views/map_state.rs
@@ -23,7 +23,7 @@ pub struct MapState<ParentState, ChildState, V, F = fn(&mut ParentState) -> &mut
 ///     count: i32,
 ///     other: i32,
 /// }
-/// 
+///
 /// fn count_view(count: i32) -> impl WidgetView<i32> {
 ///     flex((
 ///         label(format!("count: {}", count)),
@@ -31,7 +31,7 @@ pub struct MapState<ParentState, ChildState, V, F = fn(&mut ParentState) -> &mut
 ///         button("-", |count| *count -= 1),
 ///     ))
 /// }
-/// 
+///
 /// fn main() -> Result<(), EventLoopError> {
 ///     Xilem::new(AppState::default(), |state| {
 ///         map_state(count_view(state.count), |state: &mut AppState|  &mut state.count)

--- a/xilem_core/src/views/mod.rs
+++ b/xilem_core/src/views/mod.rs
@@ -1,5 +1,8 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+mod adapt;
+pub use adapt::{Adapt, AdaptThunk};
+
 mod memoize;
 pub use memoize::{memoize, Memoize};

--- a/xilem_core/src/views/mod.rs
+++ b/xilem_core/src/views/mod.rs
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod adapt;
-pub use adapt::{Adapt, AdaptThunk};
+pub use adapt::{adapt, Adapt, AdaptThunk};
+
+mod map_state;
+pub use map_state::{map_state, MapState};
+
+mod map_action;
+pub use map_action::{map_action, MapAction};
 
 mod memoize;
 pub use memoize::{memoize, Memoize};


### PR DESCRIPTION
Ports `Adapt` to new xilem_core.
It also adds `MapState` which was previously called `AdaptState` and a new view `MapAction` which is basically about how elm works.
`MapAction` and `Adapt` is shown in action in the added `elm` example, while `MapState` can be seen in action in the added `components` example.