### PR TITLE
Fix view overflow in the calc example on mobile

### DIFF
--- a/xilem/examples/calc.rs
+++ b/xilem/examples/calc.rs
@@ -300,6 +300,14 @@ fn run(event_loop: EventLoopBuilder) -> Result<(), EventLoopError> {
         .with_resizable(true)
         .with_min_inner_size(min_window_size)
         .with_inner_size(window_size);
+    // On iOS, winit has unsensible handling of `inner_size`
+    // See https://github.com/rust-windowing/winit/issues/2308 for more details
+    #[cfg(target_os = "ios")]
+    let window_attributes = {
+        let mut window_attributes = window_attributes; // to avoid `unused_mut`
+        window_attributes.inner_size = None;
+        window_attributes
+    };
     app.run_windowed_in(event_loop, window_attributes)?;
     Ok(())
 }


### PR DESCRIPTION
On mobile platforms, setting the logical width of the window to 400 can cause the view to overflow on phones with smaller screen widths (such as the iPhone SE 2nd generation).
<details>
  <summary>screenshot of the view overflow</summary>
  <img src="https://github.com/user-attachments/assets/d47c1c88-ace6-4059-a0ed-b5384dcfa207" alt="screenshot of the view overflow" width="400" />
</details>

It is more intuitive not to manually set the window size. Additionally, winit does not support set_title and set_resizable on iOS and Android (calling them does not have any effect).