### PR TITLE
xilem calc: Use Unicode minus sign.

### DIFF
--- a/xilem/examples/calc.rs
+++ b/xilem/examples/calc.rs
@@ -24,7 +24,7 @@ impl MathOperator {
     fn as_str(&self) -> &'static str {
         match self {
             MathOperator::Add => "+",
-            MathOperator::Subtract => "-",
+            MathOperator::Subtract => "\u{2212}",
             MathOperator::Multiply => "×",
             MathOperator::Divide => "÷",
         }


### PR DESCRIPTION
This lets it get read out correctly by VoiceOver in accessibility code rather than read as a hyphen or dash.