### PR TITLE
xilem_web: Document a lot and remove `start_<modifier>` as it doesn't do anything in `View::build` and may be misleading

### DIFF
--- a/xilem_web/src/after_update.rs
+++ b/xilem_web/src/after_update.rs
@@ -113,9 +113,8 @@ where
     type ViewState = V::ViewState;
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        let (el, view_state) = self.element.build(ctx);
-        // TODO:
-        // The props should be applied before the callback is invoked.
+        let (mut el, view_state) = self.element.build(ctx);
+        el.node.apply_props(&mut el.props);
         (self.callback)(&el.node);
         (el, view_state)
     }

--- a/xilem_web/src/after_update.rs
+++ b/xilem_web/src/after_update.rs
@@ -7,18 +7,24 @@ use xilem_core::{MessageResult, Mut, View, ViewId, ViewMarker};
 
 use crate::{DomNode, DomView, DynMessage, ViewCtx};
 
+/// Invokes the `callback` after the inner `element` [`DomView`] was created.
+/// See [`after_build`] for more details.
 pub struct AfterBuild<State, Action, E, F> {
     element: E,
     callback: F,
     phantom: PhantomData<fn() -> (State, Action)>,
 }
 
+/// Invokes the `callback` after the inner `element` [`DomView<State>`]
+/// See [`after_rebuild`] for more details.
 pub struct AfterRebuild<State, Action, E, F> {
     element: E,
     callback: F,
     phantom: PhantomData<fn() -> (State, Action)>,
 }
 
