### PR TITLE
Fix doc links by either correcting the item name, or making these public

### DIFF
--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -131,7 +131,7 @@ pub use action::Action;
 pub use box_constraints::BoxConstraints;
 pub use contexts::{
     AccessCtx, EventCtx, IsContext, LayoutCtx, LifeCycleCtx, PaintCtx, RawWrapper, RawWrapperMut,
-    WidgetCtx, WorkerCtx
+    WidgetCtx, WorkerCtx,
 };
 pub use event::{
     AccessEvent, InternalLifeCycle, LifeCycle, PointerButton, PointerEvent, PointerState,

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -131,7 +131,7 @@ pub use action::Action;
 pub use box_constraints::BoxConstraints;
 pub use contexts::{
     AccessCtx, EventCtx, IsContext, LayoutCtx, LifeCycleCtx, PaintCtx, RawWrapper, RawWrapperMut,
-    WidgetCtx,
+    WidgetCtx, WorkerCtx
 };
 pub use event::{
     AccessEvent, InternalLifeCycle, LifeCycle, PointerButton, PointerEvent, PointerState,

--- a/masonry/src/testing/mod.rs
+++ b/masonry/src/testing/mod.rs
@@ -14,7 +14,7 @@ mod screenshots;
 #[cfg(not(tarpaulin_include))]
 mod snapshot_utils;
 
-pub use harness::{TestHarness, HARNESS_DEFAULT_SIZE};
+pub use harness::{TestHarness, HARNESS_DEFAULT_SIZE, HARNESS_DEFAULT_BACKGROUND_COLOR};
 pub use helper_widgets::{ModularWidget, Record, Recorder, Recording, ReplaceChild, TestWidgetExt};
 
 use crate::WidgetId;

--- a/masonry/src/testing/mod.rs
+++ b/masonry/src/testing/mod.rs
@@ -14,7 +14,7 @@ mod screenshots;
 #[cfg(not(tarpaulin_include))]
 mod snapshot_utils;
 
-pub use harness::{TestHarness, HARNESS_DEFAULT_SIZE, HARNESS_DEFAULT_BACKGROUND_COLOR};
+pub use harness::{TestHarness, HARNESS_DEFAULT_BACKGROUND_COLOR, HARNESS_DEFAULT_SIZE};
 pub use helper_widgets::{ModularWidget, Record, Recorder, Recording, ReplaceChild, TestWidgetExt};
 
 use crate::WidgetId;

--- a/xilem_core/src/deferred.rs
+++ b/xilem_core/src/deferred.rs
@@ -10,7 +10,7 @@ use crate::{DynMessage, Message, NoElement, View, ViewId, ViewPathTracker};
 /// A `Context` for a [`View`](crate::View) implementation which supports
 /// asynchronous message reporting.
 pub trait AsyncCtx<Message = DynMessage>: ViewPathTracker {
-    /// Get a [`Proxy`] for this context.
+    /// Get a [`RawProxy`] for this context.
     // TODO: Maybe store the current path within this Proxy?
     fn proxy(&mut self) -> Arc<dyn RawProxy<Message>>;
 }
@@ -28,7 +28,7 @@ pub trait AsyncCtx<Message = DynMessage>: ViewPathTracker {
 ///
 /// ## Lifetimes
 ///
-/// It is valid for a [`Proxy`] to outlive the [`View`](crate::View) it is associated with.
+/// It is valid for a [`RawProxy`] to outlive the [`View`](crate::View) it is associated with.
 pub trait RawProxy<Message = DynMessage>: Send + Sync + 'static {
     /// Send a `message` to the view at `path` in this driver.
     ///
@@ -87,7 +87,7 @@ where
 {
 }
 
-/// The potential error conditions from a [`Proxy`] sending a message
+/// The potential error conditions from a [`RawProxy`] sending a message
 #[derive(Debug)]
 pub enum ProxyError {
     /// The underlying driver (such as an event loop) is no longer running.

--- a/xilem_web/src/concurrent/memoized_await.rs
+++ b/xilem_web/src/concurrent/memoized_await.rs
@@ -58,7 +58,7 @@ where
 
 /// Await a future returned by `init_future` invoked with the argument `data`, `callback` is called with the output of the resolved future. `init_future` will be invoked again, when `data` changes.
 ///
-/// The update behavior can be controlled, by [`debounce`](`MemoizedAwait::debounce`) and [`reset_debounce_on_update`](`MemoizedAwait::reset_debounce_on_update`)
+/// The update behavior can be controlled, by [`debounce_ms`](`MemoizedAwait::debounce_ms`) and [`reset_debounce_on_update`](`MemoizedAwait::reset_debounce_on_update`)
 ///
 /// # Examples
 ///


### PR DESCRIPTION
I don't think anything speaks against making the items public in masonry?