### PR TITLE
Remove manual recursion to child `paint` and `accessibility`

### DIFF
--- a/masonry/examples/calc_masonry.rs
+++ b/masonry/examples/calc_masonry.rs
@@ -223,9 +223,7 @@ impl Widget for CalcButton {
         size
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
-        self.inner.paint(ctx, scene);
-    }
+    fn paint(&mut self, _ctx: &mut PaintCtx, _scene: &mut Scene) {}
 
     fn accessibility_role(&self) -> Role {
         Role::Button
@@ -240,8 +238,6 @@ impl Widget for CalcButton {
         // ctx.current_node().set_name(name);
         ctx.current_node()
             .set_default_action_verb(DefaultActionVerb::Click);
-
-        self.inner.accessibility(ctx);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/testing/helper_widgets.rs
+++ b/masonry/src/testing/helper_widgets.rs
@@ -336,17 +336,13 @@ impl Widget for ReplaceChild {
 
     fn compose(&mut self, _ctx: &mut ComposeCtx) {}
 
-    fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
-        self.child.paint(ctx, scene);
-    }
+    fn paint(&mut self, _ctx: &mut PaintCtx, _scene: &mut Scene) {}
 
     fn accessibility_role(&self) -> Role {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
-        self.child.accessibility(ctx);
-    }
+    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         todo!()

--- a/masonry/src/widget/align.rs
+++ b/masonry/src/widget/align.rs
@@ -144,17 +144,13 @@ impl Widget for Align {
         my_size
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
-        self.child.paint(ctx, scene);
-    }
+    fn paint(&mut self, _ctx: &mut PaintCtx, _scene: &mut Scene) {}
 
     fn accessibility_role(&self) -> Role {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
-        self.child.accessibility(ctx);
-    }
+    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         smallvec![self.child.id()]

--- a/masonry/src/widget/button.rs
+++ b/masonry/src/widget/button.rs
@@ -183,8 +183,6 @@ impl Widget for Button {
             UnitPoint::TOP,
             UnitPoint::BOTTOM,
         );
-
-        self.label.paint(ctx, scene);
     }
 
     fn accessibility_role(&self) -> Role {
@@ -202,8 +200,6 @@ impl Widget for Button {
         }
         ctx.current_node()
             .set_default_action_verb(DefaultActionVerb::Click);
-
-        self.label.accessibility(ctx);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/checkbox.rs
+++ b/masonry/src/widget/checkbox.rs
@@ -177,9 +177,6 @@ impl Widget for Checkbox {
 
             scene.stroke(&style, Affine::IDENTITY, brush, None, &path);
         }
-
-        // Paint the text label
-        self.label.paint(ctx, scene);
     }
 
     fn accessibility_role(&self) -> Role {
@@ -204,8 +201,6 @@ impl Widget for Checkbox {
             ctx.current_node()
                 .set_default_action_verb(DefaultActionVerb::Check);
         }
-
-        self.label.accessibility(ctx);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -889,10 +889,6 @@ impl Widget for Flex {
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
-        for child in self.children.iter_mut().filter_map(|x| x.widget_mut()) {
-            child.paint(ctx, scene);
-        }
-
         // paint the baseline if we're debugging layout
         if ctx.debug_paint && ctx.widget_state.baseline_offset != 0.0 {
             let color = get_debug_color(ctx.widget_id().to_raw());
@@ -908,11 +904,7 @@ impl Widget for Flex {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
-        for child in self.children.iter_mut().filter_map(|x| x.widget_mut()) {
-            child.accessibility(ctx);
-        }
-    }
+    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         self.children

--- a/masonry/src/widget/portal.rs
+++ b/masonry/src/widget/portal.rs
@@ -424,10 +424,6 @@ impl<W: Widget> Widget for Portal<W> {
             .push_child(self.scrollbar_horizontal.id().into());
         ctx.current_node()
             .push_child(self.scrollbar_vertical.id().into());
-
-        self.child.accessibility(ctx);
-        self.scrollbar_horizontal.accessibility(ctx);
-        self.scrollbar_vertical.accessibility(ctx);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/root_widget.rs
+++ b/masonry/src/widget/root_widget.rs
@@ -56,17 +56,13 @@ impl<W: Widget> Widget for RootWidget<W> {
         size
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
-        self.pod.paint(ctx, scene);
-    }
+    fn paint(&mut self, _ctx: &mut PaintCtx, _scene: &mut Scene) {}
 
     fn accessibility_role(&self) -> Role {
         Role::Window
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
-        self.pod.accessibility(ctx);
-    }
+    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         smallvec![self.pod.id()]

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -385,21 +385,13 @@ impl Widget for SizedBox {
                 .to_rounded_rect(corner_radius);
             stroke(scene, &border_rect, border.color, border_width);
         };
-
-        if let Some(ref mut child) = self.child {
-            child.paint(ctx, scene);
-        }
     }
 
     fn accessibility_role(&self) -> Role {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
-        if let Some(child) = self.child.as_mut() {
-            child.accessibility(ctx);
-        }
-    }
+    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         if let Some(child) = &self.child {

--- a/masonry/src/widget/split.rs
+++ b/masonry/src/widget/split.rs
@@ -555,18 +555,13 @@ impl Widget for Split {
         } else {
             self.paint_stroked_bar(ctx, scene);
         }
-        self.child1.paint(ctx, scene);
-        self.child2.paint(ctx, scene);
     }
 
     fn accessibility_role(&self) -> Role {
         Role::Splitter
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
-        self.child1.accessibility(ctx);
-        self.child2.accessibility(ctx);
-    }
+    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         smallvec![self.child1.id(), self.child2.id()]

--- a/masonry/src/widget/tests/safety_rails.rs
+++ b/masonry/src/widget/tests/safety_rails.rs
@@ -16,9 +16,6 @@ fn make_parent_widget<W: Widget>(child: W) -> ModularWidget<WidgetPod<W>> {
             ctx.place_child(child, Point::ZERO);
             size
         })
-        .paint_fn(move |child, ctx, scene| {
-            child.paint(ctx, scene);
-        })
         .children_fn(|child| smallvec![child.id()])
 }
 

--- a/masonry/src/widget/widget_pod.rs
+++ b/masonry/src/widget/widget_pod.rs
@@ -8,8 +8,8 @@ use vello::kurbo::{Rect, Size};
 use crate::tree_arena::ArenaRefChildren;
 use crate::widget::WidgetState;
 use crate::{
-    AccessCtx, BoxConstraints, InternalLifeCycle, LayoutCtx, LifeCycle, LifeCycleCtx, PaintCtx,
-    StatusChange, Widget, WidgetId,
+    BoxConstraints, InternalLifeCycle, LayoutCtx, LifeCycle, LifeCycleCtx, StatusChange, Widget,
+    WidgetId,
 };
 
 // TODO - rewrite links in doc
@@ -587,18 +587,6 @@ impl<W: Widget> WidgetPod<W> {
             warn!("Widget `{type_name}` has an infinite height.");
         }
     }
-
-    // --- MARK: PAINT ---
-
-    // TODO - This should be removed in a follow-up PR immediately after
-    // this is merged. I'm leaving the method for now to avoid blowing up the diff.
-    pub fn paint(&mut self, _parent_ctx: &mut PaintCtx, _scene: &mut vello::Scene) {}
-
-    // --- MARK: ACCESSIBILITY ---
-
-    // TODO - This should be removed in a follow-up PR immediately after
-    // this is merged. I'm leaving the method for now to avoid blowing up the diff.
-    pub fn accessibility(&mut self, _parent_ctx: &mut AccessCtx) {}
 }
 
 // TODO - negative rects?

