### PR TITLE
xilem_web: Optimize modifiers (allocs mostly), and fix hydrating SVG elements

### DIFF
--- a/xilem_web/src/attribute.rs
+++ b/xilem_web/src/attribute.rs
@@ -55,6 +55,7 @@ pub struct Attributes {
 
 impl Attributes {
     pub(crate) fn new(size_hint: usize, #[cfg(feature = "hydration")] in_hydration: bool) -> Self {
+        #[allow(unused_mut)]
         let mut start_idx = IN_CREATION;
         #[cfg(feature = "hydration")]
         if in_hydration {

--- a/xilem_web/src/attribute.rs
+++ b/xilem_web/src/attribute.rs
@@ -39,9 +39,9 @@ enum AttributeModifier {
     EndMarker(u16),
 }
 
-const IN_HYDRATION: u16 = 1 << 14;
-const IN_CREATION: u16 = 1 << 15;
-const RESERVED_BIT_MASK: u16 = IN_HYDRATION | IN_CREATION;
+const HYDRATING: u16 = 1 << 14;
+const CREATING: u16 = 1 << 15;
+const RESERVED_BIT_MASK: u16 = HYDRATING | CREATING;
 
 /// This contains all the current attributes of an [`Element`](`crate::interfaces::Element`)
 #[derive(Debug, Default)]
@@ -56,10 +56,10 @@ pub struct Attributes {
 impl Attributes {
     pub(crate) fn new(size_hint: usize, #[cfg(feature = "hydration")] in_hydration: bool) -> Self {
         #[allow(unused_mut)]
-        let mut start_idx = IN_CREATION;
+        let mut start_idx = CREATING;
         #[cfg(feature = "hydration")]
         if in_hydration {
-            start_idx |= IN_HYDRATION;
+            start_idx |= HYDRATING;
         }
 
         Self {
@@ -126,12 +126,12 @@ fn remove_attribute(element: &web_sys::Element, name: &str) {
 impl Attributes {
     /// applies potential changes of the attributes of an element to the underlying DOM node
     pub fn apply_attribute_changes(&mut self, element: &web_sys::Element) {
-        if (self.start_idx & IN_HYDRATION) == IN_HYDRATION {
+        if (self.start_idx & HYDRATING) == HYDRATING {
             self.start_idx &= !RESERVED_BIT_MASK;
             return;
         }
 
-        if (self.start_idx & IN_CREATION) == IN_CREATION {
+        if (self.start_idx & CREATING) == CREATING {
             for modifier in self.attribute_modifiers.iter().rev() {
                 match modifier {
                     AttributeModifier::Remove(name) => {

--- a/xilem_web/src/class.rs
+++ b/xilem_web/src/class.rs
@@ -109,6 +109,7 @@ pub struct Classes {
 
 impl Classes {
     pub(crate) fn new(size_hint: usize, #[cfg(feature = "hydration")] in_hydration: bool) -> Self {
+        #[allow(unused_mut)]
         let mut start_idx = 0;
         #[cfg(feature = "hydration")]
         if in_hydration {

--- a/xilem_web/src/context.rs
+++ b/xilem_web/src/context.rs
@@ -1,10 +1,10 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "hydration")]
 use crate::vecmap::VecMap;
 #[cfg(feature = "hydration")]
-use std::any::{Any, TypeId};
+use std::any::Any;
+use std::any::TypeId;
 use std::rc::Rc;
 
 use crate::{

--- a/xilem_web/src/context.rs
+++ b/xilem_web/src/context.rs
@@ -46,6 +46,7 @@ pub struct ViewCtx {
     is_hydrating: bool,
     #[cfg(feature = "hydration")]
     pub(crate) templates: VecMap<TypeId, (web_sys::Node, Rc<dyn Any>)>,
+    modifier_size_hints: VecMap<TypeId, usize>,
 }
 
 impl Default for ViewCtx {
@@ -60,6 +61,7 @@ impl Default for ViewCtx {
             hydration_node_stack: Default::default(),
             #[cfg(feature = "hydration")]
             is_hydrating: false,
+            modifier_size_hints: Default::default(),
         }
     }
 }
@@ -114,6 +116,23 @@ impl ViewCtx {
             self.hydration_node_stack.push(next_child);
         }
         Some(node)
+    }
+
+    pub fn add_modifier_size_hint<T: 'static>(&mut self, request_size: usize) {
+        let id = TypeId::of::<T>();
+        match self.modifier_size_hints.get_mut(&id) {
+            Some(hint) => *hint += request_size + 1, // + 1 because of the marker
+            None => {
+                self.modifier_size_hints.insert(id, request_size + 1);
+            }
+        };
+    }
+
+    pub fn modifier_size_hint<T: 'static>(&mut self) -> usize {
+        match self.modifier_size_hints.get_mut(&TypeId::of::<T>()) {
+            Some(hint) => std::mem::take(hint),
+            None => 0,
+        }
     }
 }
 

--- a/xilem_web/src/elements.rs
+++ b/xilem_web/src/elements.rs
@@ -15,6 +15,7 @@ use crate::{
     vec_splice::VecSplice,
     AnyPod, DomFragment, DomNode, DynMessage, Pod, ViewCtx, HTML_NS,
 };
+use crate::{Attributes, Classes, Styles};
 
 // sealed, because this should only cover `ViewSequences` with the blanket impl below
 /// This is basically a specialized dynamically dispatchable [`ViewSequence`], It's currently not able to change the underlying type unlike [`AnyDomView`](crate::AnyDomView), so it should not be used as `dyn DomViewSequence`.
@@ -246,6 +247,10 @@ where
     Element: 'static,
     Element: From<Pod<web_sys::Element>>,
 {
+    // We need to get those size hints before traversing to the children, otherwise the hints are messed up
+    let attr_size_hint = ctx.modifier_size_hint::<Attributes>();
+    let class_size_hint = ctx.modifier_size_hint::<Classes>();
+    let style_size_hint = ctx.modifier_size_hint::<Styles>();
     let mut elements = AppendVec::default();
     #[cfg(feature = "hydration")]
     if ctx.is_hydrating() {
@@ -256,12 +261,27 @@ where
     if ctx.is_hydrating() {
         let hydrating_node = ctx.hydrate_node().unwrap_throw();
         return (
-            Pod::hydrate_element(elements.into_inner(), hydrating_node).into(),
+            Pod::hydrate_element(
+                elements.into_inner(),
+                hydrating_node,
+                attr_size_hint,
+                style_size_hint,
+                class_size_hint,
+            )
+            .into(),
             state,
         );
     }
     (
-        Pod::new_element(elements.into_inner(), ns, tag_name).into(),
+        Pod::new_element(
+            elements.into_inner(),
+            ns,
+            tag_name,
+            attr_size_hint,
+            style_size_hint,
+            class_size_hint,
+        )
+        .into(),
         state,
     )
 }

--- a/xilem_web/src/one_of.rs
+++ b/xilem_web/src/one_of.rs
@@ -197,7 +197,7 @@ impl WithAttributes for Noop {
         unreachable!()
     }
 
-    fn set_attribute(&mut self, _name: CowStr, _value: Option<AttributeValue>) {
+    fn set_attribute(&mut self, _name: &CowStr, _value: &Option<AttributeValue>) {
         unreachable!()
     }
 }
@@ -288,7 +288,7 @@ impl<
         }
     }
 
-    fn set_attribute(&mut self, name: CowStr, value: Option<AttributeValue>) {
+    fn set_attribute(&mut self, name: &CowStr, value: &Option<AttributeValue>) {
         match self {
             OneOf::A(e) => e.set_attribute(name, value),
             OneOf::B(e) => e.set_attribute(name, value),

--- a/xilem_web/src/one_of.rs
+++ b/xilem_web/src/one_of.rs
@@ -207,11 +207,11 @@ impl WithClasses for Noop {
         unreachable!()
     }
 
-    fn add_class(&mut self, _class_name: CowStr) {
+    fn add_class(&mut self, _class_name: &CowStr) {
         unreachable!()
     }
 
-    fn remove_class(&mut self, _class_name: CowStr) {
+    fn remove_class(&mut self, _class_name: &CowStr) {
         unreachable!()
     }
 
@@ -225,7 +225,7 @@ impl WithStyle for Noop {
         unreachable!()
     }
 
-    fn set_style(&mut self, _name: CowStr, _value: Option<CowStr>) {
+    fn set_style(&mut self, _name: &CowStr, _value: &Option<CowStr>) {
         unreachable!()
     }
 
@@ -329,7 +329,7 @@ impl<
         }
     }
 
-    fn add_class(&mut self, class_name: CowStr) {
+    fn add_class(&mut self, class_name: &CowStr) {
         match self {
             OneOf::A(e) => e.add_class(class_name),
             OneOf::B(e) => e.add_class(class_name),
@@ -343,7 +343,7 @@ impl<
         }
     }
 
-    fn remove_class(&mut self, class_name: CowStr) {
+    fn remove_class(&mut self, class_name: &CowStr) {
         match self {
             OneOf::A(e) => e.remove_class(class_name),
             OneOf::B(e) => e.remove_class(class_name),
@@ -398,7 +398,7 @@ impl<
         }
     }
 
-    fn set_style(&mut self, name: CowStr, value: Option<CowStr>) {
+    fn set_style(&mut self, name: &CowStr, value: &Option<CowStr>) {
         match self {
             OneOf::A(e) => e.set_style(name, value),
             OneOf::B(e) => e.set_style(name, value),

--- a/xilem_web/src/style.rs
+++ b/xilem_web/src/style.rs
@@ -128,25 +128,34 @@ pub trait WithStyle {
 enum StyleModifier {
     Remove(CowStr),
     Set(CowStr, CowStr),
-    EndMarker(usize),
+    EndMarker(u16),
 }
+
+const IN_HYDRATION: u16 = 1 << 14;
+const IN_CREATION: u16 = 1 << 15;
+const RESERVED_BIT_MASK: u16 = IN_HYDRATION | IN_CREATION;
 
 #[derive(Debug, Default)]
 /// This contains all the current style properties of an [`HtmlElement`](`crate::interfaces::Element`) or [`SvgElement`](`crate::interfaces::SvgElement`).
 pub struct Styles {
     style_modifiers: Vec<StyleModifier>,
     updated_styles: VecMap<CowStr, ()>,
-    idx: usize, // To save some memory, this could be u16 or even u8 (but this is risky)
-    start_idx: usize, // same here
-    #[cfg(feature = "hydration")]
-    pub(crate) in_hydration: bool,
+    idx: u16,
+    /// the two most significant bits are reserved for whether this was just created (bit 15) and if it's currently being hydrated (bit 14)
+    start_idx: u16,
 }
 
-#[cfg(feature = "hydration")]
 impl Styles {
-    pub(crate) fn new(in_hydration: bool) -> Self {
+    pub(crate) fn new(size_hint: usize, #[cfg(feature = "hydration")] in_hydration: bool) -> Self {
+        let mut start_idx = IN_CREATION;
+        #[cfg(feature = "hydration")]
+        if in_hydration {
+            start_idx |= IN_HYDRATION;
+        }
+
         Self {
-            in_hydration,
+            style_modifiers: Vec::with_capacity(size_hint),
+            start_idx,
             ..Default::default()
         }
     }
@@ -170,10 +179,26 @@ fn remove_style(element: &web_sys::Element, name: &str) {
 
 impl Styles {
     pub fn apply_style_changes(&mut self, element: &web_sys::Element) {
-        #[cfg(feature = "hydration")]
-        if self.in_hydration {
-            self.updated_styles.clear();
-            self.in_hydration = false;
+        if (self.start_idx & IN_HYDRATION) == IN_HYDRATION {
+            self.start_idx &= !RESERVED_BIT_MASK;
+            debug_assert!(self.updated_styles.is_empty());
+            return;
+        }
+
+        if (self.start_idx & IN_CREATION) == IN_CREATION {
+            for modifier in self.style_modifiers.iter().rev() {
+                match modifier {
+                    StyleModifier::Remove(name) => {
+                        remove_style(element, name);
+                    }
+                    StyleModifier::Set(name, value) => {
+                        set_style(element, name, value);
+                    }
+                    StyleModifier::EndMarker(_) => (),
+                }
+            }
+            self.start_idx &= !RESERVED_BIT_MASK;
+            debug_assert!(self.updated_styles.is_empty());
             return;
         }
 
@@ -200,7 +225,14 @@ impl Styles {
 
 impl WithStyle for Styles {
     fn set_style(&mut self, name: &CowStr, value: &Option<CowStr>) {
-        if let Some(modifier) = self.style_modifiers.get_mut(self.idx) {
+        if (self.start_idx & RESERVED_BIT_MASK) != 0 {
+            let modifier = if let Some(value) = value {
+                StyleModifier::Set(name.clone(), value.clone())
+            } else {
+                StyleModifier::Remove(name.clone())
+            };
+            self.style_modifiers.push(modifier);
+        } else if let Some(modifier) = self.style_modifiers.get_mut(self.idx as usize) {
             let dirty = match (&modifier, value) {
                 // early return if nothing has changed, avoids allocations
                 (StyleModifier::Set(old_name, old_value), Some(new_value)) if old_name == name => {
@@ -251,30 +283,28 @@ impl WithStyle for Styles {
 
     fn rebuild_style_modifier(&mut self) {
         if self.idx == 0 {
-            self.start_idx = 0;
+            self.start_idx &= RESERVED_BIT_MASK;
         } else {
-            let StyleModifier::EndMarker(start_idx) = self.style_modifiers[self.idx - 1] else {
+            let StyleModifier::EndMarker(start_idx) = self.style_modifiers[(self.idx - 1) as usize]
+            else {
                 unreachable!("this should not happen, as either `rebuild_style_modifier` happens first, or follows an `mark_end_of_style_modifier`")
             };
             self.idx = start_idx;
-            self.start_idx = start_idx;
+            self.start_idx = start_idx | (self.start_idx & RESERVED_BIT_MASK);
         }
     }
 
     fn mark_end_of_style_modifier(&mut self) {
-        match self.style_modifiers.get_mut(self.idx) {
-            Some(StyleModifier::EndMarker(prev_start_idx)) if *prev_start_idx == self.start_idx => {
-            } // class modifier hasn't changed
-            Some(modifier) => {
-                *modifier = StyleModifier::EndMarker(self.start_idx);
-            }
-            None => {
-                self.style_modifiers
-                    .push(StyleModifier::EndMarker(self.start_idx));
-            }
+        let start_idx = self.start_idx & !RESERVED_BIT_MASK;
+        match self.style_modifiers.get_mut(self.idx as usize) {
+            Some(StyleModifier::EndMarker(prev_start_idx)) if *prev_start_idx == start_idx => {} // style modifier hasn't changed
+            Some(modifier) => *modifier = StyleModifier::EndMarker(start_idx),
+            None => self
+                .style_modifiers
+                .push(StyleModifier::EndMarker(start_idx)),
         }
         self.idx += 1;
-        self.start_idx = self.idx;
+        self.start_idx = self.idx | (self.start_idx & RESERVED_BIT_MASK);
     }
 }
 
@@ -366,6 +396,7 @@ where
     type ViewState = E::ViewState;
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+        ctx.add_modifier_size_hint::<Styles>(self.styles.len());
         let (mut element, state) = self.el.build(ctx);
         for (key, value) in &self.styles {
             element.set_style(key, value);

--- a/xilem_web/src/style.rs
+++ b/xilem_web/src/style.rs
@@ -147,6 +147,7 @@ pub struct Styles {
 
 impl Styles {
     pub(crate) fn new(size_hint: usize, #[cfg(feature = "hydration")] in_hydration: bool) -> Self {
+        #[allow(unused_mut)]
         let mut start_idx = IN_CREATION;
         #[cfg(feature = "hydration")]
         if in_hydration {

--- a/xilem_web/src/style.rs
+++ b/xilem_web/src/style.rs
@@ -131,9 +131,9 @@ enum StyleModifier {
     EndMarker(u16),
 }
 
-const IN_HYDRATION: u16 = 1 << 14;
-const IN_CREATION: u16 = 1 << 15;
-const RESERVED_BIT_MASK: u16 = IN_HYDRATION | IN_CREATION;
+const HYDRATING: u16 = 1 << 14;
+const CREATING: u16 = 1 << 15;
+const RESERVED_BIT_MASK: u16 = HYDRATING | CREATING;
 
 #[derive(Debug, Default)]
 /// This contains all the current style properties of an [`HtmlElement`](`crate::interfaces::Element`) or [`SvgElement`](`crate::interfaces::SvgElement`).
@@ -148,10 +148,10 @@ pub struct Styles {
 impl Styles {
     pub(crate) fn new(size_hint: usize, #[cfg(feature = "hydration")] in_hydration: bool) -> Self {
         #[allow(unused_mut)]
-        let mut start_idx = IN_CREATION;
+        let mut start_idx = CREATING;
         #[cfg(feature = "hydration")]
         if in_hydration {
-            start_idx |= IN_HYDRATION;
+            start_idx |= HYDRATING;
         }
 
         Self {
@@ -180,13 +180,13 @@ fn remove_style(element: &web_sys::Element, name: &str) {
 
 impl Styles {
     pub fn apply_style_changes(&mut self, element: &web_sys::Element) {
-        if (self.start_idx & IN_HYDRATION) == IN_HYDRATION {
+        if (self.start_idx & HYDRATING) == HYDRATING {
             self.start_idx &= !RESERVED_BIT_MASK;
             debug_assert!(self.updated_styles.is_empty());
             return;
         }
 
-        if (self.start_idx & IN_CREATION) == IN_CREATION {
+        if (self.start_idx & CREATING) == CREATING {
             for modifier in self.style_modifiers.iter().rev() {
                 match modifier {
                     StyleModifier::Remove(name) => {

--- a/xilem_web/src/svg/kurbo_shape.rs
+++ b/xilem_web/src/svg/kurbo_shape.rs
@@ -4,11 +4,11 @@
 //! Implementation of the View trait for various kurbo shapes.
 
 use peniko::kurbo::{BezPath, Circle, Line, Rect};
-use std::borrow::Cow;
-
 use xilem_core::{MessageResult, Mut, OrphanView};
 
-use crate::{attribute::WithAttributes, DynMessage, IntoAttributeValue, Pod, ViewCtx, SVG_NS};
+use crate::{
+    attribute::WithAttributes, AttributeValue, DynMessage, IntoAttributeValue, Pod, ViewCtx, SVG_NS,
+};
 
 impl<State: 'static, Action: 'static> OrphanView<Line, State, Action, DynMessage> for ViewCtx {
     type OrphanViewState = ();
@@ -19,10 +19,10 @@ impl<State: 'static, Action: 'static> OrphanView<Line, State, Action, DynMessage
         _ctx: &mut ViewCtx,
     ) -> (Self::OrphanElement, Self::OrphanViewState) {
         let mut element: Self::OrphanElement = Pod::new_element(Vec::new(), SVG_NS, "line").into();
-        element.set_attribute("x1".into(), view.p0.x.into_attr_value());
-        element.set_attribute("y1".into(), view.p0.y.into_attr_value());
-        element.set_attribute("x2".into(), view.p1.x.into_attr_value());
-        element.set_attribute("y2".into(), view.p1.y.into_attr_value());
+        element.set_attribute(&"x1".into(), &view.p0.x.into_attr_value());
+        element.set_attribute(&"y1".into(), &view.p0.y.into_attr_value());
+        element.set_attribute(&"x2".into(), &view.p1.x.into_attr_value());
+        element.set_attribute(&"y2".into(), &view.p1.y.into_attr_value());
         element.mark_end_of_attribute_modifier();
         (element, ())
     }
@@ -35,10 +35,10 @@ impl<State: 'static, Action: 'static> OrphanView<Line, State, Action, DynMessage
         mut element: Mut<'el, Self::OrphanElement>,
     ) -> Mut<'el, Self::OrphanElement> {
         element.rebuild_attribute_modifier();
-        element.set_attribute("x1".into(), new.p0.x.into_attr_value());
-        element.set_attribute("y1".into(), new.p0.y.into_attr_value());
-        element.set_attribute("x2".into(), new.p1.x.into_attr_value());
-        element.set_attribute("y2".into(), new.p1.y.into_attr_value());
+        element.set_attribute(&"x1".into(), &new.p0.x.into_attr_value());
+        element.set_attribute(&"y1".into(), &new.p0.y.into_attr_value());
+        element.set_attribute(&"x2".into(), &new.p1.x.into_attr_value());
+        element.set_attribute(&"y2".into(), &new.p1.y.into_attr_value());
         element.mark_end_of_attribute_modifier();
         element
     }
@@ -71,10 +71,10 @@ impl<State: 'static, Action: 'static> OrphanView<Rect, State, Action, DynMessage
         _ctx: &mut ViewCtx,
     ) -> (Self::OrphanElement, Self::OrphanViewState) {
         let mut element: Self::OrphanElement = Pod::new_element(Vec::new(), SVG_NS, "rect").into();
-        element.set_attribute("x".into(), view.x0.into_attr_value());
-        element.set_attribute("y".into(), view.y0.into_attr_value());
-        element.set_attribute("width".into(), view.width().into_attr_value());
-        element.set_attribute("height".into(), view.height().into_attr_value());
+        element.set_attribute(&"x".into(), &view.x0.into_attr_value());
+        element.set_attribute(&"y".into(), &view.y0.into_attr_value());
+        element.set_attribute(&"width".into(), &view.width().into_attr_value());
+        element.set_attribute(&"height".into(), &view.height().into_attr_value());
         element.mark_end_of_attribute_modifier();
         (element, ())
     }
@@ -87,10 +87,10 @@ impl<State: 'static, Action: 'static> OrphanView<Rect, State, Action, DynMessage
         mut element: Mut<'el, Self::OrphanElement>,
     ) -> Mut<'el, Self::OrphanElement> {
         element.rebuild_attribute_modifier();
-        element.set_attribute("x".into(), new.x0.into_attr_value());
-        element.set_attribute("y".into(), new.y0.into_attr_value());
-        element.set_attribute("width".into(), new.width().into_attr_value());
-        element.set_attribute("height".into(), new.height().into_attr_value());
+        element.set_attribute(&"x".into(), &new.x0.into_attr_value());
+        element.set_attribute(&"y".into(), &new.y0.into_attr_value());
+        element.set_attribute(&"width".into(), &new.width().into_attr_value());
+        element.set_attribute(&"height".into(), &new.height().into_attr_value());
         element.mark_end_of_attribute_modifier();
         element
     }
@@ -124,9 +124,9 @@ impl<State: 'static, Action: 'static> OrphanView<Circle, State, Action, DynMessa
     ) -> (Self::OrphanElement, Self::OrphanViewState) {
         let mut element: Self::OrphanElement =
             Pod::new_element(Vec::new(), SVG_NS, "circle").into();
-        element.set_attribute("cx".into(), view.center.x.into_attr_value());
-        element.set_attribute("cy".into(), view.center.y.into_attr_value());
-        element.set_attribute("r".into(), view.radius.into_attr_value());
+        element.set_attribute(&"cx".into(), &view.center.x.into_attr_value());
+        element.set_attribute(&"cy".into(), &view.center.y.into_attr_value());
+        element.set_attribute(&"r".into(), &view.radius.into_attr_value());
         element.mark_end_of_attribute_modifier();
         (element, ())
     }
@@ -139,9 +139,9 @@ impl<State: 'static, Action: 'static> OrphanView<Circle, State, Action, DynMessa
         mut element: Mut<'el, Self::OrphanElement>,
     ) -> Mut<'el, Self::OrphanElement> {
         element.rebuild_attribute_modifier();
-        element.set_attribute("cx".into(), new.center.x.into_attr_value());
-        element.set_attribute("cy".into(), new.center.y.into_attr_value());
-        element.set_attribute("r".into(), new.radius.into_attr_value());
+        element.set_attribute(&"cx".into(), &new.center.x.into_attr_value());
+        element.set_attribute(&"cy".into(), &new.center.y.into_attr_value());
+        element.set_attribute(&"r".into(), &new.radius.into_attr_value());
         element.mark_end_of_attribute_modifier();
         element
     }
@@ -166,7 +166,7 @@ impl<State: 'static, Action: 'static> OrphanView<Circle, State, Action, DynMessa
 }
 
 impl<State: 'static, Action: 'static> OrphanView<BezPath, State, Action, DynMessage> for ViewCtx {
-    type OrphanViewState = Cow<'static, str>;
+    type OrphanViewState = Option<AttributeValue>;
     type OrphanElement = Pod<web_sys::SvgPathElement>;
 
     fn orphan_build(
@@ -174,8 +174,8 @@ impl<State: 'static, Action: 'static> OrphanView<BezPath, State, Action, DynMess
         _ctx: &mut ViewCtx,
     ) -> (Self::OrphanElement, Self::OrphanViewState) {
         let mut element: Self::OrphanElement = Pod::new_element(Vec::new(), SVG_NS, "path").into();
-        let svg_repr = Cow::from(view.to_svg());
-        element.set_attribute("d".into(), svg_repr.clone().into_attr_value());
+        let svg_repr = view.to_svg().into_attr_value();
+        element.set_attribute(&"d".into(), &svg_repr);
         element.mark_end_of_attribute_modifier();
         (element, svg_repr)
     }
@@ -189,10 +189,10 @@ impl<State: 'static, Action: 'static> OrphanView<BezPath, State, Action, DynMess
     ) -> Mut<'el, Self::OrphanElement> {
         // slight optimization to avoid serialization/allocation
         if new != prev {
-            *svg_repr = Cow::from(new.to_svg());
+            *svg_repr = new.to_svg().into_attr_value();
         }
         element.rebuild_attribute_modifier();
-        element.set_attribute("d".into(), svg_repr.clone().into_attr_value());
+        element.set_attribute(&"d".into(), svg_repr);
         element.mark_end_of_attribute_modifier();
         element
     }


### PR DESCRIPTION
With the risk of wasting time with micro-optimizations...

Honestly the diff bigger and more complex than I would like it to be for the effect that this change does, so I'm sorry to reviewers.
FWIW, I tested all the examples with the feature "hydration" disabled and enabled.

In effect this reduces the amount of allocs and the size of allocs of all the modifiers (since Vec allocs at least 4 elements) by:

* Adding a size hint in modifier views, to give the actual element props a hint how much memory is needed in the relevant modifier, so that only one allocation occurs when the actual modifier is added/created.
* Using bitflags encoded in the `start_idx` to avoid extra 4 bytes for just two booleans in each modifier, and also use `u16` instead of `usize` to save another 4 bytes.
* Avoiding `updated_modifiers` allocations when building the element (with the `CREATING` bitflag).
* Reduce allocations when rebuilding, by skipping non-changed modifiers (before this, `Cow` was cloned, which for example with a `String` as an attribute value resulted in an additional allocation).

This minimally increases the wasm binary size (though I'm pretty sure in a constant fashion, roughly 500bytes compressed) in exchange for faster creation of elements and less memory usage (in the 10k js-framework-bench roughly 10% less memory usage, and 7-8% faster).

I've also noticed that all the kurbo SVG views weren't hydrated yet, which I think results in buggy behavior when using it e.g. in a `Templated` view, this is kind of drive-by fix (which I didn't want to separate because of additional work...)