### PR TITLE
masonry: `TextEditor` add `Action::TextChanged` for backspace & delete

### DIFF
--- a/masonry/src/text/edit.rs
+++ b/masonry/src/text/edit.rs
@@ -124,6 +124,9 @@ impl<T: EditableText> TextEditor<T> {
                                     self.text_mut().edit(selection.range(), "");
                                     self.inner.selection =
                                         Some(Selection::caret(selection.min(), Affinity::Upstream));
+
+                                    let contents = self.text().as_str().to_string();
+                                    ctx.submit_action(Action::TextChanged(contents));
                                 } else {
                                     // TODO: more specific behavior may sometimes be warranted here
                                     //       because whole EGCs are more coarse than what people expect
@@ -135,6 +138,9 @@ impl<T: EditableText> TextEditor<T> {
                                     self.text_mut().edit(offset..selection.active, "");
                                     self.inner.selection =
                                         Some(Selection::caret(offset, selection.active_affinity));
+
+                                    let contents = self.text().as_str().to_string();
+                                    ctx.submit_action(Action::TextChanged(contents));
                                 }
                                 Handled::Yes
                             } else {
@@ -149,6 +155,9 @@ impl<T: EditableText> TextEditor<T> {
                                         selection.min(),
                                         Affinity::Downstream,
                                     ));
+
+                                    let contents = self.text().as_str().to_string();
+                                    ctx.submit_action(Action::TextChanged(contents));
                                 } else if let Some(offset) =
                                     self.text().next_grapheme_offset(selection.active)
                                 {
@@ -157,6 +166,9 @@ impl<T: EditableText> TextEditor<T> {
                                         selection.min(),
                                         selection.active_affinity,
                                     ));
+
+                                    let contents = self.text().as_str().to_string();
+                                    ctx.submit_action(Action::TextChanged(contents));
                                 }
                                 Handled::Yes
                             } else {


### PR DESCRIPTION
`masonry::text::edit::TextEditor` should emit an `Action::TextChanged(...)` also on `Backspace` and `Delete` if anything was deleted, so that e.g. `xilem::view::textbox::Textbox` receives this action. This is already implemented for `Ctrl+Backspace` and `Ctrl+Delete`.

The code changes are not elegant, but intended to be minimally invasive.

Local `cargo test` failed for the modified and an unmodified code, but sometimes with different errors&mdash;which I do not quite understand.

I apologize in advance for any mistakes on my part, I've never before worked on open source repos and did not find any guideline for your project.