### PR TITLE
Enable BackgroundBrush in SizedBox view

### DIFF
--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -142,6 +142,6 @@ pub use parley::layout::Alignment as TextAlignment;
 pub use util::{AsAny, Handled};
 pub use vello::peniko::{Color, Gradient};
 pub use widget::widget::{AllowRawMut, Widget, WidgetId};
-pub use widget::{BackgroundBrush, WidgetPod, WidgetState};
+pub use widget::{WidgetPod, WidgetState};
 
 pub use text_helpers::ArcStr;

--- a/masonry/src/widget/mod.rs
+++ b/masonry/src/widget/mod.rs
@@ -52,8 +52,6 @@ pub use widget_state::WidgetState;
 
 pub(crate) use widget_arena::WidgetArena;
 
-pub use sized_box::BackgroundBrush;
-
 use crate::{Affine, Size};
 
 // These are based on https://api.flutter.dev/flutter/painting/BoxFit-class.html

--- a/masonry/src/widget/screenshots/masonry__widget__sized_box__tests__empty_box_with_gradient_background.png
+++ b/masonry/src/widget/screenshots/masonry__widget__sized_box__tests__empty_box_with_gradient_background.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d089700d96178cbb0b101cfd9c637bb7e41ee2911fa4d15fd66a2ca0067d9c56
+size 81747

--- a/masonry/src/widget/screenshots/masonry__widget__sized_box__tests__label_box_with_size.png
+++ b/masonry/src/widget/screenshots/masonry__widget__sized_box__tests__label_box_with_size.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8c3813349a80712477a0fe65e931c046c804bb8698da4ecdebd15bd3e59f473
+size 5421

--- a/masonry/src/widget/screenshots/masonry__widget__sized_box__tests__label_box_with_solid_background.png
+++ b/masonry/src/widget/screenshots/masonry__widget__sized_box__tests__label_box_with_solid_background.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea70d4d9e961064f6988c225eda221719fee5f3fafdce1b41db38a2e3d72bead
+size 4862

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -7,7 +7,7 @@ use accesskit::Role;
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, warn, Span};
 use vello::kurbo::{Affine, RoundedRectRadii};
-use vello::peniko::{BlendMode, Brush, Color, Fill};
+use vello::peniko::{Brush, Color, Fill};
 use vello::Scene;
 
 use crate::paint_scene_helpers::stroke;

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -364,15 +364,13 @@ impl Widget for SizedBox {
             let panel = ctx.size().to_rounded_rect(corner_radius);
 
             trace_span!("paint background").in_scope(|| {
-                scene.push_layer(BlendMode::default(), 1., Affine::IDENTITY, &panel);
                 scene.fill(
                     Fill::NonZero,
                     Affine::IDENTITY,
                     &*background,
                     Some(Affine::IDENTITY),
-                    &ctx.size().to_rect(),
+                    &panel,
                 );
-                scene.pop_layer();
             });
         }
 

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -432,6 +432,7 @@ fn paint(brush: &Brush, ctx: &mut PaintCtx, scene: &mut Scene) {
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;
+    use vello::peniko::Gradient;
 
     use super::*;
     use crate::assert_render_snapshot;
@@ -500,12 +501,35 @@ mod tests {
         let widget = SizedBox::new(Label::new("hello"))
             .width(40.0)
             .height(40.0)
-            .background(Brush::Solid(Color::PLUM));
+            .background(Color::PLUM);
 
         let mut harness = TestHarness::create(widget);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "label_box_with_solid_background");
+    }
+
+    #[test]
+    fn empty_box_with_gradient_background() {
+        let widget = SizedBox::empty()
+            .width(40.)
+            .height(40.)
+            .rounded(20.)
+            .border(Color::LIGHT_SKY_BLUE, 5.)
+            .background(
+                Gradient::new_sweep((30., 30.), 0., std::f32::consts::TAU).with_stops([
+                    (0., Color::WHITE),
+                    (0.25, Color::BLACK),
+                    (0.5, Color::RED),
+                    (0.75, Color::GREEN),
+                    (1., Color::WHITE),
+                ]),
+            );
+
+        let mut harness = TestHarness::create(widget);
+
+        assert_debug_snapshot!(harness.root_widget());
+        assert_render_snapshot!(harness, "empty_box_with_gradient_background");
     }
 
     // TODO - add screenshot tests for different brush types

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -10,7 +10,7 @@ use vello::kurbo::{Affine, RoundedRectRadii};
 use vello::peniko::{BlendMode, Brush, Color, Fill};
 use vello::Scene;
 
