### PR TITLE
Use `ViewMarker` trait instead of the generic `Marker` to allow `impl ViewSequence` as return type

### DIFF
--- a/xilem/examples/calc.rs
+++ b/xilem/examples/calc.rs
@@ -5,7 +5,7 @@ use masonry::widget::{CrossAxisAlignment, MainAxisAlignment};
 use winit::dpi::LogicalSize;
 use winit::error::EventLoopError;
 use winit::window::Window;
-use xilem::view::Flex;
+use xilem::view::{Flex, FlexSequence};
 use xilem::EventLoopBuilder;
 use xilem::{
     view::{button, flex, label, sized_box, Axis, FlexExt as _, FlexSpacer},
@@ -254,7 +254,7 @@ fn app_logic(data: &mut Calculator) -> impl WidgetView<Calculator> {
 }
 
 /// Creates a horizontal centered flex row designed for the display portion of the calculator.
-pub fn centered_flex_row<Seq>(sequence: Seq) -> Flex<Seq> {
+pub fn centered_flex_row<State, Seq: FlexSequence<State>>(sequence: Seq) -> Flex<Seq, State> {
     flex(sequence)
         .direction(Axis::Horizontal)
         .cross_axis_alignment(CrossAxisAlignment::Center)
@@ -263,7 +263,7 @@ pub fn centered_flex_row<Seq>(sequence: Seq) -> Flex<Seq> {
 }
 
 /// Creates a horizontal filled flex row designed to be used in a grid.
-pub fn flex_row<Seq>(sequence: Seq) -> Flex<Seq> {
+pub fn flex_row<State, Seq: FlexSequence<State>>(sequence: Seq) -> Flex<Seq, State> {
     flex(sequence)
         .direction(Axis::Horizontal)
         .cross_axis_alignment(CrossAxisAlignment::Fill)

--- a/xilem/examples/calc.rs
+++ b/xilem/examples/calc.rs
@@ -253,7 +253,7 @@ fn app_logic(data: &mut Calculator) -> impl WidgetView<Calculator> {
 }
 
 /// Creates a horizontal centered flex row designed for the display portion of the calculator.
-pub fn centered_flex_row<Seq, Marker>(sequence: Seq) -> Flex<Seq, Marker> {
+pub fn centered_flex_row<Seq>(sequence: Seq) -> Flex<Seq> {
     flex(sequence)
         .direction(Axis::Horizontal)
         .cross_axis_alignment(CrossAxisAlignment::Center)
@@ -262,7 +262,7 @@ pub fn centered_flex_row<Seq, Marker>(sequence: Seq) -> Flex<Seq, Marker> {
 }
 
 /// Creates a horizontal filled flex row designed to be used in a grid.
-pub fn flex_row<Seq, Marker>(sequence: Seq) -> Flex<Seq, Marker> {
+pub fn flex_row<Seq>(sequence: Seq) -> Flex<Seq> {
     flex(sequence)
         .direction(Axis::Horizontal)
         .cross_axis_alignment(CrossAxisAlignment::Fill)

--- a/xilem/examples/elm.rs
+++ b/xilem/examples/elm.rs
@@ -26,7 +26,7 @@ enum CountMessage {
 
 // `map_action()` is basically how elm works, i.e. provide a message that the parent view has to handle to update the state.
 // In this case the parent adjusts the count that is given to this view according to the message
-fn elm_counter<T>(count: i32) -> impl WidgetView<T, CountMessage> {
+fn elm_counter<T: 'static>(count: i32) -> impl WidgetView<T, CountMessage> {
     flex((
         label(format!("elm count: {count}")),
         button("+", |_| CountMessage::Increment),

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -109,16 +109,18 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> {
 
 fn toggleable(data: &mut AppData) -> impl WidgetView<AppData> {
     if data.active {
-        flex((
-            button("Deactivate", |data: &mut AppData| {
-                data.active = false;
-            }),
-            button("Unlimited Power", |data: &mut AppData| {
-                data.count = -1_000_000;
-            }),
+        fork(
+            flex((
+                button("Deactivate", |data: &mut AppData| {
+                    data.active = false;
+                }),
+                button("Unlimited Power", |data: &mut AppData| {
+                    data.count = -1_000_000;
+                }),
+            ))
+            .direction(Axis::Horizontal),
             run_once(|| tracing::warn!("The pathway to unlimited power has been revealed")),
-        ))
-        .direction(Axis::Horizontal)
+        )
         .boxed()
     } else {
         button("Activate", |data: &mut AppData| data.active = true).boxed()

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -19,6 +19,7 @@ use winit::{
 };
 use xilem_core::{
     AsyncCtx, MessageResult, RawProxy, SuperElement, View, ViewElement, ViewId, ViewPathTracker,
+    ViewSequence,
 };
 
 pub use masonry::{
@@ -207,6 +208,30 @@ where
     W: Widget,
 {
     type Widget = W;
+}
+
+/// An ordered sequence of widget views, it's used for `0..N` views.
+/// See [`ViewSequence`] for more technical details.
+///
+/// # Examples
+///
+/// ```
+/// use xilem::{view::prose, WidgetViewSequence};
+///
+/// fn prose_sequence<State: 'static>(
+///     texts: impl Iterator<Item = &'static str>,
+/// ) -> impl WidgetViewSequence<State> {
+///     texts.map(prose).collect::<Vec<_>>()
+/// }
+/// ```
+pub trait WidgetViewSequence<State, Action = ()>:
+    ViewSequence<State, Action, ViewCtx, Pod<any_view::DynWidget>>
+{
+}
+
+impl<Seq, State, Action> WidgetViewSequence<State, Action> for Seq where
+    Seq: ViewSequence<State, Action, ViewCtx, Pod<any_view::DynWidget>>
+{
 }
 
 type WidgetMap = HashMap<WidgetId, Vec<ViewId>>;

--- a/xilem/src/view/async_repeat.rs
+++ b/xilem/src/view/async_repeat.rs
@@ -4,7 +4,9 @@
 use std::{future::Future, marker::PhantomData, sync::Arc};
 
 use tokio::task::JoinHandle;
-use xilem_core::{DynMessage, Message, MessageProxy, NoElement, View, ViewId, ViewPathTracker};
+use xilem_core::{
+    DynMessage, Message, MessageProxy, NoElement, View, ViewId, ViewMarker, ViewPathTracker,
+};
 
 use crate::ViewCtx;
 
@@ -70,6 +72,7 @@ pub struct AsyncRepeat<F, H, M> {
     message: PhantomData<fn() -> M>,
 }
 
+impl<F, H, M> ViewMarker for AsyncRepeat<F, H, M> {}
 impl<State, Action, F, H, M, Fut> View<State, Action, ViewCtx> for AsyncRepeat<F, H, M>
 where
     F: Fn(MessageProxy<M>) -> Fut + 'static,

--- a/xilem/src/view/button.rs
+++ b/xilem/src/view/button.rs
@@ -3,7 +3,7 @@
 
 use crate::{core::View, Pod};
 use masonry::{widget, ArcStr};
-use xilem_core::Mut;
+use xilem_core::{Mut, ViewMarker};
 
 pub use masonry::PointerButton;
 
@@ -41,6 +41,7 @@ pub struct Button<F> {
     callback: F,
 }
 
+impl<F> ViewMarker for Button<F> {}
 impl<F, State, Action> View<State, Action, ViewCtx> for Button<F>
 where
     F: Fn(&mut State, PointerButton) -> MessageResult<Action> + Send + Sync + 'static,

--- a/xilem/src/view/checkbox.rs
+++ b/xilem/src/view/checkbox.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use masonry::{widget, ArcStr};
-use xilem_core::Mut;
+use xilem_core::{Mut, ViewMarker};
 
 use crate::{MessageResult, Pod, View, ViewCtx, ViewId};
 
@@ -27,6 +27,7 @@ pub struct Checkbox<F> {
     callback: F,
 }
 
+impl<F> ViewMarker for Checkbox<F> {}
 impl<F, State, Action> View<State, Action, ViewCtx> for Checkbox<F>
 where
     F: Fn(&mut State, bool) -> Action + Send + Sync + 'static,

--- a/xilem/src/view/flex.rs
+++ b/xilem/src/view/flex.rs
@@ -16,9 +16,8 @@ use crate::{AnyWidgetView, Pod, ViewCtx, WidgetView};
 
 pub use masonry::widget::{Axis, CrossAxisAlignment, FlexParams, MainAxisAlignment};
 
-pub fn flex<Seq, Marker>(sequence: Seq) -> Flex<Seq, Marker> {
+pub fn flex<Seq>(sequence: Seq) -> Flex<Seq> {
     Flex {
-        phantom: PhantomData,
         sequence,
         axis: Axis::Vertical,
         cross_axis_alignment: CrossAxisAlignment::Center,
@@ -28,17 +27,16 @@ pub fn flex<Seq, Marker>(sequence: Seq) -> Flex<Seq, Marker> {
     }
 }
 
-pub struct Flex<Seq, Marker> {
+pub struct Flex<Seq> {
     sequence: Seq,
     axis: Axis,
     cross_axis_alignment: CrossAxisAlignment,
     main_axis_alignment: MainAxisAlignment,
     fill_major_axis: bool,
-    phantom: PhantomData<fn() -> Marker>,
     gap: Option<f64>,
 }
 
-impl<Seq, Marker> Flex<Seq, Marker> {
+impl<Seq> Flex<Seq> {
     pub fn direction(mut self, axis: Axis) -> Self {
         self.axis = axis;
         self
@@ -84,10 +82,10 @@ impl<Seq, Marker> Flex<Seq, Marker> {
         self
     }
 }
-impl<Seq, Marker> ViewMarker for Flex<Seq, Marker> {}
-impl<State, Action, Seq, Marker: 'static> View<State, Action, ViewCtx> for Flex<Seq, Marker>
+impl<Seq> ViewMarker for Flex<Seq> {}
+impl<State, Action, Seq> View<State, Action, ViewCtx> for Flex<Seq>
 where
-    Seq: ViewSequence<State, Action, ViewCtx, FlexElement, Marker>,
+    Seq: ViewSequence<State, Action, ViewCtx, FlexElement>,
 {
     type Element = Pod<widget::Flex>;
 

--- a/xilem/src/view/flex.rs
+++ b/xilem/src/view/flex.rs
@@ -9,7 +9,7 @@ use masonry::{
 };
 use xilem_core::{
     AppendVec, DynMessage, ElementSplice, MessageResult, Mut, SuperElement, View, ViewElement,
-    ViewId, ViewPathTracker, ViewSequence,
+    ViewId, ViewMarker, ViewPathTracker, ViewSequence,
 };
 
 use crate::{AnyWidgetView, Pod, ViewCtx, WidgetView};
@@ -84,7 +84,7 @@ impl<Seq, Marker> Flex<Seq, Marker> {
         self
     }
 }
-
+impl<Seq, Marker> ViewMarker for Flex<Seq, Marker> {}
 impl<State, Action, Seq, Marker: 'static> View<State, Action, ViewCtx> for Flex<Seq, Marker>
 where
     Seq: ViewSequence<State, Action, ViewCtx, FlexElement, Marker>,
@@ -407,6 +407,7 @@ where
     }
 }
 
+impl<V, State, Action> ViewMarker for FlexItem<V, State, Action> {}
 impl<State, Action, V> View<State, Action, ViewCtx> for FlexItem<V, State, Action>
 where
     State: 'static,
@@ -485,6 +486,7 @@ impl<State, Action> From<FlexSpacer> for AnyFlexChild<State, Action> {
     }
 }
 
+impl ViewMarker for FlexSpacer {}
 // This impl doesn't require a view id, as it neither receives, nor sends any messages
 // If this should ever change, it's necessary to adjust the `AnyFlexChild` `View` impl
 impl<State, Action> View<State, Action, ViewCtx> for FlexSpacer {
@@ -593,6 +595,7 @@ pub struct AnyFlexChildState<State: 'static, Action: 'static> {
     generation: u64,
 }
 
+impl<State, Action> ViewMarker for AnyFlexChild<State, Action> {}
 impl<State, Action> View<State, Action, ViewCtx> for AnyFlexChild<State, Action>
 where
     State: 'static,

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use masonry::{text::TextBrush, widget, ArcStr};
-use xilem_core::Mut;
+use xilem_core::{Mut, ViewMarker};
 
 use crate::{Color, MessageResult, Pod, TextAlignment, View, ViewCtx, ViewId};
 
@@ -43,6 +43,7 @@ impl Label {
     }
 }
 
+impl ViewMarker for Label {}
 impl<State, Action> View<State, Action, ViewCtx> for Label {
     type Element = Pod<widget::Label>;
     type ViewState = ();

--- a/xilem/src/view/prose.rs
+++ b/xilem/src/view/prose.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use masonry::{text::TextBrush, widget, ArcStr};
-use xilem_core::Mut;
+use xilem_core::{Mut, ViewMarker};
 
 use crate::{Color, MessageResult, Pod, TextAlignment, View, ViewCtx, ViewId};
 
@@ -44,6 +44,7 @@ impl Prose {
     }
 }
 
+impl ViewMarker for Prose {}
 impl<State, Action> View<State, Action, ViewCtx> for Prose {
     type Element = Pod<widget::Prose>;
     type ViewState = ();

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use masonry::widget;
+use xilem_core::ViewMarker;
 
 use crate::{
     core::{Mut, View, ViewId},
@@ -74,6 +75,7 @@ impl<V> SizedBox<V> {
     }
 }
 
+impl<V> ViewMarker for SizedBox<V> {}
 impl<V, State, Action> View<State, Action, ViewCtx> for SizedBox<V>
 where
     V: WidgetView<State, Action>,

--- a/xilem/src/view/textbox.rs
+++ b/xilem/src/view/textbox.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use masonry::{text::TextBrush, widget};
-use xilem_core::{Mut, View};
+use xilem_core::{Mut, View, ViewMarker};
 
 use crate::{Color, MessageResult, Pod, TextAlignment, ViewCtx, ViewId};
 
@@ -63,6 +63,7 @@ impl<State, Action> Textbox<State, Action> {
     }
 }
 
+impl<State, Action> ViewMarker for Textbox<State, Action> {}
 impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<State, Action> {
     type Element = Pod<widget::Textbox>;
     type ViewState = ();

--- a/xilem_core/examples/filesystem.rs
+++ b/xilem_core/examples/filesystem.rs
@@ -4,7 +4,7 @@
 use std::{io::stdin, path::PathBuf};
 
 use xilem_core::{
-    AnyElement, AnyView, Mut, SuperElement, View, ViewElement, ViewId, ViewPathTracker,
+    AnyElement, AnyView, Mut, SuperElement, View, ViewElement, ViewId, ViewMarker, ViewPathTracker,
 };
 
 #[derive(Debug)]
@@ -145,6 +145,7 @@ impl ViewElement for FsPath {
     type Mut<'a> = &'a mut PathBuf;
 }
 
+impl ViewMarker for File {}
 impl<State, Action> View<State, Action, ViewCtx> for File {
     type Element = FsPath;
     type ViewState = ();

--- a/xilem_core/examples/user_interface.rs
+++ b/xilem_core/examples/user_interface.rs
@@ -6,7 +6,8 @@
 use core::any::Any;
 
 use xilem_core::{
-    DynMessage, MessageResult, Mut, SuperElement, View, ViewElement, ViewId, ViewPathTracker,
+    DynMessage, MessageResult, Mut, SuperElement, View, ViewElement, ViewId, ViewMarker,
+    ViewPathTracker,
 };
 
 pub fn app_logic(_: &mut u32) -> impl WidgetView<u32> {
@@ -44,6 +45,7 @@ impl<W: Widget> ViewElement for WidgetPod<W> {
     type Mut<'a> = WidgetMut<'a, W>;
 }
 
+impl ViewMarker for Button {}
 impl<State, Action> View<State, Action, ViewCtx> for Button {
     type Element = WidgetPod<ButtonWidget>;
     type ViewState = ();

--- a/xilem_core/src/any_view.rs
+++ b/xilem_core/src/any_view.rs
@@ -8,7 +8,8 @@ use core::any::Any;
 use alloc::boxed::Box;
 
 use crate::{
-    AnyElement, DynMessage, MessageResult, Mut, View, ViewElement, ViewId, ViewPathTracker,
+    AnyElement, DynMessage, MessageResult, Mut, View, ViewElement, ViewId, ViewMarker,
+    ViewPathTracker,
 };
 
 /// A view which can have any view type where the [`View::Element`] is compatible with
@@ -171,6 +172,10 @@ pub struct AnyViewState {
     generation: u64,
 }
 
+impl<State, Action, Context, Element, Message> ViewMarker
+    for dyn AnyView<State, Action, Context, Element, Message>
+{
+}
 impl<State, Action, Context, Element, Message> View<State, Action, Context, Message>
     for dyn AnyView<State, Action, Context, Element, Message>
 where
@@ -220,6 +225,11 @@ where
 }
 
 // TODO: IWBN if we could avoid this
+
+impl<State, Action, Context, Element, Message> ViewMarker
+    for dyn AnyView<State, Action, Context, Element, Message> + Send
+{
+}
 impl<State, Action, Context, Element, Message> View<State, Action, Context, Message>
     for dyn AnyView<State, Action, Context, Element, Message> + Send
 where
@@ -268,6 +278,10 @@ where
     }
 }
 
+impl<State, Action, Context, Element, Message> ViewMarker
+    for dyn AnyView<State, Action, Context, Element, Message> + Send + Sync
+{
+}
 impl<State, Action, Context, Element, Message> View<State, Action, Context, Message>
     for dyn AnyView<State, Action, Context, Element, Message> + Send + Sync
 where
@@ -316,6 +330,10 @@ where
     }
 }
 
+impl<State, Action, Context, Element, Message> ViewMarker
+    for dyn AnyView<State, Action, Context, Element, Message> + Sync
+{
+}
 impl<State, Action, Context, Element, Message> View<State, Action, Context, Message>
     for dyn AnyView<State, Action, Context, Element, Message> + Sync
 where

--- a/xilem_core/src/element.rs
+++ b/xilem_core/src/element.rs
@@ -94,3 +94,16 @@ pub struct NoElement;
 impl ViewElement for NoElement {
     type Mut<'a> = ();
 }
+
+impl SuperElement<NoElement> for NoElement {
+    fn upcast(child: NoElement) -> Self {
+        child
+    }
+
+    fn with_downcast_val<R>(
+        this: Mut<'_, Self>,
+        f: impl FnOnce(Mut<'_, NoElement>) -> R,
+    ) -> (Self::Mut<'_>, R) {
+        ((), f(this))
+    }
+}

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -29,7 +29,7 @@ mod deferred;
 pub use deferred::{AsyncCtx, MessageProxy, PhantomView, ProxyError, RawProxy};
 
 mod view;
-pub use view::{View, ViewId, ViewPathTracker};
+pub use view::{View, ViewId, ViewMarker, ViewPathTracker};
 
 mod views;
 pub use views::{

--- a/xilem_core/src/sequence.rs
+++ b/xilem_core/src/sequence.rs
@@ -9,8 +9,10 @@ use core::sync::atomic::Ordering;
 use alloc::vec::Drain;
 use alloc::vec::Vec;
 
-use crate::element::NoElement;
-use crate::{DynMessage, MessageResult, SuperElement, View, ViewElement, ViewId, ViewPathTracker};
+// use crate::element::NoElement;
+use crate::{
+    DynMessage, MessageResult, SuperElement, View, ViewElement, ViewId, ViewMarker, ViewPathTracker,
+};
 
 /// An append only `Vec`.
 ///
@@ -77,8 +79,7 @@ impl<T> Default for AppendVec<T> {
 ///  - Tuples of `ViewSequences` with up to 15 elements.
 ///    These can be nested if an ad-hoc sequence of more than 15 sequences is needed.
 ///
-pub trait ViewSequence<State, Action, Context, Element, Marker, Message = DynMessage>:
-    'static
+pub trait ViewSequence<State, Action, Context, Element, Message = DynMessage>: 'static
 where
     Context: ViewPathTracker,
     Element: ViewElement,
@@ -143,15 +144,11 @@ pub trait ElementSplice<Element: ViewElement> {
     fn delete<R>(&mut self, f: impl FnOnce(Element::Mut<'_>) -> R) -> R;
 }
 
-/// Marker type to workaround trait ambiguity.
-#[doc(hidden)]
-pub struct WasAView;
-
 impl<State, Action, Context, V, Element, Message>
-    ViewSequence<State, Action, Context, Element, WasAView, Message> for V
+    ViewSequence<State, Action, Context, Element, Message> for V
 where
     Context: ViewPathTracker,
-    V: View<State, Action, Context, Message>,
+    V: View<State, Action, Context, Message> + ViewMarker,
     Element: SuperElement<V::Element>,
     V::Element: ViewElement,
 {
@@ -218,10 +215,10 @@ pub struct OptionSeqState<InnerState> {
 ///
 /// Will mark messages which were sent to a `Some` value if a `None` has since
 /// occurred as stale.
-impl<State, Action, Context, Element, Marker, Seq, Message>
-    ViewSequence<State, Action, Context, Element, Option<Marker>, Message> for Option<Seq>
+impl<State, Action, Context, Element, Seq, Message>
+    ViewSequence<State, Action, Context, Element, Message> for Option<Seq>
 where
-    Seq: ViewSequence<State, Action, Context, Element, Marker, Message>,
+    Seq: ViewSequence<State, Action, Context, Element, Message>,
     Context: ViewPathTracker,
     Element: ViewElement,
 {
@@ -340,54 +337,54 @@ where
 
 /// A `View` with [no element](crate::NoElement) can be added to any ViewSequence, because it does not use any
 /// properties of the Element type.
-impl<State, Action, Context, Element, NoElementView, Message>
-    ViewSequence<State, Action, Context, Element, NoElement, Message> for NoElementView
-where
-    NoElementView: View<State, Action, Context, Message, Element = NoElement>,
-    Element: ViewElement,
-    Context: ViewPathTracker,
-{
-    #[doc(hidden)]
-    type SeqState = NoElementView::ViewState;
+// impl<State, Action, Context, Element, NoElementView, Message>
+//     ViewSequence<State, Action, Context, Element, Message> for NoElementView
+// where
+//     NoElementView: View<State, Action, Context, Message, Element = NoElement> + NoElementViewMarker,
+//     Element: ViewElement,
+//     Context: ViewPathTracker,
+// {
+//     #[doc(hidden)]
+//     type SeqState = NoElementView::ViewState;
 
-    #[doc(hidden)]
-    fn seq_build(&self, ctx: &mut Context, _: &mut AppendVec<Element>) -> Self::SeqState {
-        let (NoElement, state) = self.build(ctx);
-        state
-    }
+//     #[doc(hidden)]
+//     fn seq_build(&self, ctx: &mut Context, _: &mut AppendVec<Element>) -> Self::SeqState {
+//         let (NoElement, state) = self.build(ctx);
+//         state
+//     }
 
-    #[doc(hidden)]
-    fn seq_rebuild(
-        &self,
-        prev: &Self,
-        seq_state: &mut Self::SeqState,
-        ctx: &mut Context,
-        _: &mut impl ElementSplice<Element>,
-    ) {
-        self.rebuild(prev, seq_state, ctx, ());
-    }
+//     #[doc(hidden)]
+//     fn seq_rebuild(
+//         &self,
+//         prev: &Self,
+//         seq_state: &mut Self::SeqState,
+//         ctx: &mut Context,
+//         _: &mut impl ElementSplice<Element>,
+//     ) {
+//         self.rebuild(prev, seq_state, ctx, ());
+//     }
 
-    #[doc(hidden)]
-    fn seq_teardown(
-        &self,
-        seq_state: &mut Self::SeqState,
-        ctx: &mut Context,
-        _: &mut impl ElementSplice<Element>,
-    ) {
-        self.teardown(seq_state, ctx, ());
-    }
+//     #[doc(hidden)]
+//     fn seq_teardown(
+//         &self,
+//         seq_state: &mut Self::SeqState,
+//         ctx: &mut Context,
+//         _: &mut impl ElementSplice<Element>,
+//     ) {
+//         self.teardown(seq_state, ctx, ());
+//     }
 
-    #[doc(hidden)]
-    fn seq_message(
-        &self,
-        seq_state: &mut Self::SeqState,
-        id_path: &[ViewId],
-        message: Message,
-        app_state: &mut State,
-    ) -> MessageResult<Action, Message> {
-        self.message(seq_state, id_path, message, app_state)
-    }
-}
+//     #[doc(hidden)]
+//     fn seq_message(
+//         &self,
+//         seq_state: &mut Self::SeqState,
+//         id_path: &[ViewId],
+//         message: Message,
+//         app_state: &mut State,
+//     ) -> MessageResult<Action, Message> {
+//         self.message(seq_state, id_path, message, app_state)
+//     }
+// }
 
 /// The state used to implement `ViewSequence` for `Vec<impl ViewSequence>`
 ///
@@ -428,10 +425,10 @@ fn view_id_to_index_generation(view_id: ViewId) -> (usize, u32) {
 ///
 /// Will mark messages which were sent to any index as stale if
 /// that index has been unused in the meantime.
-impl<State, Action, Context, Element, Marker, Seq, Message>
-    ViewSequence<State, Action, Context, Element, Vec<Marker>, Message> for Vec<Seq>
+impl<State, Action, Context, Element, Seq, Message>
+    ViewSequence<State, Action, Context, Element, Message> for Vec<Seq>
 where
-    Seq: ViewSequence<State, Action, Context, Element, Marker, Message>,
+    Seq: ViewSequence<State, Action, Context, Element, Message>,
     Context: ViewPathTracker,
     Element: ViewElement,
 {
@@ -582,10 +579,10 @@ where
     }
 }
 
-impl<State, Action, Context, Element, Marker, Seq, Message, const N: usize>
-    ViewSequence<State, Action, Context, Element, Vec<Marker>, Message> for [Seq; N]
+impl<State, Action, Context, Element, Seq, Message, const N: usize>
+    ViewSequence<State, Action, Context, Element, Message> for [Seq; N]
 where
-    Seq: ViewSequence<State, Action, Context, Element, Marker, Message>,
+    Seq: ViewSequence<State, Action, Context, Element, Message>,
     Context: ViewPathTracker,
     Element: ViewElement,
 {
@@ -661,7 +658,7 @@ where
 }
 
 impl<State, Action, Context, Element, Message>
-    ViewSequence<State, Action, Context, Element, (), Message> for ()
+    ViewSequence<State, Action, Context, Element, Message> for ()
 where
     Context: ViewPathTracker,
     Element: ViewElement,
@@ -699,10 +696,10 @@ where
     }
 }
 
-impl<State, Action, Context, Element, Marker, Seq, Message>
-    ViewSequence<State, Action, Context, Element, (Marker,), Message> for (Seq,)
+impl<State, Action, Context, Element, Seq, Message>
+    ViewSequence<State, Action, Context, Element, Message> for (Seq,)
 where
-    Seq: ViewSequence<State, Action, Context, Element, Marker, Message>,
+    Seq: ViewSequence<State, Action, Context, Element, Message>,
     Context: ViewPathTracker,
     Element: ViewElement,
 {
@@ -753,12 +750,9 @@ macro_rules! impl_view_tuple {
                 Action,
                 Context: ViewPathTracker,
                 Element: ViewElement,
-                $(
-                    $marker,
-                    $seq: ViewSequence<State, Action, Context, Element, $marker, Message>,
-                )+
+                $($seq: ViewSequence<State, Action, Context, Element, Message>,)+
                 Message,
-            > ViewSequence<State, Action, Context, Element, ($($marker,)+), Message> for ($($seq,)+)
+            > ViewSequence<State, Action, Context, Element, Message> for ($($seq,)+)
 
         {
             type SeqState = ($($seq::SeqState,)+);

--- a/xilem_core/src/sequence.rs
+++ b/xilem_core/src/sequence.rs
@@ -76,6 +76,7 @@ impl<T> Default for AppendVec<T> {
 ///    Note that this will have persistent allocation with size proportional
 ///    to the *longest* `Vec` which is ever provided in the View tree, as this
 ///    uses a generational indexing scheme.
+///  - An [`array`] of `ViewSequence` values.
 ///  - Tuples of `ViewSequences` with up to 15 elements.
 ///    These can be nested if an ad-hoc sequence of more than 15 sequences is needed.
 ///
@@ -334,57 +335,6 @@ where
         }
     }
 }
-
-/// A `View` with [no element](crate::NoElement) can be added to any ViewSequence, because it does not use any
-/// properties of the Element type.
-// impl<State, Action, Context, Element, NoElementView, Message>
-//     ViewSequence<State, Action, Context, Element, Message> for NoElementView
-// where
-//     NoElementView: View<State, Action, Context, Message, Element = NoElement> + NoElementViewMarker,
-//     Element: ViewElement,
-//     Context: ViewPathTracker,
-// {
-//     #[doc(hidden)]
-//     type SeqState = NoElementView::ViewState;
-
-//     #[doc(hidden)]
-//     fn seq_build(&self, ctx: &mut Context, _: &mut AppendVec<Element>) -> Self::SeqState {
-//         let (NoElement, state) = self.build(ctx);
-//         state
-//     }
-
-//     #[doc(hidden)]
-//     fn seq_rebuild(
-//         &self,
-//         prev: &Self,
-//         seq_state: &mut Self::SeqState,
-//         ctx: &mut Context,
-//         _: &mut impl ElementSplice<Element>,
-//     ) {
-//         self.rebuild(prev, seq_state, ctx, ());
-//     }
-
-//     #[doc(hidden)]
-//     fn seq_teardown(
-//         &self,
-//         seq_state: &mut Self::SeqState,
-//         ctx: &mut Context,
-//         _: &mut impl ElementSplice<Element>,
-//     ) {
-//         self.teardown(seq_state, ctx, ());
-//     }
-
-//     #[doc(hidden)]
-//     fn seq_message(
-//         &self,
-//         seq_state: &mut Self::SeqState,
-//         id_path: &[ViewId],
-//         message: Message,
-//         app_state: &mut State,
-//     ) -> MessageResult<Action, Message> {
-//         self.message(seq_state, id_path, message, app_state)
-//     }
-// }
 
 /// The state used to implement `ViewSequence` for `Vec<impl ViewSequence>`
 ///

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -9,6 +9,10 @@ use alloc::{boxed::Box, sync::Arc};
 
 use crate::{message::MessageResult, DynMessage, Mut, ViewElement};
 
+// TODO better doc-comment
+/// To avoid ambiguity for `impl ViewSequence for impl View`
+pub trait ViewMarker {}
+
 /// A lightweight, short-lived representation of the state of a retained
 /// structure, usually a user interface node.
 ///
@@ -34,7 +38,9 @@ use crate::{message::MessageResult, DynMessage, Mut, ViewElement};
 ///
 /// In order to support the default open-ended [`DynMessage`] type as `Message`, this trait requires an
 /// allocator to be available.
-pub trait View<State, Action, Context: ViewPathTracker, Message = DynMessage>: 'static {
+pub trait View<State, Action, Context: ViewPathTracker, Message = DynMessage>:
+    ViewMarker + 'static
+{
     /// The element type which this view operates on.
     type Element: ViewElement;
     /// State that is used over the lifetime of the retained representation of the view.
@@ -137,6 +143,7 @@ pub trait ViewPathTracker {
     }
 }
 
+impl<V: ?Sized> ViewMarker for Box<V> {}
 impl<State, Action, Context, Message, V> View<State, Action, Context, Message> for Box<V>
 where
     Context: ViewPathTracker,
@@ -180,6 +187,7 @@ where
     }
 }
 
+impl<V: ?Sized> ViewMarker for Arc<V> {}
 /// An implementation of [`View`] which only runs rebuild if the states are different
 impl<State, Action, Context, Message, V> View<State, Action, Context, Message> for Arc<V>
 where

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -11,7 +11,7 @@ use crate::{message::MessageResult, DynMessage, Mut, ViewElement};
 
 /// A type which can be a [`View`]. Imposes no requirements on the underlying type.
 /// Should be implemented alongside every `View` implementation:
-/// ```rust
+/// ```ignore
 /// impl<...> ViewMarker for Button<...> {}
 /// impl<...> View<...> for Button<...> {...}
 /// ```
@@ -49,7 +49,7 @@ pub trait ViewMarker {}
 /// Due to restrictions of the [orphan rules](https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules),
 /// `ViewMarker` needs to be implemented for every type that implements `View`, see [`ViewMarker`] for more details.
 /// For example:
-/// ```rust
+/// ```ignore
 /// impl<...> ViewMarker for Button<...> {}
 /// impl<...> View<...> for Button<...> {...}
 /// ```

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -9,8 +9,11 @@ use alloc::{boxed::Box, sync::Arc};
 
 use crate::{message::MessageResult, DynMessage, Mut, ViewElement};
 
-/// This trait is a necessary workaround of the orphan rules to be able to have `impl ViewSequence for impl View` to avoid ambiguity.
-/// It needs to be implemented for every type that implements [`View`].
+/// Because [`View`] is generic, Rust [allows you](https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules) to implement this trait for certain non-local types.
+/// These non-local types can include `Vec<_>` and `Option<_>`.
+/// If this trait were not present, those implementations of `View` would conflict with those types' implementations of `ViewSequence`.
+/// This is because every `View` type also implementations `ViewSequence`.
+/// Since `ViewMarker` is not generic, these non-local implementations are not permitted for this trait, which means that the conflicting implementation cannot happen.
 pub trait ViewMarker {}
 
 /// A lightweight, short-lived representation of the state of a retained
@@ -33,6 +36,9 @@ pub trait ViewMarker {}
 /// propagation.
 /// During message handling, mutable access to the app state is given to view nodes,
 /// which will in turn generally expose it to callbacks.
+///
+/// Due to restrictions of the [orphan rules](https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules),
+/// `ViewMarker` needs to be implemented for every type that implements `View`, see [`ViewMarker`] for more details.
 ///
 /// ## Alloc
 ///

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -9,7 +9,16 @@ use alloc::{boxed::Box, sync::Arc};
 
 use crate::{message::MessageResult, DynMessage, Mut, ViewElement};
 
-/// Because [`View`] is generic, Rust [allows you](https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules) to implement this trait for certain non-local types.
+/// A type which can be a [`View`]. Imposes no requirements on the underlying type.
+/// Should be implemented alongside every `View` implementation:
+/// ```rust
+/// impl<...> ViewMarker for Button<...> {}
+/// impl<...> View<...> for Button<...> {}
+/// ```
+///
+/// ## Details
+///
+/// Because `View` is generic, Rust [allows you](https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules) to implement this trait for certain non-local types.
 /// These non-local types can include `Vec<_>` and `Option<_>`.
 /// If this trait were not present, those implementations of `View` would conflict with those types' implementations of `ViewSequence`.
 /// This is because every `View` type also implementations `ViewSequence`.

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -48,6 +48,11 @@ pub trait ViewMarker {}
 ///
 /// Due to restrictions of the [orphan rules](https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules),
 /// `ViewMarker` needs to be implemented for every type that implements `View`, see [`ViewMarker`] for more details.
+/// For example:
+/// ```rust
+/// impl<...> ViewMarker for Button<...> {}
+/// impl<...> View<...> for Button<...> {}
+/// ```
 ///
 /// ## Alloc
 ///

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -9,8 +9,8 @@ use alloc::{boxed::Box, sync::Arc};
 
 use crate::{message::MessageResult, DynMessage, Mut, ViewElement};
 
-// TODO better doc-comment
-/// To avoid ambiguity for `impl ViewSequence for impl View`
+/// This trait is a necessary workaround of the orphan rules to be able to have `impl ViewSequence for impl View` to avoid ambiguity.
+/// It needs to be implemented for every type that implements [`View`].
 pub trait ViewMarker {}
 
 /// A lightweight, short-lived representation of the state of a retained

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -13,7 +13,7 @@ use crate::{message::MessageResult, DynMessage, Mut, ViewElement};
 /// Should be implemented alongside every `View` implementation:
 /// ```rust
 /// impl<...> ViewMarker for Button<...> {}
-/// impl<...> View<...> for Button<...> {}
+/// impl<...> View<...> for Button<...> {...}
 /// ```
 ///
 /// ## Details
@@ -51,7 +51,7 @@ pub trait ViewMarker {}
 /// For example:
 /// ```rust
 /// impl<...> ViewMarker for Button<...> {}
-/// impl<...> View<...> for Button<...> {}
+/// impl<...> View<...> for Button<...> {...}
 /// ```
 ///
 /// ## Alloc

--- a/xilem_core/src/views/adapt.rs
+++ b/xilem_core/src/views/adapt.rs
@@ -3,7 +3,7 @@
 
 use core::marker::PhantomData;
 
-use crate::{MessageResult, Mut, View, ViewId, ViewPathTracker};
+use crate::{MessageResult, Mut, View, ViewId, ViewMarker, ViewPathTracker};
 
 /// A view that wraps a child view and modifies the state that callbacks have access to.
 pub struct Adapt<
@@ -18,9 +18,7 @@ pub struct Adapt<
         &mut ParentState,
         AdaptThunk<ChildState, ChildAction, Context, ChildView, Message>,
     ) -> MessageResult<ParentAction>,
-> where
-    Context: ViewPathTracker,
-{
+> {
     proxy_fn: ProxyFn,
     child: ChildView,
     #[allow(clippy::type_complexity)]
@@ -147,6 +145,10 @@ where
     }
 }
 
+impl<ParentState, ParentAction, ChildState, ChildAction, Context, Message, V, F> ViewMarker
+    for Adapt<ParentState, ParentAction, ChildState, ChildAction, Context, V, Message, F>
+{
+}
 impl<ParentState, ParentAction, ChildState, ChildAction, Context, Message, V, F>
     View<ParentState, ParentAction, Context, Message>
     for Adapt<ParentState, ParentAction, ChildState, ChildAction, Context, V, Message, F>

--- a/xilem_core/src/views/fork.rs
+++ b/xilem_core/src/views/fork.rs
@@ -108,12 +108,8 @@ where
 
 /// A stub `ElementSplice` implementation for `NoElement`.
 ///
-/// We know that none of the methods will be called, because the `ViewSequence`
-/// implementation for `NoElement` views does not use the provided `elements`.
-///
 /// It is technically possible for someone to create an implementation of `ViewSequence`
-/// which uses a `NoElement` `ElementSplice`. But we don't think that sequence could be meaningful,
-/// so we still panic in that case.
+/// which uses a `NoElement` `ElementSplice`. But we don't think that sequence could be meaningful.
 struct NoElements;
 
 impl ElementSplice<NoElement> for NoElements {
@@ -124,21 +120,15 @@ impl ElementSplice<NoElement> for NoElements {
         ret
     }
 
-    fn insert(&mut self, _: NoElement) {
-        unreachable!()
+    fn insert(&mut self, _: NoElement) {}
+
+    fn mutate<R>(&mut self, f: impl FnOnce(<NoElement as crate::ViewElement>::Mut<'_>) -> R) -> R {
+        f(())
     }
 
-    fn mutate<R>(&mut self, _: impl FnOnce(<NoElement as crate::ViewElement>::Mut<'_>) -> R) -> R {
-        unreachable!()
-    }
+    fn skip(&mut self, _: usize) {}
 
-    fn skip(&mut self, n: usize) {
-        if n > 0 {
-            unreachable!()
-        }
-    }
-
-    fn delete<R>(&mut self, _: impl FnOnce(<NoElement as crate::ViewElement>::Mut<'_>) -> R) -> R {
-        unreachable!()
+    fn delete<R>(&mut self, f: impl FnOnce(<NoElement as crate::ViewElement>::Mut<'_>) -> R) -> R {
+        f(())
     }
 }

--- a/xilem_core/src/views/fork.rs
+++ b/xilem_core/src/views/fork.rs
@@ -4,7 +4,8 @@
 use core::marker::PhantomData;
 
 use crate::{
-    AppendVec, ElementSplice, Mut, NoElement, View, ViewId, ViewPathTracker, ViewSequence,
+    AppendVec, ElementSplice, Mut, NoElement, View, ViewId, ViewMarker, ViewPathTracker,
+    ViewSequence,
 };
 
 /// Create a view which acts as `active_view`, whilst also running `alongside_view`, without inserting it into the tree.
@@ -28,6 +29,7 @@ pub struct Fork<Active, Alongside, Marker> {
     marker: PhantomData<Marker>,
 }
 
+impl<Active, Alongside, Marker> ViewMarker for Fork<Active, Alongside, Marker> {}
 impl<State, Action, Context, Active, Alongside, Marker, Message>
     View<State, Action, Context, Message> for Fork<Active, Alongside, Marker>
 where

--- a/xilem_core/src/views/fork.rs
+++ b/xilem_core/src/views/fork.rs
@@ -1,8 +1,6 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use core::marker::PhantomData;
-
 use crate::{
     AppendVec, ElementSplice, Mut, NoElement, View, ViewId, ViewMarker, ViewPathTracker,
     ViewSequence,
@@ -11,32 +9,29 @@ use crate::{
 /// Create a view which acts as `active_view`, whilst also running `alongside_view`, without inserting it into the tree.
 ///
 /// `alongside_view` must be a `ViewSequence` with an element type of [`NoElement`].
-pub fn fork<Active, Alongside, Marker>(
+pub fn fork<Active, Alongside>(
     active_view: Active,
     alongside_view: Alongside,
-) -> Fork<Active, Alongside, Marker> {
+) -> Fork<Active, Alongside> {
     Fork {
         active_view,
         alongside_view,
-        marker: PhantomData,
     }
 }
 
 /// The view for [`fork`].
-pub struct Fork<Active, Alongside, Marker> {
+pub struct Fork<Active, Alongside> {
     active_view: Active,
     alongside_view: Alongside,
-    marker: PhantomData<Marker>,
 }
 
-impl<Active, Alongside, Marker> ViewMarker for Fork<Active, Alongside, Marker> {}
-impl<State, Action, Context, Active, Alongside, Marker, Message>
-    View<State, Action, Context, Message> for Fork<Active, Alongside, Marker>
+impl<Active, Alongside> ViewMarker for Fork<Active, Alongside> {}
+impl<State, Action, Context, Active, Alongside, Message> View<State, Action, Context, Message>
+    for Fork<Active, Alongside>
 where
     Active: View<State, Action, Context, Message>,
-    Alongside: ViewSequence<State, Action, Context, NoElement, Marker, Message>,
+    Alongside: ViewSequence<State, Action, Context, NoElement, Message>,
     Context: ViewPathTracker,
-    Marker: 'static,
 {
     type Element = Active::Element;
 

--- a/xilem_core/src/views/map_action.rs
+++ b/xilem_core/src/views/map_action.rs
@@ -3,7 +3,7 @@
 
 use core::marker::PhantomData;
 
-use crate::{Mut, View, ViewId, ViewPathTracker};
+use crate::{Mut, View, ViewId, ViewMarker, ViewPathTracker};
 
 /// A view that maps a child [`View<State,ChildAction,_>`] to [`View<State,ParentAction,_>`] while providing mutable access to `State` in the map function.
 ///
@@ -68,6 +68,10 @@ where
     }
 }
 
+impl<State, ParentAction, ChildAction, V, F> ViewMarker
+    for MapAction<State, ParentAction, ChildAction, V, F>
+{
+}
 impl<State, ParentAction, ChildAction, Context: ViewPathTracker, Message, V, F>
     View<State, ParentAction, Context, Message>
     for MapAction<State, ParentAction, ChildAction, V, F>

--- a/xilem_core/src/views/map_state.rs
+++ b/xilem_core/src/views/map_state.rs
@@ -3,7 +3,7 @@
 
 use core::marker::PhantomData;
 
-use crate::{MessageResult, Mut, View, ViewId, ViewPathTracker};
+use crate::{MessageResult, Mut, View, ViewId, ViewMarker, ViewPathTracker};
 
 /// A view that "extracts" state from a [`View<ParentState,_,_>`] to [`View<ChildState,_,_>`].
 /// This allows modularization of views based on their state.
@@ -56,6 +56,7 @@ where
     }
 }
 
+impl<ParentState, ChildState, V, F> ViewMarker for MapState<ParentState, ChildState, V, F> {}
 impl<ParentState, ChildState, Action, Context: ViewPathTracker, Message, V, F>
     View<ParentState, Action, Context, Message> for MapState<ParentState, ChildState, V, F>
 where

--- a/xilem_core/src/views/memoize.rs
+++ b/xilem_core/src/views/memoize.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{MessageResult, Mut, View, ViewId, ViewPathTracker};
+use crate::{MessageResult, Mut, View, ViewId, ViewMarker, ViewPathTracker};
 
 /// A view which supports Memoization.
 ///
@@ -46,6 +46,7 @@ It's not possible in Rust currently to check whether the (content of the) callba
     }
 }
 
+impl<Data, ViewFn> ViewMarker for Memoize<Data, ViewFn> {}
 impl<State, Action, Context, Data, V, ViewFn, Message> View<State, Action, Context, Message>
     for Memoize<Data, ViewFn>
 where

--- a/xilem_core/src/views/one_of.rs
+++ b/xilem_core/src/views/one_of.rs
@@ -3,7 +3,7 @@
 
 //! Statically typed alternatives to the type-erased [`AnyView`](`crate::AnyView`).
 
-use crate::{MessageResult, Mut, View, ViewElement, ViewId, ViewPathTracker};
+use crate::{MessageResult, Mut, View, ViewElement, ViewId, ViewMarker, ViewPathTracker};
 use hidden::OneOfState;
 
 /// This trait allows, specifying a type as `ViewElement`, which should never be constructed or used,
@@ -146,6 +146,7 @@ pub trait OneOfCtx<
     );
 }
 
+impl<A, B, C, D, E, F, G, H, I> ViewMarker for OneOf<A, B, C, D, E, F, G, H, I> {}
 /// The `OneOf` types and `Either` are [`View`]s if all of their possible types are themselves `View`s.
 impl<State, Action, Context, Message, A, B, C, D, E, F, G, H, I>
     View<State, Action, Context, Message> for OneOf<A, B, C, D, E, F, G, H, I>
@@ -517,13 +518,14 @@ where
 // to export it. Since this (`one_of`) module is public, we create a new module, allowing it to be pub but not exposed.
 #[doc(hidden)]
 mod hidden {
-    use crate::View;
+    use crate::{View, ViewMarker};
 
     use super::PhantomElementCtx;
 
     #[allow(unreachable_pub)]
     pub enum Never {}
 
+    impl ViewMarker for Never {}
     impl<State, Action, Context: PhantomElementCtx, Message> View<State, Action, Context, Message>
         for Never
     {

--- a/xilem_core/src/views/orphan.rs
+++ b/xilem_core/src/views/orphan.rs
@@ -1,7 +1,9 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{DynMessage, MessageResult, Mut, View, ViewElement, ViewId, ViewPathTracker};
+use crate::{
+    DynMessage, MessageResult, Mut, View, ViewElement, ViewId, ViewMarker, ViewPathTracker,
+};
 
 /// This trait provides a way to add [`View`] implementations for types that would be restricted otherwise by the orphan rules.
 /// Every type that can be supported with this trait, needs a concrete `View` implementation in `xilem_core`, possibly feature-gated.
@@ -43,6 +45,8 @@ pub trait OrphanView<V, State, Action, Message = DynMessage>: ViewPathTracker + 
 
 macro_rules! impl_orphan_view_for {
     ($ty: ty) => {
+        impl ViewMarker for $ty {}
+
         impl<State, Action, Context, Message> View<State, Action, Context, Message> for $ty
         where
             Context: OrphanView<$ty, State, Action, Message>,
@@ -111,7 +115,7 @@ impl_orphan_view_for!(usize);
 /// These [`OrphanView`] implementations can e.g. be used in a vector graphics context, as for example seen in `xilem_web` within svg nodes
 mod kurbo {
     use super::OrphanView;
-    use crate::{MessageResult, Mut, View, ViewId};
+    use crate::{MessageResult, Mut, View, ViewId, ViewMarker};
     impl_orphan_view_for!(kurbo::PathSeg);
     impl_orphan_view_for!(kurbo::Arc);
     impl_orphan_view_for!(kurbo::BezPath);

--- a/xilem_core/src/views/run_once.rs
+++ b/xilem_core/src/views/run_once.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Debug;
 
-use crate::{MessageResult, NoElement, View, ViewPathTracker};
+use crate::{MessageResult, NoElement, View, ViewMarker, ViewPathTracker};
 
 /// A view which executes `once` exactly once.
 ///
@@ -75,6 +75,7 @@ pub struct RunOnce<F> {
     once: F,
 }
 
+impl<F> ViewMarker for RunOnce<F> {}
 impl<F, State, Action, Context, Message> View<State, Action, Context, Message> for RunOnce<F>
 where
     Context: ViewPathTracker,

--- a/xilem_core/tests/common/mod.rs
+++ b/xilem_core/tests/common/mod.rs
@@ -4,8 +4,6 @@
 #![allow(dead_code)] // This is a utility module, which means that some exposed items aren't
 #![deny(unreachable_pub)]
 
-use std::marker::PhantomData;
-
 use xilem_core::*;
 
 #[derive(Default)]
@@ -68,28 +66,22 @@ pub(super) struct Action {
     _priv: (),
 }
 
-pub(super) struct SequenceView<Seq, Marker> {
+pub(super) struct SequenceView<Seq> {
     id: u32,
     seq: Seq,
-    phantom: PhantomData<Marker>,
 }
 
-pub(super) fn sequence<Seq, Marker>(id: u32, seq: Seq) -> SequenceView<Seq, Marker>
+pub(super) fn sequence<Seq>(id: u32, seq: Seq) -> SequenceView<Seq>
 where
-    Seq: ViewSequence<(), Action, TestCtx, TestElement, Marker>,
+    Seq: ViewSequence<(), Action, TestCtx, TestElement>,
 {
-    SequenceView {
-        id,
-        seq,
-        phantom: PhantomData,
-    }
+    SequenceView { id, seq }
 }
 
-impl<Seq, Marker> ViewMarker for SequenceView<Seq, Marker> {}
-impl<Seq, Marker> View<(), Action, TestCtx> for SequenceView<Seq, Marker>
+impl<Seq> ViewMarker for SequenceView<Seq> {}
+impl<Seq> View<(), Action, TestCtx> for SequenceView<Seq>
 where
-    Seq: ViewSequence<(), Action, TestCtx, TestElement, Marker>,
-    Marker: 'static,
+    Seq: ViewSequence<(), Action, TestCtx, TestElement>,
 {
     type Element = TestElement;
 

--- a/xilem_core/tests/common/mod.rs
+++ b/xilem_core/tests/common/mod.rs
@@ -85,6 +85,7 @@ where
     }
 }
 
+impl<Seq, Marker> ViewMarker for SequenceView<Seq, Marker> {}
 impl<Seq, Marker> View<(), Action, TestCtx> for SequenceView<Seq, Marker>
 where
     Seq: ViewSequence<(), Action, TestCtx, TestElement, Marker>,
@@ -160,6 +161,7 @@ where
     }
 }
 
+impl<const N: u32> ViewMarker for OperationView<N> {}
 impl<const N: u32> View<(), Action, TestCtx> for OperationView<N> {
     type Element = TestElement;
 

--- a/xilem_web/src/attribute.rs
+++ b/xilem_web/src/attribute.rs
@@ -3,7 +3,7 @@
 
 use std::marker::PhantomData;
 use wasm_bindgen::{JsCast, UnwrapThrowExt};
-use xilem_core::{MessageResult, Mut, View, ViewElement, ViewId};
+use xilem_core::{MessageResult, Mut, View, ViewElement, ViewId, ViewMarker};
 
 use crate::{
     vecmap::VecMap, AttributeValue, DomNode, DynMessage, ElementProps, Pod, PodMut, ViewCtx,
@@ -249,7 +249,8 @@ impl<E, T, A> Attr<E, T, A> {
     }
 }
 
-impl<T, A, E> View<T, A, ViewCtx, DynMessage> for Attr<E, T, A>
+impl<E, T, A> ViewMarker for Attr<E, T, A> {}
+impl<E, T, A> View<T, A, ViewCtx, DynMessage> for Attr<E, T, A>
 where
     T: 'static,
     A: 'static,

--- a/xilem_web/src/class.rs
+++ b/xilem_web/src/class.rs
@@ -4,7 +4,7 @@
 use std::marker::PhantomData;
 use wasm_bindgen::{JsCast, UnwrapThrowExt};
 
-use xilem_core::{MessageResult, Mut, View, ViewElement, ViewId};
+use xilem_core::{MessageResult, Mut, View, ViewElement, ViewId, ViewMarker};
 
 use crate::{vecmap::VecMap, DomNode, DynMessage, ElementProps, Pod, PodMut, ViewCtx};
 
@@ -289,6 +289,7 @@ impl<E, C, T, A> Class<E, C, T, A> {
     }
 }
 
+impl<E, C, T, A> ViewMarker for Class<E, C, T, A> {}
 impl<E, C, T, A> View<T, A, ViewCtx, DynMessage> for Class<E, C, T, A>
 where
     T: 'static,

--- a/xilem_web/src/concurrent/memoized_await.rs
+++ b/xilem_web/src/concurrent/memoized_await.rs
@@ -5,7 +5,7 @@ use std::{future::Future, marker::PhantomData};
 
 use wasm_bindgen::{closure::Closure, JsCast, UnwrapThrowExt};
 use wasm_bindgen_futures::spawn_local;
-use xilem_core::{MessageResult, Mut, NoElement, View, ViewId, ViewPathTracker};
+use xilem_core::{MessageResult, Mut, NoElement, View, ViewId, ViewMarker, ViewPathTracker};
 
 use crate::{DynMessage, OptionalAction, ViewCtx};
 
@@ -153,6 +153,10 @@ enum MemoizedAwaitMessage<Output: std::fmt::Debug> {
     ScheduleUpdate,
 }
 
+impl<State, Action, OA, InitFuture, Data, CB, F, FOut> ViewMarker
+    for MemoizedAwait<State, Action, OA, InitFuture, Data, CB, F, FOut>
+{
+}
 impl<State, Action, InitFuture, F, FOut, Data, CB, OA> View<State, Action, ViewCtx, DynMessage>
     for MemoizedAwait<State, Action, OA, InitFuture, Data, CB, F, FOut>
 where

--- a/xilem_web/src/elements.rs
+++ b/xilem_web/src/elements.rs
@@ -312,8 +312,7 @@ where
     }
 }
 impl<State, Action> ViewMarker for CustomElement<State, Action> {}
-impl<State, Action> View<State, Action, ViewCtx, DynMessage>
-    for CustomElement<State, Action>
+impl<State, Action> View<State, Action, ViewCtx, DynMessage> for CustomElement<State, Action>
 where
     State: 'static,
     Action: 'static,
@@ -403,8 +402,7 @@ macro_rules! define_element {
         }
 
         impl<State, Action> ViewMarker for $ty_name<State, Action> {}
-        impl<State, Action> View<State, Action, ViewCtx, DynMessage>
-            for $ty_name<State, Action>
+        impl<State, Action> View<State, Action, ViewCtx, DynMessage> for $ty_name<State, Action>
         where
             State: 'static,
             Action: 'static,

--- a/xilem_web/src/elements.rs
+++ b/xilem_web/src/elements.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 use wasm_bindgen::{JsCast, UnwrapThrowExt};
 
 use crate::{
-    core::{AppendVec, ElementSplice, MessageResult, Mut, View, ViewId, ViewSequence},
+    core::{AppendVec, ElementSplice, MessageResult, Mut, View, ViewId, ViewMarker, ViewSequence},
     document,
     element_props::ElementProps,
     vec_splice::VecSplice,
@@ -317,7 +317,7 @@ where
         children: Box::new(children),
     }
 }
-
+impl<State, Action, SeqMarker> ViewMarker for CustomElement<State, Action, SeqMarker> {}
 impl<State, Action, SeqMarker> View<State, Action, ViewCtx, DynMessage>
     for CustomElement<State, Action, SeqMarker>
 where
@@ -410,6 +410,7 @@ macro_rules! define_element {
             }
         }
 
+        impl<State, Action, SeqMarker> ViewMarker for $ty_name<State, Action, SeqMarker> {}
         impl<State, Action, SeqMarker> View<State, Action, ViewCtx, DynMessage>
             for $ty_name<State, Action, SeqMarker>
         where
@@ -472,7 +473,7 @@ macro_rules! define_elements {
     ($ns:ident, $($element_def:tt,)*) => {
         use super::{build_element, rebuild_element, teardown_element, DomViewSequence, ElementState};
         use crate::{
-            core::{MessageResult, Mut, ViewId, ViewSequence},
+            core::{MessageResult, Mut, ViewId, ViewSequence, ViewMarker},
             AnyPod, DynMessage, ElementProps, Pod, View, ViewCtx,
         };
         $(define_element!(crate::$ns, $element_def);)*

--- a/xilem_web/src/events.rs
+++ b/xilem_web/src/events.rs
@@ -4,7 +4,7 @@
 use std::{borrow::Cow, marker::PhantomData};
 use wasm_bindgen::{prelude::Closure, throw_str, JsCast, UnwrapThrowExt};
 use web_sys::AddEventListenerOptions;
-use xilem_core::{MessageResult, Mut, View, ViewId, ViewPathTracker};
+use xilem_core::{MessageResult, Mut, View, ViewId, ViewMarker, ViewPathTracker};
 
 use crate::{DynMessage, ElementAsRef, OptionalAction, ViewCtx};
 
@@ -224,6 +224,7 @@ where
     }
 }
 
+impl<V, State, Action, Event, Callback> ViewMarker for OnEvent<V, State, Action, Event, Callback> {}
 impl<V, State, Action, Event, Callback, OA> View<State, Action, ViewCtx, DynMessage>
     for OnEvent<V, State, Action, Event, Callback>
 where
@@ -327,6 +328,7 @@ macro_rules! event_definitions {
             pub(crate) phantom_event_ty: PhantomData<fn() -> (State, Action)>,
         }
 
+        impl<V, State, Action, Callback> ViewMarker for $ty_name<V, State, Action, Callback> {}
         impl<V, State, Action, Callback> $ty_name<V, State, Action, Callback> {
             pub fn new(element: V, handler: Callback) -> Self {
                 Self {

--- a/xilem_web/src/lib.rs
+++ b/xilem_web/src/lib.rs
@@ -59,6 +59,7 @@ pub use optional_action::{Action, OptionalAction};
 pub use pointer::{Pointer, PointerDetails, PointerMsg};
 pub use style::{style, ElementWithStyle, IntoStyles, Style, Styles, WithStyle};
 pub use xilem_core as core;
+use xilem_core::ViewSequence;
 
 /// A trait used for type erasure of [`DomNode`]s
 /// It is e.g. used in [`AnyPod`]
@@ -167,6 +168,18 @@ where
 {
     type DomNode = W;
     type Props = P;
+}
+
+pub trait DomViewSequence<State: 'static, Action = ()>:
+    ViewSequence<State, Action, ViewCtx, AnyPod, DynMessage>
+{
+}
+impl<V, State, Action> DomViewSequence<State, Action> for V
+where
+    State: 'static,
+    Action: 'static,
+    V: ViewSequence<State, Action, ViewCtx, AnyPod, DynMessage>,
+{
 }
 
 /// A container, which holds the actual DOM node, and associated props, such as attributes or classes.

--- a/xilem_web/src/lib.rs
+++ b/xilem_web/src/lib.rs
@@ -170,15 +170,23 @@ where
     type Props = P;
 }
 
-pub trait DomViewSequence<State: 'static, Action = ()>:
+/// An ordered sequence of views, or sometimes also called fragment, it's used for `0..N` [`DomView`]s.
+/// See [`ViewSequence`] for more technical details.
+///
+/// # Examples
+///
+/// ```
+/// fn huzzah(clicks: i32) -> impl xilem_web::DomFragment<i32> {
+///     (clicks >= 5).then_some("Huzzah, clicked at least 5 times")
+/// }
+/// ```
+pub trait DomFragment<State, Action = ()>:
     ViewSequence<State, Action, ViewCtx, AnyPod, DynMessage>
 {
 }
-impl<V, State, Action> DomViewSequence<State, Action> for V
-where
-    State: 'static,
-    Action: 'static,
-    V: ViewSequence<State, Action, ViewCtx, AnyPod, DynMessage>,
+
+impl<V, State, Action> DomFragment<State, Action> for V where
+    V: ViewSequence<State, Action, ViewCtx, AnyPod, DynMessage>
 {
 }
 

--- a/xilem_web/src/pointer.rs
+++ b/xilem_web/src/pointer.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 use wasm_bindgen::{prelude::Closure, throw_str, JsCast, UnwrapThrowExt};
 use web_sys::PointerEvent;
 
-use xilem_core::{MessageResult, Mut, View, ViewId, ViewPathTracker};
+use xilem_core::{MessageResult, Mut, View, ViewId, ViewMarker, ViewPathTracker};
 
 use crate::{interfaces::Element, DynMessage, ElementAsRef, ViewCtx};
 
@@ -69,6 +69,7 @@ pub fn pointer<T, A, F: Fn(&mut T, PointerMsg), V: Element<T, A>>(
     }
 }
 
+impl<V, State, Action, Callback> ViewMarker for Pointer<V, State, Action, Callback> {}
 impl<State, Action, Callback, V> View<State, Action, ViewCtx, DynMessage>
     for Pointer<V, State, Action, Callback>
 where

--- a/xilem_web/src/style.rs
+++ b/xilem_web/src/style.rs
@@ -6,7 +6,7 @@ use std::{
     marker::PhantomData,
 };
 use wasm_bindgen::{JsCast, UnwrapThrowExt};
-use xilem_core::{MessageResult, Mut, View, ViewElement, ViewId};
+use xilem_core::{MessageResult, Mut, View, ViewElement, ViewId, ViewMarker};
 
 use crate::{vecmap::VecMap, DomNode, DynMessage, ElementProps, Pod, PodMut, ViewCtx};
 
@@ -299,6 +299,7 @@ impl<E, T, A> Style<E, T, A> {
     }
 }
 
+impl<E, T, A> ViewMarker for Style<E, T, A> {}
 impl<T, A, E> View<T, A, ViewCtx, DynMessage> for Style<E, T, A>
 where
     T: 'static,

--- a/xilem_web/src/svg/common_attrs.rs
+++ b/xilem_web/src/svg/common_attrs.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use peniko::Brush;
-use xilem_core::{MessageResult, Mut, View, ViewId};
+use xilem_core::{MessageResult, Mut, View, ViewId, ViewMarker};
 
 use crate::{
     attribute::{ElementWithAttributes, WithAttributes},
@@ -61,6 +61,7 @@ fn brush_to_string(brush: &Brush) -> String {
     }
 }
 
+impl<V, State, Action> ViewMarker for Fill<V, State, Action> {}
 impl<State, Action, V> View<State, Action, ViewCtx, DynMessage> for Fill<V, State, Action>
 where
     State: 'static,
@@ -116,6 +117,7 @@ where
     }
 }
 
+impl<V, State, Action> ViewMarker for Stroke<V, State, Action> {}
 impl<State, Action, V> View<State, Action, ViewCtx, DynMessage> for Stroke<V, State, Action>
 where
     State: 'static,

--- a/xilem_web/web_examples/counter/src/main.rs
+++ b/xilem_web/web_examples/counter/src/main.rs
@@ -5,7 +5,7 @@ use xilem_web::{
     document_body,
     elements::html as el,
     interfaces::{Element, HtmlButtonElement, HtmlDivElement},
-    App,
+    App, DomViewSequence,
 };
 
 #[derive(Default)]
@@ -50,8 +50,13 @@ fn btn(
     el::button(label).on_click(click_fn)
 }
 
+fn my_fragment(state: &mut AppState) -> impl DomViewSequence<AppState> {
+    (state.clicks >= 5).then_some(el::p("Huzzah, clicked at least 5 times"))
+}
+
 fn app_logic(state: &mut AppState) -> impl HtmlDivElement<AppState> {
     el::div((
+        my_fragment(state),
         el::span(format!("clicked {} times", state.clicks)).class(state.class),
         el::br(()),
         btn("+1 click", |state, _| state.increment()),

--- a/xilem_web/web_examples/counter/src/main.rs
+++ b/xilem_web/web_examples/counter/src/main.rs
@@ -5,7 +5,7 @@ use xilem_web::{
     document_body,
     elements::html as el,
     interfaces::{Element, HtmlButtonElement, HtmlDivElement},
-    App, DomViewSequence,
+    App, DomFragment,
 };
 
 #[derive(Default)]
@@ -50,14 +50,15 @@ fn btn(
     el::button(label).on_click(click_fn)
 }
 
-fn my_fragment(state: &mut AppState) -> impl DomViewSequence<AppState> {
-    (state.clicks >= 5).then_some(el::p("Huzzah, clicked at least 5 times"))
+/// And functions that return a sequence of views.
+fn huzzah(state: &mut AppState) -> impl DomFragment<AppState> {
+    (state.clicks >= 5).then_some("Huzzah, clicked at least 5 times")
 }
 
 fn app_logic(state: &mut AppState) -> impl HtmlDivElement<AppState> {
     el::div((
-        my_fragment(state),
         el::span(format!("clicked {} times", state.clicks)).class(state.class),
+        huzzah(state),
         el::br(()),
         btn("+1 click", |state, _| state.increment()),
         btn("-1 click", |state, _| state.decrement()),


### PR DESCRIPTION
This allows returning `impl ViewSequence` as this was previously not possibly as the `Marker` generic parameter couldn't be named (easily) in `ViewSequence<..., Marker>`.

This also provides specialized `ViewSequence`s for xilem (`WidgetViewSequence` and `FlexSequence`) as well as for xilem_web (`DomFragment`). Additional doc-tests/documentation and a small example (in `counter`) for xilem_web is provided as well.

This has the drawback to not being able to reeimplement `ViewSequence` for types that already implement `View`, which was previously possible (as seen by the now removed `NoElementView` `ViewSequence` implementation).
And additionally by introducing more boilerplate by having to implement `ViewMarker` for every type that implements `View`.