### PR TITLE
Connect to tracy if the `tracy` feature is enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb949699c3e4df3a183b1d2142cb24277057055ed23c68ed58894f76c517223"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.58.0",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,6 +2003,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,11 +2049,13 @@ dependencies = [
  "time",
  "tracing",
  "tracing-subscriber",
+ "tracing-tracy",
  "tracing_android_trace",
  "unicode-segmentation",
  "vello",
  "web-time",
  "wgpu",
+ "wgpu-profiler",
  "winit",
  "xi-unicode",
 ]
@@ -3121,6 +3149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3767,6 +3801,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-tracy"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc775fdaf33c3dfd19dc354729e65e87914bc67dcdc390ca1210807b8bee5902"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracy-client",
+]
+
+[[package]]
 name = "tracing-wasm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3789,6 +3834,26 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tracy-client"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746b078c6a09ebfd5594609049e07116735c304671eaab06ce749854d23435bc"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68613466112302fdbeabc5fa55f7d57462a0b247d5a6b7d7e09401fb471a144d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3899,6 +3964,7 @@ dependencies = [
  "vello_encoding",
  "vello_shaders",
  "wgpu",
+ "wgpu-profiler",
 ]
 
 [[package]]
@@ -4266,6 +4332,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgpu-profiler"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8065ff7bd32ba1b0b0de591cc124bb5ca2d0e7df294d31f7ea3aa8c19dc0924b"
+dependencies = [
+ "parking_lot",
+ "thiserror",
+ "tracy-client",
+ "wgpu",
+]
+
+[[package]]
 name = "wgpu-types"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4330,8 +4408,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
  "windows-core 0.54.0",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.53.0",
+ "windows-interface 0.53.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
@@ -4355,6 +4443,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-implement"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4366,10 +4467,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "windows-interface"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da33557140a288fae4e1d5f8873aaf9eb6613a9cf82c3e070223ff177f598b60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -16,6 +16,17 @@ all-features = true
 # rustdoc-scrape-examples tracking issue https://github.com/rust-lang/rust/issues/88791
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
+[features]
+default = []
+# Enables tracing using tracy if the default Masonry tracing is used.
+# https://github.com/wolfpld/tracy can be connected to when this feature is enabled.
+tracy = [
+    "tracing-tracy/enable",
+    "dep:tracing-tracy",
+    "wgpu-profiler/tracy",
+    "vello/wgpu-profiler",
+]
+
 [lints]
 workspace = true
 
@@ -42,6 +53,8 @@ time = { workspace = true, features = ["macros", "formatting"] }
 cursor-icon = "1.1.0"
 dpi.workspace = true
 nv-flip.workspace = true
+tracing-tracy = { version = "0.11.3", optional = true }
+wgpu-profiler = { optional = true, version = "0.17.0", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time.workspace = true

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -23,6 +23,7 @@ default = []
 tracy = [
     "tracing-tracy/enable",
     "dep:tracing-tracy",
+    "dep:wgpu-profiler",
     "wgpu-profiler/tracy",
     "vello/wgpu-profiler",
 ]

--- a/masonry/README.md
+++ b/masonry/README.md
@@ -96,7 +96,8 @@ fn main() {
 
 The following feature flags are available:
 
-- `tracy`: Enables connecting to the [Tracy](https://github.com/wolfpld/tracy) profiler using [`tracing-tracy`][tracing_tracy].
+- `tracy`: Enables creating output for the [Tracy](https://github.com/wolfpld/tracy) profiler using [`tracing-tracy`][tracing_tracy].
+  This can be used by installing Tracy and connecting to a Masonry with this feature enabled.
 
 [winit]: https://crates.io/crates/winit
 [Druid]: https://crates.io/crates/druid

--- a/masonry/README.md
+++ b/masonry/README.md
@@ -14,6 +14,8 @@
 
 </div>
 
+[tracing_tracy]: https://crates.io/crates/tracing-tracy
+
 <!-- cargo-rdme start -->
 
 Masonry gives you a platform to create windows (using [winit] as a backend) each with a tree of widgets. It also gives you tools to inspect that widget tree at runtime, write unit tests on it, and generally have an easier time debugging and maintaining your app.
@@ -89,6 +91,12 @@ fn main() {
     .unwrap();
 }
 ```
+
+### Create feature flags
+
+The following feature flags are available:
+
+- `tracy`: Enables connecting to the [Tracy](https://github.com/wolfpld/tracy) profiler using [`tracing-tracy`][tracing_tracy].
 
 [winit]: https://crates.io/crates/winit
 [Druid]: https://crates.io/crates/druid

--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -397,7 +397,8 @@ impl MasonryState<'_> {
             let _render_span = tracing::info_span!("Rendering using Vello").entered();
             self.renderer
                 .get_or_insert_with(|| {
-                    #[cfg_attr(not(feature = "tracy"), expect(unused_mut))]
+                    // Should be `expect`, when we up our MSRV.
+                    #[cfg_attr(not(feature = "tracy"), allow(unused_mut))]
                     let mut renderer = Renderer::new(device, renderer_options).unwrap();
                     #[cfg(feature = "tracy")]
                     {

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -80,7 +80,8 @@
 //!
 //! The following feature flags are available:
 //!
-//! - `tracy`: Enables connecting to the [Tracy](https://github.com/wolfpld/tracy) profiler using [`tracing-tracy`][tracing_tracy].
+//! - `tracy`: Enables creating output for the [Tracy](https://github.com/wolfpld/tracy) profiler using [`tracing-tracy`][tracing_tracy].
+//!   This can be used by installing Tracy and connecting to a Masonry with this feature enabled.
 //!
 //! [winit]: https://crates.io/crates/winit
 //! [Druid]: https://crates.io/crates/druid

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -76,6 +76,12 @@
 //! }
 //! ```
 //!
+//! ## Create feature flags
+//!
+//! The following feature flags are available:
+//!
+//! - `tracy`: Enables connecting to the [Tracy](https://github.com/wolfpld/tracy) profiler using [`tracing-tracy`][tracing_tracy].
+//!
 //! [winit]: https://crates.io/crates/winit
 //! [Druid]: https://crates.io/crates/druid
 //! [Xilem]: https://crates.io/crates/xilem

--- a/masonry/src/tracing_backend.rs
+++ b/masonry/src/tracing_backend.rs
@@ -91,6 +91,10 @@ fn try_init_layered_tracing(default_level: LevelFilter) -> Result<(), SetGlobalD
     #[cfg(target_os = "android")]
     let registry = registry.with(android_trace_layer);
 
+    // After the above line because of https://github.com/linebender/android_trace/pull/17
+    #[cfg(feature = "tracy")]
+    let registry = registry.with(tracing_tracy::TracyLayer::default());
+
     tracing::dispatcher::set_global_default(registry.into())?;
 
     if let Some(err) = env_var_error {


### PR DESCRIPTION
This is very useful for debugging performance issues. I've already used it to debug [#masonry>`to_do_list`: Horrendous performance](https://xi.zulipchat.com/#narrow/stream/317477-masonry/topic/to_do_list.3A.20Horrendous.20performance).

Setting a feature works on a workspace-wide basis. I.e `cargo run --example mason --features tracy` works.

Some weirdness:
- Tracy seems to assume we know when a frame will "start", but we only know if we'll repaint once processing for an event has finished.
- Something seems to be starting a default "Frame", which isn't really right. We don't have any continuous frames. Maybe we should always request a redraw if tracy is enabled.

Either way, I think this feature is useful  to land *now*, so am not planning on resolving these in this PR unless someone provides a solution.