### PR TITLE
Add note about mutable child state in WidgetState::merge_up

### DIFF
--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -250,9 +250,11 @@ impl WidgetState {
 
     /// Update to incorporate state changes from a child.
     ///
-    /// This will also clear some requests in the child state.
-    ///
     /// This method is idempotent and can be called multiple times.
+    //
+    // TODO: though this method takes child state mutably, child state currently isn't actually
+    // mutated anymore. This method may start doing so again in the future, so keep taking &mut for
+    // now.
     pub(crate) fn merge_up(&mut self, child_state: &mut WidgetState) {
         self.needs_layout |= child_state.needs_layout;
         self.needs_compose |= child_state.needs_compose;


### PR DESCRIPTION
`WidgetState::merge_up` no longer actually mutates `child_state` since https://github.com/linebender/xilem/issues/488 and https://github.com/linebender/xilem/pull/599, but it may do so again in the future.

See also this Zulip thread:
https://xi.zulipchat.com/#narrow/stream/317477-masonry/topic/WidgetState.3A.3Amerge_up.20no.20longer.20needs.20mutable.20child.20state