### PR TITLE
xilem_web: Remove hardcoded `prevent_default`/`stop_propagation` as the user should decide that behavior

### DIFF
--- a/xilem_web/src/events.rs
+++ b/xilem_web/src/events.rs
@@ -70,9 +70,6 @@ fn create_event_listener<Event: JsCast + crate::Message>(
 ) -> Closure<dyn FnMut(web_sys::Event)> {
     let thunk = ctx.message_thunk();
     let callback = Closure::new(move |event: web_sys::Event| {
-        // TODO make this configurable
-        event.prevent_default();
-        event.stop_propagation();
         let event = event.dyn_into::<Event>().unwrap_throw();
         thunk.push_message(event);
     });


### PR DESCRIPTION
I think we could also create some additional sugar around that, but since the event is given to the user, they can handle that behavior anyway.

Fixes #457