### PR TITLE
Change the `OneOf` views to not use macros

### DIFF
--- a/xilem_core/src/views/mod.rs
+++ b/xilem_core/src/views/mod.rs
@@ -19,7 +19,6 @@ pub use fork::{fork, Fork};
 mod memoize;
 pub use memoize::{memoize, Memoize};
 
-/// Statically typed alternatives to the type-erased [`AnyView`](`crate::AnyView`).
 pub mod one_of;
 
 mod orphan;

--- a/xilem_core/src/views/one_of.rs
+++ b/xilem_core/src/views/one_of.rs
@@ -1,7 +1,10 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//! Statically typed alternatives to the type-erased [`AnyView`](`crate::AnyView`).
+
 use crate::{MessageResult, Mut, View, ViewElement, ViewId, ViewPathTracker};
+use hidden::OneOfState;
 
 /// This trait allows, specifying a type as `ViewElement`, which should never be constructed or used,
 /// but allows downstream implementations to adjust the behaviour of [`PhantomElementCtx::PhantomElement`],
@@ -59,15 +62,15 @@ where
 
 /// To be able to use `OneOfN` as a [`View`], it's necessary to implement [`OneOfCtx`] for your `ViewCtx` type
 pub trait OneOfCtx<
-    A: ViewElement = <Self as PhantomElementCtx>::PhantomElement,
-    B: ViewElement = <Self as PhantomElementCtx>::PhantomElement,
-    C: ViewElement = <Self as PhantomElementCtx>::PhantomElement,
-    D: ViewElement = <Self as PhantomElementCtx>::PhantomElement,
-    E: ViewElement = <Self as PhantomElementCtx>::PhantomElement,
-    F: ViewElement = <Self as PhantomElementCtx>::PhantomElement,
-    G: ViewElement = <Self as PhantomElementCtx>::PhantomElement,
-    H: ViewElement = <Self as PhantomElementCtx>::PhantomElement,
-    I: ViewElement = <Self as PhantomElementCtx>::PhantomElement,
+    A: ViewElement,
+    B: ViewElement,
+    C: ViewElement,
+    D: ViewElement,
+    E: ViewElement,
+    F: ViewElement,
+    G: ViewElement,
+    H: ViewElement,
+    I: ViewElement,
 >: PhantomElementCtx
 {
     /// Element wrapper, that holds the current view element variant
@@ -161,7 +164,51 @@ where
     >;
 
     fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
-        todo!()
+        let (element, state) = match self {
+            OneOf::A(v) => {
+                let (element, state) = v.build(ctx);
+                (OneOf::A(element), OneOf::A(state))
+            }
+            OneOf::B(v) => {
+                let (element, state) = v.build(ctx);
+                (OneOf::B(element), OneOf::B(state))
+            }
+            OneOf::C(v) => {
+                let (element, state) = v.build(ctx);
+                (OneOf::C(element), OneOf::C(state))
+            }
+            OneOf::D(v) => {
+                let (element, state) = v.build(ctx);
+                (OneOf::D(element), OneOf::D(state))
+            }
+            OneOf::E(v) => {
+                let (element, state) = v.build(ctx);
+                (OneOf::E(element), OneOf::E(state))
+            }
+            OneOf::F(v) => {
+                let (element, state) = v.build(ctx);
+                (OneOf::F(element), OneOf::F(state))
+            }
+            OneOf::G(v) => {
+                let (element, state) = v.build(ctx);
+                (OneOf::G(element), OneOf::G(state))
+            }
+            OneOf::H(v) => {
+                let (element, state) = v.build(ctx);
+                (OneOf::H(element), OneOf::H(state))
+            }
+            OneOf::I(v) => {
+                let (element, state) = v.build(ctx);
+                (OneOf::I(element), OneOf::I(state))
+            }
+        };
+        (
+            Context::upcast_one_of_element(element),
+            OneOfState {
+                generation: 0,
+                inner_state: state,
+            },
+        )
     }
 
     fn rebuild<'el>(
@@ -169,18 +216,154 @@ where
         prev: &Self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: Mut<'el, Self::Element>,
+        mut element: Mut<'el, Self::Element>,
     ) -> Mut<'el, Self::Element> {
