### PR TITLE
Support the AccessKit focus and blur actions 

### DIFF
--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -301,6 +301,11 @@ impl_context_method!(
             self.widget_state.has_focus
         }
 
+        /// Whether this specific widget is in the focus chain.
+        pub fn is_in_focus_chain(&self) -> bool {
+            self.widget_state.in_focus_chain
+        }
+
         /// The disabled state of a widget.
         ///
         /// Returns `true` if this widget or any of its ancestors is explicitly disabled.
@@ -715,6 +720,7 @@ impl LifeCycleCtx<'_> {
     pub fn register_for_focus(&mut self) {
         trace!("register_for_focus");
         self.widget_state.focus_chain.push(self.widget_id());
+        self.widget_state.in_focus_chain = true;
     }
 
     /// Register this widget as accepting text input.

--- a/masonry/src/passes/accessibility.rs
+++ b/masonry/src/passes/accessibility.rs
@@ -46,6 +46,7 @@ fn build_accessibility_tree(
             rebuild_all,
             scale_factor,
         };
+        set_common_properties(&mut ctx);
         widget.item.accessibility(&mut ctx);
 
         let id: NodeId = ctx.widget_state.id.into();
@@ -99,24 +100,28 @@ fn build_access_node(widget: &dyn Widget, state: &WidgetState, scale_factor: f64
             .collect::<Vec<NodeId>>(),
     );
 
-    if state.is_hot {
-        node.set_hovered();
-    }
-    if state.is_disabled {
-        node.set_disabled();
-    }
-    if state.is_stashed {
-        node.set_hidden();
-    }
-    if state.clip.is_some() {
-        node.set_clips_children();
-    }
-    if state.in_focus_chain {
-        node.add_action(accesskit::Action::Focus);
-        node.add_action(accesskit::Action::Blur);
-    }
-
     node
