### PR TITLE
Implement mutate pass from pass spec RFC

### DIFF
--- a/masonry/examples/calc_masonry.rs
+++ b/masonry/examples/calc_masonry.rs
@@ -145,8 +145,10 @@ impl Widget for CalcButton {
         match event {
             PointerEvent::PointerDown(_, _) => {
                 if !ctx.is_disabled() {
-                    ctx.get_mut(&mut self.inner)
-                        .set_background(self.active_color);
+                    let color = self.active_color;
+                    ctx.mutate_later(&mut self.inner, move |mut inner| {
+                        inner.set_background(color);
+                    });
                     ctx.set_active(true);
                     ctx.request_paint();
                     trace!("CalcButton {:?} pressed", ctx.widget_id());
@@ -154,11 +156,14 @@ impl Widget for CalcButton {
             }
             PointerEvent::PointerUp(_, _) => {
                 if ctx.is_active() && !ctx.is_disabled() {
+                    let color = self.base_color;
+                    ctx.mutate_later(&mut self.inner, move |mut inner| {
+                        inner.set_background(color);
+                    });
                     ctx.submit_action(Action::Other(Box::new(self.action)));
                     ctx.request_paint();
                     trace!("CalcButton {:?} released", ctx.widget_id());
                 }
-                ctx.get_mut(&mut self.inner).set_background(self.base_color);
                 ctx.set_active(false);
             }
             _ => (),
@@ -183,12 +188,15 @@ impl Widget for CalcButton {
     fn on_status_change(&mut self, ctx: &mut LifeCycleCtx, event: &StatusChange) {
         match event {
             StatusChange::HotChanged(true) => {
-                ctx.get_mut(&mut self.inner).set_border(Color::WHITE, 3.0);
+                ctx.mutate_later(&mut self.inner, move |mut inner| {
+                    inner.set_border(Color::WHITE, 3.0);
+                });
                 ctx.request_paint();
             }
             StatusChange::HotChanged(false) => {
-                ctx.get_mut(&mut self.inner)
-                    .set_border(Color::TRANSPARENT, 3.0);
+                ctx.mutate_later(&mut self.inner, move |mut inner| {
+                    inner.set_border(Color::TRANSPARENT, 3.0);
+                });
                 ctx.request_paint();
             }
             _ => (),

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -495,6 +495,7 @@ impl_context_method!(
     LifeCycleCtx<'_>,
     LayoutCtx<'_>,
     {
+        // TODO - Remove from MutateCtx?
         /// Queue a callback that will be called with a [`WidgetMut`] for this widget.
         ///
         /// The callbacks will be run in the order they were submitted during the mutate pass.

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -374,6 +374,16 @@ impl<'a> MutateCtx<'a> {
             is_reborrow: false,
         }
     }
+
+    pub(crate) fn reborrow_mut(&mut self) -> MutateCtx<'_> {
+        MutateCtx {
+            global_state: self.global_state,
+            parent_widget_state: self.parent_widget_state,
+            widget_state: self.widget_state,
+            widget_state_children: self.widget_state_children.reborrow_mut(),
+            widget_children: self.widget_children.reborrow_mut(),
+        }
+    }
 }
 
 // --- MARK: UPDATE FLAGS ---

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -34,12 +34,12 @@ macro_rules! impl_context_method {
 /// A context provided inside of [`WidgetMut`].
 ///
 /// When you declare a mutable reference type for your widget, methods of this type
-/// will have access to a `WidgetCtx`. If that method mutates the widget in a way that
+/// will have access to a `MutateCtx`. If that method mutates the widget in a way that
 /// requires a later pass (for instance, if your widget has a `set_color` method),
 /// you will need to signal that change in the pass (eg `request_paint`).
 ///
 // TODO add tutorial - See https://github.com/linebender/xilem/issues/376
-pub struct WidgetCtx<'a> {
+pub struct MutateCtx<'a> {
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) parent_widget_state: &'a mut WidgetState,
     pub(crate) widget_state: &'a mut WidgetState,
@@ -110,7 +110,7 @@ pub struct AccessCtx<'a> {
 // --- MARK: GETTERS ---
 // Methods for all context types
 impl_context_method!(
-    WidgetCtx<'_>,
+    MutateCtx<'_>,
     EventCtx<'_>,
     LifeCycleCtx<'_>,
     LayoutCtx<'_>,
@@ -158,7 +158,7 @@ impl_context_method!(
 
 // Methods for all mutable context types
 impl_context_method!(
-    WidgetCtx<'_>,
+    MutateCtx<'_>,
     EventCtx<'_>,
     LifeCycleCtx<'_>,
     LayoutCtx<'_>,
@@ -184,7 +184,7 @@ impl_context_method!(
 // Methods on all context types except LayoutCtx
 // These methods access layout info calculated during the layout pass.
 impl_context_method!(
-    WidgetCtx<'_>,
+    MutateCtx<'_>,
     EventCtx<'_>,
     LifeCycleCtx<'_>,
     PaintCtx<'_>,
@@ -226,7 +226,7 @@ impl_context_method!(
 // Methods on all context types except LayoutCtx
 // Access status information (hot/active/disabled/etc).
 impl_context_method!(
-    WidgetCtx<'_>,
+    MutateCtx<'_>,
     EventCtx<'_>,
     LifeCycleCtx<'_>,
     PaintCtx<'_>,
@@ -347,7 +347,7 @@ impl_context_method!(EventCtx<'_>, {
 
 // --- MARK: WIDGET_MUT ---
 // Methods to get a child WidgetMut from a parent.
-impl<'a> WidgetCtx<'a> {
+impl<'a> MutateCtx<'a> {
     /// Return a [`WidgetMut`] to a child widget.
     pub fn get_mut<'c, Child: Widget>(
         &'c mut self,
@@ -361,7 +361,7 @@ impl<'a> WidgetCtx<'a> {
             .widget_children
             .get_child_mut(child.id().to_raw())
             .expect("get_mut: child not found");
-        let child_ctx = WidgetCtx {
+        let child_ctx = MutateCtx {
             global_state: self.global_state,
             parent_widget_state: self.widget_state,
             widget_state: child_state_mut.item,
@@ -393,7 +393,7 @@ impl<'a> EventCtx<'a> {
             .widget_children
             .get_child_mut(child.id().to_raw())
             .expect("get_mut: child not found");
-        let child_ctx = WidgetCtx {
+        let child_ctx = MutateCtx {
             global_state: self.global_state,
             parent_widget_state: self.widget_state,
             widget_state: child_state_mut.item,
@@ -423,7 +423,7 @@ impl<'a> LifeCycleCtx<'a> {
             .widget_children
             .get_child_mut(child.id().to_raw())
             .expect("get_mut: child not found");
-        let child_ctx = WidgetCtx {
+        let child_ctx = MutateCtx {
             global_state: self.global_state,
             parent_widget_state: self.widget_state,
             widget_state: child_state_mut.item,
@@ -439,8 +439,8 @@ impl<'a> LifeCycleCtx<'a> {
 }
 
 // --- MARK: UPDATE FLAGS ---
-// Methods on WidgetCtx, EventCtx, and LifeCycleCtx
-impl_context_method!(WidgetCtx<'_>, EventCtx<'_>, LifeCycleCtx<'_>, {
+// Methods on MutateCtx, EventCtx, and LifeCycleCtx
+impl_context_method!(MutateCtx<'_>, EventCtx<'_>, LifeCycleCtx<'_>, {
     /// Request a [`paint`](crate::Widget::paint) pass.
     pub fn request_paint(&mut self) {
         trace!("request_paint");
@@ -540,7 +540,7 @@ impl_context_method!(WidgetCtx<'_>, EventCtx<'_>, LifeCycleCtx<'_>, {
 // --- MARK: OTHER METHODS ---
 // Methods on all context types except PaintCtx and AccessCtx
 impl_context_method!(
-    WidgetCtx<'_>,
+    MutateCtx<'_>,
     EventCtx<'_>,
     LifeCycleCtx<'_>,
     LayoutCtx<'_>,

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -377,9 +377,9 @@ impl<'a> MutateCtx<'a> {
     pub(crate) fn reborrow_mut(&mut self) -> MutateCtx<'_> {
         MutateCtx {
             global_state: self.global_state,
-            // We don't don't reborrow parent_widget_state. This means a WidgetMut
-            // made from this won't merge state on Drop, which is usually what you want
-            // from a reborrowed WidgetMut.
+            // We don't don't reborrow `parent_widget_state`. This avoids running
+            // `merge_up` in `WidgetMut::Drop` multiple times for the same state.
+            // It will still be called when the original borrow is dropped.
             parent_widget_state: None,
             widget_state: self.widget_state,
             widget_state_children: self.widget_state_children.reborrow_mut(),

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -493,6 +493,9 @@ impl_context_method!(
     LifeCycleCtx<'_>,
     LayoutCtx<'_>,
     {
+        /// Queue a callback that will be called with a [`WidgetMut`] for this widget.
+        ///
+        /// The callbacks will be run in the order they were submitted during the mutate pass.
         pub fn mutate_self_later(
             &mut self,
             f: impl FnOnce(WidgetMut<'_, Box<dyn Widget>>) + Send + 'static,
@@ -504,6 +507,9 @@ impl_context_method!(
             self.global_state.mutate_callbacks.push(callback);
         }
 
+        /// Queue a callback that will be called with a [`WidgetMut`] for the given child widget.
+        ///
+        /// The callbacks will be run in the order they were submitted during the mutate pass.
         pub fn mutate_later<W: Widget>(
             &mut self,
             child: &mut WidgetPod<W>,

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -130,8 +130,8 @@ mod tree_arena;
 pub use action::Action;
 pub use box_constraints::BoxConstraints;
 pub use contexts::{
-    AccessCtx, EventCtx, IsContext, LayoutCtx, LifeCycleCtx, PaintCtx, RawWrapper, RawWrapperMut,
-    MutateCtx,
+    AccessCtx, EventCtx, IsContext, LayoutCtx, LifeCycleCtx, MutateCtx, PaintCtx, RawWrapper,
+    RawWrapperMut,
 };
 pub use event::{
     AccessEvent, InternalLifeCycle, LifeCycle, PointerButton, PointerEvent, PointerState,

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -131,7 +131,7 @@ pub use action::Action;
 pub use box_constraints::BoxConstraints;
 pub use contexts::{
     AccessCtx, EventCtx, IsContext, LayoutCtx, LifeCycleCtx, PaintCtx, RawWrapper, RawWrapperMut,
-    WidgetCtx,
+    MutateCtx,
 };
 pub use event::{
     AccessEvent, InternalLifeCycle, LifeCycle, PointerButton, PointerEvent, PointerState,

--- a/masonry/src/passes/mod.rs
+++ b/masonry/src/passes/mod.rs
@@ -5,6 +5,7 @@ use crate::widget::WidgetArena;
 use crate::WidgetId;
 
 pub mod event;
+pub mod mutate;
 pub mod update;
 
 pub(crate) fn merge_state_up(arena: &mut WidgetArena, widget_id: WidgetId) {

--- a/masonry/src/passes/mutate.rs
+++ b/masonry/src/passes/mutate.rs
@@ -77,9 +77,6 @@ pub(crate) fn mutate_widget(
     id: WidgetId,
     mutate_fn: impl FnOnce(WidgetMut<'_, Box<dyn Widget>>),
 ) {
-    let mut fake_widget_state =
-        WidgetState::new(root.root.id(), Some(root.get_kurbo_size()), "<root>");
-
     let state_mut = root
         .widget_arena
         .widget_states
@@ -95,7 +92,7 @@ pub(crate) fn mutate_widget(
     let root_widget = WidgetMut {
         ctx: MutateCtx {
             global_state: &mut root.state,
-            parent_widget_state: &mut fake_widget_state,
+            parent_widget_state: root_state,
             widget_state: state_mut.item,
             widget_state_children: state_mut.children,
             widget_children: widget_mut.children,

--- a/masonry/src/passes/mutate.rs
+++ b/masonry/src/passes/mutate.rs
@@ -13,7 +13,7 @@ pub(crate) fn mutate_widget<R>(
     id: WidgetId,
     mutate_fn: impl FnOnce(WidgetMut<'_, Box<dyn Widget>>) -> R,
 ) -> R {
-    let mut dummy_state = WidgetState::root(root.root.id(), root.get_kurbo_size());
+    let mut dummy_state = WidgetState::synthetic(root.root.id(), root.get_kurbo_size());
     let (widget_mut, state_mut) = root.widget_arena.get_pair_mut(id);
 
     let _span = info_span!("mutate_widget", name = widget_mut.item.short_type_name()).entered();

--- a/masonry/src/passes/mutate.rs
+++ b/masonry/src/passes/mutate.rs
@@ -3,96 +3,27 @@
 
 use tracing::info_span;
 
-use crate::{
-    render_root::RenderRoot,
-    tree_arena::{ArenaMut, ArenaMutChildren},
-    widget::{WidgetArena, WidgetMut},
-    MutateCtx, Widget, WidgetId, WidgetState,
-};
-
-#[allow(unused)]
-// References shared by all passes
-struct PassCtx<'a> {
-    pub(crate) widget_state: ArenaMut<'a, WidgetState>,
-    pub(crate) widget_children: ArenaMutChildren<'a, Box<dyn Widget>>,
-}
-
-impl<'a> PassCtx<'a> {
-    fn parent(&self) -> Option<WidgetId> {
-        let parent_id = self.widget_state.parent_id?;
-        let parent_id = parent_id.try_into().unwrap();
-        Some(WidgetId(parent_id))
-    }
-}
-
-// TODO - Merge copy-pasted code
-fn merge_state_up(arena: &mut WidgetArena, widget_id: WidgetId, root_state: &mut WidgetState) {
-    let parent_id = get_widget_mut(arena, widget_id).1.parent();
-
-    let Some(parent_id) = parent_id else {
-        // We've reached the root
-        let child_state_mut = arena.widget_states.find_mut(widget_id.to_raw()).unwrap();
-        root_state.merge_up(child_state_mut.item);
-        return;
-    };
-
-    let mut parent_state_mut = arena.widget_states.find_mut(parent_id.to_raw()).unwrap();
-    let child_state_mut = parent_state_mut
-        .children
-        .get_child_mut(widget_id.to_raw())
-        .unwrap();
-
-    parent_state_mut.item.merge_up(child_state_mut.item);
-}
-
-fn get_widget_mut(arena: &mut WidgetArena, id: WidgetId) -> (&mut dyn Widget, PassCtx<'_>) {
-    let state_mut = arena
-        .widget_states
-        .find_mut(id.to_raw())
-        .expect("widget state not found in arena");
-    let widget_mut = arena
-        .widgets
-        .find_mut(id.to_raw())
-        .expect("widget not found in arena");
-
-    // Box<dyn Widget> -> &dyn Widget
-    // Without this step, the type of `WidgetRef::widget` would be
-    // `&Box<dyn Widget> as &dyn Widget`, which would be an additional layer
-    // of indirection.
-    let widget = widget_mut.item;
-    let widget: &mut dyn Widget = &mut **widget;
-
-    (
-        widget,
-        PassCtx {
-            widget_state: state_mut,
-            widget_children: widget_mut.children,
-        },
-    )
-}
+use crate::passes::merge_state_up;
+use crate::render_root::RenderRoot;
+use crate::widget::WidgetMut;
+use crate::{MutateCtx, Widget, WidgetId, WidgetState};
 
 pub(crate) fn mutate_widget(
     root: &mut RenderRoot,
-    root_state: &mut WidgetState,
     id: WidgetId,
     mutate_fn: impl FnOnce(WidgetMut<'_, Box<dyn Widget>>),
 ) {
-    let state_mut = root
-        .widget_arena
-        .widget_states
-        .find_mut(id.to_raw())
-        .expect("widget state not found in arena");
-    let widget_mut = root
-        .widget_arena
-        .widgets
-        .find_mut(id.to_raw())
-        .expect("widget not found in arena");
+    let mut dummy_state = WidgetState::root(root.root.id(), root.get_kurbo_size());
+    let (widget_mut, state_mut) = root.widget_arena.get_pair_mut(id);
 
     let _span = info_span!("mutate_widget").entered();
     let root_widget = WidgetMut {
         ctx: MutateCtx {
             global_state: &mut root.state,
-            parent_widget_state: root_state,
+            // FIXME - This works in practice, because the loop below will merge the
+            // state up to the root. But it's semantically awkward.
+            // parent_widget_state should probably be an Option.
+            parent_widget_state: &mut dummy_state,
             widget_state: state_mut.item,
             widget_state_children: state_mut.children,
             widget_children: widget_mut.children,
@@ -105,10 +36,8 @@ pub(crate) fn mutate_widget(
 
     let mut current_id = Some(id);
     while let Some(id) = current_id {
-        let (_widget, pass_ctx) = get_widget_mut(&mut root.widget_arena, id);
-        let parent_id = pass_ctx.parent();
-
-        merge_state_up(&mut root.widget_arena, id, root_state);
+        let parent_id = root.widget_arena.parent_of(id);
+        merge_state_up(&mut root.widget_arena, id);
         current_id = parent_id;
     }
 }
@@ -119,8 +48,9 @@ pub(crate) fn run_mutate_pass(root: &mut RenderRoot, root_state: &mut WidgetStat
 
     let callbacks = std::mem::take(&mut root.state.mutate_callbacks);
     for callback in callbacks {
-        mutate_widget(root, root_state, callback.id, callback.callback);
+        mutate_widget(root, callback.id, callback.callback);
     }
 
+    root_state.merge_up(root.widget_arena.get_state_mut(root.root.id()).item);
     // root.post_event_processing(&mut root_state);
 }

--- a/masonry/src/passes/mutate.rs
+++ b/masonry/src/passes/mutate.rs
@@ -1,0 +1,127 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use tracing::info_span;
+
+use crate::{
+    render_root::RenderRoot,
+    tree_arena::{ArenaMut, ArenaMutChildren},
+    widget::{WidgetArena, WidgetMut},
+    MutateCtx, Widget, WidgetId, WidgetState,
+};
+
+// References shared by all passes
+struct PassCtx<'a> {
+    pub(crate) widget_state: ArenaMut<'a, WidgetState>,
+    pub(crate) widget_children: ArenaMutChildren<'a, Box<dyn Widget>>,
+}
+
+impl<'a> PassCtx<'a> {
+    fn parent(&self) -> Option<WidgetId> {
+        let parent_id = self.widget_state.parent_id?;
+        let parent_id = parent_id.try_into().unwrap();
+        Some(WidgetId(parent_id))
+    }
+}
+
+// TODO - Merge copy-pasted code
+fn merge_state_up(arena: &mut WidgetArena, widget_id: WidgetId, root_state: &mut WidgetState) {
+    let parent_id = get_widget_mut(arena, widget_id).1.parent();
+
+    let Some(parent_id) = parent_id else {
+        // We've reached the root
+        let child_state_mut = arena.widget_states.find_mut(widget_id.to_raw()).unwrap();
+        root_state.merge_up(child_state_mut.item);
+        return;
+    };
+
+    let mut parent_state_mut = arena.widget_states.find_mut(parent_id.to_raw()).unwrap();
+    let child_state_mut = parent_state_mut
+        .children
+        .get_child_mut(widget_id.to_raw())
+        .unwrap();
+
+    parent_state_mut.item.merge_up(child_state_mut.item);
+}
+
+fn get_widget_mut(arena: &mut WidgetArena, id: WidgetId) -> (&mut dyn Widget, PassCtx<'_>) {
+    let state_mut = arena
+        .widget_states
+        .find_mut(id.to_raw())
+        .expect("widget state not found in arena");
+    let widget_mut = arena
+        .widgets
+        .find_mut(id.to_raw())
+        .expect("widget not found in arena");
+
+    // Box<dyn Widget> -> &dyn Widget
+    // Without this step, the type of `WidgetRef::widget` would be
+    // `&Box<dyn Widget> as &dyn Widget`, which would be an additional layer
+    // of indirection.
+    let widget = widget_mut.item;
+    let widget: &mut dyn Widget = &mut **widget;
+
+    (
+        widget,
+        PassCtx {
+            widget_state: state_mut,
+            widget_children: widget_mut.children,
+        },
+    )
+}
+
+pub(crate) fn mutate_widget(
+    root: &mut RenderRoot,
+    root_state: &mut WidgetState,
+    id: WidgetId,
+    mutate_fn: impl FnOnce(WidgetMut<'_, Box<dyn Widget>>),
+) {
+    let mut fake_widget_state =
+        WidgetState::new(root.root.id(), Some(root.get_kurbo_size()), "<root>");
+
+    let (widget, pass_ctx) = get_widget_mut(&mut root.widget_arena, id);
+
+    // Our WidgetArena stores all widgets as Box<dyn Widget>, but the "true"
+    // type of our root widget is *also* Box<dyn Widget>. We downcast so we
+    // don't add one more level of indirection to this.
+    let widget = widget
+        .as_mut_dyn_any()
+        .downcast_mut::<Box<dyn Widget>>()
+        .unwrap();
+
+    let _span = info_span!("mutate_widget").entered();
+    let root_widget = WidgetMut {
+        ctx: MutateCtx {
+            global_state: &mut root.state,
+            parent_widget_state: &mut fake_widget_state,
+            widget_state: pass_ctx.widget_state.item,
+            widget_state_children: pass_ctx.widget_state.children,
+            widget_children: pass_ctx.widget_children,
+        },
+        widget,
+        is_reborrow: false,
+    };
+
+    mutate_fn(root_widget);
+
+    let mut current_id = Some(id);
+    while let Some(id) = current_id {
+        let (_widget, pass_ctx) = get_widget_mut(&mut root.widget_arena, id);
+        let parent_id = pass_ctx.parent();
+
+        merge_state_up(&mut root.widget_arena, id, root_state);
+        current_id = parent_id;
+    }
+}
+
+pub(crate) fn run_mutate_pass(root: &mut RenderRoot, root_state: &mut WidgetState) {
+    // TODO - Factor out into a "pre-event" function?
+    // root.state.next_focused_widget = root.state.focused_widget;
+
+    let callbacks = std::mem::take(&mut root.state.mutate_callbacks);
+    for callback in callbacks {
+        mutate_widget(root, root_state, callback.id, callback.callback);
+    }
+
+    // root.post_event_processing(&mut root_state);
+}

--- a/masonry/src/passes/mutate.rs
+++ b/masonry/src/passes/mutate.rs
@@ -8,15 +8,15 @@ use crate::render_root::RenderRoot;
 use crate::widget::WidgetMut;
 use crate::{MutateCtx, Widget, WidgetId, WidgetState};
 
-pub(crate) fn mutate_widget(
+pub(crate) fn mutate_widget<R>(
     root: &mut RenderRoot,
     id: WidgetId,
-    mutate_fn: impl FnOnce(WidgetMut<'_, Box<dyn Widget>>),
-) {
+    mutate_fn: impl FnOnce(WidgetMut<'_, Box<dyn Widget>>) -> R,
+) -> R {
     let mut dummy_state = WidgetState::root(root.root.id(), root.get_kurbo_size());
     let (widget_mut, state_mut) = root.widget_arena.get_pair_mut(id);
 
-    let _span = info_span!("mutate_widget").entered();
+    let _span = info_span!("mutate_widget", name = widget_mut.item.short_type_name()).entered();
     let root_widget = WidgetMut {
         ctx: MutateCtx {
             global_state: &mut root.state,
@@ -32,16 +32,21 @@ pub(crate) fn mutate_widget(
         is_reborrow: false,
     };
 
-    mutate_fn(root_widget);
+    let result = mutate_fn(root_widget);
 
+    // Merge all state changes up to the root.
     let mut current_id = Some(id);
     while let Some(id) = current_id {
         let parent_id = root.widget_arena.parent_of(id);
         merge_state_up(&mut root.widget_arena, id);
         current_id = parent_id;
     }
+
+    result
 }
 
+// TODO - Add link to mutate pass documentation
+/// Apply any deferred mutations (created using [...Ctx::mutate_later](crate::LayoutCtx::mutate_later)).
 pub(crate) fn run_mutate_pass(root: &mut RenderRoot, root_state: &mut WidgetState) {
     // TODO - Factor out into a "pre-event" function?
     // root.state.next_focused_widget = root.state.focused_widget;

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -16,7 +16,7 @@ use std::time::Instant;
 #[cfg(target_arch = "wasm32")]
 use web_time::Instant;
 
-use crate::contexts::{LayoutCtx, LifeCycleCtx, PaintCtx, WidgetCtx};
+use crate::contexts::{LayoutCtx, LifeCycleCtx, MutateCtx, PaintCtx};
 use crate::debug_logger::DebugLogger;
 use crate::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use crate::event::{PointerEvent, TextEvent, WindowEvent};
@@ -321,7 +321,7 @@ impl RenderRoot {
 
         self.state.next_focused_widget = self.state.focused_widget;
         let root_widget = WidgetMut {
-            ctx: WidgetCtx {
+            ctx: MutateCtx {
                 global_state: &mut self.state,
                 parent_widget_state: &mut fake_widget_state,
                 widget_state: state_ref.item,

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -354,7 +354,7 @@ impl RenderRoot {
         let mut root_state = self.widget_arena.get_state_mut(self.root.id()).item.clone();
         self.post_event_processing(&mut root_state);
 
-        res.unwrap()
+        res
     }
 
     // --- MARK: POINTER_EVENT ---

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -278,7 +278,7 @@ impl RenderRoot {
         self.cursor_icon
     }
 
-    // --- MARK: GET ROOT---
+    // --- MARK: ACCESS WIDGETS---
     pub fn get_root_widget(&self) -> WidgetRef<dyn Widget> {
         let root_state_token = self.widget_arena.widget_states.root_token();
         let root_widget_token = self.widget_arena.widgets.root_token();
@@ -318,8 +318,7 @@ impl RenderRoot {
         // TODO - Factor out into a "pre-event" function?
         self.state.next_focused_widget = self.state.focused_widget;
 
-        let mut res = None;
-        mutate_widget(self, self.root.id(), |mut widget_mut| {
+        let res = mutate_widget(self, self.root.id(), |mut widget_mut| {
             // Our WidgetArena stores all widgets as Box<dyn Widget>, but the "true"
             // type of our root widget is *also* Box<dyn Widget>. We downcast so we
             // don't add one more level of indirection to this.
@@ -333,14 +332,13 @@ impl RenderRoot {
                 widget,
                 is_reborrow: true,
             };
-
-            res = Some(f(widget_mut));
+            f(widget_mut)
         });
 
         root_state.merge_up(self.widget_arena.get_state_mut(self.root.id()).item);
         self.post_event_processing(&mut root_state);
 
-        res.unwrap()
+        res
     }
 
     /// Get a [`WidgetMut`] to a specific widget.

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -325,17 +325,9 @@ impl RenderRoot {
                 .as_mut_dyn_any()
                 .downcast_mut::<Box<dyn Widget>>()
                 .unwrap();
-
-            let ctx = crate::MutateCtx {
-                global_state: widget_mut.ctx.global_state,
-                parent_widget_state: widget_mut.ctx.parent_widget_state,
-                widget_state: widget_mut.ctx.widget_state,
-                widget_state_children: widget_mut.ctx.widget_state_children.reborrow_mut(),
-                widget_children: widget_mut.ctx.widget_children.reborrow_mut(),
-            };
             let widget_mut = WidgetMut {
+                ctx: widget_mut.ctx.reborrow_mut(),
                 widget,
-                ctx,
                 is_reborrow: true,
             };
 

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -349,10 +349,7 @@ impl RenderRoot {
         // TODO - Factor out into a "pre-event" function?
         self.state.next_focused_widget = self.state.focused_widget;
 
-        let mut res = None;
-        mutate_widget(self, id, |widget_mut| {
-            res = Some(f(widget_mut));
-        });
+        let res = mutate_widget(self, id, f);
 
         let mut root_state = self.widget_arena.get_state_mut(self.root.id()).item.clone();
         self.post_event_processing(&mut root_state);

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -316,7 +316,7 @@ impl RenderRoot {
         self.state.next_focused_widget = self.state.focused_widget;
 
         let mut res = None;
-        mutate_widget(self, &mut root_state, self.root.id(), |mut widget_mut| {
+        mutate_widget(self, self.root.id(), |mut widget_mut| {
             // Our WidgetArena stores all widgets as Box<dyn Widget>, but the "true"
             // type of our root widget is *also* Box<dyn Widget>. We downcast so we
             // don't add one more level of indirection to this.
@@ -342,6 +342,7 @@ impl RenderRoot {
             res = Some(f(widget_mut));
         });
 
+        root_state.merge_up(self.widget_arena.get_state_mut(self.root.id()).item);
         self.post_event_processing(&mut root_state);
 
         res.unwrap()

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -328,7 +328,6 @@ impl RenderRoot {
             let widget_mut = WidgetMut {
                 ctx: widget_mut.ctx.reborrow_mut(),
                 widget,
-                is_reborrow: true,
             };
             f(widget_mut)
         });

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -67,6 +67,7 @@ pub(crate) struct RenderRootState {
     pub(crate) mutate_callbacks: Vec<MutateCallback>,
 }
 
+#[allow(clippy::type_complexity)]
 pub(crate) struct MutateCallback {
     pub(crate) id: WidgetId,
     pub(crate) callback: Box<dyn FnOnce(WidgetMut<'_, Box<dyn Widget>>)>,

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -16,12 +16,13 @@ use std::time::Instant;
 #[cfg(target_arch = "wasm32")]
 use web_time::Instant;
 
-use crate::contexts::{LayoutCtx, LifeCycleCtx, MutateCtx, PaintCtx};
+use crate::contexts::{LayoutCtx, LifeCycleCtx, PaintCtx};
 use crate::debug_logger::DebugLogger;
 use crate::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use crate::event::{PointerEvent, TextEvent, WindowEvent};
 use crate::kurbo::Point;
 use crate::passes::event::{root_on_access_event, root_on_pointer_event, root_on_text_event};
+use crate::passes::mutate::{mutate_widget, run_mutate_pass};
 use crate::passes::update::run_update_pointer_pass;
 use crate::text::TextBrush;
 use crate::tree_arena::TreeArena;
@@ -31,6 +32,8 @@ use crate::{
     AccessCtx, AccessEvent, Action, BoxConstraints, CursorIcon, Handled, InternalLifeCycle,
     LifeCycle, Widget, WidgetId, WidgetPod,
 };
+
+// --- MARK: STRUCTS ---
 
 // TODO - Remove pub(crate)
 pub struct RenderRoot {
@@ -61,6 +64,12 @@ pub(crate) struct RenderRootState {
     pub(crate) cursor_icon: CursorIcon,
     pub(crate) font_context: FontContext,
     pub(crate) text_layout_context: LayoutContext<TextBrush>,
+    pub(crate) mutate_callbacks: Vec<MutateCallback>,
+}
+
+pub(crate) struct MutateCallback {
+    pub(crate) id: WidgetId,
+    pub(crate) callback: Box<dyn FnOnce(WidgetMut<'_, Box<dyn Widget>>)>,
 }
 
 /// Defines how a windows size should be determined
@@ -131,6 +140,7 @@ impl RenderRoot {
                     source_cache: Default::default(),
                 },
                 text_layout_context: LayoutContext::new(),
+                mutate_callbacks: Vec::new(),
             },
             widget_arena: WidgetArena {
                 widgets: TreeArena::new(),
@@ -301,50 +311,27 @@ impl RenderRoot {
     ) -> R {
         let mut fake_widget_state =
             WidgetState::new(self.root.id(), Some(self.get_kurbo_size()), "<root>");
-        let root_state_token = self.widget_arena.widget_states.root_token_mut();
-        let root_widget_token = self.widget_arena.widgets.root_token_mut();
-        let state_ref = root_state_token
-            .into_child_mut(self.root.id().to_raw())
-            .expect("root widget not in widget tree");
-        let widget_ref = root_widget_token
-            .into_child_mut(self.root.id().to_raw())
-            .expect("root widget not in widget tree");
 
-        // Our WidgetArena stores all widgets as Box<dyn Widget>, but the "true"
-        // type of our root widget is *also* Box<dyn Widget>. We downcast so we
-        // don't add one more level of indirection to this.
-        let widget = widget_ref
-            .item
-            .as_mut_dyn_any()
-            .downcast_mut::<Box<dyn Widget>>()
-            .unwrap();
-
+        // TODO - Factor out into a "pre-event" function?
         self.state.next_focused_widget = self.state.focused_widget;
-        let root_widget = WidgetMut {
-            ctx: MutateCtx {
-                global_state: &mut self.state,
-                parent_widget_state: &mut fake_widget_state,
-                widget_state: state_ref.item,
-                widget_state_children: state_ref.children,
-                widget_children: widget_ref.children,
-            },
-            widget,
-            is_reborrow: false,
-        };
 
-        let res = {
-            let _span = info_span!("edit_root_widget").entered();
-            f(root_widget)
-        };
+        let mut res = None;
+        mutate_widget(self, &mut fake_widget_state, self.root.id(), |w| {
+            res = Some(f(w));
+        });
+
         self.post_event_processing(&mut fake_widget_state);
 
-        res
+        res.unwrap()
     }
 
     // --- MARK: POINTER_EVENT ---
     fn root_on_pointer_event(&mut self, event: PointerEvent) -> Handled {
         let mut root_state =
             WidgetState::new(self.root.id(), Some(self.get_kurbo_size()), "<root>");
+
+        // TODO - Factor out into a "pre-event" function?
+        self.state.next_focused_widget = self.state.focused_widget;
 
         let handled = root_on_pointer_event(self, &mut root_state, &event);
         run_update_pointer_pass(self, &mut root_state);
@@ -359,6 +346,9 @@ impl RenderRoot {
     fn root_on_text_event(&mut self, event: TextEvent) -> Handled {
         let mut root_state =
             WidgetState::new(self.root.id(), Some(self.get_kurbo_size()), "<root>");
+
+        // TODO - Factor out into a "pre-event" function?
+        self.state.next_focused_widget = self.state.focused_widget;
 
         let handled = root_on_text_event(self, &mut root_state, &event);
 
@@ -382,6 +372,9 @@ impl RenderRoot {
             action: event.action,
             data: event.data,
         };
+
+        // TODO - Factor out into a "pre-event" function?
+        self.state.next_focused_widget = self.state.focused_widget;
 
         root_on_access_event(self, &mut root_state, &event);
 
@@ -549,7 +542,7 @@ impl RenderRoot {
         tree_update
     }
 
-    fn get_kurbo_size(&self) -> kurbo::Size {
+    pub(crate) fn get_kurbo_size(&self) -> kurbo::Size {
         let size = self.size.to_logical(self.scale_factor);
         kurbo::Size::new(size.width, size.height)
     }
@@ -606,6 +599,8 @@ impl RenderRoot {
                 .signal_queue
                 .push_back(RenderRootSignal::RequestRedraw);
         }
+
+        run_mutate_pass(self, widget_state);
 
         #[cfg(FALSE)]
         for ime_field in widget_state.text_registrations.drain(..) {

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -508,6 +508,19 @@ impl TestHarness {
         res
     }
 
+    /// Get a [`WidgetMut`] to a specific widget.
+    ///
+    /// Because of how `WidgetMut` works, it can only be passed to a user-provided callback.
+    pub fn edit_widget<R>(
+        &mut self,
+        id: WidgetId,
+        f: impl FnOnce(WidgetMut<'_, Box<dyn Widget>>) -> R,
+    ) -> R {
+        let res = self.render_root.edit_widget(id, f);
+        self.process_state_after_event();
+        res
+    }
+
     /// Pop next action from the queue
     ///
     /// Note: Actions are still a WIP feature.

--- a/masonry/src/widget/tests/mod.rs
+++ b/masonry/src/widget/tests/mod.rs
@@ -9,3 +9,4 @@ mod lifecycle_disable;
 mod lifecycle_focus;
 mod safety_rails;
 mod status_change;
+mod widget_tree;

--- a/masonry/src/widget/tests/snapshots/masonry__widget__tests__widget_tree__access_grandchild_widget.snap
+++ b/masonry/src/widget/tests/snapshots/masonry__widget__tests__widget_tree__access_grandchild_widget.snap
@@ -1,0 +1,12 @@
+---
+source: masonry/src/widget/tests/widget_tree.rs
+assertion_line: 24
+expression: harness.root_widget()
+---
+Flex(
+    Flex(
+        Flex(
+            Label<New text>,
+        ),
+    ),
+)

--- a/masonry/src/widget/tests/widget_tree.rs
+++ b/masonry/src/widget/tests/widget_tree.rs
@@ -1,0 +1,25 @@
+use insta::assert_debug_snapshot;
+
+use crate::testing::{widget_ids, TestHarness};
+use crate::widget::{Flex, Label};
+
+#[test]
+fn access_grandchild_widget() {
+    let [id_label] = widget_ids();
+
+    let widget = Flex::column()
+        .with_child(
+            Flex::row().with_child(Flex::row().with_child_id(Label::new("Old text"), id_label)),
+        )
+        .with_flex_spacer(1.0);
+
+    let mut harness = TestHarness::create(widget);
+
+    dbg!(harness.root_widget());
+    harness.edit_widget(id_label, |mut label| {
+        let mut label = label.downcast::<Label>();
+        label.set_text("New text");
+    });
+
+    assert_debug_snapshot!(harness.root_widget());
+}

--- a/masonry/src/widget/tests/widget_tree.rs
+++ b/masonry/src/widget/tests/widget_tree.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use insta::assert_debug_snapshot;
 
 use crate::testing::{widget_ids, TestHarness};

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -227,7 +227,7 @@ pub trait Widget: AsAny {
 /// A parent widget can use [`EventCtx::get_raw_mut`], [`LifeCycleCtx::get_raw_mut`],
 /// or [`LayoutCtx::get_raw_mut`] to directly access a child widget. In that case,
 /// these methods return both a mutable reference to the child widget and a new
-/// context (`WidgetCtx`, `EventCtx`, etc) scoped to the child. The parent is
+/// context (`MutateCtx`, `EventCtx`, etc) scoped to the child. The parent is
 /// responsible for calling the context methods (eg `request_layout`,
 /// `request_accessibility_update`) for the child.
 ///

--- a/masonry/src/widget/widget_mut.rs
+++ b/masonry/src/widget/widget_mut.rs
@@ -1,7 +1,7 @@
 // Copyright 2018 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::contexts::WidgetCtx;
+use crate::contexts::MutateCtx;
 use crate::{Widget, WidgetState};
 
 // TODO - Document extension trait workaround.
@@ -15,7 +15,7 @@ use crate::{Widget, WidgetState};
 ///
 /// You can create a `WidgetMut` from [`TestHarness`](crate::testing::TestHarness),
 /// [`EventCtx`](crate::EventCtx), [`LifeCycleCtx`](crate::LifeCycleCtx) or from a parent
-/// `WidgetMut` with [`WidgetCtx`](crate::WidgetCtx).
+/// `WidgetMut` with [`MutateCtx`](crate::MutateCtx).
 ///
 /// `WidgetMut` implements [`Deref`](std::ops::Deref) with `W::Mut` as target.
 ///
@@ -24,7 +24,7 @@ use crate::{Widget, WidgetState};
 /// Once the Receiver trait is stabilized, `WidgetMut` will implement it so that custom
 /// widgets in downstream crates can use `WidgetMut` as the receiver for inherent methods.
 pub struct WidgetMut<'a, W: Widget> {
-    pub ctx: WidgetCtx<'a>,
+    pub ctx: MutateCtx<'a>,
     pub widget: &'a mut W,
     pub(crate) is_reborrow: bool,
 }
@@ -48,7 +48,7 @@ impl<'w, W: Widget> WidgetMut<'w, W> {
 
     /// Get a `WidgetMut` for the same underlying widget with a shorter lifetime.
     pub fn reborrow_mut(&mut self) -> WidgetMut<'_, W> {
-        let ctx = WidgetCtx {
+        let ctx = MutateCtx {
             global_state: self.ctx.global_state,
             parent_widget_state: self.ctx.parent_widget_state,
             widget_state: self.ctx.widget_state,
@@ -67,7 +67,7 @@ impl<'w, W: Widget> WidgetMut<'w, W> {
 impl<'a> WidgetMut<'a, Box<dyn Widget>> {
     /// Attempt to downcast to `WidgetMut` of concrete Widget type.
     pub fn try_downcast<W2: Widget>(&mut self) -> Option<WidgetMut<'_, W2>> {
-        let ctx = WidgetCtx {
+        let ctx = MutateCtx {
             global_state: self.ctx.global_state,
             parent_widget_state: self.ctx.parent_widget_state,
             widget_state: self.ctx.widget_state,
@@ -88,7 +88,7 @@ impl<'a> WidgetMut<'a, Box<dyn Widget>> {
     /// Panics if the downcast fails, with an error message that shows the
     /// discrepancy between the expected and actual types.
     pub fn downcast<W2: Widget>(&mut self) -> WidgetMut<'_, W2> {
-        let ctx = WidgetCtx {
+        let ctx = MutateCtx {
             global_state: self.ctx.global_state,
             parent_widget_state: self.ctx.parent_widget_state,
             widget_state: self.ctx.widget_state,

--- a/masonry/src/widget/widget_mut.rs
+++ b/masonry/src/widget/widget_mut.rs
@@ -48,16 +48,9 @@ impl<'w, W: Widget> WidgetMut<'w, W> {
 
     /// Get a `WidgetMut` for the same underlying widget with a shorter lifetime.
     pub fn reborrow_mut(&mut self) -> WidgetMut<'_, W> {
-        let ctx = MutateCtx {
-            global_state: self.ctx.global_state,
-            parent_widget_state: self.ctx.parent_widget_state,
-            widget_state: self.ctx.widget_state,
-            widget_state_children: self.ctx.widget_state_children.reborrow_mut(),
-            widget_children: self.ctx.widget_children.reborrow_mut(),
-        };
         let widget = &mut self.widget;
         WidgetMut {
-            ctx,
+            ctx: self.ctx.reborrow_mut(),
             widget,
             is_reborrow: true,
         }
@@ -67,15 +60,8 @@ impl<'w, W: Widget> WidgetMut<'w, W> {
 impl<'a> WidgetMut<'a, Box<dyn Widget>> {
     /// Attempt to downcast to `WidgetMut` of concrete Widget type.
     pub fn try_downcast<W2: Widget>(&mut self) -> Option<WidgetMut<'_, W2>> {
-        let ctx = MutateCtx {
-            global_state: self.ctx.global_state,
-            parent_widget_state: self.ctx.parent_widget_state,
-            widget_state: self.ctx.widget_state,
-            widget_state_children: self.ctx.widget_state_children.reborrow_mut(),
-            widget_children: self.ctx.widget_children.reborrow_mut(),
-        };
         Some(WidgetMut {
-            ctx,
+            ctx: self.ctx.reborrow_mut(),
             widget: self.widget.as_mut_any().downcast_mut()?,
             is_reborrow: true,
         })
@@ -88,17 +74,10 @@ impl<'a> WidgetMut<'a, Box<dyn Widget>> {
     /// Panics if the downcast fails, with an error message that shows the
     /// discrepancy between the expected and actual types.
     pub fn downcast<W2: Widget>(&mut self) -> WidgetMut<'_, W2> {
-        let ctx = MutateCtx {
-            global_state: self.ctx.global_state,
-            parent_widget_state: self.ctx.parent_widget_state,
-            widget_state: self.ctx.widget_state,
-            widget_state_children: self.ctx.widget_state_children.reborrow_mut(),
-            widget_children: self.ctx.widget_children.reborrow_mut(),
-        };
         let w1_name = self.widget.type_name();
         match self.widget.as_mut_any().downcast_mut() {
             Some(widget) => WidgetMut {
-                ctx,
+                ctx: self.ctx.reborrow_mut(),
                 widget,
                 is_reborrow: true,
             },

--- a/masonry/src/widget/widget_pod.rs
+++ b/masonry/src/widget/widget_pod.rs
@@ -281,16 +281,7 @@ impl<W: Widget> WidgetPod<W> {
             }
         }
 
-        // TODO - Write new constructor for WidgetState
-        let mut state = WidgetState::new(self.id, None, widget.short_type_name());
-        state.children_changed = true;
-        state.needs_layout = true;
-        state.update_focus_chain = true;
-        state.needs_layout = true;
-        state.needs_paint = true;
-        state.needs_window_origin = true;
-        state.needs_accessibility_update = true;
-        state.request_accessibility_update = true;
+        let state = WidgetState::new(self.id, widget.short_type_name());
 
         parent_ctx
             .widget_children

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -169,40 +169,18 @@ impl WidgetState {
             widget_name,
         }
     }
+
     pub(crate) fn root(id: WidgetId, size: Size) -> WidgetState {
         WidgetState {
-            id,
-            origin: Point::ORIGIN,
-            parent_window_origin: Point::ORIGIN,
             size,
-            is_expecting_place_child_call: false,
-            paint_insets: Insets::ZERO,
-            local_paint_rect: Rect::ZERO,
-            is_portal: false,
-            children_disabled_changed: false,
-            ancestor_disabled: false,
-            is_explicitly_disabled: false,
-            baseline_offset: 0.0,
-            is_hot: false,
             needs_layout: false,
             needs_paint: false,
             needs_accessibility_update: false,
             needs_window_origin: false,
-            has_focus: false,
-            request_anim: false,
             request_accessibility_update: false,
-            focus_chain: Vec::new(),
-            children: Bloom::new(),
             children_changed: false,
-            cursor: None,
-            is_explicitly_disabled_new: false,
-            text_registrations: Vec::new(),
             update_focus_chain: false,
-            is_stashed: false,
-            #[cfg(debug_assertions)]
-            needs_visit: VisitBool(false.into()),
-            #[cfg(debug_assertions)]
-            widget_name: "<root>",
+            ..WidgetState::new(id, "<root>")
         }
     }
 

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -153,7 +153,7 @@ impl WidgetState {
             needs_accessibility_update: true,
             needs_window_origin: true,
             has_focus: false,
-            request_anim: false,
+            request_anim: true,
             request_accessibility_update: true,
             focus_chain: Vec::new(),
             children: Bloom::new(),

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -133,12 +133,48 @@ pub struct WidgetState {
 pub(crate) struct VisitBool(pub AtomicBool);
 
 impl WidgetState {
-    pub(crate) fn new(id: WidgetId, size: Option<Size>, widget_name: &'static str) -> WidgetState {
+    pub(crate) fn new(id: WidgetId, widget_name: &'static str) -> WidgetState {
         WidgetState {
             id,
             origin: Point::ORIGIN,
             parent_window_origin: Point::ORIGIN,
-            size: size.unwrap_or_default(),
+            size: Size::ZERO,
+            is_expecting_place_child_call: false,
+            paint_insets: Insets::ZERO,
+            local_paint_rect: Rect::ZERO,
+            is_portal: false,
+            children_disabled_changed: false,
+            ancestor_disabled: false,
+            is_explicitly_disabled: false,
+            baseline_offset: 0.0,
+            is_hot: false,
+            needs_layout: true,
+            needs_paint: true,
+            needs_accessibility_update: true,
+            needs_window_origin: true,
+            has_focus: false,
+            request_anim: false,
+            request_accessibility_update: true,
+            focus_chain: Vec::new(),
+            children: Bloom::new(),
+            children_changed: true,
+            cursor: None,
+            is_explicitly_disabled_new: false,
+            text_registrations: Vec::new(),
+            update_focus_chain: true,
+            is_stashed: false,
+            #[cfg(debug_assertions)]
+            needs_visit: VisitBool(false.into()),
+            #[cfg(debug_assertions)]
+            widget_name,
+        }
+    }
+    pub(crate) fn root(id: WidgetId, size: Size) -> WidgetState {
+        WidgetState {
+            id,
+            origin: Point::ORIGIN,
+            parent_window_origin: Point::ORIGIN,
+            size,
             is_expecting_place_child_call: false,
             paint_insets: Insets::ZERO,
             local_paint_rect: Rect::ZERO,
@@ -166,7 +202,7 @@ impl WidgetState {
             #[cfg(debug_assertions)]
             needs_visit: VisitBool(false.into()),
             #[cfg(debug_assertions)]
-            widget_name,
+            widget_name: "<root>",
         }
     }
 

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -170,7 +170,10 @@ impl WidgetState {
         }
     }
 
-    pub(crate) fn root(id: WidgetId, size: Size) -> WidgetState {
+    /// Create a dummy root state.
+    ///
+    /// This is useful for passes that need a parent state for the root widget.
+    pub(crate) fn synthetic(id: WidgetId, size: Size) -> WidgetState {
         WidgetState {
             size,
             needs_layout: false,
@@ -178,6 +181,7 @@ impl WidgetState {
             needs_accessibility_update: false,
             needs_window_origin: false,
             request_accessibility_update: false,
+            request_anim: false,
             children_changed: false,
             update_focus_chain: false,
             ..WidgetState::new(id, "<root>")


### PR DESCRIPTION
This is part of the "Pass Specification" RFC:
https://github.com/linebender/rfcs/pull/7

Rename WidgetCtx to MutateCtx.
Add a mutate pass.
Add a `mutate_later` context method to trigger that pass.
Refactor `edit_root_widget` to use a version of that pass.
Add a separate constructor for the synthetic WidgetState created in RenderRoot.