### PR TITLE
Expose control over window background color

### DIFF
--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -82,6 +82,7 @@ pub struct MasonryState<'a> {
     // Per-Window state
     // In future, this will support multiple windows
     window: WindowState<'a>,
+    background_color: Color,
 }
 
 struct MainState<'a> {
@@ -113,7 +114,13 @@ pub fn run(
 ) -> Result<(), EventLoopError> {
     let event_loop = loop_builder.build()?;
 
-    run_with(event_loop, window_attributes, root_widget, app_driver)
+    run_with(
+        event_loop,
+        window_attributes,
+        root_widget,
+        app_driver,
+        Color::BLACK,
+    )
 }
 
 pub fn run_with(
@@ -121,9 +128,10 @@ pub fn run_with(
     window: WindowAttributes,
     root_widget: impl Widget,
     app_driver: impl AppDriver + 'static,
+    background_color: Color,
 ) -> Result<(), EventLoopError> {
     let mut main_state = MainState {
-        masonry_state: MasonryState::new(window, &event_loop, root_widget),
+        masonry_state: MasonryState::new(window, &event_loop, root_widget, background_color),
         app_driver: Box::new(app_driver),
     };
 
@@ -204,7 +212,12 @@ impl ApplicationHandler<MasonryUserEvent> for MainState<'_> {
 }
 
 impl MasonryState<'_> {
-    pub fn new(window: WindowAttributes, event_loop: &EventLoop, root_widget: impl Widget) -> Self {
+    pub fn new(
+        window: WindowAttributes,
+        event_loop: &EventLoop,
+        root_widget: impl Widget,
+        background_color: Color,
+    ) -> Self {
         let render_cx = RenderContext::new();
         // TODO: We can't know this scale factor until later?
         let scale_factor = 1.0;
@@ -217,6 +230,7 @@ impl MasonryState<'_> {
             proxy: event_loop.create_proxy(),
 
             window: WindowState::Uninitialized(window),
+            background_color,
         }
     }
 
@@ -358,7 +372,7 @@ impl MasonryState<'_> {
             num_init_threads: NonZeroUsize::new(1),
         };
         let render_params = RenderParams {
-            base_color: Color::BLACK,
+            base_color: self.background_color,
             width,
             height,
             antialiasing_method: vello::AaConfig::Area,

--- a/xilem/examples/external_event_loop.rs
+++ b/xilem/examples/external_event_loop.rs
@@ -11,7 +11,7 @@ use masonry::{
     app_driver::AppDriver,
     event_loop_runner::MasonryUserEvent,
     widget::{CrossAxisAlignment, MainAxisAlignment},
-    ArcStr,
+    ArcStr, Color,
 };
 use winit::{
     application::ApplicationHandler,
@@ -142,8 +142,12 @@ fn main() -> Result<(), EventLoopError> {
     let event_loop = EventLoop::with_user_event().build().unwrap();
     let proxy = MasonryProxy::new(event_loop.create_proxy());
     let (widget, driver) = xilem.into_driver(Arc::new(proxy));
-    let masonry_state =
-        masonry::event_loop_runner::MasonryState::new(window_attributes, &event_loop, widget);
+    let masonry_state = masonry::event_loop_runner::MasonryState::new(
+        window_attributes,
+        &event_loop,
+        widget,
+        Color::BLACK,
+    );
 
     let mut app = ExternalApp {
         masonry_state,

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -140,8 +140,9 @@ fn run(event_loop: EventLoopBuilder) {
         active: false,
     };
 
-    let app = Xilem::new(data, app_logic);
-    app.run_windowed(event_loop, "First Example".into())
+    Xilem::new(data, app_logic)
+        .background_color(Color::rgb8(0x20, 0x20, 0x20))
+        .run_windowed(event_loop, "First Example".into())
         .unwrap();
 }
 

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -61,6 +61,7 @@ where
         }
     }
 
+    /// Sets main window background color.
     pub fn background_color(mut self, color: Color) -> Self {
         self.background_color = color;
         self

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -43,6 +43,7 @@ pub struct Xilem<State, Logic> {
     state: State,
     logic: Logic,
     runtime: tokio::runtime::Runtime,
+    background_color: Color,
 }
 
 impl<State, Logic, View> Xilem<State, Logic>
@@ -56,7 +57,13 @@ where
             state,
             logic,
             runtime,
+            background_color: Color::BLACK,
         }
+    }
+
+    pub fn background_color(mut self, color: Color) -> Self {
+        self.background_color = color;
+        self
     }
 
     // TODO: Make windows a specific view
@@ -93,8 +100,9 @@ where
     {
         let event_loop = event_loop.build()?;
         let proxy = event_loop.create_proxy();
+        let bg_color = self.background_color;
         let (root_widget, driver) = self.into_driver(Arc::new(MasonryProxy(proxy)));
-        event_loop_runner::run_with(event_loop, window_attributes, root_widget, driver)
+        event_loop_runner::run_with(event_loop, window_attributes, root_widget, driver, bg_color)
     }
 
     pub fn into_driver(


### PR DESCRIPTION
Adds `Xilem::background_color` builder method and the relevant changes to Masonry. I've also modified `mason` example to demonstrate the usage of the new API. 

[Zulip discussion](https://xi.zulipchat.com/#narrow/stream/354396-xilem/topic/Window.20background.20color)
