### PR TITLE
Accessibility for text

### DIFF
--- a/masonry/src/text/selection.rs
+++ b/masonry/src/text/selection.rs
@@ -352,14 +352,10 @@ impl<T: Selectable> TextWithSelection<T> {
         } else {
             Affinity::Downstream
         };
-        if let Some(anchor) =
-            self.access_position_from_offset(self.selection.anchor, anchor_affinity)
-        {
-            if let Some(focus) = self
-                .access_position_from_offset(self.selection.active, self.selection.active_affinity)
-            {
-                parent_node.set_text_selection(TextSelection { anchor, focus });
-            }
+        let anchor = self.access_position_from_offset(self.selection.anchor, anchor_affinity);
+        let focus = self.access_position_from_offset(self.selection.active, self.selection.active_affinity);
+        if let (Some(anchor), Some(focus)) = (anchor, focus) {
+            parent_node.set_text_selection(TextSelection { anchor, focus });
         }
         parent_node.add_action(accesskit::Action::SetTextSelection);
     }

--- a/masonry/src/text/selection.rs
+++ b/masonry/src/text/selection.rs
@@ -385,6 +385,7 @@ impl<T: Selectable> TextWithSelection<T> {
             return false;
         };
         self.selection = Selection::new(anchor, active, active_affinity);
+        self.selection_visible = true;
         self.needs_selection_update = true;
         true
     }

--- a/masonry/src/text/selection.rs
+++ b/masonry/src/text/selection.rs
@@ -293,7 +293,8 @@ impl<T: Selectable> TextWithSelection<T> {
             let range = line.text_range();
             if !(range.contains(&offset)
                 || (offset == range.end
-                    && (affinity == Affinity::Upstream || line_index == self.layout.layout.len())))
+                    && (affinity == Affinity::Upstream
+                        || line_index == self.layout.layout.len() - 1)))
             {
                 continue;
             }
@@ -303,8 +304,8 @@ impl<T: Selectable> TextWithSelection<T> {
                 if !(range.contains(&offset)
                     || (offset == range.end
                         && (affinity == Affinity::Upstream
-                            || (line_index == self.layout.layout.len()
-                                && run_index == line.len()))))
+                            || (line_index == self.layout.layout.len() - 1
+                                && run_index == line.len() - 1))))
                 {
                     continue;
                 }

--- a/masonry/src/text/selection.rs
+++ b/masonry/src/text/selection.rs
@@ -353,7 +353,8 @@ impl<T: Selectable> TextWithSelection<T> {
             Affinity::Downstream
         };
         let anchor = self.access_position_from_offset(self.selection.anchor, anchor_affinity);
-        let focus = self.access_position_from_offset(self.selection.active, self.selection.active_affinity);
+        let focus =
+            self.access_position_from_offset(self.selection.active, self.selection.active_affinity);
         if let (Some(anchor), Some(focus)) = (anchor, focus) {
             parent_node.set_text_selection(TextSelection { anchor, focus });
         }

