### PR TITLE
Deny unsafe code globally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
 # unsafe code is not allowed in Xilem or Masonry
 # We would like to set this to `forbid`, but we have to use `deny` because `android_activity` 
 # requires us to use the unsafe `#[no_mangle]` attribute
+# (And cargo doesn't let us have platform specific lints here)
 rust.unsafe_code = "deny"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(FALSE)',
     'cfg(tarpaulin_include)',
 ] }
-# We cannot need unsafe code
+# unsafe code is not allowed in Xilem or Masonry
 rust.unsafe_code = "forbid"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(FALSE)',
     'cfg(tarpaulin_include)',
 ] }
+# We cannot need unsafe code
+rust.unsafe_code = "forbid"
 
 [workspace.dependencies]
 xilem_web_core = { version = "0.1.0", path = "xilem_web/xilem_web_core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,9 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(tarpaulin_include)',
 ] }
 # unsafe code is not allowed in Xilem or Masonry
-rust.unsafe_code = "forbid"
+# We would like to set this to `forbid`, but we have to use `deny` because `android_activity` 
+# requires us to use the unsafe `#[no_mangle]` attribute
+rust.unsafe_code = "deny"
 
 [workspace.dependencies]
 xilem_web_core = { version = "0.1.0", path = "xilem_web/xilem_web_core" }

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -76,7 +76,7 @@
 //! [winit]: https://crates.io/crates/winit
 //! [Druid]: https://crates.io/crates/druid
 
-#![deny(unsafe_code, clippy::trivially_copy_pass_by_ref)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
 // #![deny(rustdoc::broken_intra_doc_links)]
 // #![warn(missing_docs)]
 #![warn(unused_imports)]

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -228,11 +228,14 @@ impl WidgetId {
     /// The actual inner representation of the returned `WidgetId` will not
     /// be the same as the raw value that is passed in; it will be
     /// `u64::max_value() - raw`.
-    #[allow(unsafe_code)]
+    #[allow(clippy::missing_panics_doc)] // Can never panic
     pub const fn reserved(raw: u16) -> WidgetId {
         let id = u64::MAX - raw as u64;
-        // safety: by construction this can never be zero.
-        WidgetId(unsafe { NonZeroU64::new_unchecked(id) })
+        match NonZeroU64::new(id) {
+            Some(id) => WidgetId(id),
+            // panic safety: u64::MAX - any u16 can never be zero
+            None => unreachable!(),
+        }
     }
 
     pub fn to_raw(self) -> u64 {

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -118,6 +118,9 @@ fn main() {
 use winit::platform::android::activity::AndroidApp;
 
 #[cfg(target_os = "android")]
+// Safety: We are following `android_activity`'s docs here
+// We believe that there are no other declarations using this name in the compiled objects here
+#[allow(unsafe_code)]
 #[no_mangle]
 fn android_main(app: AndroidApp) {
     use winit::platform::android::EventLoopBuilderExtAndroid;


### PR DESCRIPTION
Related to #44

We don't have any necessary unsafe code, and I don't think any of us want to lose that.

(Vello is also no longer laundering the unsafety wrt surface creation thanks to a recent wgpu release)