### PR TITLE
masonry: Re-enable `clippy::doc_markdown`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ rust.variant_size_differences = "warn"
 clippy.allow_attributes_without_reason = "warn"
 clippy.collection_is_never_read = "warn"
 clippy.debug_assert_with_mut_call = "warn"
-# This is marked as `allow` within masonry due to https://github.com/linebender/xilem/issues/449.
 clippy.doc_markdown = "warn"
 clippy.fn_to_numeric_cast_any = "forbid"
 clippy.infinite_loop = "warn"

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -81,7 +81,7 @@
 //! [Xilem]: https://crates.io/crates/xilem
 
 // TODO: Remove this once the issues within masonry are fixed. Tracked in https://github.com/linebender/xilem/issues/449
-#![allow(rustdoc::broken_intra_doc_links, clippy::doc_markdown)]
+#![allow(rustdoc::broken_intra_doc_links)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 // #![deny(rustdoc::broken_intra_doc_links)]
 // #![warn(missing_docs)]


### PR DESCRIPTION
This is work towards #449.