### PR TITLE
xilem: Add async_worker view

### DIFF
--- a/xilem/Cargo.toml
+++ b/xilem/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { version = "1.39.1", features = ["rt", "rt-multi-thread", "time"] }
 
 [dev-dependencies]
 accesskit_winit.workspace = true
+tokio = { version = "1.39.1", features = ["sync"] }
 
 [target.'cfg(target_os = "android")'.dev-dependencies]
 winit = { features = ["android-native-activity"], workspace = true }

--- a/xilem/examples/data_thread.rs
+++ b/xilem/examples/data_thread.rs
@@ -1,0 +1,92 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{thread, time};
+
+use xilem::{
+    core::{fork, MessageProxy},
+    tokio::sync::mpsc,
+    view::{async_worker, label},
+    EventLoop, WidgetView, Xilem,
+};
+
+// TODO: Figure out type parameter F for returned AsyncWorker.
+//
+// use xilem::{core::Message, view::AsyncWorker};
+//
+// fn async_receiver<Handler, Msg, State, Action, Ftr>(
+//     receiver: Option<mpsc::Receiver<Msg>>,
+//     on_event: Handler,
+// ) -> AsyncWorker<_, Handler, Msg>
+// where
+//     Msg: Message + 'static,
+//     Handler: Fn(&mut State, Msg) -> Action + 'static,
+// {
+//     async_worker(
+//         move |proxy: MessageProxy<Msg>| async move {
+//             match receiver {
+//                 Some(mut rx) => {
+//                     while let Some(msg) = rx.recv().await {
+//                         if proxy.message(msg).is_err() {
+//                             break;
+//                         }
+//                     }
+//                 }
+//                 None => unreachable!(),
+//             }
+//         },
+//         on_event,
+//     )
+// }
+
+struct AppData {
+    receiver: Option<mpsc::Receiver<i32>>,
+    number: i32,
+}
+
+fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> {
+    let rx = data.receiver.take();
+    fork(
+        label(format!("Number: {}", &data.number)),
+        // TODO: Finish async_receiver implementation above,
+        // and use it here instead of async_worker.
+        //
+        // async_receiver(rx, |data: &mut AppData, msg: i32| {
+        //     data.number = msg;
+        // })
+        async_worker(
+            move |proxy: MessageProxy<i32>| async move {
+                if let Some(mut rx) = rx {
+                    while let Some(msg) = rx.recv().await {
+                        if proxy.message(msg).is_err() {
+                            break;
+                        }
+                    }
+                }
+            },
+            |data: &mut AppData, msg: i32| {
+                data.number = msg;
+            },
+        ),
+    )
+}
+
+fn data_thread(sender: mpsc::Sender<i32>) {
+    let mut number = 0;
+    while let Ok(()) = sender.blocking_send(number) {
+        number += 1;
+        thread::sleep(time::Duration::from_secs(1));
+    }
+}
+
+fn main() {
+    let (tx, rx) = mpsc::channel(1);
+    let data = AppData {
+        number: 0,
+        receiver: Some(rx),
+    };
+    thread::spawn(move || data_thread(tx));
+    Xilem::new(data, app_logic)
+        .run_windowed(EventLoop::with_user_event(), "Data Thread".into())
+        .unwrap();
+}

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use xilem::{
     tokio::time,
     view::{
-        async_repeat, button, button_any_pointer, checkbox, flex, label, prose, textbox, Axis,
+        async_worker, button, button_any_pointer, checkbox, flex, label, prose, textbox, Axis,
         FlexExt as _, FlexSpacer,
     },
     Color, EventLoop, EventLoopBuilder, TextAlignment, WidgetView, Xilem,
@@ -92,7 +92,7 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> {
             button("Reset", |data: &mut AppData| data.count = 0),
             flex((fizz_buzz_flex_sequence, flex_sequence)).direction(axis),
         )),
