### PR TITLE
Update to our latest CI standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ env:
 # Using cargo-hack also allows us to more easily test the feature matrix of our packages.
 # We use --each-feature & --optional-deps which will run a separate check for every feature.
 #
-# We use macos-14 explictly instead of macos-latest because:
+# We use macos-14 explicitly instead of macos-latest because:
 #   * macos-latest currently points to macos-12
 #   * macos-14 provides us with the GPU support we want for testing
 #   * macos-14 comes with the M1 CPU which compiles our code much faster than the older runners
@@ -301,4 +301,4 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: check typos
-        uses: crate-ci/typos@v1.21.0
+        uses: crate-ci/typos@v1.22.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,19 +3,59 @@ env:
   # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
   # come automatically. If the version specified here is no longer the latest stable version,
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
-  RUST_STABLE_VER: "1.79" # In quotes because otherwise 1.70 would be interpreted as 1.7
-  # We do not run the masonry snapshot tests, because those require a specific font stack
+  RUST_STABLE_VER: "1.79" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
+  # The purpose of checking with the minimum supported Rust toolchain is to detect its staleness.
+  # If the compilation fails, then the version specified here needs to be bumped up to reality.
+  # Be sure to also update the rust-version property in the workspace Cargo.toml file,
+  # plus all the README.md files of the affected packages.
+  RUST_MIN_VER: "1.77"
+  # List of packages that will be checked with the minimum supported Rust version.
+  # This should be limited to packages that are intended for publishing.
+  # If updating, synchronise RUST_MIN_VER_WASM_PKGS
+  RUST_MIN_VER_PKGS: "-p xilem -p xilem_core -p masonry"
+
+  # List of packages that can not target Wasm.
+  # If updating, synchronise RUST_MIN_VER_WASM_PKGS
+  NO_WASM_PKGS: "--exclude masonry --exclude xilem"
+  # RUST_MIN_VER_PKGS + NO_WASM_PKGS, evaluated.
+  # This is required because `cargo hack` does not support -p {x} --exclude {x}
+  RUST_MIN_VER_WASM_PKGS: "-xilem_core"
+
+  # We do not run the masonry snapshot tests, because those currently require a specific font stack
+  # See https://github.com/linebender/xilem/pull/233
   SKIP_RENDER_SNAPSHOTS: 1
   # We do not run the masonry render tests, because those require Vello rendering to be working
-  # See https://github.com/linebender/vello/pull/439
+  # See also https://github.com/linebender/vello/pull/610
   SKIP_RENDER_TESTS: 1
 
 # Rationale
 #
 # We don't run clippy with --all-targets because then even --lib and --bins are compiled with
 # dev dependencies enabled, which does not match how they would be compiled by users.
-# A dev dependency might enable a feature of a regular dependency that we need, but testing
-# with --all-targets would not catch that. Thus we split --lib & --bins into a separate step.
+# A dev dependency might enable a feature that we need for a regular dependency,
+# and checking with --all-targets would not find our feature requirements lacking.
+# This problem still applies to cargo resolver version 2.
+# Thus we split all the targets into two steps, one with --lib --bins
+# and another with --tests --benches --examples.
+# Also, we can't give --lib --bins explicitly because then cargo will error on binary-only packages.
+# Luckily the default behavior of cargo with no explicit targets is the same but without the error.
+#
+# We use cargo-hack for a similar reason. Cargo's --workspace will do feature unification across
+# the whole workspace. While cargo-hack will instead check each workspace package separately.
+#
+# Using cargo-hack also allows us to more easily test the feature matrix of our packages.
+# We use --each-feature & --optional-deps which will run a separate check for every feature.
+#
+# We use macos-14 explictly instead of macos-latest because:
+#   * macos-latest currently points to macos-12
+#   * macos-14 provides us with the GPU support we want for testing
+#   * macos-14 comes with the M1 CPU which compiles our code much faster than the older runners
+# This explicit dependency can be switched back to macos-latest once it points to macos-14,
+# which is expected to happen sometime in Q2 FY24 (April – June 2024).
+# https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
+#
+# The MSRV jobs run only cargo check because different clippy versions can disagree on goals and
+# running tests introduces dev dependencies which may require a higher MSRV than the bare package.
 
 name: CI
 
@@ -24,9 +64,9 @@ on:
   merge_group:
 
 jobs:
-  rustfmt:
-    runs-on: ubuntu-latest
+  fmt:
     name: cargo fmt
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -47,20 +87,17 @@ jobs:
       - name: check copyright headers
         run: bash .github/copyright.sh
 
