### PR TITLE
xilem_web: Add HtmlLiElement `value` attribute setter

### DIFF
--- a/xilem_web/src/interfaces.rs
+++ b/xilem_web/src/interfaces.rs
@@ -720,6 +720,10 @@ where
 pub trait HtmlLiElement<State, Action = ()>:
     HtmlElement<State, Action, DomNode: AsRef<web_sys::HtmlLiElement>>
 {
+    /// See <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li#value> for more details
+    fn value(self, value: i32) -> Attr<Self, State, Action> {
+        Attr::new(self, "value".into(), value.into_attr_value())
+    }
 }
 
 // #[cfg(feature = "HtmlLiElement")]


### PR DESCRIPTION
From manually testing in Chrome, values between `2**31` and `2**31 - 1` work, so this takes an `i32`.

It's pretty trivial code, but I think it would be really nice to add some kind of test, or even just an example which uses it.

What do you think about adding a "misc" example for `xilem_web`, which exercises a bunch of small features? I was thinking a layout with a column on the left with a list of items with a larger area on the right.  When an item on the left is clicked, the right side is populated with whatever that item is.

In this case, the item name would be `ol-li-value`, which when clicked would show something like this on the right:

```rust
ol((
  li("foo"),
  li("bar"),
  li("baz").value(10),
  li("qux"),
));
```

Ideally, this would be compiled as part of CI, to make sure that no compilation errors are introduced. Any time a small feature is added, a new item in the "misc" example could be added which uses it.

It would also be nice for development, to have a place where new, small features like this can be exercised during development. An actual test would be great, but from quick googling, I couldn't find an obvious way to test WASM code which runs in the browser. There's `wasm_bindgen_test`, but that only runs tests in WASM outside of a browser environment.