### PR TITLE
Remove `xilem_web_core` artifacts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -85,9 +85,5 @@ Contains the `View` trait, and other general implementations. Is also contains t
 ### `xilem_web/`
 An implementation of Xilem running on the DOM.
 
-### `xilem_web_core`
-A historical version of `xilem_core` used in `xilem_web`
-
-
 ### `masonry/`
 See `ARCHITECTURE.md` file located under `crates/masonry/doc`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,6 @@ clippy.unseparated_literal_suffix = "warn"
 # clippy.print_stderr = "warn"
 
 [workspace.dependencies]
-xilem_web_core = { version = "0.1.0", path = "xilem_web/xilem_web_core" }
 masonry = { version = "0.2.0", path = "masonry" }
 xilem_core = { version = "0.1.0", path = "xilem_core" }
 vello = "0.2.1"


### PR DESCRIPTION
Just noticed that it's still referenced in the `Cargo.toml`, I wonder that this is possible at all (as it points to nirvana...)