-        todo!()
+        // Happy path: All the elements are of the same type.
+        match (self, prev, &mut view_state.inner_state) {
+            (OneOf::A(this), OneOf::A(prev), OneOf::A(ref mut state)) => {
+                ctx.with_id(ViewId::new(view_state.generation), |ctx| {
+                    Context::with_downcast_a(&mut element, |element| {
+                        this.rebuild(prev, state, ctx, element);
+                    })
+                });
+                return element;
+            }
+            (OneOf::B(this), OneOf::B(prev), OneOf::B(ref mut state)) => {
+                ctx.with_id(ViewId::new(view_state.generation), |ctx| {
+                    Context::with_downcast_b(&mut element, |element| {
+                        this.rebuild(prev, state, ctx, element);
+                    })
+                });
+                return element;
+            }
+            (OneOf::C(this), OneOf::C(prev), OneOf::C(ref mut state)) => {
+                ctx.with_id(ViewId::new(view_state.generation), |ctx| {
+                    Context::with_downcast_c(&mut element, |element| {
+                        this.rebuild(prev, state, ctx, element);
+                    })
+                });
+                return element;
+            }
+            (OneOf::D(this), OneOf::D(prev), OneOf::D(ref mut state)) => {
+                ctx.with_id(ViewId::new(view_state.generation), |ctx| {
+                    Context::with_downcast_d(&mut element, |element| {
+                        this.rebuild(prev, state, ctx, element);
+                    })
+                });
+                return element;
+            }
+            (OneOf::E(this), OneOf::E(prev), OneOf::E(ref mut state)) => {
+                ctx.with_id(ViewId::new(view_state.generation), |ctx| {
+                    Context::with_downcast_e(&mut element, |element| {
+                        this.rebuild(prev, state, ctx, element);
+                    })
+                });
+                return element;
+            }
+            (OneOf::F(this), OneOf::F(prev), OneOf::F(ref mut state)) => {
+                ctx.with_id(ViewId::new(view_state.generation), |ctx| {
+                    Context::with_downcast_f(&mut element, |element| {
+                        this.rebuild(prev, state, ctx, element);
+                    })
+                });
+                return element;
+            }
+            (OneOf::G(this), OneOf::G(prev), OneOf::G(ref mut state)) => {
+                ctx.with_id(ViewId::new(view_state.generation), |ctx| {
+                    Context::with_downcast_g(&mut element, |element| {
+                        this.rebuild(prev, state, ctx, element);
+                    })
+                });
+                return element;
+            }
+            (OneOf::H(this), OneOf::H(prev), OneOf::H(ref mut state)) => {
+                ctx.with_id(ViewId::new(view_state.generation), |ctx| {
+                    Context::with_downcast_h(&mut element, |element| {
+                        this.rebuild(prev, state, ctx, element);
+                    })
+                });
+                return element;
+            }
+            (OneOf::I(this), OneOf::I(prev), OneOf::I(ref mut state)) => {
+                ctx.with_id(ViewId::new(view_state.generation), |ctx| {
+                    Context::with_downcast_i(&mut element, |element| {
+                        this.rebuild(prev, state, ctx, element);
+                    })
+                });
+                return element;
+            }
+            _ => (),
+        }
+        match (prev, view_state.inner_state) {
+            (OneOf::A(prev), OneOf::A(ref mut state)) => todo!(),
+            (OneOf::B(prev), OneOf::B(ref mut state)) => todo!(),
+            (OneOf::C(prev), OneOf::C(ref mut state)) => todo!(),
+            (OneOf::D(prev), OneOf::D(ref mut state)) => todo!(),
+            (OneOf::E(prev), OneOf::E(ref mut state)) => todo!(),
+            (OneOf::F(prev), OneOf::F(ref mut state)) => todo!(),
+            (OneOf::G(prev), OneOf::G(ref mut state)) => todo!(),
+            (OneOf::H(prev), OneOf::H(ref mut state)) => todo!(),
+            (OneOf::I(prev), OneOf::I(ref mut state)) => todo!(),
+            _ => unreachable!(),
+        }
     }
 
     fn teardown(
         &self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: Mut<'_, Self::Element>,
+        mut element: Mut<'_, Self::Element>,
     ) {
-        todo!()
+        ctx.with_id(ViewId::new(view_state.generation), |ctx| {
+            match (self, &mut view_state.inner_state) {
+                (OneOf::A(v), OneOf::A(ref mut state)) => {
+                    Context::with_downcast_a(&mut element, |element| {
+                        v.teardown(state, ctx, element);
+                    });
+                }
+                (OneOf::B(v), OneOf::B(ref mut state)) => {
+                    Context::with_downcast_b(&mut element, |element| {
+                        v.teardown(state, ctx, element);
+                    });
+                }
+                (OneOf::C(v), OneOf::C(ref mut state)) => {
+                    Context::with_downcast_c(&mut element, |element| {
+                        v.teardown(state, ctx, element);
+                    });
+                }
+                (OneOf::D(v), OneOf::D(ref mut state)) => {
+                    Context::with_downcast_d(&mut element, |element| {
+                        v.teardown(state, ctx, element);
+                    });
+                }
+                (OneOf::E(v), OneOf::E(ref mut state)) => {
+                    Context::with_downcast_e(&mut element, |element| {
+                        v.teardown(state, ctx, element);
+                    });
+                }
+                (OneOf::F(v), OneOf::F(ref mut state)) => {
+                    Context::with_downcast_f(&mut element, |element| {
+                        v.teardown(state, ctx, element);
+                    });
+                }
+                (OneOf::G(v), OneOf::G(ref mut state)) => {
+                    Context::with_downcast_g(&mut element, |element| {
+                        v.teardown(state, ctx, element);
+                    });
+                }
+                (OneOf::H(v), OneOf::H(ref mut state)) => {
+                    Context::with_downcast_h(&mut element, |element| {
+                        v.teardown(state, ctx, element);
+                    });
+                }
+                (OneOf::I(v), OneOf::I(ref mut state)) => {
+                    Context::with_downcast_i(&mut element, |element| {
+                        v.teardown(state, ctx, element);
+                    });
+                }
+                _ => unreachable!(),
+            }
+        });
     }
 
     fn message(
@@ -190,7 +373,24 @@ where
         message: Message,
         app_state: &mut State,
     ) -> MessageResult<Action, Message> {
-        todo!()
+        let (start, rest) = id_path
+            .split_first()
+            .expect("Id path has elements for OneOf");
+        if start.routing_id() != view_state.generation {
+            return MessageResult::Stale(message);
+        }
+        match (self, &mut view_state.inner_state) {
+            (OneOf::A(v), OneOf::A(ref mut state)) => v.message(state, rest, message, app_state),
+            (OneOf::B(v), OneOf::B(ref mut state)) => v.message(state, rest, message, app_state),
+            (OneOf::C(v), OneOf::C(ref mut state)) => v.message(state, rest, message, app_state),
+            (OneOf::D(v), OneOf::D(ref mut state)) => v.message(state, rest, message, app_state),
+            (OneOf::E(v), OneOf::E(ref mut state)) => v.message(state, rest, message, app_state),
+            (OneOf::F(v), OneOf::F(ref mut state)) => v.message(state, rest, message, app_state),
+            (OneOf::G(v), OneOf::G(ref mut state)) => v.message(state, rest, message, app_state),
+            (OneOf::H(v), OneOf::H(ref mut state)) => v.message(state, rest, message, app_state),
+            (OneOf::I(v), OneOf::I(ref mut state)) => v.message(state, rest, message, app_state),
+            _ => unreachable!(),
+        }
     }
 }
 
@@ -198,21 +398,56 @@ where
 // to export it. Since this (`one_of`) module is public, we create a new module, allowing it to be pub but not exposed.
 #[doc(hidden)]
 mod hidden {
+    use crate::View;
+
+    use super::PhantomElementCtx;
+
     #[allow(unreachable_pub)]
     pub enum Never {}
+
+    impl<State, Action, Context: PhantomElementCtx, Message> View<State, Action, Context, Message>
+        for Never
+    {
+        type Element = Context::PhantomElement;
+
+        type ViewState = Never;
+
+        fn build(&self, _: &mut Context) -> (Self::Element, Self::ViewState) {
+            match *self {}
+        }
+
+        fn rebuild<'el>(
+            &self,
+            _: &Self,
+            _: &mut Self::ViewState,
+            _: &mut Context,
+            _: crate::Mut<'el, Self::Element>,
+        ) -> crate::Mut<'el, Self::Element> {
+            match *self {}
+        }
+
+        fn teardown(
+            &self,
+            _: &mut Self::ViewState,
+            _: &mut Context,
+            _: crate::Mut<'_, Self::Element>,
+        ) {
+            match *self {}
+        }
+
+        fn message(
+            &self,
+            _: &mut Self::ViewState,
+            _: &[crate::ViewId],
+            _: Message,
+            _: &mut State,
+        ) -> crate::MessageResult<Action, Message> {
+            match *self {}
+        }
+    }
     /// The state used to implement `View` for `OneOfN`
     #[allow(unreachable_pub)]
