### PR TITLE
Add public methods to access clip path

### DIFF
--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -239,6 +239,14 @@ impl_context_method!(
             self.widget_state.window_origin()
         }
 
+        /// The clip path of the widget, if any was set.
+        ///
+        /// For more information, see
+        /// [`LayoutCtx::set_clip_path`](crate::LayoutCtx::set_clip_path).
+        pub fn clip_path(&self) -> Option<Rect> {
+            self.widget_state.clip_path()
+        }
+
         /// Convert a point from the widget's coordinate space to the window's.
         ///
         /// The returned point is relative to the content area; it excludes window chrome.

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -194,10 +194,9 @@ pub trait Widget: AsAny {
         ctx: QueryCtx<'c>,
         pos: Point,
     ) -> Option<WidgetRef<'c, dyn Widget>> {
-        let relative_pos = pos - ctx.widget_state.window_origin().to_vec2();
+        let relative_pos = pos - ctx.window_origin().to_vec2();
         if !ctx
-            .widget_state
-            .clip
+            .clip_path()
             .map_or(true, |clip| clip.contains(relative_pos))
         {
             return None;

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -295,6 +295,13 @@ impl WidgetState {
         Rect::from_origin_size(self.window_origin(), self.size)
     }
 
+    /// The clip path of the widget, if any was set.
+    ///
+    /// For more information, see [`LayoutCtx::set_clip_path`](crate::LayoutCtx::set_clip_path).
+    pub fn clip_path(&self) -> Option<Rect> {
+        self.clip
+    }
+
     /// Returns the area being edited by an IME, in global coordinates.
     ///
     /// By default, returns the same as [`Self::window_layout_rect`].


### PR DESCRIPTION
This adds public getters for clip path to non-`LayoutCtx` contexts, and also to `WidgetState` as it seems relevant for painting.

The motivation is to remove private field accesses from `Widget::get_child_at_pos` as mentioned in
https://github.com/linebender/xilem/pull/565#issuecomment-2374162416.

This leaves one private field access, namely `WidgetState::is_stashed`. As per the docs of `WidgetState` ("widgets will generally not interact with it directly"), that field perhaps should not be publicly accessible from `WidgetState`, but then it should be accessible from `WidgetRef`.