### PR TITLE
masonry: fix updating Portal on scrollbar drag

### DIFF
--- a/masonry/src/widget/portal.rs
+++ b/masonry/src/widget/portal.rs
@@ -298,7 +298,7 @@ impl<W: Widget> Widget for Portal<W> {
         }
 
         if scrollbar_moved {
-            ctx.request_layout();
+            ctx.request_compose();
         }
     }
 

--- a/masonry/src/widget/scroll_bar.rs
+++ b/masonry/src/widget/scroll_bar.rs
@@ -133,7 +133,8 @@ impl Widget for ScrollBar {
                 let cursor_min_length = theme::SCROLLBAR_MIN_SIZE;
                 let cursor_rect = self.get_cursor_rect(ctx.size(), cursor_min_length);
 
-                let mouse_pos = Point::new(state.position.x, state.position.y);
+                let mouse_pos =
+                    Point::new(state.position.x, state.position.y) - ctx.window_origin().to_vec2();
                 if cursor_rect.contains(mouse_pos) {
                     let (z0, z1) = self.axis.major_span(cursor_rect);
                     let mouse_major = self.axis.major_pos(mouse_pos);
@@ -147,7 +148,8 @@ impl Widget for ScrollBar {
                 ctx.request_paint();
             }
             PointerEvent::PointerMove(state) => {
-                let mouse_pos = Point::new(state.position.x, state.position.y);
+                let mouse_pos =
+                    Point::new(state.position.x, state.position.y) - ctx.window_origin().to_vec2();
                 if let Some(grab_anchor) = self.grab_anchor {
                     let cursor_min_length = theme::SCROLLBAR_MIN_SIZE;
                     self.cursor_progress = self.progress_from_mouse_pos(

--- a/masonry/src/widget/widget_ref.rs
+++ b/masonry/src/widget/widget_ref.rs
@@ -170,6 +170,9 @@ impl<'w> WidgetRef<'w, dyn Widget> {
 
     /// Recursively find innermost widget at given position.
     ///
+    /// If multiple overlapping children of a widget contain the given position in their layout
+    /// boxes, the last child as determined by [`Widget::children_ids`] is chosen.
+    ///
     /// **pos** - the position in local coordinates (zero being the top-left of the
     /// inner widget).
     pub fn find_widget_at_pos(&self, pos: Point) -> Option<WidgetRef<'w, dyn Widget>> {
@@ -190,7 +193,7 @@ impl<'w> WidgetRef<'w, dyn Widget> {
                 }
             }
             // TODO - Use Widget::get_child_at_pos method
-            if let Some(child) = innermost_widget.children().into_iter().find(|child| {
+            if let Some(child) = innermost_widget.children().into_iter().rev().find(|child| {
                 !child.widget.skip_pointer() && child.state().window_layout_rect().contains(pos)
             }) {
                 innermost_widget = child;


### PR DESCRIPTION
Fixes scrolling `Portal` on scrollbar drag by recomposing instead of relayouting.

Regression probably caused in 59ee615651266421ffe65dadee6d16663f056c9d (https://github.com/linebender/xilem/pull/488) or ff7635e4c281ff381433728bd070323347638f29 (https://github.com/linebender/xilem/pull/522).