### PR TITLE
Fix Portal widget

### DIFF
--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -708,6 +708,7 @@ impl LifeCycleCtx<'_> {
 
 // --- MARK: UPDATE LAYOUT ---
 impl LayoutCtx<'_> {
+    #[track_caller]
     fn assert_layout_done(&self, child: &WidgetPod<impl Widget>, method_name: &str) {
         if self.get_child_state(child).needs_layout {
             debug_panic!(
@@ -720,6 +721,7 @@ impl LayoutCtx<'_> {
         }
     }
 
+    #[track_caller]
     fn assert_placed(&self, child: &WidgetPod<impl Widget>, method_name: &str) {
         if self.get_child_state(child).is_expecting_place_child_call {
             debug_panic!(
@@ -760,6 +762,7 @@ impl LayoutCtx<'_> {
     ///
     /// This method will panic if the child's [`layout()`](WidgetPod::layout) method has not been called yet
     /// and if [`LayoutCtx::place_child()`] has not been called for the child.
+    #[track_caller]
     pub fn compute_insets_from_child(
         &mut self,
         child: &WidgetPod<impl Widget>,
@@ -805,17 +808,13 @@ impl LayoutCtx<'_> {
         self.widget_state.mark_as_visited(visited);
     }
 
-    pub(crate) fn mark_child_as_visited(&self, child: &WidgetPod<impl Widget>, visited: bool) {
-        #[cfg(debug_assertions)]
-        self.get_child_state(child).mark_as_visited(visited);
-    }
-
     /// The distance from the bottom of the given widget to the baseline.
     ///
     /// ## Panics
     ///
     /// This method will panic if [`WidgetPod::layout`] has not been called yet for
     /// the child.
+    #[track_caller]
     pub fn child_baseline_offset(&self, child: &WidgetPod<impl Widget>) -> f64 {
         self.assert_layout_done(child, "child_baseline_offset");
         self.get_child_state(child).baseline_offset
@@ -827,6 +826,7 @@ impl LayoutCtx<'_> {
     ///
     /// This method will panic if [`WidgetPod::layout`] and [`LayoutCtx::place_child`]
     /// have not been called yet for the child.
+    #[track_caller]
     pub fn child_layout_rect(&self, child: &WidgetPod<impl Widget>) -> Rect {
         self.assert_layout_done(child, "child_layout_rect");
         self.assert_placed(child, "child_layout_rect");
@@ -839,6 +839,7 @@ impl LayoutCtx<'_> {
     ///
     /// This method will panic if [`WidgetPod::layout`] and [`LayoutCtx::place_child`]
     /// have not been called yet for the child.
+    #[track_caller]
     pub fn child_paint_rect(&self, child: &WidgetPod<impl Widget>) -> Rect {
         self.assert_layout_done(child, "child_paint_rect");
         self.assert_placed(child, "child_paint_rect");
@@ -851,9 +852,16 @@ impl LayoutCtx<'_> {
     ///
     /// This method will panic if [`WidgetPod::layout`] has not been called yet for
     /// the child.
+    #[track_caller]
     pub fn child_size(&self, child: &WidgetPod<impl Widget>) -> Size {
         self.assert_layout_done(child, "child_size");
         self.get_child_state(child).layout_rect().size()
+    }
+
+    pub(crate) fn skip_layout(&mut self, child: &mut WidgetPod<impl Widget>) {
+        #[cfg(debug_assertions)]
+        self.get_child_state(child).mark_as_visited(true);
+        self.get_child_state_mut(child).needs_layout = false;
     }
 
     /// Set the position of a child widget, in the parent's coordinate space. This
@@ -866,6 +874,7 @@ impl LayoutCtx<'_> {
     ///
     /// This method will panic if [`WidgetPod::layout`] has not been called yet for
     /// the child.
+    #[track_caller]
     pub fn place_child<W: Widget>(&mut self, child: &mut WidgetPod<W>, origin: Point) {
         self.assert_layout_done(child, "place_child");
         if origin != self.get_child_state_mut(child).origin {

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -858,7 +858,11 @@ impl LayoutCtx<'_> {
         self.get_child_state(child).layout_rect().size()
     }
 
-    pub(crate) fn skip_layout(&mut self, child: &mut WidgetPod<impl Widget>) {
+    /// Skips running the layout pass and calling `place_child` on the child.
+    ///
+    /// This may be removed in the future. Currently it's useful for
+    /// stashed children and children whose layout is cached.
+    pub fn skip_layout(&mut self, child: &mut WidgetPod<impl Widget>) {
         #[cfg(debug_assertions)]
         self.get_child_state(child).mark_as_visited(true);
         self.get_child_state_mut(child).needs_layout = false;

--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -688,7 +688,7 @@ impl Widget for Flex {
 
                         child_size
                     } else {
-                        ctx.mark_child_as_visited(widget, true);
+                        ctx.skip_layout(widget);
                         ctx.child_layout_rect(widget).size()
                     };
 
@@ -746,7 +746,7 @@ impl Widget for Flex {
 
                         child_size
                     } else {
-                        ctx.mark_child_as_visited(widget, true);
+                        ctx.skip_layout(widget);
                         ctx.child_layout_rect(widget).size()
                     };
 
@@ -852,17 +852,10 @@ impl Widget for Flex {
             major = total_major;
         }
 
+        // my_size may be larger than the given constraints.
+        // In which case, the Flex widget will either overflow its parent
+        // or be clipped (e.g. if its parent is a Portal).
         let my_size: Size = self.direction.pack(major, minor_dim).into();
-
-        // if we don't have to fill the main axis, we loosen that axis before constraining
-        let my_size = if !self.fill_major_axis {
-            let max_major = self.direction.major(bc.max());
-            self.direction
-                .constraints(bc, 0.0, max_major)
-                .constrain(my_size)
-        } else {
-            bc.constrain(my_size)
-        };
 
         let my_bounds = Rect::ZERO.with_size(my_size);
         let insets = child_paint_rect - my_bounds;

--- a/masonry/src/widget/portal.rs
+++ b/masonry/src/widget/portal.rs
@@ -240,12 +240,14 @@ impl<W: Widget> WidgetMut<'_, Portal<W>> {
 // --- MARK: IMPL WIDGET ---
 impl<W: Widget> Widget for Portal<W> {
     fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
+        const SCROLLING_SPEED: f64 = 10.0;
+
         let portal_size = ctx.size();
         let content_size = ctx.get_raw_ref(&mut self.child).ctx().layout_rect().size();
 
         match event {
             PointerEvent::MouseWheel(delta, _) => {
-                let delta = Vec2::new(delta.x * -10., delta.y * -10.);
+                let delta = Vec2::new(delta.x * -SCROLLING_SPEED, delta.y * -SCROLLING_SPEED);
                 self.set_viewport_pos_raw(portal_size, content_size, self.viewport_pos + delta);
                 ctx.request_layout();
 

--- a/masonry/src/widget/portal.rs
+++ b/masonry/src/widget/portal.rs
@@ -245,11 +245,8 @@ impl<W: Widget> Widget for Portal<W> {
 
         match event {
             PointerEvent::MouseWheel(delta, _) => {
-                self.set_viewport_pos_raw(
-                    portal_size,
-                    content_size,
-                    self.viewport_pos + Vec2::new(delta.x, delta.y),
-                );
+                let delta = Vec2::new(delta.x * -10., delta.y * -10.);
+                self.set_viewport_pos_raw(portal_size, content_size, self.viewport_pos + delta);
                 ctx.request_layout();
 
                 // TODO - horizontal scrolling?
@@ -436,7 +433,11 @@ impl<W: Widget> Widget for Portal<W> {
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        smallvec![self.child.id()]
+        smallvec![
+            self.child.id(),
+            self.scrollbar_vertical.id(),
+            self.scrollbar_horizontal.id(),
+        ]
     }
 
     fn make_trace_span(&self) -> Span {

--- a/masonry/src/widget/widget_pod.rs
+++ b/masonry/src/widget/widget_pod.rs
@@ -572,8 +572,8 @@ impl<W: Widget> WidgetPod<W> {
         };
 
         // We reset `needs_layout` after the layout call, in case `layout` calls `request_layout`.
-        // If this did happen, it would be a bug; however, it is allowed for a child of `widget` 
-        // (accessed using `get_raw_mut`) to call `request_layout`, so long as its `layout` is called 
+        // If this did happen, it would be a bug; however, it is allowed for a child of `widget`
+        // (accessed using `get_raw_mut`) to call `request_layout`, so long as its `layout` is called
         // by the parent. We currently cannot differentiate these cases, so we allow both.
         state.needs_layout = false;
 

--- a/masonry/src/widget/widget_pod.rs
+++ b/masonry/src/widget/widget_pod.rs
@@ -571,6 +571,10 @@ impl<W: Widget> WidgetPod<W> {
             widget.layout(&mut inner_ctx, bc)
         };
 
+        // We reset `needs_layout` after the layout call, in case `layout` calls `request_layout`.
+        // If this did happen, it would be a bug; however, it is allowed for a child of `widget` 
+        // (accessed using `get_raw_mut`) to call `request_layout`, so long as its `layout` is called 
+        // by the parent. We currently cannot differentiate these cases, so we allow both.
         state.needs_layout = false;
 
         state.local_paint_rect = state

--- a/masonry/src/widget/widget_pod.rs
+++ b/masonry/src/widget/widget_pod.rs
@@ -547,7 +547,6 @@ impl<W: Widget> WidgetPod<W> {
             return false;
         }
 
-        state.needs_layout = false;
         state.needs_compose = true;
         state.is_expecting_place_child_call = true;
         // TODO - Not everything that has been re-laid out needs to be repainted.
@@ -571,6 +570,8 @@ impl<W: Widget> WidgetPod<W> {
 
             widget.layout(&mut inner_ctx, bc)
         };
+
+        state.needs_layout = false;
 
         state.local_paint_rect = state
             .local_paint_rect


### PR DESCRIPTION
One of the problems we ran into with the `to_do_list` example was that we had a `Flex` inside a `Portal`: the `Portal` widget is designed to display scrollbars and provide scrolling if the child is larger than its constraints... but then Flex's `layout` method always clipped the returned size so it wasn't ever larger than its constraints. Hence, no scrolling. Removing the `bc.constrain(my_size)` part makes the example have scrolling behavior again.

This PR also tweaks scrolling code and adds `#[track_caller]` attributes to help with debugging.