### PR TITLE
Disable hinting whilst a `VariableLabel` animation is ongoing

### DIFF
--- a/masonry/src/text/layout.rs
+++ b/masonry/src/text/layout.rs
@@ -89,6 +89,18 @@ pub enum TextBrush {
     },
 }
 
+impl TextBrush {
+    pub fn set_hinting(&mut self, hinting: Hinting) {
+        match self {
+            TextBrush::Normal(_, should_hint) => *should_hint = hinting,
+            TextBrush::Highlight {
+                hinting: should_hint,
+                ..
+            } => *should_hint = hinting,
+        }
+    }
+}
+
 impl BrushTrait for TextBrush {}
 
 impl From<peniko::Brush> for TextBrush {

--- a/masonry/src/text/layout.rs
+++ b/masonry/src/text/layout.rs
@@ -59,14 +59,33 @@ pub struct TextLayout<T> {
     scratch_scene: Scene,
 }
 
+/// Whether a section of text should be hinted.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Default)]
+pub enum Hinting {
+    #[default]
+    Yes,
+    No,
+}
+
+impl Hinting {
+    /// Whether the
+    pub fn should_hint(self) -> bool {
+        match self {
+            Hinting::Yes => true,
+            Hinting::No => false,
+        }
+    }
+}
+
 /// A custom brush for `Parley`, enabling using Parley to pass-through
 /// which glyphs are selected/highlighted
 #[derive(Clone, Debug, PartialEq)]
 pub enum TextBrush {
-    Normal(peniko::Brush),
+    Normal(peniko::Brush, Hinting),
     Highlight {
         text: peniko::Brush,
         fill: peniko::Brush,
+        hinting: Hinting,
     },
 }
 
@@ -74,26 +93,26 @@ impl BrushTrait for TextBrush {}
 
 impl From<peniko::Brush> for TextBrush {
     fn from(value: peniko::Brush) -> Self {
-        Self::Normal(value)
+        Self::Normal(value, Hinting::default())
     }
 }
 
 impl From<Gradient> for TextBrush {
     fn from(value: Gradient) -> Self {
-        Self::Normal(value.into())
+        Self::Normal(value.into(), Hinting::default())
     }
 }
 
 impl From<Color> for TextBrush {
     fn from(value: Color) -> Self {
-        Self::Normal(value.into())
+        Self::Normal(value.into(), Hinting::default())
     }
 }
 
 // Parley requires their Brush implementations to implement Default
 impl Default for TextBrush {
     fn default() -> Self {
-        Self::Normal(Default::default())
+        Self::Normal(Default::default(), Hinting::default())
     }
 }
 

--- a/masonry/src/text/mod.rs
+++ b/masonry/src/text/mod.rs
@@ -14,7 +14,7 @@ mod store;
 pub use store::{Link, TextStorage};
 
 mod layout;
-pub use layout::{LayoutMetrics, TextBrush, TextLayout};
+pub use layout::{Hinting, LayoutMetrics, TextBrush, TextLayout};
 
 mod selection;
 pub use selection::{

--- a/masonry/src/text/selection.rs
+++ b/masonry/src/text/selection.rs
@@ -42,6 +42,7 @@ impl<T: Selectable> TextWithSelection<T> {
             highlight_brush: TextBrush::Highlight {
                 text: Color::WHITE.into(),
                 fill: Color::LIGHT_BLUE.into(),
+                hinting: Default::default(),
             },
         }
     }

--- a/masonry/src/text_helpers.rs
+++ b/masonry/src/text_helpers.rs
@@ -76,9 +76,13 @@ pub fn render_text(
                 .iter()
                 .map(|coord| vello::skrifa::instance::NormalizedCoord::from_bits(*coord))
                 .collect::<Vec<_>>();
-            let text_brush = match &style.brush {
-                TextBrush::Normal(text_brush) => text_brush,
-                TextBrush::Highlight { text, fill } => {
+            let (text_brush, hinting) = match &style.brush {
+                TextBrush::Normal(text_brush, hinting) => (text_brush, hinting),
+                TextBrush::Highlight {
+                    text,
+                    fill,
+                    hinting,
+                } => {
                     scene.fill(
                         Fill::EvenOdd,
                         transform,
@@ -95,13 +99,13 @@ pub fn render_text(
                         ),
                     );
 
-                    text
+                    (text, hinting)
                 }
             };
             scratch_scene
                 .draw_glyphs(font)
                 .brush(text_brush)
-                .hint(true)
+                .hint(hinting.should_hint())
                 .transform(transform)
                 .glyph_transform(glyph_xform)
                 .font_size(font_size)
@@ -121,7 +125,8 @@ pub fn render_text(
                 );
             if let Some(underline) = &style.underline {
                 let underline_brush = match &underline.brush {
-                    TextBrush::Normal(text) => text,
+                    // Underlines aren't hinted
+                    TextBrush::Normal(text, _) => text,
                     // It doesn't make sense for an underline to have a highlight colour, so we
                     // just use the text colour for the colour
                     TextBrush::Highlight { text, .. } => text,
@@ -154,7 +159,8 @@ pub fn render_text(
             }
             if let Some(strikethrough) = &style.strikethrough {
                 let strikethrough_brush = match &strikethrough.brush {
-                    TextBrush::Normal(text) => text,
+                    // Strikethroughs aren't hinted
+                    TextBrush::Normal(text, _) => text,
                     // It doesn't make sense for an underline to have a highlight colour, so we
                     // just use the text colour for the colour
                     TextBrush::Highlight { text, .. } => text,

--- a/masonry/src/widget/variable_label.rs
+++ b/masonry/src/widget/variable_label.rs
@@ -191,7 +191,7 @@ impl VariableLabel {
     }
     /// Set the initial font weight for this text.
     pub fn with_initial_weight(mut self, weight: f32) -> Self {
-        self.weight.value = weight;
+        self.weight = AnimatedF32::stable(weight);
         self
     }
 


### PR DESCRIPTION
If using hinting during an animation, a shimmering effect can occur.