### PR TITLE
masonry: add docs for `TreeArena::get_id_path`

### DIFF
--- a/masonry/src/tree_arena.rs
+++ b/masonry/src/tree_arena.rs
@@ -207,6 +207,10 @@ impl<Item> TreeArena<Item> {
         Some(node.arena_mut(self.parents_map[&id], &mut self.parents_map))
     }
 
+    /// Construct the path of items from the given item to the root of the tree.
+    ///
+    /// The path is in order from the bottom to the top, starting at the given item and ending at
+    /// the root.
     pub fn get_id_path(&self, id: u64) -> Vec<u64> {
         let mut path = Vec::new();
 


### PR DESCRIPTION
beats reading the implementation to know the order :-)