### PR TITLE
Mason Only Add While Active

### DIFF
--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -92,6 +92,8 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> {
             button("Reset", |data: &mut AppData| data.count = 0),
             flex((fizz_buzz_flex_sequence, flex_sequence)).direction(axis),
         )),
+         // The following `async_repeat` view only exists whilst the example is in the "active" state, so
+         // the updates it performs will only be running whilst we are in that state.
         data.active.then(|| {
             async_repeat(
                 |proxy| async move {

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -92,8 +92,8 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> {
             button("Reset", |data: &mut AppData| data.count = 0),
             flex((fizz_buzz_flex_sequence, flex_sequence)).direction(axis),
         )),
-         // The following `async_repeat` view only exists whilst the example is in the "active" state, so
-         // the updates it performs will only be running whilst we are in that state.
+        // The following `async_repeat` view only exists whilst the example is in the "active" state, so
+        // the updates it performs will only be running whilst we are in that state.
         data.active.then(|| {
             async_repeat(
                 |proxy| async move {

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -102,7 +102,11 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> {
                     };
                 }
             },
-            |data: &mut AppData, ()| data.count += 1,
+            |data: &mut AppData, ()| {
+                if data.active {
+                    data.count += 1;
+                }
+            },
         ),
     )
 }

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -92,22 +92,22 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> {
             button("Reset", |data: &mut AppData| data.count = 0),
             flex((fizz_buzz_flex_sequence, flex_sequence)).direction(axis),
         )),
-        async_repeat(
-            |proxy| async move {
-                let mut interval = time::interval(Duration::from_secs(1));
-                loop {
-                    interval.tick().await;
-                    let Ok(()) = proxy.message(()) else {
-                        break;
-                    };
-                }
-            },
-            |data: &mut AppData, ()| {
-                if data.active {
+        data.active.then(|| {
+            async_repeat(
+                |proxy| async move {
+                    let mut interval = time::interval(Duration::from_secs(1));
+                    loop {
+                        interval.tick().await;
+                        let Ok(()) = proxy.message(()) else {
+                            break;
+                        };
+                    }
+                },
+                |data: &mut AppData, ()| {
                     data.count += 1;
-                }
-            },
-        ),
+                },
+            )
+        }),
     )
 }
 

--- a/xilem_core/src/views/fork.rs
+++ b/xilem_core/src/views/fork.rs
@@ -115,9 +115,7 @@ struct NoElements;
 impl ElementSplice<NoElement> for NoElements {
     fn with_scratch<R>(&mut self, f: impl FnOnce(&mut AppendVec<NoElement>) -> R) -> R {
         let mut append_vec = AppendVec::default();
-        let ret = f(&mut append_vec);
-        debug_assert!(append_vec.into_inner().is_empty());
-        ret
+        f(&mut append_vec)
     }
 
     fn insert(&mut self, _: NoElement) {}


### PR DESCRIPTION
It's jarring for the example to automatically add to the button count, so this makes it so it only increments while active is true.