### PR TITLE
xilem_core: Provide a way to add `View` implementations for external types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4013,6 +4013,7 @@ dependencies = [
 name = "xilem_core"
 version = "0.1.0"
 dependencies = [
+ "kurbo",
  "tracing",
 ]
 

--- a/xilem_core/Cargo.toml
+++ b/xilem_core/Cargo.toml
@@ -12,6 +12,7 @@ publish = false # We'll publish this alongside Xilem 0.2
 
 [dependencies]
 tracing.workspace = true
+kurbo = { optional = true, workspace = true }
 
 [lints]
 workspace = true
@@ -20,3 +21,9 @@ workspace = true
 default-target = "x86_64-unknown-linux-gnu"
 # xilem_core is entirely platform-agnostic, so only display docs for one platform
 targets = []
+
+[features]
+# TODO should std be enabled by default?
+default = ["std"]
+std = []
+kurbo = ["dep:kurbo"]

--- a/xilem_core/Cargo.toml
+++ b/xilem_core/Cargo.toml
@@ -23,7 +23,4 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [features]
-# TODO should std be enabled by default?
-default = ["std"]
-std = []
 kurbo = ["dep:kurbo"]

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -34,8 +34,8 @@ pub use view::{View, ViewId, ViewPathTracker};
 
 mod views;
 pub use views::{
-    adapt, map_action, map_state, memoize, one_of, Adapt, AdaptThunk, AsOrphanView, MapAction,
-    MapState, Memoize, OrphanView,
+    adapt, map_action, map_state, memoize, one_of, Adapt, AdaptThunk, MapAction, MapState, Memoize,
+    OrphanView,
 };
 
 mod message;

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, unreachable_pub)]
 // TODO: Point at documentation for this pattern of README include.
@@ -34,7 +34,8 @@ pub use view::{View, ViewId, ViewPathTracker};
 
 mod views;
 pub use views::{
-    adapt, map_action, map_state, memoize, one_of, Adapt, AdaptThunk, MapAction, MapState, Memoize,
+    adapt, map_action, map_state, memoize, one_of, Adapt, AdaptThunk, AsOrphanView, MapAction,
+    MapState, Memoize, OrphanView,
 };
 
 mod message;

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![cfg_attr(not(test), no_std)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, unreachable_pub)]
 // TODO: Point at documentation for this pattern of README include.

--- a/xilem_core/src/views/mod.rs
+++ b/xilem_core/src/views/mod.rs
@@ -17,4 +17,4 @@ pub use memoize::{memoize, Memoize};
 pub mod one_of;
 
 mod orphan;
-pub use orphan::{AsOrphanView, OrphanView};
+pub use orphan::OrphanView;

--- a/xilem_core/src/views/mod.rs
+++ b/xilem_core/src/views/mod.rs
@@ -15,3 +15,6 @@ pub use memoize::{memoize, Memoize};
 
 /// Statically typed alternatives to the type-erased [`AnyView`](`crate::AnyView`).
 pub mod one_of;
+
+mod orphan;
+pub use orphan::{AsOrphanView, OrphanView};

