### PR TITLE
Add a CSS `gap` inspired Flex property.

### DIFF
--- a/masonry/examples/calc.rs
+++ b/masonry/examples/calc.rs
@@ -300,6 +300,7 @@ fn flex_row(
     w4: impl Widget + 'static,
 ) -> impl Widget {
     Flex::row()
+        .gap(0.0)
         .with_flex_child(w1, 1.0)
         .with_spacer(1.0)
         .with_flex_child(w2, 1.0)
@@ -312,6 +313,7 @@ fn flex_row(
 fn build_calc() -> impl Widget {
     let display = Label::new(String::new()).with_text_size(32.0);
     Flex::column()
+        .gap(0.0)
         .with_flex_spacer(0.2)
         .with_child(display)
         .with_flex_spacer(0.2)


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/CSS/gap

Since #428, we no longer have default spacing between flex elements in Masonry. This makes the examples quite ugly.

Choices made based on [#xilem > Porting Taffy Integration to New Xilem](https://xi.zulipchat.com/#narrow/stream/354396-xilem/topic/Porting.20Taffy.20Integration.20to.20New.20Xilem). Of particular note is the choice to not have this be overwritten by spacers, due to:

> My first thought is that users are going to be very confused when they add a space between two items and the result is the items are closer together.

There is no such concept of a spacer in CSS parlance