### PR TITLE
masonry: add Pinch to PointerEvent

### DIFF
--- a/masonry/src/event.rs
+++ b/masonry/src/event.rs
@@ -195,6 +195,7 @@ pub enum PointerEvent {
     HoverFile(PathBuf, PointerState),
     DropFile(PathBuf, PointerState),
     HoverFileCancel(PointerState),
+    Pinch(f64, PointerState),
 }
 
 // TODO - Clipboard Paste?
@@ -369,7 +370,8 @@ impl PointerEvent {
             | PointerEvent::MouseWheel(_, state)
             | PointerEvent::HoverFile(_, state)
             | PointerEvent::DropFile(_, state)
-            | PointerEvent::HoverFileCancel(state) => state,
+            | PointerEvent::HoverFileCancel(state)
+            | PointerEvent::Pinch(_, state) => state,
         }
     }
 
@@ -391,6 +393,7 @@ impl PointerEvent {
             PointerEvent::HoverFile(_, _) => "HoverFile",
             PointerEvent::DropFile(_, _) => "DropFile",
             PointerEvent::HoverFileCancel(_) => "HoverFileCancel",
+            PointerEvent::Pinch(_, _) => "Pinch",
         }
     }
 
@@ -405,6 +408,7 @@ impl PointerEvent {
             PointerEvent::HoverFile(_, _) => true,
             PointerEvent::DropFile(_, _) => false,
             PointerEvent::HoverFileCancel(_) => false,
+            PointerEvent::Pinch(_, _) => true,
         }
     }
 }

--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -553,6 +553,10 @@ impl MasonryState<'_> {
                     }
                 }
             }
+            WinitWindowEvent::PinchGesture { delta, .. } => {
+                self.render_root
+                    .handle_pointer_event(PointerEvent::Pinch(delta, self.pointer_state.clone()));
+            }
             _ => (),
         }
 


### PR DESCRIPTION
I opened https://github.com/linebender/xilem/issues/473 earlier today, but I realized after looking at the code that it would be super simple to implement!

Copying over some context from that issue:

- I'm working on a graph renderer using Vello.
- I'm porting it over to a Masonry widget, so that I can build a UI around it.
- In doing so I noticed there wasn't support for winit's `PinchGesture`, which I had been using before when messing around with this on my macOS device.

Please let me know if y'all feel like this is appropriate to include inside of `PointerEvent`!