--- a/xilem_core/src/views/orphan.rs
+++ b/xilem_core/src/views/orphan.rs
@@ -1,0 +1,189 @@
+// TODO document everything, possibly different naming
+#![allow(missing_docs)]
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{DynMessage, MessageResult, Mut, View, ViewElement, ViewId, ViewPathTracker};
+
+// TODO it would be nice to be able to decide between those two ways (mostly to avoid allocations, as otherwise `as_view` would be better I think)
+
+/// A way to implement `View` for foreign types
+pub trait AsOrphanView<T, State, Action>: ViewPathTracker + Sized {
+    type V: View<State, Action, Self>;
+    fn as_view(value: &T) -> Self::V;
+}
+
+pub trait OrphanView<T, State, Action>: ViewPathTracker + Sized {
+    type Element: ViewElement;
+    type ViewState;
+
+    fn build(view: &T, ctx: &mut Self) -> (Self::Element, Self::ViewState);
+    fn rebuild<'el>(
+        new: &T,
+        prev: &T,
+        view_state: &mut Self::ViewState,
+        ctx: &mut Self,
+        element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element>;
+
+    fn teardown(
+        view: &T,
+        view_state: &mut Self::ViewState,
+        ctx: &mut Self,
+        element: Mut<'_, Self::Element>,
+    );
+    fn message(
+        view: &T,
+        view_state: &mut Self::ViewState,
+        id_path: &[ViewId],
+        message: DynMessage,
+        app_state: &mut State,
+    ) -> MessageResult<Action>;
+}
+
+macro_rules! impl_orphan_view_for {
+    ($ty: ty) => {
+        impl<State, Action, Context> View<State, Action, Context> for $ty
+        where
+            Context: OrphanView<$ty, State, Action>,
+        {
+            type Element = Context::Element;
+
+            type ViewState = Context::ViewState;
+
+            fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
+                Context::build(self, ctx)
+            }
+
+            fn rebuild<'el>(
+                &self,
+                prev: &Self,
+                view_state: &mut Self::ViewState,
+                ctx: &mut Context,
+                element: Mut<'el, Self::Element>,
+            ) -> Mut<'el, Self::Element> {
+                Context::rebuild(self, prev, view_state, ctx, element)
+            }
+
+            fn teardown(
+                &self,
+                view_state: &mut Self::ViewState,
+                ctx: &mut Context,
+                element: Mut<'_, Self::Element>,
+            ) {
+                Context::teardown(self, view_state, ctx, element);
+            }
+
+            fn message(
+                &self,
+                view_state: &mut Self::ViewState,
+                id_path: &[ViewId],
+                message: DynMessage,
+                app_state: &mut State,
+            ) -> MessageResult<Action> {
+                Context::message(self, view_state, id_path, message, app_state)
+            }
+        }
+    };
+}
+
+macro_rules! impl_as_orphan_view_for {
+    ($ty: ty) => {
+        impl<State, Action, Context> View<State, Action, Context> for $ty
+        where
+            Context: AsOrphanView<$ty, State, Action>,
+        {
+            type Element = <<Context as AsOrphanView<$ty, State, Action>>::V as View<State, Action, Context>>::Element;
+            type ViewState = <<Context as AsOrphanView<$ty, State, Action>>::V as View<State, Action, Context>>::ViewState;
+
+            fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
+                <<Context as AsOrphanView<$ty, State, Action>>::V as View<State, Action, Context>>
+                    ::build(&Context::as_view(self), ctx)
+            }
+
+            fn rebuild<'el>(
+                &self,
+                prev: &Self,
+                view_state: &mut Self::ViewState,
+                ctx: &mut Context,
+                element: Mut<'el, Self::Element>,
+            ) -> Mut<'el, Self::Element> {
+                <<Context as AsOrphanView<$ty, State, Action>>::V as View<State, Action, Context>>::rebuild(
+                    &Context::as_view(self),
+                    &Context::as_view(prev),
+                    view_state,
+                    ctx,
+                    element,
+                )
+            }
+
+            fn teardown(
+                &self,
+                view_state: &mut Self::ViewState,
+                ctx: &mut Context,
+                element: <Self::Element as ViewElement>::Mut<'_>,
+            ) {
+                <<Context as AsOrphanView<$ty, State, Action>>::V as View<State, Action, Context>>
+                    ::teardown(&Context::as_view(self), view_state, ctx, element);
+            }
+
+            fn message(
+                &self,
+                view_state: &mut Self::ViewState,
+                id_path: &[ViewId],
+                message: DynMessage,
+                app_state: &mut State,
+            ) -> MessageResult<Action> {
+                <<Context as AsOrphanView<$ty, State, Action>>::V as View<State, Action, Context>>::message(
+                    &Context::as_view(self),
+                    view_state,
+                    id_path,
+                    message,
+                    app_state,
+                )
+            }
+        }
+    };
+}
+
+// string impls
+impl_as_orphan_view_for!(&'static str);
+#[cfg(feature = "std")]
+impl_orphan_view_for!(String);
+#[cfg(feature = "std")]
+impl_as_orphan_view_for!(std::borrow::Cow<'static, str>);
+// Why does the following not work, but the `Cow` impl does??
+// #[cfg(feature = "std")]
+// impl_as_orphan_view_for!(std::sync::Arc<str>);
+
+// number impls
+impl_as_orphan_view_for!(f32);
+impl_as_orphan_view_for!(f64);
+impl_as_orphan_view_for!(i8);
+impl_as_orphan_view_for!(u8);
+impl_as_orphan_view_for!(i16);
+impl_as_orphan_view_for!(u16);
+impl_as_orphan_view_for!(i32);
+impl_as_orphan_view_for!(u32);
+impl_as_orphan_view_for!(i64);
+impl_as_orphan_view_for!(u64);
+impl_as_orphan_view_for!(u128);
+impl_as_orphan_view_for!(isize);
+impl_as_orphan_view_for!(usize);
+
+#[cfg(feature = "kurbo")]
+mod kurbo {
+    use super::OrphanView;
+    use crate::{DynMessage, MessageResult, Mut, View, ViewId};
+    impl_orphan_view_for!(kurbo::PathSeg);
+    impl_orphan_view_for!(kurbo::Arc);
+    impl_orphan_view_for!(kurbo::BezPath);
+    impl_orphan_view_for!(kurbo::Circle);
+    impl_orphan_view_for!(kurbo::CircleSegment);
+    impl_orphan_view_for!(kurbo::CubicBez);
+    impl_orphan_view_for!(kurbo::Ellipse);
+    impl_orphan_view_for!(kurbo::Line);
+    impl_orphan_view_for!(kurbo::QuadBez);
+    impl_orphan_view_for!(kurbo::Rect);
+    impl_orphan_view_for!(kurbo::RoundedRect);
+}

--- a/xilem_core/src/views/orphan.rs
+++ b/xilem_core/src/views/orphan.rs
@@ -4,7 +4,7 @@
 use crate::{DynMessage, MessageResult, Mut, View, ViewElement, ViewId, ViewPathTracker};
 
 /// This trait provides a way to add [`View`] implementations for types that would be restricted otherwise by the orphan rules.
-/// Every type that can be supported with this trait, needs a concrete `View` implementation in xilem_core, possibly feature-gated.
+/// Every type that can be supported with this trait, needs a concrete `View` implementation in `xilem_core`, possibly feature-gated.
 pub trait OrphanView<V, State, Action, Message = DynMessage>: ViewPathTracker + Sized {
     /// See [`View::Element`]
     type OrphanElement: ViewElement;
@@ -87,7 +87,7 @@ macro_rules! impl_orphan_view_for {
     };
 }
 
-// string impls
+// string impls - should be used for immutable strings which can be selected within and copied from
 impl_orphan_view_for!(&'static str);
 impl_orphan_view_for!(alloc::string::String);
 impl_orphan_view_for!(alloc::borrow::Cow<'static, str>);
@@ -108,6 +108,7 @@ impl_orphan_view_for!(isize);
 impl_orphan_view_for!(usize);
 
 #[cfg(feature = "kurbo")]
+/// These [`OrphanView`] implementations can e.g. be used in a vector graphics context, as for example seen in `xilem_web` within svg nodes
 mod kurbo {
     use super::OrphanView;
     use crate::{MessageResult, Mut, View, ViewId};

--- a/xilem_core/src/views/orphan.rs
+++ b/xilem_core/src/views/orphan.rs
@@ -148,10 +148,8 @@ macro_rules! impl_as_orphan_view_for {
 
 // string impls
 impl_as_orphan_view_for!(&'static str);
-#[cfg(feature = "std")]
-impl_orphan_view_for!(String);
-#[cfg(feature = "std")]
-impl_as_orphan_view_for!(std::borrow::Cow<'static, str>);
+impl_orphan_view_for!(alloc::string::String);
+impl_as_orphan_view_for!(alloc::borrow::Cow<'static, str>);
 // Why does the following not work, but the `Cow` impl does??
 // #[cfg(feature = "std")]
 // impl_as_orphan_view_for!(std::sync::Arc<str>);

--- a/xilem_core/tests/orphan.rs
+++ b/xilem_core/tests/orphan.rs
@@ -1,0 +1,91 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Test for the behaviour of [`OrphanView<V, State, Action>`] where `V` is a view that suffers from the orphan rules.
+//! This is more of a showcase how to use the `OrphanView` than a real test, as its implementation is trivial.
+//!
+//! This is an integration test so that it can use the infrastructure in [`common`].
+
+use xilem_core::{DynMessage, MessageResult, Mut, OrphanView, View, ViewPathTracker};
+
+mod common;
+use common::*;
+
+/// Simple string view that increments its "generation", when it has changed.
+/// This is more for documentation purposes then an actual test
+impl<State, Action> OrphanView<&'static str, State, Action> for TestCtx {
+    type OrphanElement = TestElement;
+
+    type OrphanViewState = u32;
+
+    fn orphan_build(
+        _view: &&'static str,
+        ctx: &mut Self,
+    ) -> (Self::OrphanElement, Self::OrphanViewState) {
+        let id = 0;
+        (
+            TestElement {
+                operations: vec![Operation::Build(id)],
+                view_path: ctx.view_path().to_vec(),
+                children: None,
+            },
+            id,
+        )
+    }
+
+    fn orphan_rebuild<'el>(
+        new: &&'static str,
+        prev: &&'static str,
+        generation: &mut Self::OrphanViewState,
+        ctx: &mut Self,
+        element: Mut<'el, Self::OrphanElement>,
+    ) -> Mut<'el, Self::OrphanElement> {
+        assert_eq!(&*element.view_path, ctx.view_path());
+
+        let old_generation = *generation;
+
+        if new != prev {
+            *generation += 1;
+        }
+
+        element.operations.push(Operation::Rebuild {
+            from: old_generation,
+            to: *generation,
+        });
+        element
+    }
+
+    fn orphan_teardown(
+        _view: &&'static str,
+        generation: &mut Self::OrphanViewState,
+        _ctx: &mut Self,
+        element: Mut<'_, Self::OrphanElement>,
+    ) {
+        element.operations.push(Operation::Teardown(*generation));
+    }
+
+    fn orphan_message(
+        _view: &&'static str,
+        _view_state: &mut Self::OrphanViewState,
+        _id_path: &[xilem_core::ViewId],
+        message: DynMessage,
+        _app_state: &mut State,
+    ) -> MessageResult<Action, DynMessage> {
+        MessageResult::Stale(message)
+    }
+}
+
+#[test]
+fn str_as_orphan_view() {
+    let view1 = "This string is now also a view";
+    let mut ctx = TestCtx::default();
+    let (mut element, mut generation) = View::<(), (), TestCtx>::build(&view1, &mut ctx);
+
+    let view2 = "This string is now an updated view";
+    assert_eq!(element.operations[0], Operation::Build(0));
+    let element =
+        View::<(), (), TestCtx>::rebuild(&view1, &view2, &mut generation, &mut ctx, &mut element);
+    assert_eq!(element.operations[1], Operation::Rebuild { from: 0, to: 1 });
+    View::<(), (), TestCtx>::teardown(&view1, &mut generation, &mut ctx, element);
+    assert_eq!(element.operations[2], Operation::Teardown(1));
+}


### PR DESCRIPTION
Since we're suffering from the orphan rule with the new xilem_core implementation, we cannot use `View` in downstream crates for external types such as a `WidgetView` implementation for `&'static str` in Xilem. 

This PR adds an `OrphanView` trait which the `Context` of the `View` has to implement for the type which has an implementation in xilem_core for this. The `View` impl for these types is basically a proxy for `OrphanView` (which in turn has the same method signature as `View`), so downstream crates can achieve the same as with the `View`.