-    pub struct OneOfState<
-        A = Never,
-        B = Never,
-        C = Never,
-        D = Never,
-        E = Never,
-        F = Never,
-        G = Never,
-        H = Never,
-        I = Never,
-    > {
+    pub struct OneOfState<A, B, C, D, E, F, G, H, I> {
         /// The current state of the inner view or view sequence.
         pub(super) inner_state: super::OneOf<A, B, C, D, E, F, G, H, I>,
         /// The generation this OneOfN is at.
@@ -225,246 +460,12 @@ mod hidden {
     }
 }
 
-macro_rules! one_of {
-    ($ty_name: ident, $num_word: literal, $(($variant: ident, $downcast_method: ident),)+) => {
-        // This is not optimal, as it requires $variant to contain at least `A` and `B`, but better than no doc example...
-        /// Statically typed alternative to the type-erased [`AnyView`](`crate::AnyView`).
-        ///
-        #[doc = concat!("This view container can switch between ", $num_word, " different views.")]
-        ///
-        /// # Examples
-        ///
-        /// Basic usage:
-        ///
-        /// ```ignore
-        #[doc = concat!("let mut v = ", stringify!($ty_name), "::A(my_view());")]
-        #[doc = concat!("v = ", stringify!($ty_name), "::B(my_other_view());")]
-        /// ```
-        #[allow(missing_docs)] // On variants
-        pub enum $ty_name<$($variant),+> {
-            $($variant($variant)),+
-        }
-
-        impl<T, $($variant: AsRef<T>),+> AsRef<T> for $ty_name<$($variant),+>
-        {
-            fn as_ref(&self) -> &T {
-                match self {
-                    $($ty_name::$variant(e) => <$variant as AsRef<T>>::as_ref(e)),+
-                }
-            }
-        }
-
-        impl<Context, State, Action, Message, $($variant),+> View<State, Action, Context, Message> for $ty_name<$($variant),+>
-        where
-            State: 'static,
-            Action: 'static,
-            Context: ViewPathTracker + OneOfCtx<$($variant::Element),+>,
-            $($variant: View<State, Action, Context, Message>),+
-        {
-            type Element = Context::OneOfElement;
-
-            type ViewState = hidden::OneOfState<$($variant::ViewState),+>;
-
-            fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
-                let generation = 0;
-                let (element, inner_state) =
-                    ctx.with_id(ViewId::new(generation), |ctx| match self {
-                        $($ty_name::$variant(e) => {
-                            let (element, state) = e.build(ctx);
-                            (
-                                Context::upcast_one_of_element(OneOf::$variant(element)),
-                                OneOf::$variant(state),
-                            )
-                        }),+
-                    });
-                (
-                    element,
-                    hidden::OneOfState {
-                        inner_state,
-                        generation,
-                    },
-                )
-            }
-
-            fn rebuild<'e>(
-                &self,
-                prev: &Self,
-                view_state: &mut Self::ViewState,
-                ctx: &mut Context,
-                mut element: Mut<'e, Self::Element>,
-            ) -> Mut<'e, Self::Element> {
-                // Type of the inner `View` stayed the same
-                match (prev, self, &mut view_state.inner_state) {
-                    $(($ty_name::$variant(prev), $ty_name::$variant(new), OneOf::$variant(inner_state)) => {
-                        ctx.with_id(ViewId::new(view_state.generation), |ctx| {
-                            Context::$downcast_method(&mut element, |elem| {
-                                new.rebuild(prev, inner_state, ctx, elem);
-                            });
-                        });
-                        return element;
-                    })+
-                    _ => ()
-                };
-
-                // View has changed type, teardown the old view
-                // we can't use Self::teardown, because we still need access to the element
-
-                ctx.with_id(ViewId::new(view_state.generation), |ctx| {
-                    match (prev, &mut view_state.inner_state) {
-                        $(($ty_name::$variant(prev), OneOf::$variant(old_state)) => {
-                            Context::$downcast_method(&mut element, |elem| {
-                                prev.teardown(old_state, ctx, elem);
-                            });
-                        })+
-                        _ => unreachable!(),
-                    };
-                });
-
-                // Overflow handling: u64 starts at 0, incremented by 1 always.
-                // Can never realistically overflow, scale is too large.
-                // If would overflow, wrap to zero. Would need async message sent
-                // to view *exactly* `u64::MAX` versions of the view ago, which is implausible
-                view_state.generation = view_state.generation.wrapping_add(1);
-
-                // Create the new view
-
-                ctx.with_id(ViewId::new(view_state.generation), |ctx| {
-                    match self {
-                        $($ty_name::$variant(new) => {
-                            let (new_element, state) = new.build(ctx);
-                            view_state.inner_state = OneOf::$variant(state);
-                            Context::update_one_of_element_mut(
-                                &mut element,
-                                OneOf::$variant(new_element),
-                            );
-                        })+
-                    };
-                });
-                element
-            }
-
-            fn teardown(
-                &self,
-                view_state: &mut Self::ViewState,
-                ctx: &mut Context,
-                mut element: Mut<'_, Self::Element>,
-            ) {
-                ctx.with_id(ViewId::new(view_state.generation), |ctx| {
-                    match (self, &mut view_state.inner_state) {
-                        $(($ty_name::$variant(view), OneOf::$variant(state)) => {
-                            Context::$downcast_method(&mut element, |elem| {
-                                view.teardown(state, ctx, elem);
-                            });
-                        })+
-                        _ => unreachable!(),
-                    }
-                });
-            }
-
-            fn message(
-                &self,
-                view_state: &mut Self::ViewState,
-                id_path: &[ViewId],
-                message: Message,
-                app_state: &mut State,
-            ) -> MessageResult<Action, Message> {
-                let (start, rest) = id_path
-                    .split_first()
-                    .expect(concat!("Id path has elements for `", stringify!($ty_name), "`"));
-                if start.routing_id() != view_state.generation {
-                    // The message was sent to a previous edition of the inner value
-                    return MessageResult::Stale(message);
-                }
-                match (self, &mut view_state.inner_state) {
-                    $(($ty_name::$variant(view), OneOf::$variant(state)) => {
-                        view.message(state, rest, message, app_state)
-                    }),+
-                    _ => unreachable!(),
-                }
-            }
-        }
-    };
-}
-
 type N = hidden::Never;
