### PR TITLE
Fix the handling of `Flex::gap`

### DIFF
--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -847,6 +847,12 @@ impl Widget for Flex {
             tracing::warn!("A child of Flex is flex, but Flex is unbounded.");
         }
 
+        if !self.children.is_empty() {
+            // If we have at least one child, the last child added `gap` to the total major non-flex amount, when it shouldn't have.
+            // This means that the
+            major -= gap;
+        }
+
         if flex_sum > 0.0 {
             major = total_major;
         }

--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -848,8 +848,9 @@ impl Widget for Flex {
         }
 
         if !self.children.is_empty() {
-            // If we have at least one child, the last child added `gap` to the total major non-flex amount, when it shouldn't have.
-            // This means that the
+            // If we have at least one child, the last child added `gap` to `major`, which means that `major` is
+            // not the total size of the flex in the major axis, it's instead where the "next widget" will be placed.
+            // However, for the rest of this value, we need the total size of the widget in the major axis.
             major -= gap;
         }
 


### PR DESCRIPTION
Fixes https://github.com/linebender/xilem/issues/559

See comment on the fix for an explanation. Essentially, the `major` value was used for multiple purposes, and this corrects into the expected "direction".