### PR TITLE
xilem_core: Support generic `Message`s

### DIFF
--- a/xilem_core/README.md
+++ b/xilem_core/README.md
@@ -30,6 +30,7 @@ Xilem apps will interact with some of the functions from this crate, in particul
 Xilem apps which use custom widgets (and therefore must implement custom views), will implement the [`View`][] trait.
 
 If you wish to implement the Xilem pattern in a different domain (such as for a terminal user interface), this crate can be used to do so.
+Though, while Xilem Core should be able to support all kinds of domains, the crate prioritizes the ergonomics for users of Xilem.
 
 ## Hot reloading
 

--- a/xilem_core/src/message.rs
+++ b/xilem_core/src/message.rs
@@ -11,7 +11,7 @@ use alloc::boxed::Box;
 ///
 /// [`View::message`]: crate::View::message
 #[derive(Default)]
-pub enum MessageResult<Action> {
+pub enum MessageResult<Action, Message = DynMessage> {
     /// An action for a parent message handler to use
     ///
     /// This allows for sub-sections of your app to use an elm-like architecture
@@ -25,16 +25,16 @@ pub enum MessageResult<Action> {
     /// does not require the element tree to be recreated.
     Nop,
     /// The view this message was being routed to no longer exists.
-    Stale(DynMessage),
+    Stale(Message),
 }
 
-impl<A> MessageResult<A> {
+impl<A, Message> MessageResult<A, Message> {
     /// Maps the action type `A` to `B`, i.e. [`MessageResult<A>`] to [`MessageResult<B>`]
-    pub fn map<B>(self, f: impl FnOnce(A) -> B) -> MessageResult<B> {
+    pub fn map<B>(self, f: impl FnOnce(A) -> B) -> MessageResult<B, Message> {
         match self {
             MessageResult::Action(a) => MessageResult::Action(f(a)),
             MessageResult::RequestRebuild => MessageResult::RequestRebuild,
-            MessageResult::Stale(event) => MessageResult::Stale(event),
+            MessageResult::Stale(message) => MessageResult::Stale(message),
             MessageResult::Nop => MessageResult::Nop,
         }
     }

--- a/xilem_core/src/views/map_state.rs
+++ b/xilem_core/src/views/map_state.rs
@@ -3,7 +3,7 @@
 
 use core::marker::PhantomData;
 
-use crate::{DynMessage, MessageResult, Mut, View, ViewId, ViewPathTracker};
+use crate::{MessageResult, Mut, View, ViewId, ViewPathTracker};
 
 /// A view that "extracts" state from a [`View<ParentState,_,_>`] to [`View<ChildState,_,_>`].
 /// This allows modularization of views based on their state.
@@ -39,14 +39,14 @@ pub struct MapState<ParentState, ChildState, V, F = fn(&mut ParentState) -> &mut
 ///     map_state(count_view(state.count), |state: &mut AppState|  &mut state.count)
 /// }
 /// ```
-pub fn map_state<ParentState, ChildState, Action, Context: ViewPathTracker, V, F>(
+pub fn map_state<ParentState, ChildState, Action, Context: ViewPathTracker, Message, V, F>(
     view: V,
     f: F,
 ) -> MapState<ParentState, ChildState, V, F>
 where
     ParentState: 'static,
     ChildState: 'static,
-    V: View<ChildState, Action, Context>,
+    V: View<ChildState, Action, Context, Message>,
     F: Fn(&mut ParentState) -> &mut ChildState + 'static,
 {
     MapState {
@@ -56,12 +56,12 @@ where
     }
 }
 
-impl<ParentState, ChildState, Action, Context: ViewPathTracker, V, F>
-    View<ParentState, Action, Context> for MapState<ParentState, ChildState, V, F>
+impl<ParentState, ChildState, Action, Context: ViewPathTracker, Message, V, F>
+    View<ParentState, Action, Context, Message> for MapState<ParentState, ChildState, V, F>
 where
     ParentState: 'static,
     ChildState: 'static,
-    V: View<ChildState, Action, Context>,
+    V: View<ChildState, Action, Context, Message>,
     F: Fn(&mut ParentState) -> &mut ChildState + 'static,
 {
     type ViewState = V::ViewState;
@@ -94,9 +94,9 @@ where
         &self,
         view_state: &mut Self::ViewState,
         id_path: &[ViewId],
-        message: DynMessage,
+        message: Message,
         app_state: &mut ParentState,
-    ) -> MessageResult<Action> {
+    ) -> MessageResult<Action, Message> {
         self.child
             .message(view_state, id_path, message, (self.f)(app_state))
     }

--- a/xilem_core/src/views/one_of.rs
+++ b/xilem_core/src/views/one_of.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{DynMessage, MessageResult, Mut, View, ViewElement, ViewId, ViewPathTracker};
+use crate::{MessageResult, Mut, View, ViewElement, ViewId, ViewPathTracker};
 
 /// This trait allows, specifying a type as `ViewElement`, which should never be constructed or used,
 /// but allows downstream implementations to adjust the behaviour of [`PhantomElementCtx::PhantomElement`],
@@ -179,12 +179,12 @@ macro_rules! one_of {
             }
         }
 
-        impl<Context, State, Action, $($variant),+> View<State, Action, Context> for $ty_name<$($variant),+>
+        impl<Context, State, Action, Message, $($variant),+> View<State, Action, Context, Message> for $ty_name<$($variant),+>
         where
             State: 'static,
             Action: 'static,
             Context: ViewPathTracker + OneOfCtx<$($variant::Element),+>,
-            $($variant: View<State, Action, Context>),+
+            $($variant: View<State, Action, Context, Message>),+
         {
             type Element = Context::OneOfElement;
 
@@ -290,9 +290,9 @@ macro_rules! one_of {
                 &self,
                 view_state: &mut Self::ViewState,
                 id_path: &[ViewId],
-                message: DynMessage,
+                message: Message,
                 app_state: &mut State,
-            ) -> MessageResult<Action> {
+            ) -> MessageResult<Action, Message> {
                 let (start, rest) = id_path
                     .split_first()
                     .expect(concat!("Id path has elements for `", stringify!($ty_name), "`"));


### PR DESCRIPTION
This adds yet another generic parameter `Message` to the `View`, `ViewSequence` and `AnyView` trait, such that implementors have more freedom about what the message is. This is necessary for xilem_web, as a `Send` bound is not possible to use with wasm_bindgen IIRC. (At least I had to remove it in the `DynMessage` to get it to compile...).

It was fortunately straight-forward to just add the `Message` param with the default `DynMessage`. Basically search replace... (I hope I haven't missed anything, but I went through it twice...)