### PR TITLE
Fix some `clippy::doc_markdown` lints in masonry.

### DIFF
--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -336,7 +336,7 @@ impl TestHarness {
 
     // --- MARK: EVENT HELPERS ---
 
-    /// Move an internal mouse state, and send a MouseMove event to the window.
+    /// Move an internal mouse state, and send a [`PointerMove`](PointerEvent::PointerMove) event to the window.
     pub fn mouse_move(&mut self, pos: impl Into<Point>) {
         // FIXME - Account for scaling
         let pos = pos.into();
@@ -349,19 +349,19 @@ impl TestHarness {
         self.process_pointer_event(PointerEvent::PointerMove(self.mouse_state.clone()));
     }
 
-    /// Send a MouseDown event to the window.
+    /// Send a [`PointerDown`](PointerEvent::PointerDown) event to the window.
     pub fn mouse_button_press(&mut self, button: PointerButton) {
         self.mouse_state.buttons.insert(button);
         self.process_pointer_event(PointerEvent::PointerDown(button, self.mouse_state.clone()));
     }
 
-    /// Send a MouseUp event to the window.
+    /// Send a [`PointerUp`](PointerEvent::PointerUp) event to the window.
     pub fn mouse_button_release(&mut self, button: PointerButton) {
         self.mouse_state.buttons.remove(&button);
         self.process_pointer_event(PointerEvent::PointerUp(button, self.mouse_state.clone()));
     }
 
-    /// Send a Wheel event to the window
+    /// Send a [`MouseWheel`](PointerEvent::MouseWheel) event to the window.
     pub fn mouse_wheel(&mut self, wheel_delta: Vec2) {
         let pixel_delta = LogicalPosition::new(wheel_delta.x, wheel_delta.y);
         self.process_pointer_event(PointerEvent::MouseWheel(

--- a/masonry/src/text/backspace.rs
+++ b/masonry/src/text/backspace.rs
@@ -8,7 +8,7 @@ use xi_unicode::*;
 use super::{EditableTextCursor, Selectable};
 
 /// Logic adapted from Android and
-/// https://github.com/xi-editor/xi-editor/pull/837
+/// <https://github.com/xi-editor/xi-editor/pull/837>
 /// See links present in that PR for upstream Android Source
 /// Matches Android Logic as at 2024-05-10
 #[allow(clippy::cognitive_complexity)]

--- a/masonry/src/text/edit.rs
+++ b/masonry/src/text/edit.rs
@@ -75,7 +75,7 @@ impl<T: EditableText> TextEditor<T> {
 
     /// Rebuild the text.
     ///
-    /// See also [TextLayout::rebuild](crate::text2::TextLayout::rebuild) for more comprehensive docs.
+    /// See also [`TextLayout::rebuild`](crate::text::TextLayout::rebuild) for more comprehensive docs.
     pub fn rebuild(
         &mut self,
         font_ctx: &mut FontContext,

--- a/masonry/src/text/selection.rs
+++ b/masonry/src/text/selection.rs
@@ -211,7 +211,7 @@ impl<T: Selectable> TextWithSelection<T> {
 
     /// Rebuild the text layout.
     ///
-    /// See also [TextLayout::rebuild] for more comprehensive docs.
+    /// See also [`TextLayout::rebuild`] for more comprehensive docs.
     pub fn rebuild(
         &mut self,
         font_ctx: &mut FontContext,
@@ -223,7 +223,7 @@ impl<T: Selectable> TextWithSelection<T> {
     // Intentionally aliases the method on `TextLayout`
     /// Rebuild the text layout, adding attributes to the builder.
     ///
-    /// See also [TextLayout::rebuild_with_attributes] for more comprehensive docs.
+    /// See also [`TextLayout::rebuild_with_attributes`] for more comprehensive docs.
     pub fn rebuild_with_attributes(
         &mut self,
         font_ctx: &mut FontContext,

--- a/masonry/src/tree_arena.rs
+++ b/masonry/src/tree_arena.rs
@@ -35,7 +35,7 @@ pub struct TreeArena<Item> {
 
 /// A reference type giving shared access to an item's children.
 ///
-/// When you borrow an item from a TreeArena, you get two values, returned
+/// When you borrow an item from a [`TreeArena`], you get two values, returned
 /// separately for lifetime reasons: a reference to the item itself, and a token
 /// to access its children.
 pub struct TreeArenaToken<'a, Item> {
@@ -52,10 +52,9 @@ impl<'a, Item> Copy for TreeArenaToken<'a, Item> {}
 
 /// A reference type giving mutable access to an item's children.
 ///
-/// When you borrow an item from a TreeArena, you get two values, returned
+/// When you borrow an item from a [`TreeArena`], you get two values, returned
 /// separately for lifetime reasons: a reference to the item itself, and a token
 /// to access its children.
-
 pub struct TreeArenaTokenMut<'a, Item> {
     children: &'a mut Vec<TreeNode<Item>>,
 }

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -59,7 +59,7 @@ pub struct WidgetId(pub(crate) NonZeroU64);
 /// for details **(TODO)**.
 ///
 /// Generally speaking, widgets aren't used directly. They are stored in
-/// [`WidgetPods`](crate::WidgetPod). Widget methods are called by WidgetPods, and the
+/// [`WidgetPod`](crate::WidgetPod)s. Widget methods are called by `WidgetPod`s, and the
 /// widget is mutated either during a method call (eg `on_event` or `lifecycle`) or
 /// through a [`WidgetMut`](crate::widget::WidgetMut). See tutorials for details.
 pub trait Widget: AsAny {
@@ -217,7 +217,7 @@ pub trait Widget: AsAny {
 /// responsible for calling the context methods (eg `request_layout`,
 /// `request_accessibility_update`) for the child.
 ///
-/// Widgets implementing AllowRawMut are usually private widgets used as an
+/// Widgets implementing `AllowRawMut` are usually private widgets used as an
 /// internal implementation detail of public widgets.
 pub trait AllowRawMut: Widget {}
 


### PR DESCRIPTION
This is a start on #449.