-use crate::paint_scene_helpers::{fill_color, stroke};
+use crate::paint_scene_helpers::stroke;
 use crate::widget::{WidgetMut, WidgetPod};
 use crate::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
@@ -365,7 +365,13 @@ impl Widget for SizedBox {
 
             trace_span!("paint background").in_scope(|| {
                 scene.push_layer(BlendMode::default(), 1., Affine::IDENTITY, &panel);
-                paint(background, ctx, scene);
+                scene.fill(
+                    Fill::NonZero,
+                    Affine::IDENTITY,
+                    &*background,
+                    Some(Affine::IDENTITY),
+                    &ctx.size().to_rect(),
+                );
                 scene.pop_layer();
             });
         }
@@ -405,24 +411,6 @@ impl Widget for SizedBox {
 
     fn make_trace_span(&self) -> Span {
         trace_span!("SizedBox")
-    }
-}
-
-// --- BackgroundBrush ---
-
-/// Draw this brush into a provided [`PaintCtx`].
-fn paint(brush: &Brush, ctx: &mut PaintCtx, scene: &mut Scene) {
-    let bounds = ctx.size().to_rect();
-    match brush {
-        Brush::Solid(color) => fill_color(scene, &bounds, *color),
-        Brush::Gradient(grad) => scene.fill(
-            Fill::NonZero,
-            Affine::IDENTITY,
-            grad,
-            Some(Affine::IDENTITY),
-            &bounds,
-        ),
-        Brush::Image(image) => scene.draw_image(image, Affine::IDENTITY),
     }
 }
 

--- a/masonry/src/widget/snapshots/masonry__widget__sized_box__tests__empty_box_with_gradient_background.snap
+++ b/masonry/src/widget/snapshots/masonry__widget__sized_box__tests__empty_box_with_gradient_background.snap
@@ -1,0 +1,5 @@
+---
+source: masonry/src/widget/sized_box.rs
+expression: harness.root_widget()
+---
+SizedBox

--- a/masonry/src/widget/snapshots/masonry__widget__sized_box__tests__label_box_with_solid_background.snap
+++ b/masonry/src/widget/snapshots/masonry__widget__sized_box__tests__label_box_with_solid_background.snap
@@ -1,0 +1,7 @@
+---
+source: masonry/src/widget/sized_box.rs
+expression: harness.root_widget()
+---
+SizedBox(
+    Label<hello>,
+)

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -13,13 +13,6 @@ use crate::{
     Pod, ViewCtx, WidgetView,
 };
 
-/// Something that can be used as the border for a widget.
-#[derive(PartialEq)]
-struct BorderStyle {
-    width: f64,
-    color: Color,
-}
-
 /// A widget with predefined size.
 ///
 /// This widget forces its child to have a specific width and/or height (assuming values are permitted by
@@ -210,4 +203,11 @@ where
     ) -> crate::MessageResult<Action> {
         self.inner.message(view_state, id_path, message, app_state)
     }
+}
+
+/// Something that can be used as the border for a widget.
+#[derive(PartialEq)]
+struct BorderStyle {
+    width: f64,
+    color: Color,
 }


### PR DESCRIPTION
The `SizedBox` widget in Masonry had the option to set a background brush that was not exposed in its corresponding view in Xilem. The `SizedBox` view now exposes the option.

Incidentally, `BackgroundBrush::PainterFn` variant had the wrong type, as such it was not usable. A `scene` parameter is added and the closure now requires to be `Send + Sync`.