--- a/xilem/src/any_view.rs
+++ b/xilem/src/any_view.rs
@@ -92,17 +92,13 @@ impl Widget for DynWidget {
         size
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
-        self.inner.paint(ctx, scene);
-    }
+    fn paint(&mut self, _ctx: &mut PaintCtx, _scene: &mut Scene) {}
 
     fn accessibility_role(&self) -> Role {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
-        self.inner.accessibility(ctx);
-    }
+    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         smallvec![self.inner.id()]

--- a/xilem/src/one_of.rs
+++ b/xilem/src/one_of.rs
@@ -288,37 +288,13 @@ impl<
         }
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
-        match self {
-            OneOfWidget::A(w) => w.paint(ctx, scene),
-            OneOfWidget::B(w) => w.paint(ctx, scene),
-            OneOfWidget::C(w) => w.paint(ctx, scene),
-            OneOfWidget::D(w) => w.paint(ctx, scene),
-            OneOfWidget::E(w) => w.paint(ctx, scene),
-            OneOfWidget::F(w) => w.paint(ctx, scene),
-            OneOfWidget::G(w) => w.paint(ctx, scene),
-            OneOfWidget::H(w) => w.paint(ctx, scene),
-            OneOfWidget::I(w) => w.paint(ctx, scene),
-        }
-    }
+    fn paint(&mut self, _ctx: &mut PaintCtx, _scene: &mut Scene) {}
 
     fn accessibility_role(&self) -> Role {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
-        match self {
-            OneOfWidget::A(w) => w.accessibility(ctx),
-            OneOfWidget::B(w) => w.accessibility(ctx),
-            OneOfWidget::C(w) => w.accessibility(ctx),
-            OneOfWidget::D(w) => w.accessibility(ctx),
-            OneOfWidget::E(w) => w.accessibility(ctx),
-            OneOfWidget::F(w) => w.accessibility(ctx),
-            OneOfWidget::G(w) => w.accessibility(ctx),
-            OneOfWidget::H(w) => w.accessibility(ctx),
-            OneOfWidget::I(w) => w.accessibility(ctx),
-        }
-    }
+    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         match self {


### PR DESCRIPTION
Recursing is done inside the paint and accessibility passes since ff7635e4c281ff381433728bd070323347638f29. I believe this is the correct continuation of #522, with the removal of these methods "left for later" as mentioned in https://github.com/linebender/xilem/pull/522#issuecomment-2298610203.

One note is that Flex now debug-paints its baseline under its children, rather than over them.