-pub type One2Of2<A, B> = OneOf<A, B, N, N, N, N, N, N, N>;
-pub type One2Of3<A, B, C> = OneOf<A, B, C, N, N, N, N, N, N>;
-pub type One2Of4<A, B, C, D> = OneOf<A, B, C, D, N, N, N, N, N>;
-pub type One2Of5<A, B, C, D, E> = OneOf<A, B, C, D, E, N, N, N, N>;
-pub type One2Of6<A, B, C, D, E, F> = OneOf<A, B, C, D, E, F, N, N, N>;
-pub type One2Of7<A, B, C, D, E, F, G> = OneOf<A, B, C, D, E, F, G, N, N>;
-pub type One2Of8<A, B, C, D, E, F, G, H> = OneOf<A, B, C, D, E, F, G, H, N>;
-pub type One2Of9<A, B, C, D, E, F, G, H, I> = OneOf<A, B, C, D, E, F, G, H, I>;
-
-// one_of!(OneOf2, "two", (A, with_downcast_a), (B, with_downcast_b),);
-one_of!(
-    OneOf3,
-    "three",
-    (A, with_downcast_a),
-    (B, with_downcast_b),
-    (C, with_downcast_c),
-);
-one_of!(
-    OneOf4,
-    "four",
-    (A, with_downcast_a),
-    (B, with_downcast_b),
-    (C, with_downcast_c),
-    (D, with_downcast_d),
-);
-one_of!(
-    OneOf5,
-    "five",
-    (A, with_downcast_a),
-    (B, with_downcast_b),
-    (C, with_downcast_c),
-    (D, with_downcast_d),
-    (E, with_downcast_e),
-);
-one_of!(
-    OneOf6,
-    "six",
-    (A, with_downcast_a),
-    (B, with_downcast_b),
-    (C, with_downcast_c),
-    (D, with_downcast_d),
-    (E, with_downcast_e),
-    (F, with_downcast_f),
-);
-one_of!(
-    OneOf7,
-    "seven",
-    (A, with_downcast_a),
-    (B, with_downcast_b),
-    (C, with_downcast_c),
-    (D, with_downcast_d),
-    (E, with_downcast_e),
-    (F, with_downcast_f),
-    (G, with_downcast_g),
-);
-one_of!(
-    OneOf8,
-    "eight",
-    (A, with_downcast_a),
-    (B, with_downcast_b),
-    (C, with_downcast_c),
-    (D, with_downcast_d),
-    (E, with_downcast_e),
-    (F, with_downcast_f),
-    (G, with_downcast_g),
-    (H, with_downcast_h),
-);
-one_of!(
-    OneOf9,
-    "nine",
-    (A, with_downcast_a),
-    (B, with_downcast_b),
-    (C, with_downcast_c),
-    (D, with_downcast_d),
-    (E, with_downcast_e),
-    (F, with_downcast_f),
-    (G, with_downcast_g),
-    (H, with_downcast_h),
-    (I, with_downcast_i),
-);
-Never
+pub type OneOf2<A, B> = OneOf<A, B, N, N, N, N, N, N, N>;
+pub type OneOf3<A, B, C> = OneOf<A, B, C, N, N, N, N, N, N>;
+pub type OneOf4<A, B, C, D> = OneOf<A, B, C, D, N, N, N, N, N>;
+pub type OneOf5<A, B, C, D, E> = OneOf<A, B, C, D, E, N, N, N, N>;
+pub type OneOf6<A, B, C, D, E, F> = OneOf<A, B, C, D, E, F, N, N, N>;
+pub type OneOf7<A, B, C, D, E, F, G> = OneOf<A, B, C, D, E, F, G, N, N>;
+pub type OneOf8<A, B, C, D, E, F, G, H> = OneOf<A, B, C, D, E, F, G, H, N>;
+pub type OneOf9<A, B, C, D, E, F, G, H, I> = OneOf<A, B, C, D, E, F, G, H, I>;

--- a/xilem_core/src/views/one_of.rs
+++ b/xilem_core/src/views/one_of.rs
@@ -119,6 +119,81 @@ pub trait OneOfCtx<
     );
 }
 
+impl<State, Action, Context, Message, A, B, C, D, E, F, G, H, I>
+    View<State, Action, Context, Message> for OneOf<A, B, C, D, E, F, G, H, I>
+where
+    State: 'static,
+    Action: 'static,
+    Context: ViewPathTracker
+        + OneOfCtx<
+            A::Element,
+            B::Element,
+            C::Element,
+            D::Element,
+            E::Element,
+            F::Element,
+            G::Element,
+            H::Element,
+            I::Element,
+        >,
+    A: View<State, Action, Context, Message>,
+    B: View<State, Action, Context, Message>,
+    C: View<State, Action, Context, Message>,
+    D: View<State, Action, Context, Message>,
+    E: View<State, Action, Context, Message>,
+    F: View<State, Action, Context, Message>,
+    G: View<State, Action, Context, Message>,
+    H: View<State, Action, Context, Message>,
+    I: View<State, Action, Context, Message>,
+{
+    type Element = Context::OneOfElement;
+
+    type ViewState = hidden::OneOfState<
+        A::ViewState,
+        B::ViewState,
+        C::ViewState,
+        D::ViewState,
+        E::ViewState,
+        F::ViewState,
+        G::ViewState,
+        H::ViewState,
+        I::ViewState,
+    >;
+
+    fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
+        todo!()
+    }
+
+    fn rebuild<'el>(
+        &self,
+        prev: &Self,
+        view_state: &mut Self::ViewState,
+        ctx: &mut Context,
+        element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
+        todo!()
+    }
+
+    fn teardown(
+        &self,
+        view_state: &mut Self::ViewState,
+        ctx: &mut Context,
+        element: Mut<'_, Self::Element>,
+    ) {
+        todo!()
+    }
+
+    fn message(
+        &self,
+        view_state: &mut Self::ViewState,
+        id_path: &[ViewId],
+        message: Message,
+        app_state: &mut State,
+    ) -> MessageResult<Action, Message> {
+        todo!()
+    }
+}
+
 // Because `OneOfState` is not public API, but is part of a public trait `impl`, it must be marked pub, but we don't want
 // to export it. Since this (`one_of`) module is public, we create a new module, allowing it to be pub but not exposed.
 #[doc(hidden)]
@@ -311,7 +386,17 @@ macro_rules! one_of {
     };
 }
 
