### PR TITLE
Use `cargo-rdme` to sync README and documentation root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ on:
 
 jobs:
   fmt:
-    name: cargo fmt
+    name: check formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -78,6 +78,15 @@ jobs:
 
       - name: check copyright headers
         run: bash .github/copyright.sh
+
+      - name: install cargo-rdme
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-rdme
+
+      - name: cargo rdme
+        run: |
+          cargo rdme --check --workspace-project=masonry
 
   clippy-stable:
     name: cargo clippy

--- a/masonry/README.md
+++ b/masonry/README.md
@@ -1,9 +1,5 @@
 <div align="center">
 
-# Masonry
-
-**Foundational framework for Rust GUI libraries**
-
 [![Latest published version.](https://img.shields.io/crates/v/masonry.svg)](https://crates.io/crates/masonry)
 [![Documentation build status.](https://img.shields.io/docsrs/masonry.svg)](https://docs.rs/masonry)
 [![Apache 2.0 license.](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
@@ -12,12 +8,18 @@
 [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/xilem/ci.yml?logo=github&label=CI)](https://github.com/linebender/xilem/actions)
 [![Dependency staleness status.](https://deps.rs/crate/masonry/latest/status.svg)](https://deps.rs/crate/masonry)
 
+# Masonry
+
 </div>
 
-Masonry gives you a platform to create a window (using [winit] as a backend) with a tree of widgets.
-It also gives you tools to inspect that widget tree at runtime, write unit tests on it, and generally have an easier time debugging and maintaining your app.
+<!-- cargo-rdme start -->
+
+**A foundational framework for Rust GUI libraries.**
+
+Masonry gives you a platform to create windows (using [winit] as a backend) each with a tree of widgets. It also gives you tools to inspect that widget tree at runtime, write unit tests on it, and generally have an easier time debugging and maintaining your app.
 
 The framework is not opinionated about what your user-facing abstraction will be: you can implement immediate-mode GUI, the Elm architecture, functional reactive GUI, etc, on top of Masonry.
+
 See [Xilem] as an example of reactive UI built on top of Masonry.
 
 Masonry was originally a fork of [Druid] that emerged from discussions within the Linebender community about what it would look like to turn Druid into a foundational library.
@@ -88,6 +90,12 @@ fn main() {
 }
 ```
 
+[winit]: https://crates.io/crates/winit
+[Druid]: https://crates.io/crates/druid
+[Xilem]: https://crates.io/crates/xilem
+
+<!-- cargo-rdme end -->
+
 ## Minimum supported Rust Version (MSRV)
 
 This version of Masonry has been verified to compile with **Rust 1.79** and later.
@@ -121,7 +129,4 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 Licensed under the Apache License, Version 2.0 ([LICENSE](LICENSE) or <http://www.apache.org/licenses/LICENSE-2.0>)
 
-[Xilem]: https://crates.io/crates/xilem
-[Druid]: https://crates.io/crates/druid
-[winit]: https://crates.io/crates/winit
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -1,15 +1,20 @@
 // Copyright 2018 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//! A framework that aims to provide the foundation for Rust GUI libraries.
+//! **A foundational framework for Rust GUI libraries.**
 //!
 //! Masonry gives you a platform to create windows (using [winit] as a backend) each with a tree of widgets. It also gives you tools to inspect that widget tree at runtime, write unit tests on it, and generally have an easier time debugging and maintaining your app.
 //!
 //! The framework is not opinionated about what your user-facing abstraction will be: you can implement immediate-mode GUI, the Elm architecture, functional reactive GUI, etc, on top of Masonry.
 //!
+//! See [Xilem] as an example of reactive UI built on top of Masonry.
+//!
 //! Masonry was originally a fork of [Druid] that emerged from discussions within the Linebender community about what it would look like to turn Druid into a foundational library.
 //!
-//! ## Example
+//! Masonry can currently be considered to be in an alpha state.
+//! Lots of things need improvements, e.g. text input is janky and snapshot testing is not consistent across platforms.
+//!
+//! # Example
 //!
 //! The to-do-list example looks like this:
 //!
@@ -75,6 +80,7 @@
 //!
 //! [winit]: https://crates.io/crates/winit
 //! [Druid]: https://crates.io/crates/druid
+//! [Xilem]: https://crates.io/crates/xilem
 
 #![deny(clippy::trivially_copy_pass_by_ref)]
 // #![deny(rustdoc::broken_intra_doc_links)]


### PR DESCRIPTION
This was remarkably painless.

I especially appreciate @taiki-e providing an install-action which does 90% of the CI work for us.