### PR TITLE
Implement compose pass

### DIFF
--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -887,6 +887,9 @@ impl ComposeCtx<'_> {
         self.widget_state.needs_compose
     }
 
+    /// Set a translation for the child widget.
+    ///
+    /// The translation is applied on top of the position from [`LayoutCtx::place_child`].
     pub fn set_child_translation(&mut self, translation: Vec2) {
         if self.widget_state.translation != translation {
             self.widget_state.translation = translation;

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -6,9 +6,9 @@
 use std::time::Duration;
 
 use accesskit::{NodeBuilder, TreeUpdate};
-use kurbo::Vec2;
 use parley::{FontContext, LayoutContext};
 use tracing::{trace, warn};
+use vello::kurbo::Vec2;
 
 use crate::action::Action;
 use crate::render_root::{MutateCallback, RenderRootSignal, RenderRootState};

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -424,7 +424,7 @@ impl_context_method!(MutateCtx<'_>, EventCtx<'_>, LifeCycleCtx<'_>, {
     }
 
     // TODO - Document better
-    /// Request a compose pass.
+    /// Request a [`compose`] pass.
     ///
     /// The compose pass is often cheaper than the layout pass, because it can only transform individual widgets' position.
     /// [`compose`]: crate::Widget::compose

--- a/masonry/src/debug_logger.rs
+++ b/masonry/src/debug_logger.rs
@@ -207,7 +207,6 @@ impl DebugLogger {
             StateTree::new("is_explicitly_disabled", w_state.is_explicitly_disabled),
             StateTree::new("is_hot", w_state.is_hot),
             StateTree::new("needs_layout", w_state.needs_layout),
-            StateTree::new("needs_window_origin", w_state.needs_window_origin),
             StateTree::new("has_focus", w_state.has_focus),
             StateTree::new("request_anim", w_state.request_anim),
             StateTree::new("children_changed", w_state.children_changed),

--- a/masonry/src/event.rs
+++ b/masonry/src/event.rs
@@ -330,11 +330,6 @@ pub enum InternalLifeCycle {
 
     /// Used to route the `DisabledChanged` event to the required widgets.
     RouteDisabledChanged,
-
-    /// The parents widget origin in window coordinate space has changed.
-    ParentWindowOrigin {
-        mouse_pos: Option<LogicalPosition<f64>>,
-    },
 }
 
 /// Event indicating status changes within the widget hierarchy.
@@ -525,7 +520,6 @@ impl LifeCycle {
                 InternalLifeCycle::RouteWidgetAdded => "RouteWidgetAdded",
                 InternalLifeCycle::RouteFocusChanged { .. } => "RouteFocusChanged",
                 InternalLifeCycle::RouteDisabledChanged => "RouteDisabledChanged",
-                InternalLifeCycle::ParentWindowOrigin { .. } => "ParentWindowOrigin",
             },
             LifeCycle::WidgetAdded => "WidgetAdded",
             LifeCycle::AnimFrame(_) => "AnimFrame",
@@ -550,7 +544,6 @@ impl InternalLifeCycle {
             InternalLifeCycle::RouteWidgetAdded
             | InternalLifeCycle::RouteFocusChanged { .. }
             | InternalLifeCycle::RouteDisabledChanged => true,
-            InternalLifeCycle::ParentWindowOrigin { .. } => false,
         }
     }
 }

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -130,8 +130,8 @@ mod tree_arena;
 pub use action::Action;
 pub use box_constraints::BoxConstraints;
 pub use contexts::{
-    AccessCtx, EventCtx, IsContext, LayoutCtx, LifeCycleCtx, MutateCtx, PaintCtx, RawWrapper,
-    RawWrapperMut,
+    AccessCtx, ComposeCtx, EventCtx, IsContext, LayoutCtx, LifeCycleCtx, MutateCtx, PaintCtx,
+    RawWrapper, RawWrapperMut,
 };
 pub use event::{
     AccessEvent, InternalLifeCycle, LifeCycle, PointerButton, PointerEvent, PointerState,

--- a/masonry/src/passes/compose.rs
+++ b/masonry/src/passes/compose.rs
@@ -51,9 +51,6 @@ fn compose_widget(
 ) {
     let moved = parent_moved || state.item.translation_changed;
     let translation = parent_translation + state.item.translation + state.item.origin.to_vec2();
-    state.item.needs_compose = false;
-    state.item.request_compose = false;
-    state.item.translation_changed = false;
     state.item.window_origin = Point::new(translation.x, translation.y);
 
     let mut ctx = ComposeCtx {
@@ -65,6 +62,10 @@ fn compose_widget(
     if ctx.widget_state.request_compose {
         widget.item.compose(&mut ctx);
     }
+
+    state.item.needs_compose = false;
+    state.item.request_compose = false;
+    state.item.translation_changed = false;
 
     let id = state.item.id;
     let parent_state = state.item;

--- a/masonry/src/passes/compose.rs
+++ b/masonry/src/passes/compose.rs
@@ -1,0 +1,102 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use kurbo::{Point, Vec2};
+use tracing::info_span;
+
+use crate::render_root::{RenderRoot, RenderRootState};
+use crate::tree_arena::{ArenaMut, ArenaMutChildren};
+use crate::{ComposeCtx, Widget, WidgetId, WidgetState};
+
+fn recurse_on_children(
+    id: WidgetId,
+    mut widget: ArenaMut<'_, Box<dyn Widget>>,
+    mut state: ArenaMutChildren<'_, WidgetState>,
+    mut callback: impl FnMut(ArenaMut<'_, Box<dyn Widget>>, ArenaMut<'_, WidgetState>),
+) {
+    let parent_name = widget.item.short_type_name();
+    let parent_id = id;
+
+    for child_id in widget.item.children_ids() {
+        let widget = widget
+            .children
+            .get_child_mut(child_id.to_raw())
+            .unwrap_or_else(|| {
+                panic!(
+                    "Error in '{}' #{}: cannot find child #{} returned by children_ids()",
+                    parent_name,
+                    parent_id.to_raw(),
+                    child_id.to_raw()
+                )
+            });
+        let state = state.get_child_mut(child_id.to_raw()).unwrap_or_else(|| {
+            panic!(
+                "Error in '{}' #{}: cannot find child #{} returned by children_ids()",
+                parent_name,
+                parent_id.to_raw(),
+                child_id.to_raw()
+            )
+        });
+
+        callback(widget, state);
+    }
+}
+
+fn compose_widget(
+    global_state: &mut RenderRootState,
+    mut widget: ArenaMut<'_, Box<dyn Widget>>,
+    mut state: ArenaMut<'_, WidgetState>,
+    parent_moved: bool,
+    parent_translation: Vec2,
+) {
+    let moved = parent_moved || state.item.translation_changed;
+    let translation = parent_translation + state.item.translation + state.item.origin.to_vec2();
+    state.item.needs_compose = false;
+    state.item.request_compose = false;
+    state.item.translation_changed = false;
+    state.item.window_origin = Point::new(translation.x, translation.y);
+
+    let mut ctx = ComposeCtx {
+        global_state,
+        widget_state: state.item,
+        widget_state_children: state.children.reborrow_mut(),
+        widget_children: widget.children.reborrow_mut(),
+    };
+    if ctx.widget_state.request_compose {
+        widget.item.compose(&mut ctx);
+    }
+
+    let id = state.item.id;
+    let parent_state = state.item;
+    recurse_on_children(
+        id,
+        widget.reborrow_mut(),
+        state.children,
+        |widget, mut state| {
+            if !moved && !state.item.translation_changed && !state.item.needs_compose {
+                return;
+            }
+            compose_widget(
+                global_state,
+                widget,
+                state.reborrow_mut(),
+                moved,
+                translation,
+            );
+            parent_state.merge_up(state.item);
+        },
+    );
+
+    // state.item.moved = false;
+}
+
+// ----------------
+
+pub fn root_compose(root: &mut RenderRoot, global_root_state: &mut WidgetState) {
+    let _span = info_span!("compose").entered();
+
+    let (root_widget, root_state) = root.widget_arena.get_pair_mut(root.root.id());
+    compose_widget(&mut root.state, root_widget, root_state, false, Vec2::ZERO);
+
+    global_root_state.merge_up(root.widget_arena.get_state_mut(root.root.id()).item);
+}

--- a/masonry/src/passes/compose.rs
+++ b/masonry/src/passes/compose.rs
@@ -1,8 +1,8 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use kurbo::Vec2;
 use tracing::info_span;
+use vello::kurbo::Vec2;
 
 use crate::render_root::{RenderRoot, RenderRootState};
 use crate::tree_arena::{ArenaMut, ArenaMutChildren};

--- a/masonry/src/passes/compose.rs
+++ b/masonry/src/passes/compose.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use kurbo::{Point, Vec2};
+use kurbo::Vec2;
 use tracing::info_span;
 
 use crate::render_root::{RenderRoot, RenderRootState};
@@ -51,7 +51,7 @@ fn compose_widget(
 ) {
     let moved = parent_moved || state.item.translation_changed;
     let translation = parent_translation + state.item.translation + state.item.origin.to_vec2();
-    state.item.window_origin = Point::new(translation.x, translation.y);
+    state.item.window_origin = translation.to_point();
 
     let mut ctx = ComposeCtx {
         global_state,

--- a/masonry/src/passes/compose.rs
+++ b/masonry/src/passes/compose.rs
@@ -87,8 +87,6 @@ fn compose_widget(
             parent_state.merge_up(state.item);
         },
     );
-
-    // state.item.moved = false;
 }
 
 // ----------------

--- a/masonry/src/passes/mod.rs
+++ b/masonry/src/passes/mod.rs
@@ -4,6 +4,7 @@
 use crate::widget::WidgetArena;
 use crate::WidgetId;
 
+pub mod compose;
 pub mod event;
 pub mod mutate;
 pub mod update;

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -20,6 +20,7 @@ use crate::contexts::{LayoutCtx, LifeCycleCtx, PaintCtx};
 use crate::debug_logger::DebugLogger;
 use crate::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use crate::event::{PointerEvent, TextEvent, WindowEvent};
+use crate::passes::compose::root_compose;
 use crate::passes::event::{root_on_access_event, root_on_pointer_event, root_on_text_event};
 use crate::passes::mutate::{mutate_widget, run_mutate_pass};
 use crate::passes::update::run_update_pointer_pass;
@@ -603,11 +604,8 @@ impl RenderRoot {
             self.state.debug_logger.layout_tree.root = Some(self.root.id().to_raw() as u32);
         }
 
-        if self.root_state().needs_window_origin && !self.root_state().needs_layout {
-            let event = LifeCycle::Internal(InternalLifeCycle::ParentWindowOrigin {
-                mouse_pos: self.last_mouse_pos,
-            });
-            self.root_lifecycle(event);
+        if self.root_state().needs_compose && !self.root_state().needs_layout {
+            root_compose(self, widget_state);
         }
 
         // Update the disabled state if necessary

--- a/masonry/src/tree_arena.rs
+++ b/masonry/src/tree_arena.rs
@@ -97,6 +97,14 @@ pub struct ArenaMutChildren<'a, Item> {
 
 // -- MARK: IMPLS ---
 
+impl<'a, Item> Clone for ArenaRef<'a, Item> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, Item> Copy for ArenaRef<'a, Item> {}
+
 impl<'a, Item> Clone for ArenaRefChildren<'a, Item> {
     fn clone(&self) -> Self {
         *self
@@ -374,12 +382,14 @@ impl<'a, Item> ArenaMutChildren<'a, Item> {
 
 impl<'a, Item> ArenaRef<'a, Item> {
     pub fn id(&self) -> u64 {
+        // ArenaRefChildren always has an id when it's a member of ArenaRef
         self.children.id.unwrap()
     }
 }
 
 impl<'a, Item> ArenaMut<'a, Item> {
     pub fn id(&self) -> u64 {
+        // ArenaRefChildren always has an id when it's a member of ArenaRef
         self.children.id.unwrap()
     }
 

--- a/masonry/src/tree_arena.rs
+++ b/masonry/src/tree_arena.rs
@@ -372,6 +372,38 @@ impl<'a, Item> ArenaMutChildren<'a, Item> {
     }
 }
 
+impl<'a, Item> ArenaRef<'a, Item> {
+    pub fn id(&self) -> u64 {
+        self.children.id.unwrap()
+    }
+}
+
+impl<'a, Item> ArenaMut<'a, Item> {
+    pub fn id(&self) -> u64 {
+        self.children.id.unwrap()
+    }
+
+    /// Returns a shared token equivalent to this one.
+    pub fn reborrow(&mut self) -> ArenaRef<'_, Item> {
+        ArenaRef {
+            parent_id: self.parent_id,
+            item: self.item,
+            children: self.children.reborrow(),
+        }
+    }
+
+    /// Returns a mutable token equivalent to this one.
+    ///
+    /// This is sometimes useful to work with the borrow checker.
+    pub fn reborrow_mut(&mut self) -> ArenaMut<'_, Item> {
+        ArenaMut {
+            parent_id: self.parent_id,
+            item: self.item,
+            children: self.children.reborrow_mut(),
+        }
+    }
+}
+
 // This is a sketch of what the unsafe version of this code would look like,
 // one with an actual arena.
 #[cfg(FALSE)]

--- a/masonry/src/widget/tests/snapshots/masonry__widget__tests__lifecycle_basic__app_creation.snap
+++ b/masonry/src/widget/tests/snapshots/masonry__widget__tests__lifecycle_basic__app_creation.snap
@@ -18,11 +18,5 @@ expression: record
     Layout(
         400.0W×400.0H,
     ),
-    L(
-        Internal(
-            ParentWindowOrigin {
-                mouse_pos: None,
-            },
-        ),
-    ),
+    Compose,
 ]

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -12,6 +12,7 @@ use smallvec::SmallVec;
 use tracing::{trace_span, Span};
 use vello::Scene;
 
+use crate::contexts::ComposeCtx;
 use crate::event::{AccessEvent, PointerEvent, StatusChange, TextEvent};
 use crate::{
     AccessCtx, AsAny, BoxConstraints, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx, Size,
@@ -104,6 +105,8 @@ pub trait Widget: AsAny {
     ///
     /// The layout strategy is strongly inspired by Flutter.
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size;
+
+    fn compose(&mut self, ctx: &mut ComposeCtx) {}
 
     /// Paint the widget appearance.
     ///
@@ -306,6 +309,10 @@ impl Widget for Box<dyn Widget> {
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size {
         self.deref_mut().layout(ctx, bc)
+    }
+
+    fn compose(&mut self, ctx: &mut ComposeCtx) {
+        self.deref_mut().compose(ctx);
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {

--- a/masonry/src/widget/widget_pod.rs
+++ b/masonry/src/widget/widget_pod.rs
@@ -372,8 +372,9 @@ impl<W: Widget> WidgetPod<W> {
                     }
                 }
                 InternalLifeCycle::ParentWindowOrigin { .. } => {
-                    state.parent_window_origin = parent_ctx.widget_state.window_origin();
-                    state.needs_window_origin = false;
+                    // FIXME
+                    //state.parent_window_origin = parent_ctx.widget_state.window_origin();
+                    //state.needs_window_origin = false;
                     // TODO - state.is_hidden
                     true
                 }
@@ -554,6 +555,7 @@ impl<W: Widget> WidgetPod<W> {
         }
 
         state.needs_layout = false;
+        state.needs_compose = true;
         state.is_expecting_place_child_call = true;
         // TODO - Not everything that has been re-laid out needs to be repainted.
         state.needs_paint = true;

--- a/masonry/src/widget/widget_pod.rs
+++ b/masonry/src/widget/widget_pod.rs
@@ -371,13 +371,6 @@ impl<W: Widget> WidgetPod<W> {
                         _ => false,
                     }
                 }
-                InternalLifeCycle::ParentWindowOrigin { .. } => {
-                    // FIXME
-                    //state.parent_window_origin = parent_ctx.widget_state.window_origin();
-                    //state.needs_window_origin = false;
-                    // TODO - state.is_hidden
-                    true
-                }
             },
             LifeCycle::WidgetAdded => {
                 trace!(

--- a/masonry/src/widget/widget_ref.rs
+++ b/masonry/src/widget/widget_ref.rs
@@ -209,7 +209,7 @@ impl<'w> WidgetRef<'w, dyn Widget> {
             );
         }
 
-        if after_layout && (self.state().needs_layout || self.state().needs_window_origin) {
+        if after_layout && self.state().needs_layout {
             debug_panic!(
                 "Widget '{}' #{} is invalid: widget layout state not cleared",
                 self.deref().short_type_name(),

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -4,9 +4,7 @@
 #![cfg(not(tarpaulin_include))]
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use vello::kurbo::{Insets, Point, Rect, Size};
-
-use kurbo::Vec2;
+use vello::kurbo::{Insets, Point, Rect, Size, Vec2};
 
 use crate::bloom::Bloom;
 use crate::text_helpers::TextFieldRegistration;


### PR DESCRIPTION
Add `Widget::compose` method.
Add `ComposeCtx` type.
Add `needs_compose`, `request_compose`, `translation_changed` flags to WidgetState.
Add `window_origin` attribute to WidgetState.
Add convenience methods to TreeArena.
Remove `needs_window_origin` flag and `parent_window_origin` attribute.