### PR TITLE
Fix the mentions of Masonry issues to use issue links

### DIFF
--- a/masonry/doc/ARCHITECTURE.md
+++ b/masonry/doc/ARCHITECTURE.md
@@ -46,11 +46,11 @@ The composition root of the framework. See **General architecture** section.
 
 ### `src/debug_logger.rs`, `src/debug_values.rs`
 
-WIP logger to get record of widget passes. See issue #11 in masonry repo.
+WIP logger to get record of widget passes. See <https://github.com/linebender/xilem/issues/370>.
 
 ## Module organization principles
 
-(Some of these principles aren't actually applied in the codebase yet. See issue #14 on Github.)
+(Some of these principles aren't actually applied in the codebase yet. See <https://github.com/linebender/xilem/issues/367>.)
 
 ### Module structure
 
@@ -135,7 +135,7 @@ Testing is provided by the **TestHarness** type implemented in the `src/testing/
 
 Ideally, the harness should provide ways to emulate absolutely every feature that Masonry apps can use. Besides the widget tree, that means keyboard events, mouse events, IME, timers, communication with background threads, animations, accessibility info, etc.
 
-(TODO - Some of that emulation support is not implemented yet. See issue #12.)
+(TODO - Some of that emulation support is not implemented yet. See <https://github.com/linebender/xilem/issues/369>.)
 
 Each widget has unit tests in its module and major features have modules with dedicated unit test suites. Ideally, we would like to achieve complete coverage within the crate.
 

--- a/masonry/doc/ROADMAP.md
+++ b/masonry/doc/ROADMAP.md
@@ -65,12 +65,12 @@
 
 # TODO - Next steps
 
-- [X] Remove Env type and Data trait (#8)
-- [ ] Re-add Dialog feature (#25)
-- [ ] Switch to using Vello and Glazier (#24)
-- [ ] Refactor TextLayout (#23)
+- [X] Remove Env type and Data trait (<https://github.com/linebender/xilem/issues/373>)
+- [ ] Re-add Dialog feature (<https://github.com/linebender/xilem/issues/356>)
+- [ ] Switch to using Vello and Glazier (<https://github.com/linebender/xilem/issues/357>)
+- [ ] Refactor TextLayout (<https://github.com/linebender/xilem/issues/358>)
 
-- [ ] Rework Widget trait (#26)
+- [ ] Rework Widget trait (<https://github.com/linebender/xilem/issues/355>)
 
 - [ ] Write Widget Inspector
 

--- a/masonry/src/action.rs
+++ b/masonry/src/action.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use crate::event::PointerButton;
 
-// TODO - Refactor - See issue #1
+// TODO - Refactor - See issue https://github.com/linebender/xilem/issues/335
 
 // TODO - TextCursor changed, ImeChanged, EnterKey, MouseEnter
 #[non_exhaustive]

--- a/masonry/src/box_constraints.rs
+++ b/masonry/src/box_constraints.rs
@@ -191,7 +191,7 @@ impl BoxConstraints {
         }
 
         // Then we check if any `Size`s with our desired aspect ratio are inside the constraints.
-        // TODO this currently outputs garbage when things are < 0 - See issue #4
+        // TODO this currently outputs garbage when things are < 0 - See https://github.com/linebender/xilem/issues/377
         let min_w_min_h = self.min.height / self.min.width;
         let max_w_min_h = self.min.height / self.max.width;
         let min_w_max_h = self.max.height / self.min.width;

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -40,7 +40,7 @@ macro_rules! impl_context_method {
 /// requires a later pass (for instance, if your widget has a `set_color` method),
 /// you will need to signal that change in the pass (eg `request_paint`).
 ///
-// TODO add tutorial - See issue #5
+// TODO add tutorial - See https://github.com/linebender/xilem/issues/376
 pub struct WidgetCtx<'a> {
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) parent_widget_state: &'a mut WidgetState,
@@ -124,7 +124,7 @@ impl_context_method!(
         /// doing so as a mistake, and panics if debug assertions are on.
         ///
         /// This tells the framework that a child was deliberately skipped.
-        // TODO - see event flow tutorial - See issue #5
+        // TODO - see event flow tutorial - See https://github.com/linebender/xilem/issues/376
         pub fn skip_child(&self, child: &mut WidgetPod<impl Widget>) {
             child.mark_as_visited();
         }
@@ -567,7 +567,7 @@ impl LifeCycleCtx<'_> {
     ///
     /// In general, you should not need to call this method; it is handled by
     /// the `WidgetPod`.
-    // TODO - See issue #9
+    // TODO - See https://github.com/linebender/xilem/issues/372
     pub(crate) fn register_child(&mut self, child_id: WidgetId) {
         trace!("register_child id={:?}", child_id);
         self.widget_state.children.add(&child_id);
@@ -593,7 +593,7 @@ impl LifeCycleCtx<'_> {
         self.widget_state.text_registrations.push(registration);
     }
 
-    // TODO - remove - See issue #15
+    // TODO - remove - See issue https://github.com/linebender/xilem/issues/366
     /// Register this widget as a portal.
     ///
     /// This should only be used by scroll areas.

--- a/masonry/src/event.rs
+++ b/masonry/src/event.rs
@@ -5,7 +5,7 @@
 
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::kurbo::Rect;
-// TODO - See issue #14
+// TODO - See issue https://github.com/linebender/xilem/issues/367
 use crate::WidgetId;
 
 use std::{collections::HashSet, path::PathBuf};
@@ -357,7 +357,7 @@ impl PointerState {
 }
 
 impl LifeCycle {
-    // TODO - link this to documentation of stashed widgets - See issue #9
+    // TODO - link this to documentation of stashed widgets - See issue https://github.com/linebender/xilem/issues/372
     /// Whether this event should be sent to widgets which are currently not visible and not
     /// accessible.
     ///

--- a/masonry/src/testing/snapshot_utils.rs
+++ b/masonry/src/testing/snapshot_utils.rs
@@ -3,7 +3,7 @@
 
 // This is based on: https://github.com/mitsuhiko/insta/blob/660f2b00e3092de50d4f7a59f28336d8a9da50b7/src/env.rs
 
-// TODO - clean this all up - See #18
+// TODO - clean this all up - See https://github.com/linebender/xilem/issues/363
 
 use std::collections::BTreeMap;
 use std::env;

--- a/masonry/src/widget/align.rs
+++ b/masonry/src/widget/align.rs
@@ -6,7 +6,7 @@
 // TODO - Improve the ergonomics of widget layout. The Align widget is a bandaid
 // that has several problem; in particular, the fact that Align will pass "loosened"
 // size constraints to its child means that "aligning" a widget may actually change
-// its computed size. See issue #3.
+// its computed size. See https://github.com/linebender/xilem/issues/378
 
 use accesskit::Role;
 use smallvec::{smallvec, SmallVec};

--- a/masonry/src/widget/portal.rs
+++ b/masonry/src/widget/portal.rs
@@ -19,7 +19,7 @@ use crate::{
     PointerEvent, StatusChange, TextEvent, Widget, WidgetPod,
 };
 
-// TODO - refactor - see issue #15
+// TODO - refactor - see https://github.com/linebender/xilem/issues/366
 // TODO - rename "Portal" to "ScrollPortal"?
 // Conceptually, a Portal is a Widget giving a restricted view of a child widget
 // Imagine a very large widget, and a rect that represents the part of the widget we see

--- a/masonry/src/widget/spinner.rs
+++ b/masonry/src/widget/spinner.rs
@@ -174,7 +174,7 @@ mod tests {
         let mut harness = TestHarness::create(spinner);
         assert_render_snapshot!(harness, "spinner_init");
 
-        // TODO - See issue #12
+        // TODO - See https://github.com/linebender/xilem/issues/369
         //harness.move_timers_forward(Duration::from_millis(700));
         //assert_render_snapshot!(harness, "spinner_700ms");
     }

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -42,7 +42,7 @@ use crate::{
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct WidgetId(pub(crate) NonZeroU64);
 
-// TODO - Add tutorial: implementing a widget - See issue #5
+// TODO - Add tutorial: implementing a widget - See https://github.com/linebender/xilem/issues/376
 /// The trait implemented by all widgets.
 ///
 /// For details on how to implement this trait, see tutorial **(TODO)**

--- a/masonry/src/widget/widget_pod.rs
+++ b/masonry/src/widget/widget_pod.rs
@@ -328,14 +328,14 @@ impl<W: Widget> WidgetPod<W> {
 impl<W: Widget> WidgetPod<W> {
     /// --- MARK: ON_XXX_EVENT ---
 
-    // TODO #5 - Some implicit invariants:
+    // TODO https://github.com/linebender/xilem/issues/376 - Some implicit invariants:
     // - If a Widget gets a keyboard event or an ImeStateChange, then
     // focus is on it, its child or its parent.
     // - If a Widget has focus, then none of its parents is hidden
 
     pub fn on_pointer_event(&mut self, parent_ctx: &mut EventCtx, event: &PointerEvent) {
         let _span = self.inner.make_trace_span().entered();
-        // TODO #11
+        // TODO https://github.com/linebender/xilem/issues/370
         parent_ctx
             .global_state
             .debug_logger
@@ -425,7 +425,7 @@ impl<W: Widget> WidgetPod<W> {
 
     pub fn on_text_event(&mut self, parent_ctx: &mut EventCtx, event: &TextEvent) {
         let _span = self.inner.make_trace_span().entered();
-        // TODO #11
+        // TODO https://github.com/linebender/xilem/issues/370
         parent_ctx
             .global_state
             .debug_logger
@@ -494,7 +494,7 @@ impl<W: Widget> WidgetPod<W> {
 
     pub fn on_access_event(&mut self, parent_ctx: &mut EventCtx, event: &AccessEvent) {
         let _span = self.inner.make_trace_span().entered();
-        // TODO #11
+        // TODO https://github.com/linebender/xilem/issues/370
         parent_ctx
             .global_state
             .debug_logger
@@ -547,14 +547,14 @@ impl<W: Widget> WidgetPod<W> {
 
     // --- MARK: LIFECYCLE ---
 
-    // TODO #5 - Some implicit invariants:
+    // TODO https://github.com/linebender/xilem/issues/376 - Some implicit invariants:
     // - A widget only receives BuildFocusChain if none of its parents are hidden.
 
     /// Propagate a [`LifeCycle`] event.
     pub fn lifecycle(&mut self, parent_ctx: &mut LifeCycleCtx, event: &LifeCycle) {
         let _span = self.inner.make_trace_span().entered();
 
-        // TODO #11
+        // TODO https://github.com/linebender/xilem/issues/370
         parent_ctx
             .global_state
             .debug_logger
@@ -815,7 +815,7 @@ impl<W: Widget> WidgetPod<W> {
     pub fn layout(&mut self, parent_ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size {
         let _span = self.inner.make_trace_span().entered();
 
-        // TODO #11
+        // TODO https://github.com/linebender/xilem/issues/370
         parent_ctx
             .global_state
             .debug_logger
@@ -901,7 +901,7 @@ impl<W: Widget> WidgetPod<W> {
         // - Panic: too harsh?
         // Also, we need to avoid spurious crashes when we initialize the app and the
         // size is (0,0)
-        // See issue #4
+        // See https://github.com/linebender/xilem/issues/377
 
         parent_ctx.widget_state.merge_up(&mut self.state);
         self.state.size = new_size;

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -11,7 +11,7 @@ use crate::text_helpers::TextFieldRegistration;
 use crate::widget::CursorChange;
 use crate::{CursorIcon, WidgetId};
 
-// FIXME #5 - Make a note documenting this: the only way to get a &mut WidgetState should be in a pass.
+// FIXME https://github.com/linebender/xilem/issues/376 - Make a note documenting this: the only way to get a &mut WidgetState should be in a pass.
 // A pass should reborrow the parent widget state (to avoid crossing wires) and call merge_up at
 // the end so that invalidations are always bubbled up.
 // Widgets with methods that require invalidation (eg Label::set_text) should take a


### PR DESCRIPTION
Since we merged https://github.com/linebender/masonry into this repository, these issue numbers were out-of-date.

I found these by search for `#[0-9]`, and got the updated links using `https://github.com/linebender/masonry/issues/{x}`