### PR TITLE
Use window.outer_size on iOS

### DIFF
--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -135,6 +135,10 @@ impl ApplicationHandler<accesskit_winit::Event> for MainState<'_> {
                 let adapter = Adapter::with_event_loop_proxy(&window, self.proxy.clone());
                 window.set_visible(visible);
                 let window = Arc::new(window);
+                // https://github.com/rust-windowing/winit/issues/2308
+                #[cfg(target_os = "ios")]
+                let size = window.outer_size();
+                #[cfg(not(target_os = "ios"))]
                 let size = window.inner_size();
                 let surface = pollster::block_on(self.render_cx.create_surface(
                     window.clone(),
@@ -156,6 +160,10 @@ impl ApplicationHandler<accesskit_winit::Event> for MainState<'_> {
                 window,
                 accesskit_adapter,
             } => {
+                // https://github.com/rust-windowing/winit/issues/2308
+                #[cfg(target_os = "ios")]
+                let size = window.outer_size();
+                #[cfg(not(target_os = "ios"))]
                 let size = window.inner_size();
                 let surface = pollster::block_on(self.render_cx.create_surface(
                     window.clone(),
@@ -379,6 +387,10 @@ impl MainState<'_> {
             return;
         };
         let scale_factor = window.scale_factor();
+        // https://github.com/rust-windowing/winit/issues/2308
+        #[cfg(target_os = "ios")]
+        let size = window.outer_size();
+        #[cfg(not(target_os = "ios"))]
         let size = window.inner_size();
         let width = size.width;
         let height = size.height;


### PR DESCRIPTION
As I understand it, on iOS the outer_size corresponds to the size of the window, meaning when the surface is rendered using inner_size(the safe/non-obscured size) the elements get stretched.

There's an open issue in winit about clarifying/standardizing the different sizes, but until that's done switching to outer_size fixes the issue.

The touch positions now also match the rendering

Winit issue: https://github.com/rust-windowing/winit/issues/2308

Fixes #419


<details>
  <summary>Before</summary>

![xilem ios](https://github.com/linebender/xilem/assets/7433263/8bde0880-90e7-498b-b45c-c9964a0ae153)

</details>


<details>
  <summary>After</summary>

![ios after](https://github.com/linebender/xilem/assets/7433263/8f6703d3-bb99-4f42-a941-d936ca5da6cf)


</details>