### PR TITLE
Support `text_size` in `Label`/`Prose` views

### DIFF
--- a/masonry/src/text2/layout.rs
+++ b/masonry/src/text2/layout.rs
@@ -172,6 +172,7 @@ impl<T> TextLayout<T> {
     }
 
     /// Set the font size.
+    #[doc(alias = "set_font_size")]
     pub fn set_text_size(&mut self, size: f32) {
         if size != self.text_size {
             self.text_size = size;

--- a/masonry/src/widget/label.rs
+++ b/masonry/src/widget/label.rs
@@ -15,8 +15,8 @@ use vello::Scene;
 use crate::text2::{TextBrush, TextLayout, TextStorage};
 use crate::widget::{WidgetMut, WidgetRef};
 use crate::{
-    AccessCtx, AccessEvent, ArcStr, BoxConstraints, Color, EventCtx, LayoutCtx, LifeCycle,
-    LifeCycleCtx, PaintCtx, PointerEvent, StatusChange, TextEvent, Widget,
+    AccessCtx, AccessEvent, ArcStr, BoxConstraints, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx,
+    PaintCtx, PointerEvent, StatusChange, TextEvent, Widget,
 };
 
 // added padding between the edges of the widget and the text.
@@ -62,11 +62,12 @@ impl Label {
     }
 
     #[doc(alias = "with_text_color")]
-    pub fn with_text_brush(mut self, color: Color) -> Self {
-        self.text_layout.set_brush(color);
+    pub fn with_text_brush(mut self, brush: impl Into<TextBrush>) -> Self {
+        self.text_layout.set_brush(brush);
         self
     }
 
+    #[doc(alias = "with_font_size")]
     pub fn with_text_size(mut self, size: f32) -> Self {
         self.text_layout.set_text_size(size);
         self

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -57,6 +57,7 @@ impl Prose {
         self
     }
 
+    #[doc(alias = "with_font_size")]
     pub fn with_text_size(mut self, size: f32) -> Self {
         self.text_layout.set_text_size(size);
         self

--- a/xilem/examples/flex.rs
+++ b/xilem/examples/flex.rs
@@ -24,7 +24,7 @@ fn app_logic(data: &mut i32) -> impl WidgetView<i32> {
         big_button("-", |data| {
             *data -= 1;
         }),
-        label(format!("count: {}", data)),
+        label(format!("count: {}", data)).text_size(32.),
         big_button("+", |data| {
             *data += 1;
         }),

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -35,7 +35,7 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> {
     flex((
         flex((
             label("Label")
-                .color(Color::REBECCA_PURPLE)
+                .brush(Color::REBECCA_PURPLE)
                 .alignment(TextAlignment::Start),
             // TODO masonry doesn't allow setting disabled manually anymore?
             // label("Disabled label").disabled(),
@@ -48,7 +48,7 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> {
             },
         ))
         .direction(Axis::Horizontal),
-        prose(LOREM).alignment(TextAlignment::Middle),
+        prose(LOREM).alignment(TextAlignment::Middle).text_size(18.),
         button_any_pointer(button_label, |data: &mut AppData, button| match button {
             masonry::PointerButton::None => tracing::warn!("Got unexpected None from button"),
             masonry::PointerButton::Primary => data.count += 1,

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::{widget, ArcStr};
+use masonry::{text2::TextBrush, widget, ArcStr};
 use xilem_core::Mut;
 
 use crate::{Color, MessageResult, Pod, TextAlignment, View, ViewCtx, ViewId};
@@ -9,23 +9,25 @@ use crate::{Color, MessageResult, Pod, TextAlignment, View, ViewCtx, ViewId};
 pub fn label(label: impl Into<ArcStr>) -> Label {
     Label {
         label: label.into(),
-        text_color: Color::WHITE,
+        text_brush: Color::WHITE.into(),
         alignment: TextAlignment::default(),
-        disabled: false,
+        text_size: masonry::theme::TEXT_SIZE_NORMAL as f32,
     }
 }
 
 pub struct Label {
     label: ArcStr,
-    text_color: Color,
+
+    text_brush: TextBrush,
     alignment: TextAlignment,
-    disabled: bool,
+    text_size: f32,
     // TODO: add more attributes of `masonry::widget::Label`
 }
 
 impl Label {
-    pub fn color(mut self, color: Color) -> Self {
-        self.text_color = color;
+    #[doc(alias = "color")]
+    pub fn brush(mut self, brush: impl Into<TextBrush>) -> Self {
+        self.text_brush = brush.into();
         self
     }
 
@@ -34,8 +36,9 @@ impl Label {
         self
     }
 
-    pub fn disabled(mut self) -> Self {
-        self.disabled = true;
+    #[doc(alias = "font_size")]
+    pub fn text_size(mut self, text_size: f32) -> Self {
+        self.text_size = text_size;
         self
     }
 }
@@ -47,8 +50,9 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
     fn build(&self, _ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let widget_pod = Pod::new(
             widget::Label::new(self.label.clone())
-                .with_text_brush(self.text_color)
-                .with_text_alignment(self.alignment),
+                .with_text_brush(self.text_brush.clone())
+                .with_text_alignment(self.alignment)
+                .with_text_size(self.text_size),
         );
         (widget_pod, ())
     }
@@ -64,16 +68,16 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
             element.set_text(self.label.clone());
             ctx.mark_changed();
         }
-        // if prev.disabled != self.disabled {
-        //     element.set_disabled(self.disabled);
-        //     ctx.mark_changed();
-        // }
-        if prev.text_color != self.text_color {
-            element.set_text_brush(self.text_color);
+        if prev.text_brush != self.text_brush {
+            element.set_text_brush(self.text_brush.clone());
             ctx.mark_changed();
         }
         if prev.alignment != self.alignment {
             element.set_alignment(self.alignment);
+            ctx.mark_changed();
+        }
+        if prev.text_size != self.text_size {
+            element.set_text_size(self.text_size);
             ctx.mark_changed();
         }
         element

--- a/xilem/src/view/prose.rs
+++ b/xilem/src/view/prose.rs
@@ -6,27 +6,29 @@ use xilem_core::Mut;
 
 use crate::{Color, MessageResult, Pod, TextAlignment, View, ViewCtx, ViewId};
 
-pub fn prose(label: impl Into<ArcStr>) -> Prose {
+pub fn prose(content: impl Into<ArcStr>) -> Prose {
     Prose {
-        label: label.into(),
+        content: content.into(),
         text_brush: Color::WHITE.into(),
         alignment: TextAlignment::default(),
-        disabled: false,
+        text_size: masonry::theme::TEXT_SIZE_NORMAL as f32,
     }
 }
 
 pub struct Prose {
-    label: ArcStr,
+    content: ArcStr,
+
     text_brush: TextBrush,
     alignment: TextAlignment,
-    disabled: bool,
-    // TODO: add more attributes of `masonry::widget::Label`
+    text_size: f32,
+    // TODO: disabled: bool,
+    // TODO: add more attributes of `masonry::widget::Prose`
 }
 
 impl Prose {
     #[doc(alias = "color")]
-    pub fn brush(mut self, color: impl Into<TextBrush>) -> Self {
-        self.text_brush = color.into();
+    pub fn brush(mut self, brush: impl Into<TextBrush>) -> Self {
+        self.text_brush = brush.into();
         self
     }
 
@@ -35,8 +37,9 @@ impl Prose {
         self
     }
 
-    pub fn disabled(mut self) -> Self {
-        self.disabled = true;
+    #[doc(alias = "font_size")]
+    pub fn text_size(mut self, text_size: f32) -> Self {
+        self.text_size = text_size;
         self
     }
 }
@@ -47,9 +50,10 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
 
     fn build(&self, _ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let widget_pod = Pod::new(
-            widget::Prose::new(self.label.clone())
+            widget::Prose::new(self.content.clone())
                 .with_text_brush(self.text_brush.clone())
-                .with_text_alignment(self.alignment),
+                .with_text_alignment(self.alignment)
+                .with_text_size(self.text_size),
         );
         (widget_pod, ())
     }
@@ -61,8 +65,8 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
         ctx: &mut ViewCtx,
         mut element: Mut<'el, Self::Element>,
     ) -> Mut<'el, Self::Element> {
-        if prev.label != self.label {
-            element.set_text(self.label.clone());
+        if prev.content != self.content {
+            element.set_text(self.content.clone());
             ctx.mark_changed();
         }
         if prev.text_brush != self.text_brush {
@@ -71,6 +75,10 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
         }
         if prev.alignment != self.alignment {
             element.set_alignment(self.alignment);
+            ctx.mark_changed();
+        }
+        if prev.text_size != self.text_size {
+            element.set_text_size(self.text_size);
             ctx.mark_changed();
         }
         element


### PR DESCRIPTION
Format:
```rust
label("everything").text_size(42.)
```
and the same with `prose`.

I've also added `font_size` aliases for these, because people will expect it to have these names.