### PR TITLE
Reduce logs in tests

### DIFF
--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -139,7 +139,7 @@ pub fn run_with(
     // already been set, we get an error which we swallow.
     // By now, we're about to take control of the event loop. The user is unlikely
     // to try to set their own subscriber once the event loop has started.
-    let _ = crate::tracing_backend::try_init_tracing();
+    let _ = crate::tracing_backend::try_init_tracing(false);
 
     event_loop.run_app(&mut main_state)
 }

--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -139,7 +139,7 @@ pub fn run_with(
     // already been set, we get an error which we swallow.
     // By now, we're about to take control of the event loop. The user is unlikely
     // to try to set their own subscriber once the event loop has started.
-    let _ = crate::tracing_backend::try_init_tracing(false);
+    let _ = crate::tracing_backend::try_init_tracing();
 
     event_loop.run_app(&mut main_state)
 }

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -20,7 +20,7 @@ use crate::action::Action;
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::event::{PointerButton, PointerEvent, PointerState, TextEvent, WindowEvent};
 use crate::render_root::{RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy};
-use crate::tracing_backend::try_init_tracing;
+use crate::tracing_backend::try_init_test_tracing;
 use crate::widget::{WidgetMut, WidgetRef};
 use crate::{Color, Handled, Point, Size, Vec2, Widget, WidgetId};
 
@@ -177,7 +177,7 @@ impl TestHarness {
         // Having a default subscriber is helpful for tests; swallowing errors means
         // we don't panic if the user has already set one, or a test creates multiple
         // harnesses.
-        let _ = try_init_tracing(true);
+        let _ = try_init_test_tracing();
 
         let mut harness = TestHarness {
             render_root: RenderRoot::new(

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -177,7 +177,7 @@ impl TestHarness {
         // Having a default subscriber is helpful for tests; swallowing errors means
         // we don't panic if the user has already set one, or a test creates multiple
         // harnesses.
-        let _ = try_init_tracing();
+        let _ = try_init_tracing(true);
 
         let mut harness = TestHarness {
             render_root: RenderRoot::new(

--- a/masonry/src/tracing_backend.rs
+++ b/masonry/src/tracing_backend.rs
@@ -6,7 +6,6 @@ use std::time::UNIX_EPOCH;
 
 use time::macros::format_description;
 use tracing::subscriber::SetGlobalDefaultError;
-use tracing::Level;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::time::UtcTime;
 use tracing_subscriber::prelude::*;

--- a/masonry/src/tracing_backend.rs
+++ b/masonry/src/tracing_backend.rs
@@ -34,11 +34,13 @@ pub(crate) fn try_init_wasm_tracing() -> Result<(), SetGlobalDefaultError> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn try_init_layered_tracing() -> Result<(), SetGlobalDefaultError> {
-    // Default level is DEBUG in --dev, INFO in --release
+pub(crate) fn try_init_layered_tracing(testing: bool) -> Result<(), SetGlobalDefaultError> {
+    // Default level is DEBUG in --dev, INFO in --release, WARN in unit tests.
     // DEBUG should print a few logs per low-density event.
     // INFO should only print logs for noteworthy things.
-    let default_level = if cfg!(debug_assertions) {
+    let default_level = if testing {
+        LevelFilter::WARN
+    } else if cfg!(debug_assertions) {
         LevelFilter::DEBUG
     } else {
         LevelFilter::INFO
@@ -99,10 +101,10 @@ pub(crate) fn try_init_layered_tracing() -> Result<(), SetGlobalDefaultError> {
     Ok(())
 }
 
-pub(crate) fn try_init_tracing() -> Result<(), SetGlobalDefaultError> {
+pub(crate) fn try_init_tracing(testing: bool) -> Result<(), SetGlobalDefaultError> {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        try_init_layered_tracing()
+        try_init_layered_tracing(testing)
     }
 
     #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
Stop debug log lines from showing up between test indicators when running `cargo test`.