### PR TITLE
Correctly set `rust-version` in all `Cargo.toml`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,26 @@ To install them on Debian or Ubuntu, run
 sudo apt-get install pkg-config clang libwayland-dev libxkbcommon-x11-dev libvulkan-dev
 ```
 
+## Minimum supported Rust Version (MSRV)
+
+This version of Xilem has been verified to compile with **Rust 1.79** and later.
+
+Future versions of Xilem might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some of Xilem's dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+
+</details>
+
 ## License
 
 Licensed under the Apache License, Version 2.0

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 exclude = ["/doc/", ".gitignore"]
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/xilem/Cargo.toml
+++ b/xilem/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/xilem_core/Cargo.toml
+++ b/xilem_core/Cargo.toml
@@ -7,6 +7,7 @@ categories = ["gui"]
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 publish = false # We'll publish this alongside Xilem 0.2
 

--- a/xilem_web/Cargo.toml
+++ b/xilem_web/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/xilem_web/README.md
+++ b/xilem_web/README.md
@@ -50,11 +50,31 @@ pub fn main() {
 }
 ```
 
+## Minimum supported Rust Version (MSRV)
+
+This version of Xilem Web has been verified to compile with **Rust 1.79** and later.
+
+Future versions of Xilem Web might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some of Xilem Web's dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+
+</details>
+
 <div class="rustdoc-hidden">
 
 ## Community
 
-Discussion of Xilem Core development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically in
+Discussion of Xilem Web development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically in
 [#xilem](https://xi.zulipchat.com/#narrow/stream/354396-xilem).
 All public content can be read without logging in.
 


### PR DESCRIPTION
Discovered in #432; this would otherwise cause errors for users of nightly (or 1.81 beta, due to be released next week)