### PR TITLE
xilem_web: Refactor unnecessary generic type parameter `Props` to associated type

### DIFF
--- a/xilem_web/src/attribute.rs
+++ b/xilem_web/src/attribute.rs
@@ -216,7 +216,11 @@ impl WithAttributes for ElementProps {
     }
 }
 
-impl<E: DomNode<P>, P: WithAttributes> WithAttributes for Pod<E, P> {
+impl<N> WithAttributes for Pod<N>
+where
+    N: DomNode,
+    N::Props: WithAttributes,
+{
     fn rebuild_attribute_modifier(&mut self) {
         self.props.rebuild_attribute_modifier();
     }
@@ -230,7 +234,11 @@ impl<E: DomNode<P>, P: WithAttributes> WithAttributes for Pod<E, P> {
     }
 }
 
-impl<E: DomNode<P>, P: WithAttributes> WithAttributes for PodMut<'_, E, P> {
+impl<N> WithAttributes for PodMut<'_, N>
+where
+    N: DomNode,
+    N::Props: WithAttributes,
+{
     fn rebuild_attribute_modifier(&mut self) {
         self.props.rebuild_attribute_modifier();
     }

--- a/xilem_web/src/class.rs
+++ b/xilem_web/src/class.rs
@@ -238,7 +238,10 @@ impl WithClasses for ElementProps {
     }
 }
 
-impl<E: DomNode<P>, P: WithClasses> WithClasses for Pod<E, P> {
+impl<N: DomNode> WithClasses for Pod<N>
+where
+    N::Props: WithClasses,
+{
     fn rebuild_class_modifier(&mut self) {
         self.props.rebuild_class_modifier();
     }
@@ -256,7 +259,10 @@ impl<E: DomNode<P>, P: WithClasses> WithClasses for Pod<E, P> {
     }
 }
 
-impl<E: DomNode<P>, P: WithClasses> WithClasses for PodMut<'_, E, P> {
+impl<N: DomNode> WithClasses for PodMut<'_, N>
+where
+    N::Props: WithClasses,
+{
     fn rebuild_class_modifier(&mut self) {
         self.props.rebuild_class_modifier();
     }

--- a/xilem_web/src/element_props.rs
+++ b/xilem_web/src/element_props.rs
@@ -66,7 +66,7 @@ impl ElementProps {
     }
 }
 
-impl Pod<web_sys::Element, ElementProps> {
+impl Pod<web_sys::Element> {
     /// Creates a new Pod with [`web_sys::Element`] as element and `ElementProps` as its [`DomView::Props`](`crate::DomView::Props`)
     pub fn new_element(children: Vec<AnyPod>, ns: &str, elem_name: &str) -> Self {
         let element = document()

--- a/xilem_web/src/elements.rs
+++ b/xilem_web/src/elements.rs
@@ -244,7 +244,7 @@ where
     State: 'static,
     Action: 'static,
     Element: 'static,
-    Element: From<Pod<web_sys::Element, ElementProps>>,
+    Element: From<Pod<web_sys::Element>>,
 {
     let mut elements = AppendVec::default();
     #[cfg(feature = "hydration")]
@@ -269,15 +269,15 @@ where
 pub(crate) fn rebuild_element<'el, State, Action, Element>(
     children: &dyn DomViewSequence<State, Action>,
     prev_children: &dyn DomViewSequence<State, Action>,
-    element: Mut<'el, Pod<Element, ElementProps>>,
+    element: Mut<'el, Pod<Element>>,
     state: &mut ElementState,
     ctx: &mut ViewCtx,
-) -> Mut<'el, Pod<Element, ElementProps>>
+) -> Mut<'el, Pod<Element>>
 where
     State: 'static,
     Action: 'static,
     Element: 'static,
-    Element: DomNode<ElementProps>,
+    Element: DomNode<Props = ElementProps>,
 {
     let mut dom_children_splice = DomChildrenSplice::new(
         &mut state.append_scratch,
@@ -300,14 +300,14 @@ where
 
 pub(crate) fn teardown_element<State, Action, Element>(
     children: &dyn DomViewSequence<State, Action>,
-    element: Mut<'_, Pod<Element, ElementProps>>,
+    element: Mut<'_, Pod<Element>>,
     state: &mut ElementState,
     ctx: &mut ViewCtx,
 ) where
     State: 'static,
     Action: 'static,
     Element: 'static,
-    Element: DomNode<ElementProps>,
+    Element: DomNode<Props = ElementProps>,
 {
     let mut dom_children_splice = DomChildrenSplice::new(
         &mut state.append_scratch,
@@ -353,7 +353,7 @@ where
     State: 'static,
     Action: 'static,
 {
-    type Element = Pod<web_sys::HtmlElement, ElementProps>;
+    type Element = Pod<web_sys::HtmlElement>;
 
     type ViewState = ElementState;
 
@@ -444,7 +444,7 @@ macro_rules! define_element {
             State: 'static,
             Action: 'static,
         {
-            type Element = Pod<web_sys::$dom_interface, ElementProps>;
+            type Element = Pod<web_sys::$dom_interface>;
 
             type ViewState = ElementState;
 
@@ -501,7 +501,7 @@ macro_rules! define_elements {
         use super::{build_element, rebuild_element, teardown_element, DomViewSequence, ElementState};
         use crate::{
             core::{MessageResult, Mut, ViewId, ViewMarker},
-            DomFragment, DynMessage, ElementProps, Pod, View, ViewCtx,
+            DomFragment, DynMessage, Pod, View, ViewCtx,
         };
         $(define_element!(crate::$ns, $element_def);)*
     };

--- a/xilem_web/src/interfaces.rs
+++ b/xilem_web/src/interfaces.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Opinionated extension traits roughly resembling their equivalently named DOM interfaces.
+//!
 //! It is used for DOM elements, e.g. created with [`html::span`](`crate::elements::html::span`) to modify the underlying element, such as [`Element::attr`] or [`HtmlElement::style`]
 //!
 //! These traits can also be used as return type of components to allow modifying the underlying DOM element that is returned.
@@ -18,7 +19,7 @@ use crate::{
     class::{AsClassIter, Class, WithClasses},
     events,
     style::{IntoStyles, Style, WithStyle},
-    DomView, IntoAttributeValue, OptionalAction, Pointer, PointerMsg,
+    DomNode, DomView, IntoAttributeValue, OptionalAction, Pointer, PointerMsg,
 };
 use wasm_bindgen::JsCast;
 
@@ -50,7 +51,11 @@ macro_rules! event_handler_mixin {
 
 pub trait Element<State, Action = ()>:
     Sized
-    + DomView<State, Action, Props: WithAttributes + WithClasses, DomNode: AsRef<web_sys::Element>>
+    + DomView<
+        State,
+        Action,
+        DomNode: DomNode<Props: WithAttributes + WithClasses> + AsRef<web_sys::Element>,
+    >
 {
     /// Set an attribute for an [`Element`]
     ///
@@ -270,7 +275,7 @@ pub trait Element<State, Action = ()>:
 impl<State, Action, T> Element<State, Action> for T
 where
     T: DomView<State, Action>,
-    T::Props: WithAttributes + WithClasses,
+    <T::DomNode as DomNode>::Props: WithAttributes + WithClasses,
     T::DomNode: AsRef<web_sys::Element>,
 {
 }
@@ -495,7 +500,7 @@ where
 
 // #[cfg(feature = "HtmlElement")]
 pub trait HtmlElement<State, Action = ()>:
-    Element<State, Action, Props: WithStyle, DomNode: AsRef<web_sys::HtmlElement>>
+    Element<State, Action, DomNode: DomNode<Props: WithStyle> + AsRef<web_sys::HtmlElement>>
 {
     /// Set a style attribute
     fn style(self, style: impl IntoStyles) -> Style<Self, State, Action> {
@@ -510,7 +515,7 @@ impl<State, Action, T> HtmlElement<State, Action> for T
 where
     T: Element<State, Action>,
     T::DomNode: AsRef<web_sys::HtmlElement>,
-    T::Props: WithStyle,
+    <T::DomNode as DomNode>::Props: WithStyle,
 {
 }
 
@@ -1472,7 +1477,7 @@ where
 
 // #[cfg(feature = "SvgElement")]
 pub trait SvgElement<State, Action = ()>:
-    Element<State, Action, Props: WithStyle, DomNode: AsRef<web_sys::SvgElement>>
+    Element<State, Action, DomNode: DomNode<Props: WithStyle> + AsRef<web_sys::SvgElement>>
 {
     /// Set a style attribute
     fn style(self, style: impl IntoStyles) -> Style<Self, State, Action> {
@@ -1487,7 +1492,7 @@ impl<State, Action, T> SvgElement<State, Action> for T
 where
     T: Element<State, Action>,
     T::DomNode: AsRef<web_sys::SvgElement>,
-    T::Props: WithStyle,
+    <T::DomNode as DomNode>::Props: WithStyle,
 {
 }
 

--- a/xilem_web/src/one_of.rs
+++ b/xilem_web/src/one_of.rs
@@ -14,53 +14,34 @@ use crate::{
 
 type CowStr = std::borrow::Cow<'static, str>;
 
-impl<P1, P2, P3, P4, P5, P6, P7, P8, P9, N1, N2, N3, N4, N5, N6, N7, N8, N9>
-    OneOfCtx<
-        Pod<N1, P1>,
-        Pod<N2, P2>,
-        Pod<N3, P3>,
-        Pod<N4, P4>,
-        Pod<N5, P5>,
-        Pod<N6, P6>,
-        Pod<N7, P7>,
-        Pod<N8, P8>,
-        Pod<N9, P9>,
-    > for ViewCtx
+impl<N1, N2, N3, N4, N5, N6, N7, N8, N9>
+    OneOfCtx<Pod<N1>, Pod<N2>, Pod<N3>, Pod<N4>, Pod<N5>, Pod<N6>, Pod<N7>, Pod<N8>, Pod<N9>>
+    for ViewCtx
 where
-    P1: 'static,
-    P2: 'static,
-    P3: 'static,
-    P4: 'static,
-    P5: 'static,
-    P6: 'static,
-    P7: 'static,
-    P8: 'static,
-    P9: 'static,
-    N1: DomNode<P1>,
-    N2: DomNode<P2>,
-    N3: DomNode<P3>,
-    N4: DomNode<P4>,
-    N5: DomNode<P5>,
-    N6: DomNode<P6>,
-    N7: DomNode<P7>,
-    N8: DomNode<P8>,
-    N9: DomNode<P9>,
+    N1: DomNode,
+    N2: DomNode,
+    N3: DomNode,
+    N4: DomNode,
+    N5: DomNode,
+    N6: DomNode,
+    N7: DomNode,
+    N8: DomNode,
+    N9: DomNode,
 {
-    type OneOfElement =
-        Pod<OneOf<N1, N2, N3, N4, N5, N6, N7, N8, N9>, OneOf<P1, P2, P3, P4, P5, P6, P7, P8, P9>>;
+    type OneOfElement = Pod<OneOf<N1, N2, N3, N4, N5, N6, N7, N8, N9>>;
 
     fn upcast_one_of_element(
         &mut self,
         elem: OneOf<
-            Pod<N1, P1>,
-            Pod<N2, P2>,
-            Pod<N3, P3>,
-            Pod<N4, P4>,
-            Pod<N5, P5>,
-            Pod<N6, P6>,
-            Pod<N7, P7>,
-            Pod<N8, P8>,
-            Pod<N9, P9>,
+            Pod<N1>,
+            Pod<N2>,
+            Pod<N3>,
+            Pod<N4>,
+            Pod<N5>,
+            Pod<N6>,
+            Pod<N7>,
+            Pod<N8>,
+            Pod<N9>,
         >,
     ) -> Self::OneOfElement {
         match elem {
@@ -106,15 +87,15 @@ where
     fn update_one_of_element_mut(
         elem_mut: &mut Mut<'_, Self::OneOfElement>,
         new_elem: OneOf<
-            Pod<N1, P1>,
-            Pod<N2, P2>,
-            Pod<N3, P3>,
-            Pod<N4, P4>,
-            Pod<N5, P5>,
-            Pod<N6, P6>,
-            Pod<N7, P7>,
-            Pod<N8, P8>,
-            Pod<N9, P9>,
+            Pod<N1>,
+            Pod<N2>,
+            Pod<N3>,
+            Pod<N4>,
+            Pod<N5>,
+            Pod<N6>,
+            Pod<N7>,
+            Pod<N8>,
+            Pod<N9>,
         >,
     ) {
         let old_node: &web_sys::Node = elem_mut.node.as_ref();
@@ -137,90 +118,63 @@ where
         };
     }
 
-    fn with_downcast_a(
-        elem: &mut Mut<'_, Self::OneOfElement>,
-        f: impl FnOnce(Mut<'_, Pod<N1, P1>>),
-    ) {
+    fn with_downcast_a(elem: &mut Mut<'_, Self::OneOfElement>, f: impl FnOnce(Mut<'_, Pod<N1>>)) {
         let (OneOf::A(node), OneOf::A(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
     }
 
-    fn with_downcast_b(
-        elem: &mut Mut<'_, Self::OneOfElement>,
-        f: impl FnOnce(Mut<'_, Pod<N2, P2>>),
-    ) {
+    fn with_downcast_b(elem: &mut Mut<'_, Self::OneOfElement>, f: impl FnOnce(Mut<'_, Pod<N2>>)) {
         let (OneOf::B(node), OneOf::B(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
     }
 
-    fn with_downcast_c(
-        elem: &mut Mut<'_, Self::OneOfElement>,
-        f: impl FnOnce(Mut<'_, Pod<N3, P3>>),
-    ) {
+    fn with_downcast_c(elem: &mut Mut<'_, Self::OneOfElement>, f: impl FnOnce(Mut<'_, Pod<N3>>)) {
         let (OneOf::C(node), OneOf::C(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
     }
 
-    fn with_downcast_d(
-        elem: &mut Mut<'_, Self::OneOfElement>,
-        f: impl FnOnce(Mut<'_, Pod<N4, P4>>),
-    ) {
+    fn with_downcast_d(elem: &mut Mut<'_, Self::OneOfElement>, f: impl FnOnce(Mut<'_, Pod<N4>>)) {
         let (OneOf::D(node), OneOf::D(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
     }
 
-    fn with_downcast_e(
-        elem: &mut Mut<'_, Self::OneOfElement>,
-        f: impl FnOnce(Mut<'_, Pod<N5, P5>>),
-    ) {
+    fn with_downcast_e(elem: &mut Mut<'_, Self::OneOfElement>, f: impl FnOnce(Mut<'_, Pod<N5>>)) {
         let (OneOf::E(node), OneOf::E(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
     }
 
-    fn with_downcast_f(
-        elem: &mut Mut<'_, Self::OneOfElement>,
-        f: impl FnOnce(Mut<'_, Pod<N6, P6>>),
-    ) {
+    fn with_downcast_f(elem: &mut Mut<'_, Self::OneOfElement>, f: impl FnOnce(Mut<'_, Pod<N6>>)) {
         let (OneOf::F(node), OneOf::F(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
     }
 
-    fn with_downcast_g(
-        elem: &mut Mut<'_, Self::OneOfElement>,
-        f: impl FnOnce(Mut<'_, Pod<N7, P7>>),
-    ) {
+    fn with_downcast_g(elem: &mut Mut<'_, Self::OneOfElement>, f: impl FnOnce(Mut<'_, Pod<N7>>)) {
         let (OneOf::G(node), OneOf::G(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
     }
 
-    fn with_downcast_h(
-        elem: &mut Mut<'_, Self::OneOfElement>,
-        f: impl FnOnce(Mut<'_, Pod<N8, P8>>),
-    ) {
+    fn with_downcast_h(elem: &mut Mut<'_, Self::OneOfElement>, f: impl FnOnce(Mut<'_, Pod<N8>>)) {
         let (OneOf::H(node), OneOf::H(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
         f(PodMut::new(node, props, elem.parent, elem.was_removed));
     }
 
-    fn with_downcast_i(
-        elem: &mut Mut<'_, Self::OneOfElement>,
-        f: impl FnOnce(Mut<'_, Pod<N9, P9>>),
-    ) {
+    fn with_downcast_i(elem: &mut Mut<'_, Self::OneOfElement>, f: impl FnOnce(Mut<'_, Pod<N9>>)) {
         let (OneOf::I(node), OneOf::I(props)) = (&mut elem.node, &mut elem.props) else {
             unreachable!()
         };
@@ -231,7 +185,7 @@ where
 pub enum Noop {}
 
 impl PhantomElementCtx for ViewCtx {
-    type PhantomElement = Pod<Noop, Noop>;
+    type PhantomElement = Pod<Noop>;
 }
 
 impl WithAttributes for Noop {
@@ -286,10 +240,12 @@ impl<T> AsRef<T> for Noop {
     }
 }
 
-impl<P> DomNode<P> for Noop {
-    fn apply_props(&self, _props: &mut P) {
+impl DomNode for Noop {
+    fn apply_props(&self, _props: &mut Self::Props) {
         unreachable!()
     }
+
+    type Props = Noop;
 }
 
 impl<
@@ -471,20 +427,30 @@ impl<
     }
 }
 
-impl<P1, P2, P3, P4, P5, P6, P7, P8, P9, E1, E2, E3, E4, E5, E6, E7, E8, E9>
-    DomNode<OneOf<P1, P2, P3, P4, P5, P6, P7, P8, P9>> for OneOf<E1, E2, E3, E4, E5, E6, E7, E8, E9>
+impl<N1, N2, N3, N4, N5, N6, N7, N8, N9> DomNode for OneOf<N1, N2, N3, N4, N5, N6, N7, N8, N9>
 where
-    E1: DomNode<P1>,
-    E2: DomNode<P2>,
-    E3: DomNode<P3>,
-    E4: DomNode<P4>,
-    E5: DomNode<P5>,
-    E6: DomNode<P6>,
-    E7: DomNode<P7>,
-    E8: DomNode<P8>,
-    E9: DomNode<P9>,
+    N1: DomNode,
+    N2: DomNode,
+    N3: DomNode,
+    N4: DomNode,
+    N5: DomNode,
+    N6: DomNode,
+    N7: DomNode,
+    N8: DomNode,
+    N9: DomNode,
 {
-    fn apply_props(&self, props: &mut OneOf<P1, P2, P3, P4, P5, P6, P7, P8, P9>) {
+    type Props = OneOf<
+        N1::Props,
+        N2::Props,
+        N3::Props,
+        N4::Props,
+        N5::Props,
+        N6::Props,
+        N7::Props,
+        N8::Props,
+        N9::Props,
+    >;
+    fn apply_props(&self, props: &mut Self::Props) {
         match (self, props) {
             (OneOf::A(el), OneOf::A(props)) => el.apply_props(props),
             (OneOf::B(el), OneOf::B(props)) => el.apply_props(props),

--- a/xilem_web/src/style.rs
+++ b/xilem_web/src/style.rs
@@ -105,8 +105,9 @@ where
     }
 }
 
-/// This trait allows (modifying) the `style` property of `HTMLElement`/`SVGElement`s, used in the DOM interface traits [`HtmlElement`](`crate::interfaces::HtmlElement`) and [`SvgElement`](`crate::interfaces::SvgElement`).
+/// This trait allows (modifying) the `style` property of `HTMLElement`/`SVGElement`s
 ///
+/// It's e.g. used in the DOM interface traits [`HtmlElement`](`crate::interfaces::HtmlElement`) and [`SvgElement`](`crate::interfaces::SvgElement`).
 /// Modifications have to be done on the up-traversal of [`View::rebuild`], i.e. after [`View::rebuild`] was invoked for descendent views.
 /// See [`Style::build`] and [`Style::rebuild`], how to use this for [`ViewElement`]s that implement this trait.
 /// When these methods are used, they have to be used in every reconciliation pass (i.e. [`View::rebuild`]).
@@ -271,7 +272,10 @@ impl WithStyle for ElementProps {
     }
 }
 
-impl<E: DomNode<P>, P: WithStyle> WithStyle for Pod<E, P> {
+impl<N: DomNode> WithStyle for Pod<N>
+where
+    N::Props: WithStyle,
+{
     fn rebuild_style_modifier(&mut self) {
         self.props.rebuild_style_modifier();
     }
@@ -285,7 +289,10 @@ impl<E: DomNode<P>, P: WithStyle> WithStyle for Pod<E, P> {
     }
 }
 
-impl<E: DomNode<P>, P: WithStyle> WithStyle for PodMut<'_, E, P> {
+impl<N: DomNode> WithStyle for PodMut<'_, N>
+where
+    N::Props: WithStyle,
+{
     fn rebuild_style_modifier(&mut self) {
         self.props.rebuild_style_modifier();
     }

--- a/xilem_web/src/svg/kurbo_shape.rs
+++ b/xilem_web/src/svg/kurbo_shape.rs
@@ -8,14 +8,11 @@ use std::borrow::Cow;
 
 use xilem_core::{MessageResult, Mut, OrphanView};
 
-use crate::{
-    attribute::WithAttributes, element_props::ElementProps, DynMessage, IntoAttributeValue, Pod,
-    ViewCtx, SVG_NS,
-};
+use crate::{attribute::WithAttributes, DynMessage, IntoAttributeValue, Pod, ViewCtx, SVG_NS};
 
 impl<State: 'static, Action: 'static> OrphanView<Line, State, Action, DynMessage> for ViewCtx {
     type OrphanViewState = ();
-    type OrphanElement = Pod<web_sys::SvgLineElement, ElementProps>;
+    type OrphanElement = Pod<web_sys::SvgLineElement>;
 
     fn orphan_build(
         view: &Line,
@@ -67,7 +64,7 @@ impl<State: 'static, Action: 'static> OrphanView<Line, State, Action, DynMessage
 
 impl<State: 'static, Action: 'static> OrphanView<Rect, State, Action, DynMessage> for ViewCtx {
     type OrphanViewState = ();
-    type OrphanElement = Pod<web_sys::SvgRectElement, ElementProps>;
+    type OrphanElement = Pod<web_sys::SvgRectElement>;
 
     fn orphan_build(
         view: &Rect,
@@ -119,7 +116,7 @@ impl<State: 'static, Action: 'static> OrphanView<Rect, State, Action, DynMessage
 
 impl<State: 'static, Action: 'static> OrphanView<Circle, State, Action, DynMessage> for ViewCtx {
     type OrphanViewState = ();
-    type OrphanElement = Pod<web_sys::SvgCircleElement, ElementProps>;
+    type OrphanElement = Pod<web_sys::SvgCircleElement>;
 
     fn orphan_build(
         view: &Circle,
@@ -170,7 +167,7 @@ impl<State: 'static, Action: 'static> OrphanView<Circle, State, Action, DynMessa
 
 impl<State: 'static, Action: 'static> OrphanView<BezPath, State, Action, DynMessage> for ViewCtx {
     type OrphanViewState = Cow<'static, str>;
-    type OrphanElement = Pod<web_sys::SvgPathElement, ElementProps>;
+    type OrphanElement = Pod<web_sys::SvgPathElement>;
 
     fn orphan_build(
         view: &BezPath,

--- a/xilem_web/src/templated.rs
+++ b/xilem_web/src/templated.rs
@@ -110,6 +110,7 @@ where
 }
 
 /// This view creates an internally cached deep-clone of the underlying DOM node.
+///
 /// When the inner view is created again, this will be done more efficiently.
 /// It's recommended to use this as wrapper, when it's expected that the inner `view` is a little bigger and will be created a lot, for example in a long list
 /// It's *not* recommended to use this, when the inner `view` is rather small (as in the example),

--- a/xilem_web/src/text.rs
+++ b/xilem_web/src/text.rs
@@ -11,7 +11,7 @@ use crate::{DynMessage, Pod, ViewCtx};
 macro_rules! impl_string_view {
     ($ty:ty) => {
         impl<State, Action> OrphanView<$ty, State, Action, DynMessage> for ViewCtx {
-            type OrphanElement = Pod<web_sys::Text, ()>;
+            type OrphanElement = Pod<web_sys::Text>;
 
             type OrphanViewState = ();
 
@@ -47,7 +47,7 @@ macro_rules! impl_string_view {
                 _view: &$ty,
                 _view_state: &mut Self::OrphanViewState,
                 _ctx: &mut ViewCtx,
-                _element: Mut<'_, Pod<web_sys::Text, ()>>,
+                _element: Mut<'_, Pod<web_sys::Text>>,
             ) {
             }
 
@@ -71,7 +71,7 @@ impl_string_view!(std::borrow::Cow<'static, str>);
 macro_rules! impl_to_string_view {
     ($ty:ty) => {
         impl<State, Action> OrphanView<$ty, State, Action, DynMessage> for ViewCtx {
-            type OrphanElement = Pod<web_sys::Text, ()>;
+            type OrphanElement = Pod<web_sys::Text>;
 
             type OrphanViewState = ();
 
@@ -107,7 +107,7 @@ macro_rules! impl_to_string_view {
                 _view: &$ty,
                 _view_state: &mut Self::OrphanViewState,
                 _ctx: &mut ViewCtx,
-                _element: Mut<'_, Pod<web_sys::Text, ()>>,
+                _element: Mut<'_, Pod<web_sys::Text>>,
             ) {
             }
 


### PR DESCRIPTION
This was the initial plan of #403, I can't remember anymore why I didn't made it to work back then. Anyway this should simplify the type signature of `Pod` and `PodMut` a little bit.

This also includes a little bit of refactoring otherwise (mostly aesthetic + removal of unnecessary wrapper  `DynNode`)