+/// Invokes the `callback` before the inner `element` [`DomView`] (and its underlying DOM node) is destroyed.
+/// See [`before_teardown`] for more details.
 pub struct BeforeTeardown<State, Action, E, F> {
     element: E,
     callback: F,

--- a/xilem_web/src/class.rs
+++ b/xilem_web/src/class.rs
@@ -164,7 +164,7 @@ impl WithClasses for Classes {
             self.start_idx = 0;
         } else {
             let ClassModifier::EndMarker(start_idx) = self.class_modifiers[self.idx - 1] else {
-                unreachable!("this should not happen, as either `start_class_modifier` is happens first, or follows an end_class_modifier")
+                unreachable!("this should not happen, as either `rebuild_class_modifier` is happens first, or follows an `mark_end_of_class_modifier`")
             };
             self.idx = start_idx;
             self.start_idx = start_idx;

--- a/xilem_web/src/class.rs
+++ b/xilem_web/src/class.rs
@@ -57,23 +57,23 @@ impl<T: AsClassIter, const N: usize> AsClassIter for [T; N] {
 /// This trait enables having classes (via `className`) on DOM [`Element`](`crate::interfaces::Element`)s. It is used within [`View`]s that modify the classes of an element.
 ///
 /// Modifications have to be done on the up-traversal of [`View::rebuild`], i.e. after [`View::rebuild`] was invoked for descendent views.
-/// See the [`View`] implementation of [`Class`] for more details how to use it for [`ViewElement`]s that implement this trait.
+/// See [`Class::build`] and [`Class::rebuild`], how to use this for [`ViewElement`]s that implement this trait.
 /// When these methods are used, they have to be used in every reconciliation pass (i.e. [`View::rebuild`]).
 pub trait WithClasses {
-    /// Needs to be invoked within a [`View::build`] or [`View::rebuild`] before traversing to descendent views, and before any modifications are done
-    fn start_class_modifier(&mut self);
+    /// Needs to be invoked within a [`View::rebuild`] before traversing to descendent views, and before any modifications (with [`add_class`](`WithClasses::add_class`) or [`remove_class`](`WithClasses::remove_class`)) are done in that view
+    fn rebuild_class_modifier(&mut self);
 
     /// Needs to be invoked after any modifications are done
-    fn end_class_modifier(&mut self);
+    fn mark_end_of_class_modifier(&mut self);
 
     /// Adds a class to the element
     ///
-    /// It needs to be invoked on the up-traversal, i.e. after [`View::rebuild`] was invoked for descendent views.
+    /// When in [`View::rebuild`] this has to be invoked *after* traversing the inner `View` with [`View::rebuild`]
     fn add_class(&mut self, class_name: CowStr);
 
     /// Removes a possibly previously added class from the element
     ///
-    /// It needs to be invoked on the up-traversal, i.e. after [`View::rebuild`] was invoked for descendent views.
+    /// When in [`View::rebuild`] this has to be invoked *after* traversing the inner `View` with [`View::rebuild`]
     fn remove_class(&mut self, class_name: CowStr);
 
     // TODO something like the following, but I'm not yet sure how to support that efficiently (and without much binary bloat)
@@ -101,8 +101,6 @@ pub struct Classes {
     idx: usize,
     start_idx: usize,
     dirty: bool,
-    /// a flag necessary, such that `start_class_modifier` doesn't always overwrite the last changes in `View::build`
-    build_finished: bool,
     #[cfg(feature = "hydration")]
     pub(crate) in_hydration: bool,
 }
@@ -157,26 +155,23 @@ impl Classes {
                 element.set_class_name(&self.class_name);
             }
         }
-        self.build_finished = true;
     }
 }
 
 impl WithClasses for Classes {
-    fn start_class_modifier(&mut self) {
-        if self.build_finished {
-            if self.idx == 0 {
-                self.start_idx = 0;
-            } else {
-                let ClassModifier::EndMarker(start_idx) = self.class_modifiers[self.idx - 1] else {
-                    unreachable!("this should not happen, as either `start_class_modifier` is happens first, or follows an end_class_modifier")
-                };
-                self.idx = start_idx;
-                self.start_idx = start_idx;
-            }
+    fn rebuild_class_modifier(&mut self) {
+        if self.idx == 0 {
+            self.start_idx = 0;
+        } else {
+            let ClassModifier::EndMarker(start_idx) = self.class_modifiers[self.idx - 1] else {
+                unreachable!("this should not happen, as either `start_class_modifier` is happens first, or follows an end_class_modifier")
+            };
+            self.idx = start_idx;
+            self.start_idx = start_idx;
         }
     }
 
-    fn end_class_modifier(&mut self) {
+    fn mark_end_of_class_modifier(&mut self) {
         match self.class_modifiers.get_mut(self.idx) {
             Some(ClassModifier::EndMarker(_)) if !self.dirty => (), // class modifier hasn't changed
             Some(modifier) => {
@@ -226,12 +221,12 @@ impl WithClasses for Classes {
 }
 
 impl WithClasses for ElementProps {
-    fn start_class_modifier(&mut self) {
-        self.classes().start_class_modifier();
+    fn rebuild_class_modifier(&mut self) {
+        self.classes().rebuild_class_modifier();
     }
 
-    fn end_class_modifier(&mut self) {
-        self.classes().end_class_modifier();
+    fn mark_end_of_class_modifier(&mut self) {
+        self.classes().mark_end_of_class_modifier();
     }
 
     fn add_class(&mut self, class_name: CowStr) {
@@ -244,12 +239,12 @@ impl WithClasses for ElementProps {
 }
 
 impl<E: DomNode<P>, P: WithClasses> WithClasses for Pod<E, P> {
-    fn start_class_modifier(&mut self) {
-        self.props.start_class_modifier();
+    fn rebuild_class_modifier(&mut self) {
+        self.props.rebuild_class_modifier();
     }
 
-    fn end_class_modifier(&mut self) {
-        self.props.end_class_modifier();
+    fn mark_end_of_class_modifier(&mut self) {
+        self.props.mark_end_of_class_modifier();
     }
 
     fn add_class(&mut self, class_name: CowStr) {
@@ -262,12 +257,12 @@ impl<E: DomNode<P>, P: WithClasses> WithClasses for Pod<E, P> {
 }
 
 impl<E: DomNode<P>, P: WithClasses> WithClasses for PodMut<'_, E, P> {
-    fn start_class_modifier(&mut self) {
-        self.props.start_class_modifier();
+    fn rebuild_class_modifier(&mut self) {
+        self.props.rebuild_class_modifier();
     }
 
-    fn end_class_modifier(&mut self) {
-        self.props.end_class_modifier();
+    fn mark_end_of_class_modifier(&mut self) {
+        self.props.mark_end_of_class_modifier();
     }
 
     fn add_class(&mut self, class_name: CowStr) {
@@ -321,11 +316,10 @@ where
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let (mut e, s) = self.el.build(ctx);
-        e.start_class_modifier();
         for class in self.classes.class_iter() {
             e.add_class(class);
         }
-        e.end_class_modifier();
+        e.mark_end_of_class_modifier();
         (e, s)
     }
 
@@ -338,12 +332,12 @@ where
     ) -> Mut<'e, Self::Element> {
         // This has to happen, before any children are rebuilt, otherwise this state machine breaks...
         // The actual modifiers also have to happen after the children are rebuilt, see `add_class` below.
-        element.start_class_modifier();
+        element.rebuild_class_modifier();
         let mut element = self.el.rebuild(&prev.el, view_state, ctx, element);
         for class in self.classes.class_iter() {
             element.add_class(class);
         }
-        element.end_class_modifier();
+        element.mark_end_of_class_modifier();
         element
     }
 

--- a/xilem_web/src/context.rs
+++ b/xilem_web/src/context.rs
@@ -25,7 +25,7 @@ impl MessageThunk {
     ///
     /// # Panics
     ///
-    /// When this is called synchronously (i.e. not via an event callback or by queing it in the event loop with e.g. [`spawn_local`](`wasm_bindgen_futures::spawn_local`).
+    /// When this is called synchronously (i.e. not via an event callback or by queuing it in the event loop with e.g. [`spawn_local`](`wasm_bindgen_futures::spawn_local`).
     pub fn push_message(&self, message_body: impl Message) {
         let message = AppMessage {
             id_path: Rc::clone(&self.id_path),

--- a/xilem_web/src/lib.rs
+++ b/xilem_web/src/lib.rs
@@ -90,6 +90,8 @@ impl<N: AsRef<web_sys::Node> + Any> AnyNode for N {
 
 /// A trait to represent DOM nodes, which can optionally have associated `props` that are applied while building/rebuilding the views
 pub trait DomNode<P>: AnyNode + 'static {
+    /// When this is called any accumulated (virtual) `props` changes are applied to the underlying DOM node.
+    /// Where `props` stands for all kinds of modifiable properties, like attributes, styles, classes or more specific properties related to an element.
     fn apply_props(&self, props: &mut P);
 }
 

--- a/xilem_web/src/one_of.rs
+++ b/xilem_web/src/one_of.rs
@@ -234,11 +234,11 @@ impl PhantomElementCtx for ViewCtx {
 }
 
 impl WithAttributes for Noop {
-    fn start_attribute_modifier(&mut self) {
+    fn rebuild_attribute_modifier(&mut self) {
         unreachable!()
     }
 
-    fn end_attribute_modifier(&mut self) {
+    fn mark_end_of_attribute_modifier(&mut self) {
         unreachable!()
     }
 
@@ -248,7 +248,7 @@ impl WithAttributes for Noop {
 }
 
 impl WithClasses for Noop {
-    fn start_class_modifier(&mut self) {
+    fn rebuild_class_modifier(&mut self) {
         unreachable!()
     }
 
@@ -260,13 +260,13 @@ impl WithClasses for Noop {
         unreachable!()
     }
 
-    fn end_class_modifier(&mut self) {
+    fn mark_end_of_class_modifier(&mut self) {
         unreachable!()
     }
 }
 
 impl WithStyle for Noop {
-    fn start_style_modifier(&mut self) {
+    fn rebuild_style_modifier(&mut self) {
         unreachable!()
     }
 
@@ -274,7 +274,7 @@ impl WithStyle for Noop {
         unreachable!()
     }
 
-    fn end_style_modifier(&mut self) {
+    fn mark_end_of_style_modifier(&mut self) {
         unreachable!()
     }
 }
@@ -303,31 +303,31 @@ impl<
         E9: WithAttributes,
     > WithAttributes for OneOf<E1, E2, E3, E4, E5, E6, E7, E8, E9>
 {
-    fn start_attribute_modifier(&mut self) {
+    fn rebuild_attribute_modifier(&mut self) {
         match self {
-            OneOf::A(e) => e.start_attribute_modifier(),
-            OneOf::B(e) => e.start_attribute_modifier(),
-            OneOf::C(e) => e.start_attribute_modifier(),
-            OneOf::D(e) => e.start_attribute_modifier(),
-            OneOf::E(e) => e.start_attribute_modifier(),
-            OneOf::F(e) => e.start_attribute_modifier(),
-            OneOf::G(e) => e.start_attribute_modifier(),
-            OneOf::H(e) => e.start_attribute_modifier(),
-            OneOf::I(e) => e.start_attribute_modifier(),
+            OneOf::A(e) => e.rebuild_attribute_modifier(),
+            OneOf::B(e) => e.rebuild_attribute_modifier(),
+            OneOf::C(e) => e.rebuild_attribute_modifier(),
+            OneOf::D(e) => e.rebuild_attribute_modifier(),
+            OneOf::E(e) => e.rebuild_attribute_modifier(),
+            OneOf::F(e) => e.rebuild_attribute_modifier(),
+            OneOf::G(e) => e.rebuild_attribute_modifier(),
+            OneOf::H(e) => e.rebuild_attribute_modifier(),
+            OneOf::I(e) => e.rebuild_attribute_modifier(),
         }
     }
 
-    fn end_attribute_modifier(&mut self) {
+    fn mark_end_of_attribute_modifier(&mut self) {
         match self {
-            OneOf::A(e) => e.end_attribute_modifier(),
-            OneOf::B(e) => e.end_attribute_modifier(),
-            OneOf::C(e) => e.end_attribute_modifier(),
-            OneOf::D(e) => e.end_attribute_modifier(),
-            OneOf::E(e) => e.end_attribute_modifier(),
-            OneOf::F(e) => e.end_attribute_modifier(),
-            OneOf::G(e) => e.end_attribute_modifier(),
-            OneOf::H(e) => e.end_attribute_modifier(),
-            OneOf::I(e) => e.end_attribute_modifier(),
+            OneOf::A(e) => e.mark_end_of_attribute_modifier(),
+            OneOf::B(e) => e.mark_end_of_attribute_modifier(),
+            OneOf::C(e) => e.mark_end_of_attribute_modifier(),
+            OneOf::D(e) => e.mark_end_of_attribute_modifier(),
+            OneOf::E(e) => e.mark_end_of_attribute_modifier(),
+            OneOf::F(e) => e.mark_end_of_attribute_modifier(),
+            OneOf::G(e) => e.mark_end_of_attribute_modifier(),
+            OneOf::H(e) => e.mark_end_of_attribute_modifier(),
+            OneOf::I(e) => e.mark_end_of_attribute_modifier(),
         }
     }
 
@@ -358,17 +358,17 @@ impl<
         E9: WithClasses,
     > WithClasses for OneOf<E1, E2, E3, E4, E5, E6, E7, E8, E9>
 {
-    fn start_class_modifier(&mut self) {
+    fn rebuild_class_modifier(&mut self) {
         match self {
-            OneOf::A(e) => e.start_class_modifier(),
-            OneOf::B(e) => e.start_class_modifier(),
-            OneOf::C(e) => e.start_class_modifier(),
-            OneOf::D(e) => e.start_class_modifier(),
-            OneOf::E(e) => e.start_class_modifier(),
-            OneOf::F(e) => e.start_class_modifier(),
-            OneOf::G(e) => e.start_class_modifier(),
-            OneOf::H(e) => e.start_class_modifier(),
-            OneOf::I(e) => e.start_class_modifier(),
+            OneOf::A(e) => e.rebuild_class_modifier(),
+            OneOf::B(e) => e.rebuild_class_modifier(),
+            OneOf::C(e) => e.rebuild_class_modifier(),
+            OneOf::D(e) => e.rebuild_class_modifier(),
+            OneOf::E(e) => e.rebuild_class_modifier(),
+            OneOf::F(e) => e.rebuild_class_modifier(),
+            OneOf::G(e) => e.rebuild_class_modifier(),
+            OneOf::H(e) => e.rebuild_class_modifier(),
+            OneOf::I(e) => e.rebuild_class_modifier(),
         }
     }
 
@@ -400,17 +400,17 @@ impl<
         }
     }
 
-    fn end_class_modifier(&mut self) {
+    fn mark_end_of_class_modifier(&mut self) {
         match self {
-            OneOf::A(e) => e.end_class_modifier(),
-            OneOf::B(e) => e.end_class_modifier(),
-            OneOf::C(e) => e.end_class_modifier(),
-            OneOf::D(e) => e.end_class_modifier(),
-            OneOf::E(e) => e.end_class_modifier(),
-            OneOf::F(e) => e.end_class_modifier(),
-            OneOf::G(e) => e.end_class_modifier(),
-            OneOf::H(e) => e.end_class_modifier(),
-            OneOf::I(e) => e.end_class_modifier(),
+            OneOf::A(e) => e.mark_end_of_class_modifier(),
+            OneOf::B(e) => e.mark_end_of_class_modifier(),
+            OneOf::C(e) => e.mark_end_of_class_modifier(),
+            OneOf::D(e) => e.mark_end_of_class_modifier(),
+            OneOf::E(e) => e.mark_end_of_class_modifier(),
+            OneOf::F(e) => e.mark_end_of_class_modifier(),
+            OneOf::G(e) => e.mark_end_of_class_modifier(),
+            OneOf::H(e) => e.mark_end_of_class_modifier(),
+            OneOf::I(e) => e.mark_end_of_class_modifier(),
         }
     }
 }
@@ -427,17 +427,17 @@ impl<
         E9: WithStyle,
     > WithStyle for OneOf<E1, E2, E3, E4, E5, E6, E7, E8, E9>
 {
-    fn start_style_modifier(&mut self) {
+    fn rebuild_style_modifier(&mut self) {
         match self {
-            OneOf::A(e) => e.start_style_modifier(),
-            OneOf::B(e) => e.start_style_modifier(),
-            OneOf::C(e) => e.start_style_modifier(),
-            OneOf::D(e) => e.start_style_modifier(),
-            OneOf::E(e) => e.start_style_modifier(),
-            OneOf::F(e) => e.start_style_modifier(),
-            OneOf::G(e) => e.start_style_modifier(),
-            OneOf::H(e) => e.start_style_modifier(),
-            OneOf::I(e) => e.start_style_modifier(),
+            OneOf::A(e) => e.rebuild_style_modifier(),
+            OneOf::B(e) => e.rebuild_style_modifier(),
+            OneOf::C(e) => e.rebuild_style_modifier(),
+            OneOf::D(e) => e.rebuild_style_modifier(),
+            OneOf::E(e) => e.rebuild_style_modifier(),
+            OneOf::F(e) => e.rebuild_style_modifier(),
+            OneOf::G(e) => e.rebuild_style_modifier(),
+            OneOf::H(e) => e.rebuild_style_modifier(),
+            OneOf::I(e) => e.rebuild_style_modifier(),
         }
     }
 
@@ -455,17 +455,17 @@ impl<
         }
     }
 
-    fn end_style_modifier(&mut self) {
+    fn mark_end_of_style_modifier(&mut self) {
         match self {
-            OneOf::A(e) => e.end_style_modifier(),
-            OneOf::B(e) => e.end_style_modifier(),
-            OneOf::C(e) => e.end_style_modifier(),
-            OneOf::D(e) => e.end_style_modifier(),
-            OneOf::E(e) => e.end_style_modifier(),
-            OneOf::F(e) => e.end_style_modifier(),
-            OneOf::G(e) => e.end_style_modifier(),
-            OneOf::H(e) => e.end_style_modifier(),
-            OneOf::I(e) => e.end_style_modifier(),
+            OneOf::A(e) => e.mark_end_of_style_modifier(),
+            OneOf::B(e) => e.mark_end_of_style_modifier(),
+            OneOf::C(e) => e.mark_end_of_style_modifier(),
+            OneOf::D(e) => e.mark_end_of_style_modifier(),
+            OneOf::E(e) => e.mark_end_of_style_modifier(),
+            OneOf::F(e) => e.mark_end_of_style_modifier(),
+            OneOf::G(e) => e.mark_end_of_style_modifier(),
+            OneOf::H(e) => e.mark_end_of_style_modifier(),
+            OneOf::I(e) => e.mark_end_of_style_modifier(),
         }
     }
 }

--- a/xilem_web/src/style.rs
+++ b/xilem_web/src/style.rs
@@ -134,6 +134,7 @@ enum StyleModifier {
 }
 
 #[derive(Debug, Default)]
+/// This contains all the current style properties of an [`HtmlElement`](`crate::interfaces::Element`) or [`SvgElement`](`crate::interfaces::SvgElement`).
 pub struct Styles {
     style_modifiers: Vec<StyleModifier>,
     updated_styles: VecMap<CowStr, ()>,
@@ -300,6 +301,7 @@ impl<E: DomNode<P>, P: WithStyle> WithStyle for PodMut<'_, E, P> {
     }
 }
 
+/// Syntax sugar for adding a type bound on the `ViewElement` of a view, such that both, [`ViewElement`] and [`ViewElement::Mut`] are bound to [`WithStyle`]
 pub trait ElementWithStyle: for<'a> ViewElement<Mut<'a>: WithStyle> + WithStyle {}
 
 impl<T> ElementWithStyle for T
@@ -310,6 +312,7 @@ where
 }
 
 #[derive(Clone, Debug)]
+/// A view to add `style` properties of `HTMLElement` and `SVGElement` derived elements,
 pub struct Style<E, T, A> {
     el: E,
     styles: Vec<(CowStr, CowStr)>,

--- a/xilem_web/src/style.rs
+++ b/xilem_web/src/style.rs
@@ -105,12 +105,25 @@ where
     }
 }
 
+/// This trait allows (modifying) the `style` property of `HTMLElement`/`SVGElement`s, used in the DOM interface traits [`HtmlElement`](`crate::interfaces::HtmlElement`) and [`SvgElement`](`crate::interfaces::SvgElement`).
+///
+/// Modifications have to be done on the up-traversal of [`View::rebuild`], i.e. after [`View::rebuild`] was invoked for descendent views.
+/// See [`Style::build`] and [`Style::rebuild`], how to use this for [`ViewElement`]s that implement this trait.
+/// When these methods are used, they have to be used in every reconciliation pass (i.e. [`View::rebuild`]).
 pub trait WithStyle {
-    fn start_style_modifier(&mut self);
-    fn end_style_modifier(&mut self);
+    /// Needs to be invoked within a [`View::rebuild`] before traversing to descendent views, and before any modifications (with [`set_style`](`WithStyle::set_style`)) are done in that view
+    fn rebuild_style_modifier(&mut self);
+
+    /// Needs to be invoked after any modifications are done
+    fn mark_end_of_style_modifier(&mut self);
+
+    /// Sets or removes (when value is `None`) a style property from the underlying element.
+    ///
+    /// When in [`View::rebuild`] this has to be invoked *after* traversing the inner `View` with [`View::rebuild`]
     fn set_style(&mut self, name: CowStr, value: Option<CowStr>);
+
     // TODO first find a use-case for this...
-    // fn get_attr(&self, name: &str) -> Option<&CowStr>;
+    // fn get_style(&self, name: &str) -> Option<&CowStr>;
 }
 
 #[derive(Debug, PartialEq)]
@@ -126,8 +139,6 @@ pub struct Styles {
     updated_styles: VecMap<CowStr, ()>,
     idx: usize, // To save some memory, this could be u16 or even u8 (but this is risky)
     start_idx: usize, // same here
-    /// a flag necessary, such that `start_style_modifier` doesn't always overwrite the last changes in `View::build`
-    build_finished: bool,
     #[cfg(feature = "hydration")]
     pub(crate) in_hydration: bool,
 }
@@ -163,7 +174,6 @@ impl Styles {
         #[cfg(feature = "hydration")]
         if self.in_hydration {
             self.updated_styles.clear();
-            self.build_finished = true;
             self.in_hydration = false;
             return;
         }
@@ -188,7 +198,6 @@ impl Styles {
             }
             debug_assert!(self.updated_styles.is_empty());
         }
-        self.build_finished = true;
     }
 }
 
@@ -220,21 +229,19 @@ impl WithStyle for Styles {
         self.idx += 1;
     }
 
-    fn start_style_modifier(&mut self) {
-        if self.build_finished {
-            if self.idx == 0 {
-                self.start_idx = 0;
-            } else {
-                let StyleModifier::EndMarker(start_idx) = self.style_modifiers[self.idx - 1] else {
-                    unreachable!("this should not happen, as either `start_style_modifier` happens first, or follows an end_style_modifier")
-                };
-                self.idx = start_idx;
-                self.start_idx = start_idx;
-            }
+    fn rebuild_style_modifier(&mut self) {
+        if self.idx == 0 {
+            self.start_idx = 0;
+        } else {
+            let StyleModifier::EndMarker(start_idx) = self.style_modifiers[self.idx - 1] else {
+                unreachable!("this should not happen, as either `rebuild_style_modifier` happens first, or follows an `mark_end_of_style_modifier`")
+            };
+            self.idx = start_idx;
+            self.start_idx = start_idx;
         }
     }
 
-    fn end_style_modifier(&mut self) {
+    fn mark_end_of_style_modifier(&mut self) {
         match self.style_modifiers.get_mut(self.idx) {
             Some(StyleModifier::EndMarker(prev_start_idx)) if *prev_start_idx == self.start_idx => {
             } // class modifier hasn't changed
@@ -252,12 +259,12 @@ impl WithStyle for Styles {
 }
 
 impl WithStyle for ElementProps {
-    fn start_style_modifier(&mut self) {
-        self.styles().start_style_modifier();
+    fn rebuild_style_modifier(&mut self) {
+        self.styles().rebuild_style_modifier();
     }
 
-    fn end_style_modifier(&mut self) {
-        self.styles().end_style_modifier();
+    fn mark_end_of_style_modifier(&mut self) {
+        self.styles().mark_end_of_style_modifier();
     }
 
     fn set_style(&mut self, name: CowStr, value: Option<CowStr>) {
@@ -266,12 +273,12 @@ impl WithStyle for ElementProps {
 }
 
 impl<E: DomNode<P>, P: WithStyle> WithStyle for Pod<E, P> {
-    fn start_style_modifier(&mut self) {
-        self.props.start_style_modifier();
+    fn rebuild_style_modifier(&mut self) {
+        self.props.rebuild_style_modifier();
     }
 
-    fn end_style_modifier(&mut self) {
-        self.props.end_style_modifier();
+    fn mark_end_of_style_modifier(&mut self) {
+        self.props.mark_end_of_style_modifier();
     }
 
     fn set_style(&mut self, name: CowStr, value: Option<CowStr>) {
@@ -280,12 +287,12 @@ impl<E: DomNode<P>, P: WithStyle> WithStyle for Pod<E, P> {
 }
 
 impl<E: DomNode<P>, P: WithStyle> WithStyle for PodMut<'_, E, P> {
-    fn start_style_modifier(&mut self) {
-        self.props.start_style_modifier();
+    fn rebuild_style_modifier(&mut self) {
+        self.props.rebuild_style_modifier();
     }
 
-    fn end_style_modifier(&mut self) {
-        self.props.end_style_modifier();
+    fn mark_end_of_style_modifier(&mut self) {
+        self.props.mark_end_of_style_modifier();
     }
 
     fn set_style(&mut self, name: CowStr, value: Option<CowStr>) {
@@ -332,11 +339,10 @@ where
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let (mut element, state) = self.el.build(ctx);
-        element.start_style_modifier();
         for (key, value) in &self.styles {
             element.set_style(key.clone(), Some(value.clone()));
         }
-        element.end_style_modifier();
+        element.mark_end_of_style_modifier();
         (element, state)
     }
 
@@ -347,12 +353,12 @@ where
         ctx: &mut ViewCtx,
         mut element: Mut<'e, Self::Element>,
     ) -> Mut<'e, Self::Element> {
-        element.start_style_modifier();
+        element.rebuild_style_modifier();
         let mut element = self.el.rebuild(&prev.el, view_state, ctx, element);
         for (key, value) in &self.styles {
             element.set_style(key.clone(), Some(value.clone()));
         }
-        element.end_style_modifier();
+        element.mark_end_of_style_modifier();
         element
     }
 

--- a/xilem_web/src/svg/common_attrs.rs
+++ b/xilem_web/src/svg/common_attrs.rs
@@ -100,10 +100,9 @@ where
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let (mut element, child_state) = self.child.build(ctx);
         let brush_svg_repr = Cow::from(brush_to_string(&self.brush));
-        element.start_attribute_modifier();
         element.set_attribute("fill".into(), brush_svg_repr.clone().into_attr_value());
         add_opacity_to_element(&self.brush, &mut element, "fill-opacity");
-        element.end_attribute_modifier();
+        element.mark_end_of_attribute_modifier();
         (element, (brush_svg_repr, child_state))
     }
 
@@ -114,14 +113,14 @@ where
         ctx: &mut ViewCtx,
         mut element: Mut<'el, Self::Element>,
     ) -> Mut<'el, Self::Element> {
-        element.start_attribute_modifier();
+        element.rebuild_attribute_modifier();
         let mut element = self.child.rebuild(&prev.child, child_state, ctx, element);
         if self.brush != prev.brush {
             *brush_svg_repr = Cow::from(brush_to_string(&self.brush));
         }
         element.set_attribute("fill".into(), brush_svg_repr.clone().into_attr_value());
         add_opacity_to_element(&self.brush, &mut element, "fill-opacity");
-        element.end_attribute_modifier();
+        element.mark_end_of_attribute_modifier();
         element
     }
 
@@ -163,9 +162,6 @@ where
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let (mut element, child_state) = self.child.build(ctx);
-
-        element.start_attribute_modifier();
-
         let brush_svg_repr = Cow::from(brush_to_string(&self.brush));
         element.set_attribute("stroke".into(), brush_svg_repr.clone().into_attr_value());
         let stroke_dash_pattern_svg_repr = (!self.style.dash_pattern.is_empty())
@@ -177,7 +173,7 @@ where
         element.set_attribute("stroke-width".into(), self.style.width.into_attr_value());
         add_opacity_to_element(&self.brush, &mut element, "stroke-opacity");
 
-        element.end_attribute_modifier();
+        element.mark_end_of_attribute_modifier();
         (
             element,
             StrokeState {
@@ -199,7 +195,7 @@ where
         ctx: &mut ViewCtx,
         mut element: Mut<'el, Self::Element>,
     ) -> Mut<'el, Self::Element> {
-        element.start_attribute_modifier();
+        element.rebuild_attribute_modifier();
 
         let mut element = self.child.rebuild(&prev.child, child_state, ctx, element);
 
@@ -218,7 +214,7 @@ where
         element.set_attribute("stroke-width".into(), self.style.width.into_attr_value());
         add_opacity_to_element(&self.brush, &mut element, "stroke-opacity");
 
-        element.end_attribute_modifier();
+        element.mark_end_of_attribute_modifier();
         element
     }
 

--- a/xilem_web/src/svg/kurbo_shape.rs
+++ b/xilem_web/src/svg/kurbo_shape.rs
@@ -22,12 +22,11 @@ impl<State: 'static, Action: 'static> OrphanView<Line, State, Action, DynMessage
         _ctx: &mut ViewCtx,
     ) -> (Self::OrphanElement, Self::OrphanViewState) {
         let mut element: Self::OrphanElement = Pod::new_element(Vec::new(), SVG_NS, "line").into();
-        element.start_attribute_modifier();
         element.set_attribute("x1".into(), view.p0.x.into_attr_value());
         element.set_attribute("y1".into(), view.p0.y.into_attr_value());
         element.set_attribute("x2".into(), view.p1.x.into_attr_value());
         element.set_attribute("y2".into(), view.p1.y.into_attr_value());
-        element.end_attribute_modifier();
+        element.mark_end_of_attribute_modifier();
         (element, ())
     }
 
@@ -38,12 +37,12 @@ impl<State: 'static, Action: 'static> OrphanView<Line, State, Action, DynMessage
         _ctx: &mut ViewCtx,
         mut element: Mut<'el, Self::OrphanElement>,
     ) -> Mut<'el, Self::OrphanElement> {
-        element.start_attribute_modifier();
+        element.rebuild_attribute_modifier();
         element.set_attribute("x1".into(), new.p0.x.into_attr_value());
         element.set_attribute("y1".into(), new.p0.y.into_attr_value());
         element.set_attribute("x2".into(), new.p1.x.into_attr_value());
         element.set_attribute("y2".into(), new.p1.y.into_attr_value());
-        element.end_attribute_modifier();
+        element.mark_end_of_attribute_modifier();
         element
     }
 
@@ -75,12 +74,11 @@ impl<State: 'static, Action: 'static> OrphanView<Rect, State, Action, DynMessage
         _ctx: &mut ViewCtx,
     ) -> (Self::OrphanElement, Self::OrphanViewState) {
         let mut element: Self::OrphanElement = Pod::new_element(Vec::new(), SVG_NS, "rect").into();
-        element.start_attribute_modifier();
         element.set_attribute("x".into(), view.x0.into_attr_value());
         element.set_attribute("y".into(), view.y0.into_attr_value());
         element.set_attribute("width".into(), view.width().into_attr_value());
         element.set_attribute("height".into(), view.height().into_attr_value());
-        element.end_attribute_modifier();
+        element.mark_end_of_attribute_modifier();
         (element, ())
     }
 
@@ -91,12 +89,12 @@ impl<State: 'static, Action: 'static> OrphanView<Rect, State, Action, DynMessage
         _ctx: &mut ViewCtx,
         mut element: Mut<'el, Self::OrphanElement>,
     ) -> Mut<'el, Self::OrphanElement> {
-        element.start_attribute_modifier();
+        element.rebuild_attribute_modifier();
         element.set_attribute("x".into(), new.x0.into_attr_value());
         element.set_attribute("y".into(), new.y0.into_attr_value());
         element.set_attribute("width".into(), new.width().into_attr_value());
         element.set_attribute("height".into(), new.height().into_attr_value());
-        element.end_attribute_modifier();
+        element.mark_end_of_attribute_modifier();
         element
     }
 
@@ -129,11 +127,10 @@ impl<State: 'static, Action: 'static> OrphanView<Circle, State, Action, DynMessa
     ) -> (Self::OrphanElement, Self::OrphanViewState) {
         let mut element: Self::OrphanElement =
             Pod::new_element(Vec::new(), SVG_NS, "circle").into();
-        element.start_attribute_modifier();
         element.set_attribute("cx".into(), view.center.x.into_attr_value());
         element.set_attribute("cy".into(), view.center.y.into_attr_value());
         element.set_attribute("r".into(), view.radius.into_attr_value());
-        element.end_attribute_modifier();
+        element.mark_end_of_attribute_modifier();
         (element, ())
     }
 
@@ -144,11 +141,11 @@ impl<State: 'static, Action: 'static> OrphanView<Circle, State, Action, DynMessa
         _ctx: &mut ViewCtx,
         mut element: Mut<'el, Self::OrphanElement>,
     ) -> Mut<'el, Self::OrphanElement> {
-        element.start_attribute_modifier();
+        element.rebuild_attribute_modifier();
         element.set_attribute("cx".into(), new.center.x.into_attr_value());
         element.set_attribute("cy".into(), new.center.y.into_attr_value());
         element.set_attribute("r".into(), new.radius.into_attr_value());
-        element.end_attribute_modifier();
+        element.mark_end_of_attribute_modifier();
         element
     }
 
@@ -181,9 +178,8 @@ impl<State: 'static, Action: 'static> OrphanView<BezPath, State, Action, DynMess
     ) -> (Self::OrphanElement, Self::OrphanViewState) {
         let mut element: Self::OrphanElement = Pod::new_element(Vec::new(), SVG_NS, "path").into();
         let svg_repr = Cow::from(view.to_svg());
-        element.start_attribute_modifier();
         element.set_attribute("d".into(), svg_repr.clone().into_attr_value());
-        element.end_attribute_modifier();
+        element.mark_end_of_attribute_modifier();
         (element, svg_repr)
     }
 
@@ -198,9 +194,9 @@ impl<State: 'static, Action: 'static> OrphanView<BezPath, State, Action, DynMess
         if new != prev {
             *svg_repr = Cow::from(new.to_svg());
         }
-        element.start_attribute_modifier();
+        element.rebuild_attribute_modifier();
         element.set_attribute("d".into(), svg_repr.clone().into_attr_value());
-        element.end_attribute_modifier();
+        element.mark_end_of_attribute_modifier();
         element
     }
 

--- a/xilem_web/src/templated.rs
+++ b/xilem_web/src/templated.rs
@@ -8,6 +8,7 @@ use xilem_core::{MessageResult, View, ViewMarker};
 
 use crate::{DomNode, DomView, DynMessage, PodMut, ViewCtx};
 
+/// This view creates an internally cached deep-clone of the underlying DOM node. When the inner view is created again, this will be done more efficiently.
 pub struct Templated<E>(Rc<E>);
 
 pub struct TemplatedState<ViewState> {


### PR DESCRIPTION
I think I've covered every pub item at the top level.

It also renames  (taking `Attributes` as example)  `start_attribute_modifier` -> `rebuild_attribute_modifier`,
and `end_attribute_modifier` -> `mark_end_of_attribute_modifier`, as I think that makes it more clear what these methods do.
`start_attribute_modifier` was a noop in `View::build` and may lead to buggy behavior when `DomNode::apply_props` is called before every parent `View::build` has done modifying the props. This should make `DomNode::apply_props` robust. And `AfterBuild` is fixed now with that.