--- a/masonry/src/text/selection.rs
+++ b/masonry/src/text/selection.rs
@@ -345,7 +345,8 @@ impl<T: Selectable> TextWithSelection<T> {
     }
 
     pub fn accessibility(&mut self, update: &mut TreeUpdate, parent_node: &mut NodeBuilder) {
-        self.layout.accessibility(update, parent_node);
+        self.layout
+            .accessibility(self.text.as_ref(), update, parent_node);
         let anchor_affinity = if self.selection.anchor == self.selection.active {
             self.selection.active_affinity
         } else {

--- a/masonry/src/text/selection.rs
+++ b/masonry/src/text/selection.rs
@@ -6,7 +6,7 @@
 use std::borrow::Cow;
 use std::ops::{Deref, DerefMut, Range};
 
-use accesskit::{NodeBuilder, TextPosition, TextSelection};
+use accesskit::{NodeBuilder, TextPosition, TextSelection, TreeUpdate};
 use parley::context::RangedBuilder;
 use parley::{FontContext, LayoutContext};
 use tracing::debug;
@@ -18,7 +18,7 @@ use winit::keyboard::NamedKey;
 
 use crate::event::{AccessEvent, PointerButton, PointerState};
 use crate::text::{TextBrush, TextLayout};
-use crate::{AccessCtx, Handled, TextEvent};
+use crate::{Handled, TextEvent};
 
 pub struct TextWithSelection<T: Selectable> {
     text: T,
@@ -335,8 +335,8 @@ impl<T: Selectable> TextWithSelection<T> {
         panic!("offset not within the range of any run");
     }
 
-    pub fn accessibility(&mut self, ctx: &mut AccessCtx, parent_node: &mut NodeBuilder) {
-        self.layout.accessibility(ctx, parent_node);
+    pub fn accessibility(&mut self, update: &mut TreeUpdate, parent_node: &mut NodeBuilder) {
+        self.layout.accessibility(update, parent_node);
         let anchor_affinity = if self.selection.anchor == self.selection.active {
             self.selection.active_affinity
         } else {

--- a/masonry/src/text/selection.rs
+++ b/masonry/src/text/selection.rs
@@ -290,6 +290,14 @@ impl<T: Selectable> TextWithSelection<T> {
         assert!(offset <= text.len());
 
         for (line_index, line) in self.layout.layout.lines().enumerate() {
+            let range = line.text_range();
+            if !(range.contains(&offset)
+                || (offset == range.end
+                    && (affinity == Affinity::Upstream || line_index == self.layout.layout.len())))
+            {
+                continue;
+            }
+
             for (run_index, run) in line.runs().enumerate() {
                 let range = run.text_range();
                 if !(range.contains(&offset)
@@ -300,6 +308,7 @@ impl<T: Selectable> TextWithSelection<T> {
                 {
                     continue;
                 }
+
                 let run_offset = offset - range.start;
                 let run_path = (line_index, run_index);
                 let id = *self.layout.access_ids_by_run_path.get(&run_path).unwrap();

--- a/masonry/src/text/selection.rs
+++ b/masonry/src/text/selection.rs
@@ -287,7 +287,7 @@ impl<T: Selectable> TextWithSelection<T> {
 
     fn access_position_from_offset(&self, offset: usize, affinity: Affinity) -> TextPosition {
         let text = self.text().as_ref();
-        assert!(offset <= text.len());
+        debug_assert!(offset <= text.len(), "offset out of range");
 
         for (line_index, line) in self.layout.layout.lines().enumerate() {
             let range = line.text_range();
@@ -330,7 +330,8 @@ impl<T: Selectable> TextWithSelection<T> {
                 };
             }
         }
-        unreachable!()
+
+        panic!("offset not within the range of any run");
     }
 
     pub fn accessibility(&mut self, ctx: &mut AccessCtx, parent_node: &mut NodeBuilder) {

--- a/masonry/src/text/selection.rs
+++ b/masonry/src/text/selection.rs
@@ -352,6 +352,7 @@ impl<T: Selectable> TextWithSelection<T> {
             self.selection.active_affinity,
         );
         parent_node.set_text_selection(TextSelection { anchor, focus });
+        parent_node.add_action(accesskit::Action::SetTextSelection);
     }
 
     fn offset_from_access_position(&self, pos: TextPosition) -> Option<(usize, Affinity)> {

--- a/masonry/src/text/text_layout.rs
+++ b/masonry/src/text/text_layout.rs
@@ -6,7 +6,7 @@
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
-use accesskit::{NodeBuilder, NodeId, Role};
+use accesskit::{NodeBuilder, NodeId, Role, TreeUpdate};
 use parley::context::RangedBuilder;
 use parley::fontique::{Style, Weight};
 use parley::layout::{Alignment, Cursor};
@@ -18,7 +18,7 @@ use vello::peniko::{self, Color, Gradient};
 use vello::Scene;
 
 use crate::text::render_text;
-use crate::{AccessCtx, WidgetId};
+use crate::WidgetId;
 
 /// A component for displaying text on screen.
 ///
@@ -471,7 +471,7 @@ impl TextLayout {
         );
     }
 
-    pub fn accessibility(&mut self, ctx: &mut AccessCtx, parent_node: &mut NodeBuilder) {
+    pub fn accessibility(&mut self, update: &mut TreeUpdate, parent_node: &mut NodeBuilder) {
         self.assert_rebuilt("accessibility");
 
         let text = self.text.as_ref();
@@ -507,7 +507,7 @@ impl TextLayout {
                 if let Some((last_id, mut last_node)) = last_node.take() {
                     last_node.set_next_on_line(id);
                     node.set_previous_on_line(last_id);
-                    ctx.tree_update.nodes.push((last_id, last_node.build()));
+                    update.nodes.push((last_id, last_node.build()));
                     parent_node.push_child(last_id);
                 }
 
@@ -544,7 +544,7 @@ impl TextLayout {
             }
 
             if let Some((id, node)) = last_node {
-                ctx.tree_update.nodes.push((id, node.build()));
+                update.nodes.push((id, node.build()));
                 parent_node.push_child(id);
             }
         }

--- a/masonry/src/text/text_layout.rs
+++ b/masonry/src/text/text_layout.rs
@@ -471,10 +471,14 @@ impl TextLayout {
         );
     }
 
-    pub fn accessibility(&mut self, update: &mut TreeUpdate, parent_node: &mut NodeBuilder) {
+    pub fn accessibility(
+        &mut self,
+        text: &str,
+        update: &mut TreeUpdate,
+        parent_node: &mut NodeBuilder,
+    ) {
         self.assert_rebuilt("accessibility");
 
-        let text = self.text.as_ref();
         // Build a set of node IDs for the runs encountered in this pass.
         let mut ids = HashSet::<NodeId>::new();
 

--- a/masonry/src/text/text_layout.rs
+++ b/masonry/src/text/text_layout.rs
@@ -3,10 +3,8 @@
 
 //! A type for laying out, drawing, and interacting with text.
 
-use std::{
-    collections::{HashMap, HashSet},
-    rc::Rc,
-};
+use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
 
 use accesskit::{NodeBuilder, NodeId, Role};
 use parley::context::RangedBuilder;

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -288,7 +288,7 @@ impl Widget for Prose {
 
     fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut NodeBuilder) {
         node.set_read_only();
-        self.text_layout.accessibility(&mut ctx.tree_update, node);
+        self.text_layout.accessibility(ctx.tree_update, node);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -288,7 +288,7 @@ impl Widget for Prose {
 
     fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut NodeBuilder) {
         node.set_read_only();
-        self.text_layout.accessibility(ctx, node);
+        self.text_layout.accessibility(&mut ctx.tree_update, node);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -274,11 +274,12 @@ impl Widget for Prose {
     }
 
     fn accessibility_role(&self) -> Role {
-        Role::Paragraph
+        Role::Document
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, node: &mut NodeBuilder) {
-        node.set_name(self.text().as_ref().to_string());
+    fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut NodeBuilder) {
+        node.set_read_only();
+        self.text_layout.accessibility(ctx, node);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -189,8 +189,17 @@ impl Widget for Prose {
         }
     }
 
-    fn on_access_event(&mut self, _ctx: &mut EventCtx, _event: &AccessEvent) {
-        // TODO - Handle accesskit::Action::SetTextSelection
+    fn on_access_event(&mut self, ctx: &mut EventCtx, event: &AccessEvent) {
+        if event.target == ctx.widget_id() {
+            match event.action {
+                accesskit::Action::SetTextSelection => {
+                    if self.text_layout.set_selection_from_access_event(event) {
+                        ctx.request_layout();
+                    }
+                }
+                _ => (),
+            }
+        }
     }
 
     fn register_children(&mut self, _ctx: &mut RegisterCtx) {}

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -190,15 +190,13 @@ impl Widget for Prose {
     }
 
     fn on_access_event(&mut self, ctx: &mut EventCtx, event: &AccessEvent) {
-        if event.target == ctx.widget_id() {
-            match event.action {
-                accesskit::Action::SetTextSelection => {
-                    if self.text_layout.set_selection_from_access_event(event) {
-                        ctx.request_layout();
-                    }
+        match event.action {
+            accesskit::Action::SetTextSelection => {
+                if self.text_layout.set_selection_from_access_event(event) {
+                    ctx.request_layout();
                 }
-                _ => (),
             }
+            _ => (),
         }
     }
 

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -334,7 +334,7 @@ impl Widget for Textbox {
     }
 
     fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut NodeBuilder) {
-        self.editor.accessibility(ctx, node);
+        self.editor.accessibility(&mut ctx.tree_update, node);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -334,7 +334,7 @@ impl Widget for Textbox {
     }
 
     fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut NodeBuilder) {
-        self.editor.accessibility(&mut ctx.tree_update, node);
+        self.editor.accessibility(ctx.tree_update, node);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -215,8 +215,17 @@ impl Widget for Textbox {
         }
     }
 
-    fn on_access_event(&mut self, _ctx: &mut EventCtx, _event: &AccessEvent) {
-        // TODO - Handle accesskit::Action::SetTextSelection
+    fn on_access_event(&mut self, ctx: &mut EventCtx, event: &AccessEvent) {
+        if event.target == ctx.widget_id() {
+            match event.action {
+                accesskit::Action::SetTextSelection => {
+                    if self.editor.set_selection_from_access_event(event) {
+                        ctx.request_layout();
+                    }
+                }
+                _ => (),
+            }
+        }
         // TODO - Handle accesskit::Action::ReplaceSelectedText
         // TODO - Handle accesskit::Action::SetValue
     }
@@ -324,9 +333,8 @@ impl Widget for Textbox {
         Role::TextInput
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, node: &mut NodeBuilder) {
-        // TODO: Replace with full accessibility.
-        node.set_value(self.text());
+    fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut NodeBuilder) {
+        self.editor.accessibility(ctx, node);
     }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -216,15 +216,13 @@ impl Widget for Textbox {
     }
 
     fn on_access_event(&mut self, ctx: &mut EventCtx, event: &AccessEvent) {
-        if event.target == ctx.widget_id() {
-            match event.action {
-                accesskit::Action::SetTextSelection => {
-                    if self.editor.set_selection_from_access_event(event) {
-                        ctx.request_layout();
-                    }
+        match event.action {
+            accesskit::Action::SetTextSelection => {
+                if self.editor.set_selection_from_access_event(event) {
+                    ctx.request_layout();
                 }
-                _ => (),
             }
+            _ => (),
         }
         // TODO - Handle accesskit::Action::ReplaceSelectedText
         // TODO - Handle accesskit::Action::SetValue


### PR DESCRIPTION
This adds the necessary AccessKit properties and child nodes to expose detailed information about text widgets. It also supports the `SetTextSelection` action.