### PR TITLE
Improve tracing for use of Android GPU Inspector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1891,6 +1891,7 @@ dependencies = [
  "once_cell",
  "parley",
  "pollster",
+ "profiling",
  "serde",
  "serde_json",
  "smallvec",
@@ -2606,6 +2607,20 @@ name = "profiling"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
+dependencies = [
+ "profiling-procmacros",
+ "tracing",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
+dependencies = [
+ "quote",
+ "syn 2.0.72",
+]
 
 [[package]]
 name = "quick-xml"
@@ -4269,6 +4284,7 @@ version = "0.1.0"
 dependencies = [
  "accesskit",
  "masonry",
+ "profiling",
  "smallvec",
  "time",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_trace"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d564b0f7a9c9e272c7e43c59f1f09ba04d060774ba7c5fa14c2f966bbd6c4e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +1898,7 @@ dependencies = [
  "time",
  "tracing",
  "tracing-subscriber",
+ "tracing_android_trace",
  "unicode-segmentation",
  "vello",
  "web-time",
@@ -3355,6 +3365,20 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "tracing_android_trace"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fae205f9c07bfae3d36d199ab985118c90d225ff70a38e7ff3ecbdb4ef61bc"
+dependencies = [
+ "android_trace",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -54,6 +54,9 @@ insta = { version = "1.39.0" }
 assert_matches = "1.5.0"
 tempfile = "3.10.1"
 
+# Make wgpu use tracing for its spans.
+profiling = { version = "1.0.15", features = ["profile-with-tracing"] }
+
 [[example]]
 name = "simple_image"
 #required-features = ["image", "png"]

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -57,3 +57,6 @@ tempfile = "3.10.1"
 [[example]]
 name = "simple_image"
 #required-features = ["image", "png"]
+
+[target.'cfg(target_os = "android")'.dependencies]
+tracing_android_trace = "0.1.0"

--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -389,10 +389,13 @@ impl MasonryState<'_> {
         };
         // TODO: Run this in-between `submit` and `present`.
         window.pre_present_notify();
-        self.renderer
-            .get_or_insert_with(|| Renderer::new(device, renderer_options).unwrap())
-            .render_to_surface(device, queue, scene_ref, &surface_texture, &render_params)
-            .expect("failed to render to surface");
+        {
+            let _render_span = tracing::info_span!("Rendering using Vello").entered();
+            self.renderer
+                .get_or_insert_with(|| Renderer::new(device, renderer_options).unwrap())
+                .render_to_surface(device, queue, scene_ref, &surface_texture, &render_params)
+                .expect("failed to render to surface");
+        }
         surface_texture.present();
         device.poll(wgpu::Maintain::Wait);
     }

--- a/masonry/src/tracing_backend.rs
+++ b/masonry/src/tracing_backend.rs
@@ -90,9 +90,15 @@ pub(crate) fn try_init_layered_tracing(
         None
     };
 
+    #[cfg(target_os = "android")]
+    let android_trace_layer = tracing_android_trace::AndroidTraceLayer::new();
+
     let registry = tracing_subscriber::registry()
         .with(console_layer)
         .with(log_file_layer);
+
+    #[cfg(target_os = "android")]
+    let registry = registry.with(android_trace_layer);
 
     tracing::dispatcher::set_global_default(registry.into())?;
 

--- a/masonry/src/widget/variable_label.rs
+++ b/masonry/src/widget/variable_label.rs
@@ -401,7 +401,7 @@ impl Widget for VariableLabel {
     }
 
     fn make_trace_span(&self) -> Span {
-        trace_span!("Label")
+        trace_span!("VariableLabel")
     }
 
     fn get_debug_text(&self) -> Option<String> {

--- a/xilem/Cargo.toml
+++ b/xilem/Cargo.toml
@@ -71,6 +71,9 @@ tokio = { version = "1.39.1", features = ["rt", "rt-multi-thread", "time"] }
 # Used for `variable_clock`
 time = { workspace = true, features = ["local-offset"] }
 
+# Make wgpu use tracing for its spans.
+profiling = { version = "1.0.15", features = ["profile-with-tracing"] }
+
 [target.'cfg(target_os = "android")'.dev-dependencies]
 winit = { features = ["android-native-activity"], workspace = true }
 

--- a/xilem/Cargo.toml
+++ b/xilem/Cargo.toml
@@ -73,3 +73,8 @@ time = { workspace = true, features = ["local-offset"] }
 
 [target.'cfg(target_os = "android")'.dev-dependencies]
 winit = { features = ["android-native-activity"], workspace = true }
+
+# This makes the examples discoverable to (e.g.) Android GPU inspector without needing to provide the full name manually.
+# Do not use when releasing a production app.
+[package.metadata.android.application]
+debuggable = true


### PR DESCRIPTION
- Adds tracing_android_trace
- Correct the span for VariableLabel
- Make the created apps "debuggable"
- Enable spans for `wgpu`'s `profiling` results
- Add a span around the Vello rendering to show when that is