-  test-stable:
+  clippy-stable:
+    name: cargo clippy
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
-    name: cargo clippy + test
+        os: [windows-latest, macos-14, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
 
-      - name: install additional linux dependencies
-        run: |
-          sudo apt update
-          sudo apt install libwayland-dev libxkbcommon-x11-dev
-        if: contains(matrix.os, 'ubuntu')
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
 
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
@@ -68,58 +105,194 @@ jobs:
           toolchain: ${{ env.RUST_STABLE_VER }}
           components: clippy
 
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
+      - name: install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
 
-      - name: cargo clippy (no default features)
-        run: cargo clippy --workspace --lib --bins --no-default-features -- -D warnings
-        # No default features means no backend on Linux, so we won't run it
-        if: contains(matrix.os, 'ubuntu') == false
+      - name: install native dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
 
-      - name: cargo clippy (no default features) (auxiliary)
-        run: cargo clippy --workspace --tests --benches --examples --no-default-features -- -D warnings
-        # No default features means no backend on Linux, so we won't run it
-        if: contains(matrix.os, 'ubuntu') == false
+      - name: cargo clippy
+        run: cargo hack clippy --workspace --locked --each-feature --optional-deps -- -D warnings
 
-      - name: cargo clippy (default features)
-        run: cargo clippy --workspace --lib --bins -- -D warnings
+      - name: cargo clippy (auxiliary)
+        run: cargo hack clippy --workspace --locked --each-feature --optional-deps --tests --benches --examples -- -D warnings
 
-      - name: cargo clippy (default features) (auxiliary)
-        run: cargo clippy --workspace --tests --benches --examples -- -D warnings
-
-      - name: cargo clippy (all features)
-        run: cargo clippy --workspace --lib --bins --all-features -- -D warnings
-
-      - name: cargo clippy (all features) (auxiliary)
-        run: cargo clippy --workspace --tests --benches --examples --all-features -- -D warnings
-
-      - name: cargo test
-        run: cargo test --workspace --all-features
-
-  docs:
-    name: cargo doc
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+  clippy-stable-wasm:
+    name: cargo clippy (wasm32)
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: install additional linux dependencies
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          targets: wasm32-unknown-unknown
+          components: clippy
+
+      - name: install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: cargo clippy
+        run: cargo hack clippy --workspace ${{ env.NO_WASM_PKGS }} --locked --target wasm32-unknown-unknown --each-feature --optional-deps -- -D warnings
+
+      - name: cargo clippy (auxiliary)
+        run: cargo hack clippy --workspace ${{ env.NO_WASM_PKGS }} --locked --target wasm32-unknown-unknown --each-feature --optional-deps --tests --benches --examples -- -D warnings
+
+  test-stable:
+    name: cargo test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-14, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+
+      - name: install native dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+
+      # Adapted from https://github.com/bevyengine/bevy/blob/b446374392adc70aceb92621b080d1a6cf7a7392/.github/workflows/validation-jobs.yml#L74-L79
+      - name: install xvfb, llvmpipe and lavapipe
+        if: matrix.os == 'ubuntu-latest'
+        # https://launchpad.net/~kisak/+archive/ubuntu/turtle
         run: |
-          sudo apt update
-          sudo apt install libwayland-dev libxkbcommon-x11-dev
-        if: contains(matrix.os, 'ubuntu')
+          sudo apt-get update -y -qq
+          sudo add-apt-repository ppa:kisak/turtle -y
+          sudo apt-get update
+          sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+
+      - name: cargo test
+        run: cargo test --workspace --locked --all-features
+
+  test-stable-wasm:
+    name: cargo test (wasm32)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          targets: wasm32-unknown-unknown
+
+      # TODO: Find a way to make tests work. Until then the tests are merely compiled.
+      - name: cargo test compile
+        run: cargo test --workspace ${{ env.NO_WASM_PKGS }} --locked --target wasm32-unknown-unknown --all-features --no-run
+
+  check-stable-android:
+    name: cargo check (aarch64-android)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          targets: aarch64-linux-android
+
+      - name: install cargo apk
+        run: cargo install cargo-apk
+
+      - name: cargo apk check (android)
+        run: cargo apk check -p xilem --example mason_android
+        env:
+          # This is a bit of a hack, but cargo apk doesn't seem to allow customising this otherwise
+          RUSTFLAGS: '-D warnings'
+
+  check-msrv:
+    name: cargo check (msrv)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-14, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: install msrv toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_MIN_VER }}
+
+      - name: install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: install native dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+
+      - name: cargo check
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --each-feature --optional-deps
+
+  check-msrv-wasm:
+    name: cargo check (msrv) (wasm32)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: install msrv toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_MIN_VER }}
+          targets: wasm32-unknown-unknown
+
+      - name: install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: cargo check
+        run: cargo hack check ${{ env.RUST_MIN_VER_WASM_PKGS }} --locked --target wasm32-unknown-unknown --each-feature --optional-deps
+
+  doc:
+    name: cargo doc
+    # NOTE: We don't have any platform specific docs in this workspace, so we only run on Ubuntu.
+    #       If we get per-platform docs (win/macos/linux/wasm32/..) then doc jobs should match that.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
 
       - name: install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-
