### PR TITLE
xilem_web: Support `Fill` for `SvgPathElement` instead of `SvgmPathElement`

### DIFF
--- a/xilem_web/src/interfaces.rs
+++ b/xilem_web/src/interfaces.rs
@@ -2004,9 +2004,6 @@ where
 pub trait SvgmPathElement<State, Action = ()>:
     SvgElement<State, Action, DomNode: AsRef<web_sys::SvgmPathElement>>
 {
-    fn fill(self, brush: impl Into<peniko::Brush>) -> crate::svg::Fill<Self, State, Action> {
-        crate::svg::fill(self, brush)
-    }
 }
 
 // #[cfg(feature = "SvgmPathElement")]
@@ -2021,6 +2018,9 @@ where
 pub trait SvgPathElement<State, Action = ()>:
     SvgGeometryElement<State, Action, DomNode: AsRef<web_sys::SvgPathElement>>
 {
+    fn fill(self, brush: impl Into<peniko::Brush>) -> crate::svg::Fill<Self, State, Action> {
+        crate::svg::fill(self, brush)
+    }
 }
 
 // #[cfg(feature = "SvgPathElement")]


### PR DESCRIPTION
Fixes #446 

I guess I missed the m before the path