### PR TITLE
Remove `current_node` from `AccessCtx`

### DIFF
--- a/masonry/examples/calc_masonry.rs
+++ b/masonry/examples/calc_masonry.rs
@@ -7,7 +7,7 @@
 #![windows_subsystem = "windows"]
 #![allow(variant_size_differences, clippy::single_match)]
 
-use accesskit::{DefaultActionVerb, Role};
+use accesskit::{DefaultActionVerb, NodeBuilder, Role};
 use masonry::app_driver::{AppDriver, DriverCtx};
 use masonry::dpi::LogicalSize;
 use masonry::widget::{Align, CrossAxisAlignment, Flex, Label, RootWidget, SizedBox};
@@ -228,15 +228,14 @@ impl Widget for CalcButton {
         Role::Button
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
         let _name = match self.action {
             CalcAction::Digit(digit) => digit.to_string(),
             CalcAction::Op(op) => op.to_string(),
         };
         // We may want to add a name if it doesn't interfere with the child label
         // ctx.current_node().set_name(name);
-        ctx.current_node()
-            .set_default_action_verb(DefaultActionVerb::Click);
+        builder.set_default_action_verb(DefaultActionVerb::Click);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/examples/calc_masonry.rs
+++ b/masonry/examples/calc_masonry.rs
@@ -228,14 +228,14 @@ impl Widget for CalcButton {
         Role::Button
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, node: &mut NodeBuilder) {
         let _name = match self.action {
             CalcAction::Digit(digit) => digit.to_string(),
             CalcAction::Op(op) => op.to_string(),
         };
         // We may want to add a name if it doesn't interfere with the child label
         // ctx.current_node().set_name(name);
-        builder.set_default_action_verb(DefaultActionVerb::Click);
+        node.set_default_action_verb(DefaultActionVerb::Click);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/examples/custom_widget.rs
+++ b/masonry/examples/custom_widget.rs
@@ -132,9 +132,9 @@ impl Widget for CustomWidget {
         Role::Window
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, node: &mut NodeBuilder) {
         let text = &self.0;
-        builder.set_name(
+        node.set_name(
             format!("This is a demo of the Masonry Widget trait. Masonry has accessibility tree support. The demo shows colored shapes with the text '{text}'."),
         );
     }

--- a/masonry/examples/custom_widget.rs
+++ b/masonry/examples/custom_widget.rs
@@ -7,7 +7,7 @@
 // On Windows platform, don't show a console when opening the app.
 #![windows_subsystem = "windows"]
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use masonry::app_driver::{AppDriver, DriverCtx};
 use masonry::kurbo::{BezPath, Stroke};
 use masonry::widget::{FillStrat, RootWidget};
@@ -132,9 +132,9 @@ impl Widget for CustomWidget {
         Role::Window
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
         let text = &self.0;
-        ctx.current_node().set_name(
+        builder.set_name(
             format!("This is a demo of the Masonry Widget trait. Masonry has accessibility tree support. The demo shows colored shapes with the text '{text}'."),
         );
     }

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -5,7 +5,7 @@
 
 use std::time::Duration;
 
-use accesskit::{NodeBuilder, TreeUpdate};
+use accesskit::TreeUpdate;
 use parley::{FontContext, LayoutContext};
 use tracing::{trace, warn};
 use vello::kurbo::Vec2;
@@ -115,7 +115,6 @@ pub struct AccessCtx<'a> {
     pub(crate) widget_state_children: ArenaMutChildren<'a, WidgetState>,
     pub(crate) widget_children: ArenaMutChildren<'a, Box<dyn Widget>>,
     pub(crate) tree_update: &'a mut TreeUpdate,
-    pub(crate) current_node: NodeBuilder,
     pub(crate) rebuild_all: bool,
     pub(crate) scale_factor: f64,
 }
@@ -1017,12 +1016,6 @@ impl_context_method!(LayoutCtx<'_>, PaintCtx<'_>, {
     }
 });
 
-impl AccessCtx<'_> {
-    pub fn current_node(&mut self) -> &mut NodeBuilder {
-        &mut self.current_node
-    }
-}
-
 // --- MARK: RAW WRAPPERS ---
 macro_rules! impl_get_raw {
     ($SomeCtx:tt) => {
@@ -1125,9 +1118,6 @@ impl<'s> AccessCtx<'s> {
             widget_children: child_mut.children,
             global_state: self.global_state,
             tree_update: self.tree_update,
-            // TODO - This doesn't make sense. NodeBuilder should probably be split
-            // out from AccessCtx.
-            current_node: NodeBuilder::default(),
             rebuild_all: self.rebuild_all,
             scale_factor: self.scale_factor,
         };

--- a/masonry/src/passes/accessibility.rs
+++ b/masonry/src/passes/accessibility.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::render_root::RenderRoot;
-use accesskit::{NodeBuilder, NodeId, TreeUpdate};
+use accesskit::{Node, NodeBuilder, NodeId, TreeUpdate};
 use tracing::debug;
 use tracing::info_span;
 use tracing::trace;
@@ -34,7 +34,6 @@ fn build_accessibility_tree(
             widget.item.short_type_name(),
             id.to_raw(),
         );
-        let mut builder = build_access_node(widget.item, state.item, scale_factor);
 
         let mut ctx = AccessCtx {
             global_state,
@@ -45,17 +44,16 @@ fn build_accessibility_tree(
             rebuild_all,
             scale_factor,
         };
-        set_common_properties(&mut ctx, &mut builder);
-        widget.item.accessibility(&mut ctx, &mut builder);
+        let node = build_access_node(widget.item, &mut ctx);
 
         let id: NodeId = ctx.widget_state.id.into();
         trace!(
             "Built node #{} with role={:?}, default_action={:?}",
             id.0,
-            builder.role(),
-            builder.default_action_verb(),
+            node.role(),
+            node.default_action_verb(),
         );
-        ctx.tree_update.nodes.push((id, builder.build()));
+        ctx.tree_update.nodes.push((id, node));
     }
 
     state.item.request_accessibility = false;
@@ -83,9 +81,12 @@ fn build_accessibility_tree(
     );
 }
 
-fn build_access_node(widget: &dyn Widget, state: &WidgetState, scale_factor: f64) -> NodeBuilder {
+fn build_access_node(widget: &mut dyn Widget, ctx: &mut AccessCtx) -> Node {
     let mut node = NodeBuilder::new(widget.accessibility_role());
-    node.set_bounds(to_accesskit_rect(state.window_layout_rect(), scale_factor));
+    node.set_bounds(to_accesskit_rect(
+        ctx.widget_state.window_layout_rect(),
+        ctx.scale_factor,
+    ));
 
     node.set_children(
         widget
@@ -96,28 +97,28 @@ fn build_access_node(widget: &dyn Widget, state: &WidgetState, scale_factor: f64
             .collect::<Vec<NodeId>>(),
     );
 
-    node
-}
-
-fn set_common_properties(ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
     if ctx.is_hot() {
-        builder.set_hovered();
+        node.set_hovered();
     }
     if ctx.is_disabled() {
-        builder.set_disabled();
+        node.set_disabled();
     }
     if ctx.is_stashed() {
-        builder.set_hidden();
+        node.set_hidden();
     }
     if ctx.widget_state.clip.is_some() {
-        builder.set_clips_children();
+        node.set_clips_children();
     }
     if ctx.is_in_focus_chain() && !ctx.is_disabled() {
-        builder.add_action(accesskit::Action::Focus);
+        node.add_action(accesskit::Action::Focus);
     }
     if ctx.is_focused() {
-        builder.add_action(accesskit::Action::Blur);
+        node.add_action(accesskit::Action::Blur);
     }
+
+    widget.accessibility(ctx, &mut node);
+
+    node.build()
 }
 
 fn to_accesskit_rect(r: Rect, scale_factor: f64) -> accesskit::Rect {

--- a/masonry/src/testing/helper_widgets.rs
+++ b/masonry/src/testing/helper_widgets.rs
@@ -15,7 +15,7 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use accesskit_winit::Event;
 use smallvec::SmallVec;
 use vello::Scene;
@@ -34,7 +34,7 @@ pub type LayoutFn<S> = dyn FnMut(&mut S, &mut LayoutCtx, &BoxConstraints) -> Siz
 pub type ComposeFn<S> = dyn FnMut(&mut S, &mut ComposeCtx);
 pub type PaintFn<S> = dyn FnMut(&mut S, &mut PaintCtx, &mut Scene);
 pub type RoleFn<S> = dyn Fn(&S) -> Role;
-pub type AccessFn<S> = dyn FnMut(&mut S, &mut AccessCtx);
+pub type AccessFn<S> = dyn FnMut(&mut S, &mut AccessCtx, &mut NodeBuilder);
 pub type ChildrenFn<S> = dyn Fn(&S) -> SmallVec<[WidgetId; 16]>;
 
 #[cfg(FALSE)]
@@ -214,7 +214,10 @@ impl<S> ModularWidget<S> {
         self
     }
 
-    pub fn access_fn(mut self, f: impl FnMut(&mut S, &mut AccessCtx) + 'static) -> Self {
+    pub fn access_fn(
+        mut self,
+        f: impl FnMut(&mut S, &mut AccessCtx, &mut NodeBuilder) + 'static,
+    ) -> Self {
         self.access = Some(Box::new(f));
         self
     }
@@ -293,9 +296,9 @@ impl<S: 'static> Widget for ModularWidget<S> {
         }
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
+    fn accessibility(&mut self, ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
         if let Some(f) = self.access.as_mut() {
-            f(&mut self.state, ctx);
+            f(&mut self.state, ctx, builder);
         }
     }
 
@@ -364,7 +367,7 @@ impl Widget for ReplaceChild {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         todo!()
@@ -453,9 +456,9 @@ impl<W: Widget> Widget for Recorder<W> {
         self.child.accessibility_role()
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
+    fn accessibility(&mut self, ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
         self.recording.push(Record::Access);
-        self.child.accessibility(ctx);
+        self.child.accessibility(ctx, builder);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/testing/helper_widgets.rs
+++ b/masonry/src/testing/helper_widgets.rs
@@ -296,9 +296,9 @@ impl<S: 'static> Widget for ModularWidget<S> {
         }
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
+    fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut NodeBuilder) {
         if let Some(f) = self.access.as_mut() {
-            f(&mut self.state, ctx, builder);
+            f(&mut self.state, ctx, node);
         }
     }
 
@@ -367,7 +367,7 @@ impl Widget for ReplaceChild {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         todo!()
@@ -456,9 +456,9 @@ impl<W: Widget> Widget for Recorder<W> {
         self.child.accessibility_role()
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
+    fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut NodeBuilder) {
         self.recording.push(Record::Access);
-        self.child.accessibility(ctx, builder);
+        self.child.accessibility(ctx, node);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/align.rs
+++ b/masonry/src/widget/align.rs
@@ -150,7 +150,7 @@ impl Widget for Align {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         smallvec![self.child.id()]

--- a/masonry/src/widget/align.rs
+++ b/masonry/src/widget/align.rs
@@ -8,7 +8,7 @@
 // size constraints to its child means that "aligning" a widget may actually change
 // its computed size. See https://github.com/linebender/xilem/issues/378
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, Span};
 use vello::Scene;
@@ -150,7 +150,7 @@ impl Widget for Align {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         smallvec![self.child.id()]

--- a/masonry/src/widget/button.rs
+++ b/masonry/src/widget/button.rs
@@ -183,16 +183,16 @@ impl Widget for Button {
         Role::Button
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
+    fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut NodeBuilder) {
         // IMPORTANT: We don't want to merge this code in practice, because
         // the child label already has a 'name' property.
         // This is more of a proof of concept of `get_raw_ref()`.
         if false {
             let label = ctx.get_raw_ref(&self.label);
             let name = label.widget().text().as_ref().to_string();
-            builder.set_name(name);
+            node.set_name(name);
         }
-        builder.set_default_action_verb(DefaultActionVerb::Click);
+        node.set_default_action_verb(DefaultActionVerb::Click);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/button.rs
+++ b/masonry/src/widget/button.rs
@@ -3,7 +3,7 @@
 
 //! A button widget.
 
-use accesskit::{DefaultActionVerb, Role};
+use accesskit::{DefaultActionVerb, NodeBuilder, Role};
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, Span};
 use vello::Scene;
@@ -183,17 +183,16 @@ impl Widget for Button {
         Role::Button
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
+    fn accessibility(&mut self, ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
         // IMPORTANT: We don't want to merge this code in practice, because
         // the child label already has a 'name' property.
         // This is more of a proof of concept of `get_raw_ref()`.
         if false {
             let label = ctx.get_raw_ref(&self.label);
             let name = label.widget().text().as_ref().to_string();
-            ctx.current_node().set_name(name);
+            builder.set_name(name);
         }
-        ctx.current_node()
-            .set_default_action_verb(DefaultActionVerb::Click);
+        builder.set_default_action_verb(DefaultActionVerb::Click);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/checkbox.rs
+++ b/masonry/src/widget/checkbox.rs
@@ -185,21 +185,21 @@ impl Widget for Checkbox {
         Role::CheckBox
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
+    fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut NodeBuilder) {
         // IMPORTANT: We don't want to merge this code in practice, because
         // the child label already has a 'name' property.
         // This is more of a proof of concept of `get_raw_ref()`.
         if false {
             let label = ctx.get_raw_ref(&self.label);
             let name = label.widget().text().as_ref().to_string();
-            builder.set_name(name);
+            node.set_name(name);
         }
         if self.checked {
-            builder.set_toggled(Toggled::True);
-            builder.set_default_action_verb(DefaultActionVerb::Uncheck);
+            node.set_toggled(Toggled::True);
+            node.set_default_action_verb(DefaultActionVerb::Uncheck);
         } else {
-            builder.set_toggled(Toggled::False);
-            builder.set_default_action_verb(DefaultActionVerb::Check);
+            node.set_toggled(Toggled::False);
+            node.set_default_action_verb(DefaultActionVerb::Check);
         }
     }
 

--- a/masonry/src/widget/checkbox.rs
+++ b/masonry/src/widget/checkbox.rs
@@ -3,7 +3,7 @@
 
 //! A checkbox widget.
 
-use accesskit::{DefaultActionVerb, Role, Toggled};
+use accesskit::{DefaultActionVerb, NodeBuilder, Role, Toggled};
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, Span};
 use vello::kurbo::{Affine, BezPath, Cap, Join, Size, Stroke};
@@ -185,23 +185,21 @@ impl Widget for Checkbox {
         Role::CheckBox
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
+    fn accessibility(&mut self, ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
         // IMPORTANT: We don't want to merge this code in practice, because
         // the child label already has a 'name' property.
         // This is more of a proof of concept of `get_raw_ref()`.
         if false {
             let label = ctx.get_raw_ref(&self.label);
             let name = label.widget().text().as_ref().to_string();
-            ctx.current_node().set_name(name);
+            builder.set_name(name);
         }
         if self.checked {
-            ctx.current_node().set_toggled(Toggled::True);
-            ctx.current_node()
-                .set_default_action_verb(DefaultActionVerb::Uncheck);
+            builder.set_toggled(Toggled::True);
+            builder.set_default_action_verb(DefaultActionVerb::Uncheck);
         } else {
-            ctx.current_node().set_toggled(Toggled::False);
-            ctx.current_node()
-                .set_default_action_verb(DefaultActionVerb::Check);
+            builder.set_toggled(Toggled::False);
+            builder.set_default_action_verb(DefaultActionVerb::Check);
         }
     }
 

--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -1182,7 +1182,7 @@ impl Widget for Flex {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         self.children

--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -3,7 +3,7 @@
 
 //! A widget that arranges its children in a one-dimensional array.
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use smallvec::SmallVec;
 use tracing::{trace, trace_span, Span};
 use vello::kurbo::{common::FloatExt, Affine, Line, Stroke, Vec2};
@@ -1182,7 +1182,7 @@ impl Widget for Flex {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         self.children

--- a/masonry/src/widget/grid.rs
+++ b/masonry/src/widget/grid.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use smallvec::SmallVec;
 use tracing::{trace_span, Span};
 use vello::kurbo::{Affine, Line, Stroke};
@@ -281,7 +281,7 @@ impl Widget for Grid {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, _: &mut AccessCtx) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         self.children

--- a/masonry/src/widget/grid.rs
+++ b/masonry/src/widget/grid.rs
@@ -281,7 +281,7 @@ impl Widget for Grid {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         self.children

--- a/masonry/src/widget/image.rs
+++ b/masonry/src/widget/image.rs
@@ -115,7 +115,7 @@ impl Widget for Image {
         Role::Image
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut NodeBuilder) {
         // TODO - Handle alt text and such.
     }
 

--- a/masonry/src/widget/image.rs
+++ b/masonry/src/widget/image.rs
@@ -4,7 +4,7 @@
 //! An Image widget.
 //! Please consider using SVG and the SVG widget as it scales much better.
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use smallvec::SmallVec;
 use tracing::{trace, trace_span, Span};
 use vello::kurbo::Affine;
@@ -115,7 +115,7 @@ impl Widget for Image {
         Role::Image
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx) {
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {
         // TODO - Handle alt text and such.
     }
 

--- a/masonry/src/widget/label.rs
+++ b/masonry/src/widget/label.rs
@@ -3,7 +3,7 @@
 
 //! A label widget.
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use parley::layout::Alignment;
 use parley::style::{FontFamily, FontStack};
 use smallvec::SmallVec;
@@ -261,9 +261,8 @@ impl Widget for Label {
         Role::Label
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
-        ctx.current_node()
-            .set_name(self.text().as_ref().to_string());
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
+        builder.set_name(self.text().as_ref().to_string());
     }
 
     fn skip_pointer(&self) -> bool {

--- a/masonry/src/widget/label.rs
+++ b/masonry/src/widget/label.rs
@@ -261,8 +261,8 @@ impl Widget for Label {
         Role::Label
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
-        builder.set_name(self.text().as_ref().to_string());
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, node: &mut NodeBuilder) {
+        node.set_name(self.text().as_ref().to_string());
     }
 
     fn skip_pointer(&self) -> bool {

--- a/masonry/src/widget/portal.rs
+++ b/masonry/src/widget/portal.rs
@@ -5,7 +5,7 @@
 
 use std::ops::Range;
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace_span, Span};
 use vello::kurbo::{Point, Rect, Size, Vec2};
@@ -446,13 +446,13 @@ impl<W: Widget> Widget for Portal<W> {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
+    fn accessibility(&mut self, ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
         // TODO - Double check this code
         // Not sure about these values
         if false {
-            ctx.current_node().set_scroll_x(self.viewport_pos.x);
-            ctx.current_node().set_scroll_y(self.viewport_pos.y);
-            ctx.current_node().set_scroll_x_min(0.0);
+            builder.set_scroll_x(self.viewport_pos.x);
+            builder.set_scroll_y(self.viewport_pos.y);
+            builder.set_scroll_x_min(0.0);
 
             let x_max = ctx
                 .get_raw_ref(&self.scrollbar_horizontal)
@@ -462,12 +462,12 @@ impl<W: Widget> Widget for Portal<W> {
                 .get_raw_ref(&self.scrollbar_vertical)
                 .widget()
                 .portal_size;
-            ctx.current_node().set_scroll_x_max(x_max);
-            ctx.current_node().set_scroll_y_min(0.0);
-            ctx.current_node().set_scroll_y_max(y_max);
+            builder.set_scroll_x_max(x_max);
+            builder.set_scroll_y_min(0.0);
+            builder.set_scroll_y_max(y_max);
         }
 
-        ctx.current_node().set_clips_children();
+        builder.set_clips_children();
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/portal.rs
+++ b/masonry/src/widget/portal.rs
@@ -446,13 +446,13 @@ impl<W: Widget> Widget for Portal<W> {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
+    fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut NodeBuilder) {
         // TODO - Double check this code
         // Not sure about these values
         if false {
-            builder.set_scroll_x(self.viewport_pos.x);
-            builder.set_scroll_y(self.viewport_pos.y);
-            builder.set_scroll_x_min(0.0);
+            node.set_scroll_x(self.viewport_pos.x);
+            node.set_scroll_y(self.viewport_pos.y);
+            node.set_scroll_x_min(0.0);
 
             let x_max = ctx
                 .get_raw_ref(&self.scrollbar_horizontal)
@@ -462,12 +462,12 @@ impl<W: Widget> Widget for Portal<W> {
                 .get_raw_ref(&self.scrollbar_vertical)
                 .widget()
                 .portal_size;
-            builder.set_scroll_x_max(x_max);
-            builder.set_scroll_y_min(0.0);
-            builder.set_scroll_y_max(y_max);
+            node.set_scroll_x_max(x_max);
+            node.set_scroll_y_min(0.0);
+            node.set_scroll_y_max(y_max);
         }
 
-        builder.set_clips_children();
+        node.set_clips_children();
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/progress_bar.rs
+++ b/masonry/src/widget/progress_bar.rs
@@ -4,7 +4,7 @@
 //! A progress bar widget.
 
 use crate::Point;
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, Span};
 use vello::Scene;
@@ -191,10 +191,10 @@ impl Widget for ProgressBar {
         Role::ProgressIndicator
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
-        ctx.current_node().set_value(self.value_accessibility());
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
+        builder.set_value(self.value_accessibility());
         if let Some(value) = self.progress {
-            ctx.current_node().set_numeric_value(value * 100.0);
+            builder.set_numeric_value(value * 100.0);
         }
     }
 

--- a/masonry/src/widget/progress_bar.rs
+++ b/masonry/src/widget/progress_bar.rs
@@ -191,10 +191,10 @@ impl Widget for ProgressBar {
         Role::ProgressIndicator
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
-        builder.set_value(self.value_accessibility());
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, node: &mut NodeBuilder) {
+        node.set_value(self.value_accessibility());
         if let Some(value) = self.progress {
-            builder.set_numeric_value(value * 100.0);
+            node.set_numeric_value(value * 100.0);
         }
     }
 

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -284,8 +284,8 @@ impl Widget for Prose {
         Role::Paragraph
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
-        builder.set_name(self.text().as_ref().to_string());
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, node: &mut NodeBuilder) {
+        node.set_name(self.text().as_ref().to_string());
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -1,7 +1,7 @@
 // Copyright 2018 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use parley::{
     layout::Alignment,
     style::{FontFamily, FontStack},
@@ -284,9 +284,8 @@ impl Widget for Prose {
         Role::Paragraph
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
-        ctx.current_node()
-            .set_name(self.text().as_ref().to_string());
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
+        builder.set_name(self.text().as_ref().to_string());
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/root_widget.rs
+++ b/masonry/src/widget/root_widget.rs
@@ -62,7 +62,7 @@ impl<W: Widget> Widget for RootWidget<W> {
         Role::Window
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         smallvec![self.pod.id()]

--- a/masonry/src/widget/root_widget.rs
+++ b/masonry/src/widget/root_widget.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace_span, Span};
 use vello::kurbo::Point;
@@ -62,7 +62,7 @@ impl<W: Widget> Widget for RootWidget<W> {
         Role::Window
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         smallvec![self.pod.id()]

--- a/masonry/src/widget/scroll_bar.rs
+++ b/masonry/src/widget/scroll_bar.rs
@@ -221,7 +221,7 @@ impl Widget for ScrollBar {
         Role::ScrollBar
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut NodeBuilder) {
         // TODO
         // Use set_scroll_x/y_min/max?
     }

--- a/masonry/src/widget/scroll_bar.rs
+++ b/masonry/src/widget/scroll_bar.rs
@@ -3,7 +3,7 @@
 
 #![allow(missing_docs)]
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use smallvec::SmallVec;
 use tracing::{trace_span, Span};
 use vello::kurbo::Rect;
@@ -221,7 +221,7 @@ impl Widget for ScrollBar {
         Role::ScrollBar
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx) {
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {
         // TODO
         // Use set_scroll_x/y_min/max?
     }

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -389,7 +389,7 @@ impl Widget for SizedBox {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         if let Some(child) = &self.child {

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -3,7 +3,7 @@
 
 //! A widget with predefined size.
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, warn, Span};
 use vello::kurbo::{Affine, RoundedRectRadii};
@@ -389,7 +389,7 @@ impl Widget for SizedBox {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         if let Some(child) = &self.child {

--- a/masonry/src/widget/spinner.rs
+++ b/masonry/src/widget/spinner.rs
@@ -157,7 +157,7 @@ impl Widget for Spinner {
         Role::Unknown
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         SmallVec::new()

--- a/masonry/src/widget/spinner.rs
+++ b/masonry/src/widget/spinner.rs
@@ -5,7 +5,7 @@
 
 use std::f64::consts::PI;
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use smallvec::SmallVec;
 use tracing::{trace, trace_span, Span};
 use vello::kurbo::{Affine, Cap, Line, Stroke};
@@ -157,7 +157,7 @@ impl Widget for Spinner {
         Role::Unknown
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         SmallVec::new()

--- a/masonry/src/widget/split.rs
+++ b/masonry/src/widget/split.rs
@@ -560,7 +560,7 @@ impl Widget for Split {
         Role::Splitter
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         smallvec![self.child1.id(), self.child2.id()]

--- a/masonry/src/widget/split.rs
+++ b/masonry/src/widget/split.rs
@@ -3,7 +3,7 @@
 
 //! A widget which splits an area in two, with a settable ratio, and optional draggable resizing.
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, warn, Span};
 use vello::Scene;
@@ -560,7 +560,7 @@ impl Widget for Split {
         Role::Splitter
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         smallvec![self.child1.id(), self.child2.id()]

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -1,7 +1,7 @@
 // Copyright 2018 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use parley::{
     layout::Alignment,
     style::{FontFamily, FontStack},
@@ -338,9 +338,9 @@ impl Widget for Textbox {
         Role::TextInput
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
         // TODO: Replace with full accessibility.
-        ctx.current_node().set_value(self.text());
+        builder.set_value(self.text());
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -338,9 +338,9 @@ impl Widget for Textbox {
         Role::TextInput
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, node: &mut NodeBuilder) {
         // TODO: Replace with full accessibility.
-        builder.set_value(self.text());
+        node.set_value(self.text());
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/variable_label.rs
+++ b/masonry/src/widget/variable_label.rs
@@ -5,7 +5,7 @@
 
 use std::cmp::Ordering;
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use parley::fontique::Weight;
 use parley::layout::Alignment;
 use parley::style::{FontFamily, FontStack};
@@ -405,9 +405,8 @@ impl Widget for VariableLabel {
         Role::Label
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
-        ctx.current_node()
-            .set_name(self.text().as_ref().to_string());
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
+        builder.set_name(self.text().as_ref().to_string());
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/variable_label.rs
+++ b/masonry/src/widget/variable_label.rs
@@ -405,8 +405,8 @@ impl Widget for VariableLabel {
         Role::Label
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
-        builder.set_name(self.text().as_ref().to_string());
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, node: &mut NodeBuilder) {
+        node.set_name(self.text().as_ref().to_string());
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -126,7 +126,7 @@ pub trait Widget: AsAny {
 
     fn accessibility_role(&self) -> Role;
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx, builder: &mut NodeBuilder);
+    fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut NodeBuilder);
 
     /// Return references to this widget's children.
     ///
@@ -338,8 +338,8 @@ impl Widget for Box<dyn Widget> {
         self.deref().accessibility_role()
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
-        self.deref_mut().accessibility(ctx, builder);
+    fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut NodeBuilder) {
+        self.deref_mut().accessibility(ctx, node);
     }
 
     fn type_name(&self) -> &'static str {

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -6,7 +6,7 @@ use std::num::NonZeroU64;
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use cursor_icon::CursorIcon;
 use smallvec::SmallVec;
 use tracing::{trace_span, Span};
@@ -126,7 +126,7 @@ pub trait Widget: AsAny {
 
     fn accessibility_role(&self) -> Role;
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx);
+    fn accessibility(&mut self, ctx: &mut AccessCtx, builder: &mut NodeBuilder);
 
     /// Return references to this widget's children.
     ///
@@ -338,8 +338,8 @@ impl Widget for Box<dyn Widget> {
         self.deref().accessibility_role()
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx) {
-        self.deref_mut().accessibility(ctx);
+    fn accessibility(&mut self, ctx: &mut AccessCtx, builder: &mut NodeBuilder) {
+        self.deref_mut().accessibility(ctx, builder);
     }
 
     fn type_name(&self) -> &'static str {

--- a/xilem/src/any_view.rs
+++ b/xilem/src/any_view.rs
@@ -98,7 +98,7 @@ impl Widget for DynWidget {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         smallvec![self.inner.id()]

--- a/xilem/src/any_view.rs
+++ b/xilem/src/any_view.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use masonry::widget::WidgetMut;
 use masonry::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, Point,
@@ -98,7 +98,7 @@ impl Widget for DynWidget {
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         smallvec![self.inner.id()]

--- a/xilem/src/one_of.rs
+++ b/xilem/src/one_of.rs
@@ -295,7 +295,7 @@ impl<
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         match self {

--- a/xilem/src/one_of.rs
+++ b/xilem/src/one_of.rs
@@ -3,7 +3,7 @@
 
 //! Statically typed alternatives to the type-erased [`AnyView`](`crate::AnyView`).
 
-use accesskit::Role;
+use accesskit::{NodeBuilder, Role};
 use masonry::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, LifeCycleCtx, PaintCtx, Point,
     PointerEvent, RegisterCtx, Size, StatusChange, TextEvent, Widget, WidgetId, WidgetPod,
@@ -295,7 +295,7 @@ impl<
         Role::GenericContainer
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx) {}
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _builder: &mut NodeBuilder) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         match self {


### PR DESCRIPTION
It makes more sense to pass the `NodeBuilder` reference separately to the `accessibility` method. In particular, this avoids the need to keep calling a method on `AccessCtx` to get that mutable reference.