### PR TITLE
Propagate the `stashed` state correctly

### DIFF
--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -581,8 +581,9 @@ impl_context_method!(
         /// **Note:** Stashed widgets are a WIP feature.
         pub fn set_stashed(&mut self, child: &mut WidgetPod<impl Widget>, stashed: bool) {
             let child_state = self.get_child_state_mut(child);
-            // Stashing is generally a static property based on the parent widget's state, so
-            // allowing it to be set superfluously can help performance.
+            // Stashing is generally a property derived from the parent widget's state
+            // (rather than set imperatively), so it is likely to be set as part of passes.
+            // Therefore, we avoid re-running the update_stashed_pass in most cases.
             if child_state.is_explicitly_stashed != stashed {
                 child_state.needs_update_stashed = true;
                 child_state.is_explicitly_stashed = stashed;

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -580,8 +580,13 @@ impl_context_method!(
         ///
         /// **Note:** Stashed widgets are a WIP feature.
         pub fn set_stashed(&mut self, child: &mut WidgetPod<impl Widget>, stashed: bool) {
-            self.get_child_state_mut(child).needs_update_stashed = true;
-            self.get_child_state_mut(child).is_explicitly_stashed = stashed;
+            let child_state = self.get_child_state_mut(child);
+            // Stashing is generally a static property based on the parent widget's state, so
+            // allowing it to be set superfluously can help performance.
+            if child_state.is_explicitly_stashed != stashed {
+                child_state.needs_update_stashed = true;
+                child_state.is_explicitly_stashed = stashed;
+            }
         }
     }
 );

--- a/masonry/src/passes/layout.rs
+++ b/masonry/src/passes/layout.rs
@@ -150,7 +150,11 @@ pub(crate) fn run_layout_inner<W: Widget>(
     let widget = widget_mut.item;
     let state = state_mut.item;
 
-    if state.is_stashed {
+    // The parent (and only the parent) controls the stashed state, and it is valid to set `stashed` in layout.
+    // Because of that, we use the local value rather than the global value.
+    // Note that if we are stashed by a grandparent, this check would trigger for that grandparent, so we should
+    // never be called.
+    if state.is_explicitly_stashed {
         debug_panic!(
             "Error in '{}' #{}: trying to compute layout of stashed widget.",
             widget.short_type_name(),

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -263,6 +263,7 @@ impl WidgetState {
         self.has_focus |= child_state.has_focus;
         self.children_changed |= child_state.children_changed;
         self.update_focus_chain |= child_state.update_focus_chain;
+        self.needs_update_stashed |= child_state.needs_update_stashed;
     }
 
     #[inline]


### PR DESCRIPTION
When the scrollbars are not being set, the calculations get NaNs. This breaks rendering, causing extreme slowdowns and artifacts.

This is discussed in [#masonry>`to_do_list`: Horrendous performance](https://xi.zulipchat.com/#narrow/stream/317477-masonry/topic/to_do_list.3A.20Horrendous.20performance)

I've made this work now using `is_explicitly_stashed` in layout. It does not currently cause issues there.

The underlying issue of `NaN`s being created (and not detected) have not been resolved.