### PR TITLE
xilem_web: Fix `DomChildrenSplice::with_scratch`

### DIFF
--- a/xilem_web/Cargo.toml
+++ b/xilem_web/Cargo.toml
@@ -31,6 +31,7 @@ features = [
   "console",
   "CssStyleDeclaration",
   "Document",
+  "DocumentFragment",
   "DomTokenList",
   "Element",
   "Event",

--- a/xilem_web/src/context.rs
+++ b/xilem_web/src/context.rs
@@ -25,10 +25,20 @@ impl MessageThunk {
 }
 
 /// The [`View`](`crate::core::View`) `Context` which is used for all [`DomView`](`crate::DomView`)s
-#[derive(Default)]
 pub struct ViewCtx {
     id_path: Vec<ViewId>,
     app_ref: Option<Box<dyn AppRunner>>,
+    pub(crate) fragment: Rc<web_sys::DocumentFragment>,
+}
+
+impl Default for ViewCtx {
+    fn default() -> Self {
+        ViewCtx {
+            id_path: Vec::default(),
+            app_ref: None,
+            fragment: Rc::new(crate::document().create_document_fragment()),
+        }
+    }
 }
 
 impl ViewCtx {


### PR DESCRIPTION
I'm surprised that this was not noticed yet, `DomChildrenSplice::with_scratch` previously only appended new elements to the end of the children of an element in the DOM tree, whereas it should've inserted it at the current index of the `ElementSplice`. This should fix this, using a `DocumentFragment` which is shared on the `ViewCtx` to avoid unnecessary allocations.