-        async_repeat(
+        async_worker(
             |proxy| async move {
                 let mut interval = time::interval(Duration::from_secs(1));
                 loop {

--- a/xilem/src/view/async_worker.rs
+++ b/xilem/src/view/async_worker.rs
@@ -1,0 +1,92 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{future::Future, marker::PhantomData, sync::Mutex};
+
+use tokio::task::JoinHandle;
+use xilem_core::{DynMessage, Message, MessageProxy, NoElement, View, ViewPathTracker};
+
+use crate::ViewCtx;
+
+/// Launches a task which will run until the view is no longer in the tree,
+/// and allows to update app state in reaction to the events from that task.
+///
+/// `task` is given a [`MessageProxy`], and returns a future which will be
+/// spawned when the view is built.
+/// This `MessageProxy` can be used to send a message to `on_event`, which
+/// can then update the app's state.
+///
+/// Note that this task will not be updated if the view is rebuilt.
+pub fn async_worker<M, F, H, State, Action, Fut>(task: F, on_event: H) -> AsyncWorker<F, H, M>
+where
+    F: FnOnce(MessageProxy<M>) -> Fut,
+    Fut: Future<Output = ()> + Send + 'static,
+    H: Fn(&mut State, M) -> Action + 'static,
+    M: Message + 'static,
+{
+    AsyncWorker {
+        task: Mutex::new(Some(task)),
+        on_event,
+        message: PhantomData,
+    }
+}
+
+pub struct AsyncWorker<F, H, M> {
+    task: Mutex<Option<F>>,
+    on_event: H,
+    message: PhantomData<fn() -> M>,
+}
+
+impl<State, Action, F, H, M, Fut> View<State, Action, ViewCtx> for AsyncWorker<F, H, M>
+where
+    F: FnOnce(MessageProxy<M>) -> Fut + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+    H: Fn(&mut State, M) -> Action + 'static,
+    M: Message + 'static,
+{
+    type Element = NoElement;
+
+    type ViewState = Option<JoinHandle<()>>;
+
+    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+        let handle = self.task.lock().unwrap().take().map(|task| {
+            let proxy = MessageProxy::new(ctx.proxy.clone(), ctx.view_path().into());
+            ctx.runtime().spawn((task)(proxy))
+        });
+        (NoElement, handle)
+    }
+
+    fn rebuild<'el>(
+        &self,
+        _: &Self,
+        _: &mut Self::ViewState,
+        _: &mut ViewCtx,
+        (): xilem_core::Mut<'el, Self::Element>,
+    ) -> xilem_core::Mut<'el, Self::Element> {
+        // Nothing to do
+    }
+
+    fn teardown(
+        &self,
+        join_handle: &mut Self::ViewState,
+        _: &mut ViewCtx,
+        _: xilem_core::Mut<'_, Self::Element>,
+    ) {
+        join_handle.as_ref().map(JoinHandle::abort);
+    }
+
+    fn message(
+        &self,
+        _: &mut Self::ViewState,
+        id_path: &[xilem_core::ViewId],
+        message: DynMessage,
+        app_state: &mut State,
+    ) -> xilem_core::MessageResult<Action> {
+        debug_assert!(
+            id_path.is_empty(),
+            "id path should be empty in AsyncRepeat::message"
+        );
+        let message = message.downcast::<M>().unwrap();
+        xilem_core::MessageResult::Action((self.on_event)(app_state, *message))
+    }
+}

--- a/xilem/src/view/mod.rs
+++ b/xilem/src/view/mod.rs
@@ -4,6 +4,9 @@
 mod async_repeat;
 pub use async_repeat::*;
 
+mod async_worker;
+pub use async_worker::*;
+
 mod button;
 pub use button::*;
 


### PR DESCRIPTION
In this PR I'm trying to explore an alternative `async_repeat` implementation, which accepts `FnOnce` closure and hence allows more use-cases. I called it `async_worker` as a more general-purpose component.

It does require interior mutability currently, but only to workaround the immutable `&self` reference in `View::build`. (Btw, I'm sure there are many implications I haven't considered, but would it be a terrible idea to have `&mut self` in `View::build`?) Anyway, the interior mutability seems not too inappropriate here, because the framework calls `View::build` or `View::rebuild` once per lifetime of the view, but this isn't expressed in the type system.

The TL;DR on the implementation is that it stores the task closure as an interior-mutable `Option<FnOnce>` so it just `take`-s it out of the option in `View::build` before calling. 

I think it should also be a suitable base to build wrappers on top, such as [this `async_receiver`](https://github.com/linebender/xilem/pull/463/files#diff-d98aa1b6f994304a53f2404b78455da6463792748856bcdb9800dc009b370525R15-R40) view, but I couldn't figure out the type parameters yet. UPD: Not sure if it's actually possible, help wanted :pray:.

See also [this](https://xi.zulipchat.com/#narrow/stream/354396-xilem/topic/How.20to.20do.20frequent.20data.20updates.20from.20another.20thread.3F) Zulip thread, the PR is introduced in [this](https://xi.zulipchat.com/#narrow/stream/354396-xilem/topic/How.20to.20do.20frequent.20data.20updates.20from.20another.20thread.3F/near/454681976) message.