+}
+
+fn set_common_properties(ctx: &mut AccessCtx) {
+    if ctx.is_hot() {
+        ctx.current_node().set_hovered();
+    }
+    if ctx.is_disabled() {
+        ctx.current_node().set_disabled();
+    }
+    if ctx.is_stashed() {
+        ctx.current_node().set_hidden();
+    }
+    if ctx.widget_state.clip.is_some() {
+        ctx.current_node().set_clips_children();
+    }
+    if ctx.is_in_focus_chain() && !ctx.is_disabled() {
+        ctx.current_node().add_action(accesskit::Action::Focus);
+    }
+    if ctx.is_focused() {
+        ctx.current_node().add_action(accesskit::Action::Blur);
+    }
 }
 
 fn to_accesskit_rect(r: Rect, scale_factor: f64) -> accesskit::Rect {

--- a/masonry/src/passes/accessibility.rs
+++ b/masonry/src/passes/accessibility.rs
@@ -111,6 +111,10 @@ fn build_access_node(widget: &dyn Widget, state: &WidgetState, scale_factor: f64
     if state.clip.is_some() {
         node.set_clips_children();
     }
+    if state.in_focus_chain {
+        node.add_action(accesskit::Action::Focus);
+        node.add_action(accesskit::Action::Blur);
+    }
 
     node
 }

--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -195,6 +195,7 @@ pub(crate) fn root_on_access_event(
         event,
         false,
         |widget, ctx, event| {
+            // TODO - Split into "access_event_focus" pass or something similar.
             if event.target == ctx.widget_id() {
                 match event.action {
                     accesskit::Action::Focus => {

--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -195,6 +195,23 @@ pub(crate) fn root_on_access_event(
         event,
         false,
         |widget, ctx, event| {
+            if event.target == ctx.widget_id() {
+                match event.action {
+                    accesskit::Action::Focus => {
+                        if ctx.is_in_focus_chain() && !ctx.is_disabled() && !ctx.is_focused() {
+                            ctx.request_focus();
+                        }
+                        return;
+                    }
+                    accesskit::Action::Blur => {
+                        if ctx.is_focused() {
+                            ctx.resign_focus();
+                        }
+                        return;
+                    }
+                    _ => {}
+                }
+            }
             widget.on_access_event(ctx, event);
         },
     );

--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -200,14 +200,16 @@ pub(crate) fn root_on_access_event(
                     accesskit::Action::Focus => {
                         if ctx.is_in_focus_chain() && !ctx.is_disabled() && !ctx.is_focused() {
                             ctx.request_focus();
+                            ctx.set_handled();
+                            return;
                         }
-                        return;
                     }
                     accesskit::Action::Blur => {
                         if ctx.is_focused() {
                             ctx.resign_focus();
+                            ctx.set_handled();
+                            return;
                         }
-                        return;
                     }
                     _ => {}
                 }

--- a/masonry/src/passes/update.rs
+++ b/masonry/src/passes/update.rs
@@ -502,6 +502,7 @@ fn update_focus_chain_for_widget(
     state.item.has_focus = global_state.focused_widget == Some(id);
     let had_focus = state.item.has_focus;
 
+    state.item.in_focus_chain = false;
     state.item.focus_chain.clear();
     {
         let mut ctx = LifeCycleCtx {

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -220,22 +220,7 @@ impl Widget for Textbox {
         }
     }
 
-    fn on_access_event(&mut self, ctx: &mut EventCtx, event: &AccessEvent) {
-        if event.target == ctx.widget_id() {
-            match event.action {
-                accesskit::Action::Focus => {
-                    if !ctx.is_disabled() && !ctx.is_focused() {
-                        ctx.request_focus();
-                    }
-                }
-                accesskit::Action::Blur => {
-                    if ctx.is_focused() {
-                        ctx.resign_focus();
-                    }
-                }
-                _ => {}
-            }
-        }
+    fn on_access_event(&mut self, _ctx: &mut EventCtx, _event: &AccessEvent) {
         // TODO - Handle accesskit::Action::SetTextSelection
         // TODO - Handle accesskit::Action::ReplaceSelectedText
         // TODO - Handle accesskit::Action::SetValue
@@ -369,8 +354,6 @@ impl Widget for Textbox {
     }
 
     fn accessibility(&mut self, ctx: &mut AccessCtx) {
-        ctx.current_node().add_action(accesskit::Action::Focus);
-        ctx.current_node().add_action(accesskit::Action::Blur);
         // TODO: Replace with full accessibility.
         ctx.current_node().set_value(self.text());
     }

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -220,7 +220,22 @@ impl Widget for Textbox {
         }
     }
 
-    fn on_access_event(&mut self, _ctx: &mut EventCtx, _event: &AccessEvent) {
+    fn on_access_event(&mut self, ctx: &mut EventCtx, event: &AccessEvent) {
+        if event.target == ctx.widget_id() {
+            match event.action {
+                accesskit::Action::Focus => {
+                    if !ctx.is_disabled() && !ctx.is_focused() {
+                        ctx.request_focus();
+                    }
+                }
+                accesskit::Action::Blur => {
+                    if ctx.is_focused() {
+                        ctx.resign_focus();
+                    }
+                }
+                _ => {}
+            }
+        }
         // TODO - Handle accesskit::Action::SetTextSelection
         // TODO - Handle accesskit::Action::ReplaceSelectedText
         // TODO - Handle accesskit::Action::SetValue
@@ -354,6 +369,8 @@ impl Widget for Textbox {
     }
 
     fn accessibility(&mut self, ctx: &mut AccessCtx) {
+        ctx.current_node().add_action(accesskit::Action::Focus);
+        ctx.current_node().add_action(accesskit::Action::Blur);
         // TODO: Replace with full accessibility.
         ctx.current_node().set_value(self.text());
     }

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -133,6 +133,9 @@ pub struct WidgetState {
     /// Descendants of the focused widget are not in the focused path.
     pub(crate) has_focus: bool,
 
+    /// Whether this specific widget is in the focus chain.
+    pub(crate) in_focus_chain: bool,
+
     // TODO - document
     pub(crate) is_stashed: bool,
 
@@ -179,6 +182,7 @@ impl WidgetState {
             request_accessibility: true,
             needs_accessibility: true,
             has_focus: false,
+            in_focus_chain: false,
             request_anim: true,
             needs_anim: true,
             needs_update_disabled: true,


### PR DESCRIPTION
I believe this is necessary to activate and deactivate input focus with TalkBack on Android. Assistive technologies on other platforms can also request the focus action, though none of the AccessKit backends support the blur action yet.