+      # We test documentation using nightly to match docs.rs. This prevents potential breakages
       - name: cargo doc
-        # We currently skip checking masonry's docs
-        run: cargo doc --workspace --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples --exclude masonry
+        run: cargo doc --workspace --locked --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
 
   # If this fails, consider changing your text or adding something to .typos.toml
   typos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,6 @@ env:
 # Using cargo-hack also allows us to more easily test the feature matrix of our packages.
 # We use --each-feature & --optional-deps which will run a separate check for every feature.
 #
-# We use macos-14 explicitly instead of macos-latest because:
-#   * macos-latest currently points to macos-12
-#   * macos-14 provides us with the GPU support we want for testing
-#   * macos-14 comes with the M1 CPU which compiles our code much faster than the older runners
-# This explicit dependency can be switched back to macos-latest once it points to macos-14,
-# which is expected to happen sometime in Q2 FY24 (April – June 2024).
-# https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
-#
 # The MSRV jobs run only cargo check because different clippy versions can disagree on goals and
 # running tests introduces dev dependencies which may require a higher MSRV than the bare package.
 
@@ -92,7 +84,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-14, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -152,7 +144,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-14, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -229,7 +221,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-14, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
   NO_WASM_PKGS: "--exclude masonry --exclude xilem"
   # RUST_MIN_VER_PKGS + NO_WASM_PKGS, evaluated.
   # This is required because `cargo hack` does not support -p {x} --exclude {x}
-  RUST_MIN_VER_WASM_PKGS: "-xilem_core"
+  RUST_MIN_VER_WASM_PKGS: "-p xilem_core"
 
   # We do not run the masonry snapshot tests, because those currently require a specific font stack
   # See https://github.com/linebender/xilem/pull/233

--- a/.typos.toml
+++ b/.typos.toml
@@ -24,6 +24,11 @@ FillStrat = "FillStrat" # short for strategy
 seeked = "seeked" # Part of the HTML standard
 
 [files]
+# Include .github, .cargo, etc.
+ignore-hidden = false
 extend-exclude = [
-    "masonry/resources/i18n"
+    "masonry/resources/i18n",
+    # /.git isn't in .gitignore, because git never tracks it.
+    # Typos doesn't know that, though.
+    "/.git",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ members = [
 
 [workspace.package]
 edition = "2021"
+# Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files.
+rust-version = "1.77"
 license = "Apache-2.0"
 repository = "https://github.com/linebender/xilem"
 homepage = "https://xilem.dev/"

--- a/masonry/README.md
+++ b/masonry/README.md
@@ -88,6 +88,26 @@ fn main() {
 }
 ```
 
+## Minimum supported Rust Version (MSRV)
+
+This version of Masonry has been verified to compile with **Rust 1.77** and later.
+
+Future versions of Masonry might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some of Masonry's dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+
+</details>
+
 ## Community
 
 Discussion of Masonry development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#masonry stream](https://xi.zulipchat.com/#narrow/stream/317477-masonry).

--- a/xilem/README.md
+++ b/xilem/README.md
@@ -31,6 +31,26 @@ Xilem's reactive layer is built on top of a wide array of foundational Rust UI p
 Xilem can currently be considered to be in an alpha state.
 Lots of things need improvements.
 
+## Minimum supported Rust Version (MSRV)
+
+This version of Xilem has been verified to compile with **Rust 1.77** and later.
+
+Future versions of Xilem might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some of Xilem's dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+
+</details>
+
 ## Community
 
 Discussion of Xilem development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#xilem stream](https://xi.zulipchat.com/#narrow/stream/354396-xilem).

--- a/xilem_core/README.md
+++ b/xilem_core/README.md
@@ -49,7 +49,25 @@ Xilem Core supports running with `#![no_std]`, but does require an allocator to 
 It is plausible that this reactivity pattern could be used without allocation being required, but that is not provided by this package.
 If you wish to use Xilem Core in environments where an allocator is not available, feel free to bring this up on [Zulip](#community).
 
-<!-- MSRV will go here once we settle on that for this repository -->
+## Minimum supported Rust Version (MSRV)
+
+This version of Xilem Core has been verified to compile with **Rust 1.77** and later.
+
+Future versions of Xilem Core might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some of Xilem Core's dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+
+</details>
 
 <!-- We hide these elements when viewing in Rustdoc, because they're not expected to be present in crate level docs -->
 <div class="rustdoc-hidden">


### PR DESCRIPTION
This was most recently updated in https://github.com/linebender/vello/pull/505

The main differences are:
1) Greater concurrency between clippy and testing
2) More explanations
3) MSRV checking
4) Use of `cargo hack`
5) WASM checked in CI

I've also added the current values of our MSRVs to the main three crates.