-one_of!(OneOf2, "two", (A, with_downcast_a), (B, with_downcast_b),);
+type N = hidden::Never;
+pub type One2Of2<A, B> = OneOf<A, B, N, N, N, N, N, N, N>;
+pub type One2Of3<A, B, C> = OneOf<A, B, C, N, N, N, N, N, N>;
+pub type One2Of4<A, B, C, D> = OneOf<A, B, C, D, N, N, N, N, N>;
+pub type One2Of5<A, B, C, D, E> = OneOf<A, B, C, D, E, N, N, N, N>;
+pub type One2Of6<A, B, C, D, E, F> = OneOf<A, B, C, D, E, F, N, N, N>;
+pub type One2Of7<A, B, C, D, E, F, G> = OneOf<A, B, C, D, E, F, G, N, N>;
+pub type One2Of8<A, B, C, D, E, F, G, H> = OneOf<A, B, C, D, E, F, G, H, N>;
+pub type One2Of9<A, B, C, D, E, F, G, H, I> = OneOf<A, B, C, D, E, F, G, H, I>;
+
+// one_of!(OneOf2, "two", (A, with_downcast_a), (B, with_downcast_b),);
 one_of!(
     OneOf3,
     "three",
@@ -382,3 +467,4 @@ one_of!(
     (H, with_downcast_h),
     (I, with_downcast_i),
 );
+Never

--- a/xilem_core/tests/one_of.rs
+++ b/xilem_core/tests/one_of.rs
@@ -6,7 +6,7 @@
 //! This is an integration test so that it can use the infrastructure in [`common`].
 
 use xilem_core::{
-    one_of::{OneOf, OneOf2, OneOfCtx, PhantomElementCtx},
+    one_of::{OneOf2, OneOf9, OneOfCtx, PhantomElementCtx},
     MessageResult, Mut, View, ViewId,
 };
 
@@ -41,7 +41,7 @@ impl
     type OneOfElement = TestElement;
 
     fn upcast_one_of_element(
-        elem: OneOf<
+        elem: OneOf9<
             TestElement,
             TestElement,
             TestElement,
@@ -54,15 +54,15 @@ impl
         >,
     ) -> Self::OneOfElement {
         match elem {
-            OneOf::A(e) => e,
-            OneOf::B(e) => e,
+            OneOf9::A(e) => e,
+            OneOf9::B(e) => e,
             _ => unreachable!(),
         }
     }
 
     fn update_one_of_element_mut(
         elem_mut: &mut Mut<'_, Self::OneOfElement>,
-        new_elem: OneOf<
+        new_elem: OneOf9<
             TestElement,
             TestElement,
             TestElement,
@@ -75,7 +75,7 @@ impl
         >,
     ) {
         match new_elem {
-            OneOf::A(new_elem) | OneOf::B(new_elem) => {
+            OneOf9::A(new_elem) | OneOf9::B(new_elem) => {
                 assert_eq!(new_elem.operations.len(), 1);
                 let Some(Operation::Build(new_id)) = new_elem.operations.first() else {
                     unreachable!()

--- a/xilem_core/tests/one_of.rs
+++ b/xilem_core/tests/one_of.rs
@@ -25,7 +25,19 @@ impl PhantomElementCtx for TestCtx {
     type PhantomElement = TestElement;
 }
 
-impl OneOfCtx<TestElement, TestElement> for TestCtx {
+impl
+    OneOfCtx<
+        TestElement,
+        TestElement,
+        TestElement,
+        TestElement,
+        TestElement,
+        TestElement,
+        TestElement,
+        TestElement,
+        TestElement,
+    > for TestCtx
+{
     type OneOfElement = TestElement;
 
     fn upcast_one_of_element(

--- a/xilem_web/src/one_of.rs
+++ b/xilem_web/src/one_of.rs
@@ -3,7 +3,7 @@
 
 use wasm_bindgen::UnwrapThrowExt;
 use xilem_core::{
-    one_of::{OneOf, OneOfCtx, PhantomElementCtx},
+    one_of::{OneOf9, OneOfCtx, PhantomElementCtx},
     Mut,
 };
 
@@ -47,10 +47,10 @@ where
     N9: DomNode<P9>,
 {
     type OneOfElement =
-        Pod<OneOf<N1, N2, N3, N4, N5, N6, N7, N8, N9>, OneOf<P1, P2, P3, P4, P5, P6, P7, P8, P9>>;
+        Pod<OneOf9<N1, N2, N3, N4, N5, N6, N7, N8, N9>, OneOf9<P1, P2, P3, P4, P5, P6, P7, P8, P9>>;
 
     fn upcast_one_of_element(
-        elem: OneOf<
+        elem: OneOf9<
             Pod<N1, P1>,
             Pod<N2, P2>,
             Pod<N3, P3>,
@@ -63,48 +63,48 @@ where
         >,
     ) -> Self::OneOfElement {
         match elem {
-            OneOf::A(e) => Pod {
-                node: OneOf::A(e.node),
-                props: OneOf::A(e.props),
+            OneOf9::A(e) => Pod {
+                node: OneOf9::A(e.node),
+                props: OneOf9::A(e.props),
             },
-            OneOf::B(e) => Pod {
-                node: OneOf::B(e.node),
-                props: OneOf::B(e.props),
+            OneOf9::B(e) => Pod {
+                node: OneOf9::B(e.node),
+                props: OneOf9::B(e.props),
             },
-            OneOf::C(e) => Pod {
-                node: OneOf::C(e.node),
-                props: OneOf::C(e.props),
+            OneOf9::C(e) => Pod {
+                node: OneOf9::C(e.node),
+                props: OneOf9::C(e.props),
             },
-            OneOf::D(e) => Pod {
-                node: OneOf::D(e.node),
-                props: OneOf::D(e.props),
+            OneOf9::D(e) => Pod {
+                node: OneOf9::D(e.node),
+                props: OneOf9::D(e.props),
             },
-            OneOf::E(e) => Pod {
-                node: OneOf::E(e.node),
-                props: OneOf::E(e.props),
+            OneOf9::E(e) => Pod {
+                node: OneOf9::E(e.node),
+                props: OneOf9::E(e.props),
             },
-            OneOf::F(e) => Pod {
-                node: OneOf::F(e.node),
-                props: OneOf::F(e.props),
+            OneOf9::F(e) => Pod {
+                node: OneOf9::F(e.node),
+                props: OneOf9::F(e.props),
             },
-            OneOf::G(e) => Pod {
-                node: OneOf::G(e.node),
-                props: OneOf::G(e.props),
+            OneOf9::G(e) => Pod {
+                node: OneOf9::G(e.node),
+                props: OneOf9::G(e.props),
             },
-            OneOf::H(e) => Pod {
-                node: OneOf::H(e.node),
-                props: OneOf::H(e.props),
+            OneOf9::H(e) => Pod {
+                node: OneOf9::H(e.node),
+                props: OneOf9::H(e.props),
             },
-            OneOf::I(e) => Pod {
-                node: OneOf::I(e.node),
-                props: OneOf::I(e.props),
+            OneOf9::I(e) => Pod {
+                node: OneOf9::I(e.node),
+                props: OneOf9::I(e.props),
             },
         }
     }
 
     fn update_one_of_element_mut(
         elem_mut: &mut Mut<'_, Self::OneOfElement>,
-        new_elem: OneOf<
+        new_elem: OneOf9<
             Pod<N1, P1>,
             Pod<N2, P2>,
             Pod<N3, P3>,
@@ -125,15 +125,15 @@ where
                 .unwrap_throw();
         }
         (*elem_mut.node, *elem_mut.props) = match new_elem {
-            OneOf::A(e) => (OneOf::A(e.node), OneOf::A(e.props)),
-            OneOf::B(e) => (OneOf::B(e.node), OneOf::B(e.props)),
-            OneOf::C(e) => (OneOf::C(e.node), OneOf::C(e.props)),
-            OneOf::D(e) => (OneOf::D(e.node), OneOf::D(e.props)),
-            OneOf::E(e) => (OneOf::E(e.node), OneOf::E(e.props)),
-            OneOf::F(e) => (OneOf::F(e.node), OneOf::F(e.props)),
-            OneOf::G(e) => (OneOf::G(e.node), OneOf::G(e.props)),
-            OneOf::H(e) => (OneOf::H(e.node), OneOf::H(e.props)),
-            OneOf::I(e) => (OneOf::I(e.node), OneOf::I(e.props)),
+            OneOf9::A(e) => (OneOf9::A(e.node), OneOf9::A(e.props)),
+            OneOf9::B(e) => (OneOf9::B(e.node), OneOf9::B(e.props)),
+            OneOf9::C(e) => (OneOf9::C(e.node), OneOf9::C(e.props)),
+            OneOf9::D(e) => (OneOf9::D(e.node), OneOf9::D(e.props)),
+            OneOf9::E(e) => (OneOf9::E(e.node), OneOf9::E(e.props)),
+            OneOf9::F(e) => (OneOf9::F(e.node), OneOf9::F(e.props)),
+            OneOf9::G(e) => (OneOf9::G(e.node), OneOf9::G(e.props)),
+            OneOf9::H(e) => (OneOf9::H(e.node), OneOf9::H(e.props)),
+            OneOf9::I(e) => (OneOf9::I(e.node), OneOf9::I(e.props)),
         };
     }
 
@@ -141,7 +141,7 @@ where
         elem: &mut Mut<'_, Self::OneOfElement>,
         f: impl FnOnce(Mut<'_, Pod<N1, P1>>),
     ) {
-        let (OneOf::A(node), OneOf::A(props)) = (&mut elem.node, &mut elem.props) else {
+        let (OneOf9::A(node), OneOf9::A(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
@@ -151,7 +151,7 @@ where
         elem: &mut Mut<'_, Self::OneOfElement>,
         f: impl FnOnce(Mut<'_, Pod<N2, P2>>),
     ) {
-        let (OneOf::B(node), OneOf::B(props)) = (&mut elem.node, &mut elem.props) else {
+        let (OneOf9::B(node), OneOf9::B(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
@@ -161,7 +161,7 @@ where
         elem: &mut Mut<'_, Self::OneOfElement>,
         f: impl FnOnce(Mut<'_, Pod<N3, P3>>),
     ) {
-        let (OneOf::C(node), OneOf::C(props)) = (&mut elem.node, &mut elem.props) else {
+        let (OneOf9::C(node), OneOf9::C(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
@@ -171,7 +171,7 @@ where
         elem: &mut Mut<'_, Self::OneOfElement>,
         f: impl FnOnce(Mut<'_, Pod<N4, P4>>),
     ) {
-        let (OneOf::D(node), OneOf::D(props)) = (&mut elem.node, &mut elem.props) else {
+        let (OneOf9::D(node), OneOf9::D(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
@@ -181,7 +181,7 @@ where
         elem: &mut Mut<'_, Self::OneOfElement>,
         f: impl FnOnce(Mut<'_, Pod<N5, P5>>),
     ) {
-        let (OneOf::E(node), OneOf::E(props)) = (&mut elem.node, &mut elem.props) else {
+        let (OneOf9::E(node), OneOf9::E(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
@@ -191,7 +191,7 @@ where
         elem: &mut Mut<'_, Self::OneOfElement>,
         f: impl FnOnce(Mut<'_, Pod<N6, P6>>),
     ) {
-        let (OneOf::F(node), OneOf::F(props)) = (&mut elem.node, &mut elem.props) else {
+        let (OneOf9::F(node), OneOf9::F(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
@@ -201,7 +201,7 @@ where
         elem: &mut Mut<'_, Self::OneOfElement>,
         f: impl FnOnce(Mut<'_, Pod<N7, P7>>),
     ) {
-        let (OneOf::G(node), OneOf::G(props)) = (&mut elem.node, &mut elem.props) else {
+        let (OneOf9::G(node), OneOf9::G(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
@@ -211,7 +211,7 @@ where
         elem: &mut Mut<'_, Self::OneOfElement>,
         f: impl FnOnce(Mut<'_, Pod<N8, P8>>),
     ) {
-        let (OneOf::H(node), OneOf::H(props)) = (&mut elem.node, &mut elem.props) else {
+        let (OneOf9::H(node), OneOf9::H(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
@@ -221,7 +221,7 @@ where
         elem: &mut Mut<'_, Self::OneOfElement>,
         f: impl FnOnce(Mut<'_, Pod<N9, P9>>),
     ) {
-        let (OneOf::I(node), OneOf::I(props)) = (&mut elem.node, &mut elem.props) else {
+        let (OneOf9::I(node), OneOf9::I(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
@@ -302,47 +302,47 @@ impl<
         E7: WithAttributes,
         E8: WithAttributes,
         E9: WithAttributes,
-    > WithAttributes for OneOf<E1, E2, E3, E4, E5, E6, E7, E8, E9>
+    > WithAttributes for OneOf9<E1, E2, E3, E4, E5, E6, E7, E8, E9>
 {
     fn start_attribute_modifier(&mut self) {
         match self {
-            OneOf::A(e) => e.start_attribute_modifier(),
-            OneOf::B(e) => e.start_attribute_modifier(),
-            OneOf::C(e) => e.start_attribute_modifier(),
-            OneOf::D(e) => e.start_attribute_modifier(),
-            OneOf::E(e) => e.start_attribute_modifier(),
-            OneOf::F(e) => e.start_attribute_modifier(),
-            OneOf::G(e) => e.start_attribute_modifier(),
-            OneOf::H(e) => e.start_attribute_modifier(),
-            OneOf::I(e) => e.start_attribute_modifier(),
+            OneOf9::A(e) => e.start_attribute_modifier(),
+            OneOf9::B(e) => e.start_attribute_modifier(),
+            OneOf9::C(e) => e.start_attribute_modifier(),
+            OneOf9::D(e) => e.start_attribute_modifier(),
+            OneOf9::E(e) => e.start_attribute_modifier(),
+            OneOf9::F(e) => e.start_attribute_modifier(),
+            OneOf9::G(e) => e.start_attribute_modifier(),
+            OneOf9::H(e) => e.start_attribute_modifier(),
+            OneOf9::I(e) => e.start_attribute_modifier(),
         }
     }
 
     fn end_attribute_modifier(&mut self) {
         match self {
-            OneOf::A(e) => e.end_attribute_modifier(),
-            OneOf::B(e) => e.end_attribute_modifier(),
-            OneOf::C(e) => e.end_attribute_modifier(),
-            OneOf::D(e) => e.end_attribute_modifier(),
-            OneOf::E(e) => e.end_attribute_modifier(),
-            OneOf::F(e) => e.end_attribute_modifier(),
-            OneOf::G(e) => e.end_attribute_modifier(),
-            OneOf::H(e) => e.end_attribute_modifier(),
-            OneOf::I(e) => e.end_attribute_modifier(),
+            OneOf9::A(e) => e.end_attribute_modifier(),
+            OneOf9::B(e) => e.end_attribute_modifier(),
+            OneOf9::C(e) => e.end_attribute_modifier(),
+            OneOf9::D(e) => e.end_attribute_modifier(),
+            OneOf9::E(e) => e.end_attribute_modifier(),
+            OneOf9::F(e) => e.end_attribute_modifier(),
+            OneOf9::G(e) => e.end_attribute_modifier(),
+            OneOf9::H(e) => e.end_attribute_modifier(),
+            OneOf9::I(e) => e.end_attribute_modifier(),
         }
     }
 
     fn set_attribute(&mut self, name: CowStr, value: Option<AttributeValue>) {
         match self {
-            OneOf::A(e) => e.set_attribute(name, value),
-            OneOf::B(e) => e.set_attribute(name, value),
-            OneOf::C(e) => e.set_attribute(name, value),
-            OneOf::D(e) => e.set_attribute(name, value),
-            OneOf::E(e) => e.set_attribute(name, value),
-            OneOf::F(e) => e.set_attribute(name, value),
-            OneOf::G(e) => e.set_attribute(name, value),
-            OneOf::H(e) => e.set_attribute(name, value),
-            OneOf::I(e) => e.set_attribute(name, value),
+            OneOf9::A(e) => e.set_attribute(name, value),
+            OneOf9::B(e) => e.set_attribute(name, value),
+            OneOf9::C(e) => e.set_attribute(name, value),
+            OneOf9::D(e) => e.set_attribute(name, value),
+            OneOf9::E(e) => e.set_attribute(name, value),
+            OneOf9::F(e) => e.set_attribute(name, value),
+            OneOf9::G(e) => e.set_attribute(name, value),
+            OneOf9::H(e) => e.set_attribute(name, value),
+            OneOf9::I(e) => e.set_attribute(name, value),
         }
     }
 }
@@ -357,61 +357,61 @@ impl<
         E7: WithClasses,
         E8: WithClasses,
         E9: WithClasses,
-    > WithClasses for OneOf<E1, E2, E3, E4, E5, E6, E7, E8, E9>
+    > WithClasses for OneOf9<E1, E2, E3, E4, E5, E6, E7, E8, E9>
 {
     fn start_class_modifier(&mut self) {
         match self {
-            OneOf::A(e) => e.start_class_modifier(),
-            OneOf::B(e) => e.start_class_modifier(),
-            OneOf::C(e) => e.start_class_modifier(),
-            OneOf::D(e) => e.start_class_modifier(),
-            OneOf::E(e) => e.start_class_modifier(),
-            OneOf::F(e) => e.start_class_modifier(),
-            OneOf::G(e) => e.start_class_modifier(),
-            OneOf::H(e) => e.start_class_modifier(),
-            OneOf::I(e) => e.start_class_modifier(),
+            OneOf9::A(e) => e.start_class_modifier(),
+            OneOf9::B(e) => e.start_class_modifier(),
+            OneOf9::C(e) => e.start_class_modifier(),
+            OneOf9::D(e) => e.start_class_modifier(),
+            OneOf9::E(e) => e.start_class_modifier(),
+            OneOf9::F(e) => e.start_class_modifier(),
+            OneOf9::G(e) => e.start_class_modifier(),
+            OneOf9::H(e) => e.start_class_modifier(),
+            OneOf9::I(e) => e.start_class_modifier(),
         }
     }
 
     fn add_class(&mut self, class_name: CowStr) {
         match self {
-            OneOf::A(e) => e.add_class(class_name),
-            OneOf::B(e) => e.add_class(class_name),
-            OneOf::C(e) => e.add_class(class_name),
-            OneOf::D(e) => e.add_class(class_name),
-            OneOf::E(e) => e.add_class(class_name),
-            OneOf::F(e) => e.add_class(class_name),
-            OneOf::G(e) => e.add_class(class_name),
-            OneOf::H(e) => e.add_class(class_name),
-            OneOf::I(e) => e.add_class(class_name),
+            OneOf9::A(e) => e.add_class(class_name),
+            OneOf9::B(e) => e.add_class(class_name),
+            OneOf9::C(e) => e.add_class(class_name),
+            OneOf9::D(e) => e.add_class(class_name),
+            OneOf9::E(e) => e.add_class(class_name),
+            OneOf9::F(e) => e.add_class(class_name),
+            OneOf9::G(e) => e.add_class(class_name),
+            OneOf9::H(e) => e.add_class(class_name),
+            OneOf9::I(e) => e.add_class(class_name),
         }
     }
 
     fn remove_class(&mut self, class_name: CowStr) {
         match self {
-            OneOf::A(e) => e.remove_class(class_name),
-            OneOf::B(e) => e.remove_class(class_name),
-            OneOf::C(e) => e.remove_class(class_name),
-            OneOf::D(e) => e.remove_class(class_name),
-            OneOf::E(e) => e.remove_class(class_name),
-            OneOf::F(e) => e.remove_class(class_name),
-            OneOf::G(e) => e.remove_class(class_name),
-            OneOf::H(e) => e.remove_class(class_name),
-            OneOf::I(e) => e.remove_class(class_name),
+            OneOf9::A(e) => e.remove_class(class_name),
+            OneOf9::B(e) => e.remove_class(class_name),
+            OneOf9::C(e) => e.remove_class(class_name),
+            OneOf9::D(e) => e.remove_class(class_name),
+            OneOf9::E(e) => e.remove_class(class_name),
+            OneOf9::F(e) => e.remove_class(class_name),
+            OneOf9::G(e) => e.remove_class(class_name),
+            OneOf9::H(e) => e.remove_class(class_name),
+            OneOf9::I(e) => e.remove_class(class_name),
         }
     }
 
     fn end_class_modifier(&mut self) {
         match self {
-            OneOf::A(e) => e.end_class_modifier(),
-            OneOf::B(e) => e.end_class_modifier(),
-            OneOf::C(e) => e.end_class_modifier(),
-            OneOf::D(e) => e.end_class_modifier(),
-            OneOf::E(e) => e.end_class_modifier(),
-            OneOf::F(e) => e.end_class_modifier(),
-            OneOf::G(e) => e.end_class_modifier(),
-            OneOf::H(e) => e.end_class_modifier(),
-            OneOf::I(e) => e.end_class_modifier(),
+            OneOf9::A(e) => e.end_class_modifier(),
+            OneOf9::B(e) => e.end_class_modifier(),
+            OneOf9::C(e) => e.end_class_modifier(),
+            OneOf9::D(e) => e.end_class_modifier(),
+            OneOf9::E(e) => e.end_class_modifier(),
+            OneOf9::F(e) => e.end_class_modifier(),
+            OneOf9::G(e) => e.end_class_modifier(),
+            OneOf9::H(e) => e.end_class_modifier(),
+            OneOf9::I(e) => e.end_class_modifier(),
         }
     }
 }
@@ -426,53 +426,54 @@ impl<
         E7: WithStyle,
         E8: WithStyle,
         E9: WithStyle,
-    > WithStyle for OneOf<E1, E2, E3, E4, E5, E6, E7, E8, E9>
+    > WithStyle for OneOf9<E1, E2, E3, E4, E5, E6, E7, E8, E9>
 {
     fn start_style_modifier(&mut self) {
         match self {
-            OneOf::A(e) => e.start_style_modifier(),
-            OneOf::B(e) => e.start_style_modifier(),
-            OneOf::C(e) => e.start_style_modifier(),
-            OneOf::D(e) => e.start_style_modifier(),
-            OneOf::E(e) => e.start_style_modifier(),
-            OneOf::F(e) => e.start_style_modifier(),
-            OneOf::G(e) => e.start_style_modifier(),
-            OneOf::H(e) => e.start_style_modifier(),
-            OneOf::I(e) => e.start_style_modifier(),
+            OneOf9::A(e) => e.start_style_modifier(),
+            OneOf9::B(e) => e.start_style_modifier(),
+            OneOf9::C(e) => e.start_style_modifier(),
+            OneOf9::D(e) => e.start_style_modifier(),
+            OneOf9::E(e) => e.start_style_modifier(),
+            OneOf9::F(e) => e.start_style_modifier(),
+            OneOf9::G(e) => e.start_style_modifier(),
+            OneOf9::H(e) => e.start_style_modifier(),
+            OneOf9::I(e) => e.start_style_modifier(),
         }
     }
 
     fn set_style(&mut self, name: CowStr, value: Option<CowStr>) {
         match self {
-            OneOf::A(e) => e.set_style(name, value),
-            OneOf::B(e) => e.set_style(name, value),
-            OneOf::C(e) => e.set_style(name, value),
-            OneOf::D(e) => e.set_style(name, value),
-            OneOf::E(e) => e.set_style(name, value),
-            OneOf::F(e) => e.set_style(name, value),
-            OneOf::G(e) => e.set_style(name, value),
-            OneOf::H(e) => e.set_style(name, value),
-            OneOf::I(e) => e.set_style(name, value),
+            OneOf9::A(e) => e.set_style(name, value),
+            OneOf9::B(e) => e.set_style(name, value),
+            OneOf9::C(e) => e.set_style(name, value),
+            OneOf9::D(e) => e.set_style(name, value),
+            OneOf9::E(e) => e.set_style(name, value),
+            OneOf9::F(e) => e.set_style(name, value),
+            OneOf9::G(e) => e.set_style(name, value),
+            OneOf9::H(e) => e.set_style(name, value),
+            OneOf9::I(e) => e.set_style(name, value),
         }
     }
 
     fn end_style_modifier(&mut self) {
         match self {
-            OneOf::A(e) => e.end_style_modifier(),
-            OneOf::B(e) => e.end_style_modifier(),
-            OneOf::C(e) => e.end_style_modifier(),
-            OneOf::D(e) => e.end_style_modifier(),
-            OneOf::E(e) => e.end_style_modifier(),
-            OneOf::F(e) => e.end_style_modifier(),
-            OneOf::G(e) => e.end_style_modifier(),
-            OneOf::H(e) => e.end_style_modifier(),
-            OneOf::I(e) => e.end_style_modifier(),
+            OneOf9::A(e) => e.end_style_modifier(),
+            OneOf9::B(e) => e.end_style_modifier(),
+            OneOf9::C(e) => e.end_style_modifier(),
+            OneOf9::D(e) => e.end_style_modifier(),
+            OneOf9::E(e) => e.end_style_modifier(),
+            OneOf9::F(e) => e.end_style_modifier(),
+            OneOf9::G(e) => e.end_style_modifier(),
+            OneOf9::H(e) => e.end_style_modifier(),
+            OneOf9::I(e) => e.end_style_modifier(),
         }
     }
 }
 
 impl<P1, P2, P3, P4, P5, P6, P7, P8, P9, E1, E2, E3, E4, E5, E6, E7, E8, E9>
-    DomNode<OneOf<P1, P2, P3, P4, P5, P6, P7, P8, P9>> for OneOf<E1, E2, E3, E4, E5, E6, E7, E8, E9>
+    DomNode<OneOf9<P1, P2, P3, P4, P5, P6, P7, P8, P9>>
+    for OneOf9<E1, E2, E3, E4, E5, E6, E7, E8, E9>
 where
     E1: DomNode<P1>,
     E2: DomNode<P2>,
@@ -484,17 +485,17 @@ where
     E8: DomNode<P8>,
     E9: DomNode<P9>,
 {
-    fn apply_props(&self, props: &mut OneOf<P1, P2, P3, P4, P5, P6, P7, P8, P9>) {
+    fn apply_props(&self, props: &mut OneOf9<P1, P2, P3, P4, P5, P6, P7, P8, P9>) {
         match (self, props) {
-            (OneOf::A(el), OneOf::A(props)) => el.apply_props(props),
-            (OneOf::B(el), OneOf::B(props)) => el.apply_props(props),
-            (OneOf::C(el), OneOf::C(props)) => el.apply_props(props),
-            (OneOf::D(el), OneOf::D(props)) => el.apply_props(props),
-            (OneOf::E(el), OneOf::E(props)) => el.apply_props(props),
-            (OneOf::F(el), OneOf::F(props)) => el.apply_props(props),
-            (OneOf::G(el), OneOf::G(props)) => el.apply_props(props),
-            (OneOf::H(el), OneOf::H(props)) => el.apply_props(props),
-            (OneOf::I(el), OneOf::I(props)) => el.apply_props(props),
+            (OneOf9::A(el), OneOf9::A(props)) => el.apply_props(props),
+            (OneOf9::B(el), OneOf9::B(props)) => el.apply_props(props),
+            (OneOf9::C(el), OneOf9::C(props)) => el.apply_props(props),
+            (OneOf9::D(el), OneOf9::D(props)) => el.apply_props(props),
+            (OneOf9::E(el), OneOf9::E(props)) => el.apply_props(props),
+            (OneOf9::F(el), OneOf9::F(props)) => el.apply_props(props),
+            (OneOf9::G(el), OneOf9::G(props)) => el.apply_props(props),
+            (OneOf9::H(el), OneOf9::H(props)) => el.apply_props(props),
+            (OneOf9::I(el), OneOf9::I(props)) => el.apply_props(props),
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
This still needs to be implemented in Xilem.

But I think this is an improvement overall