### PR TITLE
Rename mentions of Zulip Stream to Channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ This repo contains an experimental architecture, implemented with a toy UI. At a
 
 [![Xi Zulip](https://img.shields.io/badge/Xi%20Zulip-%23xilem-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/354396-xilem)
 
-Discussion of Xilem development happens in the [Xi Zulip](https://xi.zulipchat.com/), specifically the [#xilem stream](https://xi.zulipchat.com/#narrow/stream/354396-xilem). All public content can be read without logging in
+Discussion of Xilem development happens in the [Xi Zulip](https://xi.zulipchat.com/), specifically the [#xilem channel](https://xi.zulipchat.com/#narrow/stream/354396-xilem). 
+All public content can be read without logging in
 
 ## Project structure
 

--- a/masonry/README.md
+++ b/masonry/README.md
@@ -118,7 +118,7 @@ cargo update -p package_name --precise 0.1.1
 
 ## Community
 
-Discussion of Masonry development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#masonry stream](https://xi.zulipchat.com/#narrow/stream/317477-masonry).
+Discussion of Masonry development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#masonry channel](https://xi.zulipchat.com/#narrow/stream/317477-masonry).
 All public content can be read without logging in.
 
 Contributions are welcome by pull request. The [Rust code of conduct] applies.

--- a/xilem/README.md
+++ b/xilem/README.md
@@ -53,7 +53,7 @@ cargo update -p package_name --precise 0.1.1
 
 ## Community
 
-Discussion of Xilem development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#xilem stream](https://xi.zulipchat.com/#narrow/stream/354396-xilem).
+Discussion of Xilem development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#xilem channel](https://xi.zulipchat.com/#narrow/stream/354396-xilem).
 All public content can be read without logging in.
 
 Contributions are welcome by pull request. The [Rust code of conduct] applies.

--- a/xilem_core/README.md
+++ b/xilem_core/README.md
@@ -70,8 +70,7 @@ cargo update -p package_name --precise 0.1.1
 
 ## Community
 
-Discussion of Xilem Core development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically in
-[#xilem](https://xi.zulipchat.com/#narrow/stream/354396-xilem).
+Discussion of Xilem Core development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#xilem channel](https://xi.zulipchat.com/#narrow/stream/354396-xilem).
 All public content can be read without logging in.
 
 Contributions are welcome by pull request. The [Rust code of conduct][] applies.


### PR DESCRIPTION
See https://blog.zulip.com/2024/07/25/zulip-9-0-released/#streams-renamed-to-channels