### PR TITLE
Move to a single global `parley::LayoutContext`

### DIFF
--- a/masonry/examples/custom_widget.rs
+++ b/masonry/examples/custom_widget.rs
@@ -102,7 +102,7 @@ impl Widget for CustomWidget {
 
         // To render text, we first create a LayoutBuilder and set the text properties.
         let mut lcx = parley::LayoutContext::new();
-        let mut text_layout_builder = lcx.ranged_builder(ctx.font_ctx(), &self.0, 1.0);
+        let mut text_layout_builder = lcx.ranged_builder(ctx.text_contexts().0, &self.0, 1.0);
 
         text_layout_builder.push_default(&StyleProperty::FontStack(FontStack::Single(
             FontFamily::Generic(parley::style::GenericFamily::Serif),

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -7,13 +7,14 @@ use std::any::Any;
 use std::time::Duration;
 
 use accesskit::{NodeBuilder, TreeUpdate};
-use parley::FontContext;
+use parley::{FontContext, LayoutContext};
 use tracing::{trace, warn};
 
 use crate::action::Action;
 use crate::dpi::LogicalPosition;
 use crate::promise::PromiseToken;
 use crate::render_root::{RenderRootSignal, RenderRootState};
+use crate::text2::TextBrush;
 use crate::text_helpers::{ImeChangeSignal, TextFieldRegistration};
 use crate::widget::{CursorChange, WidgetMut, WidgetState};
 use crate::{CursorIcon, Insets, Point, Rect, Size, Widget, WidgetId, WidgetPod};
@@ -662,8 +663,12 @@ impl LayoutCtx<'_> {
 }
 
 impl_context_method!(LayoutCtx<'_>, PaintCtx<'_>, {
-    pub fn font_ctx(&mut self) -> &mut FontContext {
-        &mut self.global_state.font_context
+    /// Get the contexts needed to build and paint text sections.
+    pub fn text_contexts(&mut self) -> (&mut FontContext, &mut LayoutContext<TextBrush>) {
+        (
+            &mut self.global_state.font_context,
+            &mut self.global_state.text_layout_context,
+        )
     }
 });
 

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -5,7 +5,7 @@ use std::collections::VecDeque;
 
 use accesskit::{ActionRequest, NodeBuilder, Tree, TreeUpdate};
 use kurbo::Affine;
-use parley::FontContext;
+use parley::{FontContext, LayoutContext};
 use tracing::{debug, info_span, warn};
 use vello::peniko::{Color, Fill};
 use vello::Scene;
@@ -21,6 +21,7 @@ use crate::debug_logger::DebugLogger;
 use crate::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use crate::event::{PointerEvent, TextEvent, WindowEvent};
 use crate::kurbo::Point;
+use crate::text2::TextBrush;
 use crate::widget::{WidgetMut, WidgetState};
 use crate::{
     AccessCtx, AccessEvent, Action, BoxConstraints, CursorIcon, Handled, InternalLifeCycle,
@@ -51,6 +52,7 @@ pub(crate) struct RenderRootState {
     pub(crate) focused_widget: Option<WidgetId>,
     pub(crate) next_focused_widget: Option<WidgetId>,
     pub(crate) font_context: FontContext,
+    pub(crate) text_layout_context: LayoutContext<TextBrush>,
 }
 
 /// Defines how a windows size should be determined
@@ -99,6 +101,7 @@ impl RenderRoot {
                 focused_widget: None,
                 next_focused_widget: None,
                 font_context: FontContext::default(),
+                text_layout_context: LayoutContext::new(),
             },
             rebuild_access_tree: true,
         };

--- a/masonry/src/text2/edit.rs
+++ b/masonry/src/text2/edit.rs
@@ -4,7 +4,7 @@
 use std::ops::{Deref, DerefMut, Range};
 
 use kurbo::Point;
-use parley::FontContext;
+use parley::{FontContext, LayoutContext};
 use vello::Scene;
 use winit::{
     event::Ime,
@@ -19,7 +19,7 @@ use crate::{
 use super::{
     offset_for_delete_backwards,
     selection::{Affinity, Selection},
-    Selectable, TextWithSelection,
+    Selectable, TextBrush, TextWithSelection,
 };
 
 /// Text which can be edited
@@ -73,18 +73,24 @@ impl<T: EditableText> TextEditor<T> {
         self.preedit_range = None;
     }
 
-    pub fn rebuild(&mut self, fcx: &mut FontContext) {
-        // TODO: Add the pre-edit range as an underlined region in the text attributes
-
-        self.inner.rebuild_with_attributes(fcx, |mut builder| {
-            if let Some(range) = self.preedit_range.as_ref() {
-                builder.push(
-                    &parley::style::StyleProperty::Underline(true),
-                    range.clone(),
-                );
-            }
-            builder
-        });
+    /// Rebuild the text.
+    ///
+    /// See also [TextLayout::rebuild](crate::text2::TextLayout::rebuild) for more comprehensive docs.
+    pub fn rebuild(
+        &mut self,
+        font_ctx: &mut FontContext,
+        layout_ctx: &mut LayoutContext<TextBrush>,
+    ) {
+        self.inner
+            .rebuild_with_attributes(font_ctx, layout_ctx, |mut builder| {
+                if let Some(range) = self.preedit_range.as_ref() {
+                    builder.push(
+                        &parley::style::StyleProperty::Underline(true),
+                        range.clone(),
+                    );
+                }
+                builder
+            });
     }
 
     pub fn draw(&mut self, scene: &mut Scene, point: impl Into<Point>) {

--- a/masonry/src/widget/label.rs
+++ b/masonry/src/widget/label.rs
@@ -214,7 +214,8 @@ impl Widget for Label {
         };
         self.text_layout.set_max_advance(max_advance);
         if self.text_layout.needs_rebuild() {
-            self.text_layout.rebuild(ctx.font_ctx());
+            let (font_ctx, layout_ctx) = ctx.text_contexts();
+            self.text_layout.rebuild(font_ctx, layout_ctx);
         }
         // We ignore trailing whitespace for a label
         let text_size = self.text_layout.size();

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -248,7 +248,8 @@ impl Widget for Prose {
         };
         self.text_layout.set_max_advance(max_advance);
         if self.text_layout.needs_rebuild() {
-            self.text_layout.rebuild(ctx.font_ctx());
+            let (font_ctx, layout_ctx) = ctx.text_contexts();
+            self.text_layout.rebuild(font_ctx, layout_ctx);
         }
         // We ignore trailing whitespace for a label
         let text_size = self.text_layout.size();

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -273,7 +273,8 @@ impl Widget for Textbox {
         };
         self.editor.set_max_advance(max_advance);
         if self.editor.needs_rebuild() {
-            self.editor.rebuild(ctx.font_ctx());
+            let (font_ctx, layout_ctx) = ctx.text_contexts();
+            self.editor.rebuild(font_ctx, layout_ctx);
         }
         let text_size = self.editor.size();
         let width = if bc.max().width.is_finite() {


### PR DESCRIPTION
Based on a suggestion from @dfrg.

This appears to have improved performance with the 30_000 hello's example from ~$\frac{1}{20}$ms to $\frac{1}{160}$ms
So an approx 8x increase in throughput for that scene.