### PR TITLE
Improve `calc` and xilem_web's `mathml_svg` example

### DIFF
--- a/xilem/examples/calc.rs
+++ b/xilem/examples/calc.rs
@@ -187,6 +187,12 @@ impl Calculator {
 const DISPLAY_FONT_SIZE: f32 = 30.;
 const GRID_GAP: f64 = 2.;
 fn app_logic(data: &mut Calculator) -> impl WidgetView<Calculator> {
+    let num_row = |nums: [&'static str; 3], operator| {
+        flex_row((
+            nums.map(|num| digit_button(num).flex(1.)),
+            operator_button(operator).flex(1.),
+        ))
+    };
     flex((
         // Display
         centered_flex_row((
@@ -205,45 +211,21 @@ fn app_logic(data: &mut Calculator) -> impl WidgetView<Calculator> {
         FlexSpacer::Fixed(10.0),
         // Top row
         flex_row((
-            expanded_button("CE", |data: &mut Calculator| {
-                data.clear_entry();
-            })
-            .flex(1.),
-            expanded_button("C", |data: &mut Calculator| data.clear_all()).flex(1.),
-            expanded_button("DEL", |data: &mut Calculator| data.on_delete()).flex(1.),
+            expanded_button("CE", Calculator::clear_entry).flex(1.),
+            expanded_button("C", Calculator::clear_all).flex(1.),
+            expanded_button("DEL", Calculator::on_delete).flex(1.),
             operator_button(MathOperator::Divide).flex(1.),
         ))
         .flex(1.0),
-        // 7 8 9 X
-        flex_row((
-            digit_button("7").flex(1.),
-            digit_button("8").flex(1.),
-            digit_button("9").flex(1.),
-            operator_button(MathOperator::Multiply).flex(1.),
-        ))
-        .flex(1.0),
-        // 4 5 6 -
-        flex_row((
-            digit_button("4").flex(1.),
-            digit_button("5").flex(1.),
-            digit_button("6").flex(1.),
-            operator_button(MathOperator::Subtract).flex(1.),
-        ))
-        .flex(1.0),
-        // 1 2 3 +
-        flex_row((
-            digit_button("1").flex(1.),
-            digit_button("2").flex(1.),
-            digit_button("3").flex(1.),
-            operator_button(MathOperator::Add).flex(1.),
-        ))
-        .flex(1.0),
+        num_row(["7", "8", "9"], MathOperator::Multiply),
+        num_row(["4", "5", "6"], MathOperator::Subtract),
+        num_row(["1", "2", "3"], MathOperator::Add),
         // bottom row
         flex_row((
-            expanded_button("±", |data: &mut Calculator| data.negate()).flex(1.),
+            expanded_button("±", Calculator::negate).flex(1.),
             digit_button("0").flex(1.),
             digit_button(".").flex(1.),
-            expanded_button("=", |data: &mut Calculator| data.on_equals()).flex(1.),
+            expanded_button("=", Calculator::on_equals).flex(1.),
         ))
         .flex(1.0),
     ))

--- a/xilem_web/web_examples/mathml_svg/src/main.rs
+++ b/xilem_web/web_examples/mathml_svg/src/main.rs
@@ -83,11 +83,11 @@ pub fn main() {
                 slider(150, t.b, |t, e| t.b = get_value(e)),
             )),
             ml::math(ml::mrow((
-                ml::msup((ml::mi(format!("{}", t.a)), ml::mn("2"))),
+                ml::msup((ml::mi(t.a), ml::mn(2))),
                 ml::mo("+"),
-                ml::msup((ml::mi(format!("{}", t.b)), ml::mn("2"))),
+                ml::msup((ml::mi(t.b), ml::mn(2))),
                 ml::mo("="),
-                ml::msup((ml::mi(format!("{c}")), ml::mn("2"))),
+                ml::msup((ml::mi(c), ml::mn(2))),
             ))),
         ))
     })


### PR DESCRIPTION
Reduces a little bit of the boilerplate in `calc`