### PR TITLE
masonry: set pointer-captured ancestors of hover target as hot

### DIFF
--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -254,7 +254,9 @@ impl_context_method!(
         /// Discussion: there is currently some confusion about whether a
         /// widget can be considered hot when some other widget is active (for
         /// example, when clicking to one widget and dragging to the next).
-        /// The documentation should clearly state the resolution.
+        /// The documentation should clearly state the resolution. At the
+        /// moment, if a widget has pointer capture, it and its ancestors can
+        /// be hot, but no other widgets can be.
         pub fn is_hot(&self) -> bool {
             self.widget_state.is_hot
         }


### PR DESCRIPTION
Currently when a widget has pointer capture and the pointer is over one of its descendants, no widget is considered hot. This changes the hot logic such that the widget with the pointer capture and its ancestors are considered hot, but not its descendants.

The current behavior is troublesome. For example, when applying the following patch, a button does not register as having been pressed when the pointer is pressed while over its descendant label. That's because during the `PointerUp` event, the button is not considered hot (it has captured the pointer, but the pointer is not directly over the button: it's over its descendant label).

```diff
diff --git a/masonry/src/widget/widget_ref.rs b/masonry/src/widget/widget_ref.rs
index 2f85ea5..3494fcd 100644
--- a/masonry/src/widget/widget_ref.rs
+++ b/masonry/src/widget/widget_ref.rs
@@ -191,7 +191,8 @@ impl<'w> WidgetRef<'w, dyn Widget> {
             }
             // TODO - Use Widget::get_child_at_pos method
             if let Some(child) = innermost_widget.children().into_iter().find(|child| {
-                !child.widget.skip_pointer() && child.state().window_layout_rect().contains(pos)
+                child.state().window_layout_rect().contains(pos)
             }) {
                 innermost_widget = child;
             } else {
```