### PR TITLE
add checkbox to widget example

### DIFF
--- a/xilem/examples/widgets.rs
+++ b/xilem/examples/widgets.rs
@@ -48,7 +48,7 @@ fn checkbox_view(data: bool) -> impl WidgetView<bool> {
     })
 }
 
-/// Wrap widgets in a box with a border
+/// Wrap `inner` in a box with a border
 fn border_box<State: 'static, Action: 'static>(
     inner: impl WidgetView<State, Action>,
 ) -> impl WidgetView<State, Action> {

--- a/xilem/src/view/mod.rs
+++ b/xilem/src/view/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//! A collection of useful pre-made views (sometimes called 'widgets' in other UI systems)
+//! Views for the widgets which are built-in to Masonry. These are the primitives your Xilem app's view tree will generally be constructed from.
 
 mod task;
 pub use task::*;

--- a/xilem/src/view/mod.rs
+++ b/xilem/src/view/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//! A collection of useful pre-made views (sometimes called 'widgets' in other UI systems)
+
 mod task;
 pub use task::*;
 


### PR DESCRIPTION
This PR adds another widget to the widgets example, and also draws boxes around each widget to separate them visually. I wanted to use flex wrap to display them, but I don't think that's implemented yet in Xilem, and the layout I did use isn't bad.

It also provides a simple example of the use of `Adapt`