### PR TITLE
docs(#581): fix missing char in `ARCHITECTURE.md`

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,12 +82,12 @@ The associated Elements of the `View` trait are either DOM nodes for `xilem_web`
 ### `xilem_core`
 Contains the `View` trait, and other general implementations. Is also contains the `Message`, `MessageResult`, `Id` types and the tree-structrure tracking.
 
-### `xilem_web/
+### `xilem_web/`
 An implementation of Xilem running on the DOM.
 
 ### `xilem_web_core`
 A historical version of `xilem_core` used in `xilem_web`
 
 
-### `masonry/
+### `masonry/`
 See `ARCHITECTURE.md` file located under `crates/masonry/doc`


### PR DESCRIPTION
Fix issue #581.