### PR TITLE
Add safety rail for register_children method

### DIFF
--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -76,6 +76,8 @@ pub struct EventCtx<'a> {
 pub struct RegisterCtx<'a> {
     pub(crate) widget_state_children: ArenaMutChildren<'a, WidgetState>,
     pub(crate) widget_children: ArenaMutChildren<'a, Box<dyn Widget>>,
+    #[cfg(debug_assertions)]
+    pub(crate) registered_ids: Vec<WidgetId>,
 }
 
 /// A context provided to the [`lifecycle`] method on widgets.
@@ -759,6 +761,11 @@ impl RegisterCtx<'_> {
         let Some(widget) = child.take_inner() else {
             return;
         };
+
+        #[cfg(debug_assertions)]
+        {
+            self.registered_ids.push(child.id());
+        }
 
         let id = child.id().to_raw();
         let state = WidgetState::new(child.id(), widget.short_type_name());

--- a/masonry/src/passes/update.rs
+++ b/masonry/src/passes/update.rs
@@ -508,7 +508,8 @@ fn update_new_widgets(
         for child_id in widget.item.children_ids() {
             if widget.children.get_child(child_id.to_raw()).is_none() {
                 panic!(
-                    "Error in '{}' #{}: method register_children() did not call RegisterCtx::register_child() on child #{} returned by children_ids()",
+                    "Error in '{}' #{}: method register_children() did not call \
+                    RegisterCtx::register_child() on child #{} returned by children_ids()",
                     widget.item.short_type_name(),
                     id.to_raw(),
                     child_id.to_raw()

--- a/masonry/src/widget/tests/safety_rails.rs
+++ b/masonry/src/widget/tests/safety_rails.rs
@@ -64,6 +64,20 @@ fn check_forget_to_recurse_widget_added() {
     let _harness = TestHarness::create(widget);
 }
 
+#[should_panic(expected = "did not call RegisterCtx::register_child()")]
+#[test]
+#[cfg_attr(
+    not(debug_assertions),
+    ignore = "This test doesn't work without debug assertions (i.e. in release mode). See https://github.com/linebender/xilem/issues/477"
+)]
+fn check_forget_register_child() {
+    let widget = make_parent_widget(Flex::row()).register_children_fn(|_child, _ctx| {
+        // We forget to call ctx.register_child();
+    });
+
+    let _harness = TestHarness::create(widget);
+}
+
 #[should_panic(expected = "not visited in method layout")]
 #[test]
 #[cfg_attr(

--- a/masonry/src/widget/tests/safety_rails.rs
+++ b/masonry/src/widget/tests/safety_rails.rs
@@ -78,6 +78,21 @@ fn check_forget_register_child() {
     let _harness = TestHarness::create(widget);
 }
 
+#[should_panic(expected = "in the list returned by children_ids")]
+#[test]
+#[cfg_attr(
+    not(debug_assertions),
+    ignore = "This test doesn't work without debug assertions (i.e. in release mode). See https://github.com/linebender/xilem/issues/477"
+)]
+fn check_register_invalid_child() {
+    let widget = make_parent_widget(Flex::row()).register_children_fn(|child, ctx| {
+        ctx.register_child(child);
+        ctx.register_child(&mut WidgetPod::new(Flex::row()));
+    });
+
+    let _harness = TestHarness::create(widget);
+}
+
 #[should_panic(expected = "not visited in method layout")]
 #[test]
 #[cfg_attr(

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -87,7 +87,8 @@ pub trait Widget: AsAny {
     /// Leaf widgets can implement this with an empty body.
     ///
     /// Container widgets need to call [`RegisterCtx::register_child`] for all
-    /// their children. Forgetting to do so is a logic error and may lead to crashes.
+    /// their children. Forgetting to do so is a logic error and may lead to debug panics.
+    /// All the children returned by `children_ids` should be visited.
     fn register_children(&mut self, ctx: &mut RegisterCtx);
 
     /// Handle a lifecycle notification.
@@ -110,6 +111,9 @@ pub trait Widget: AsAny {
     /// the size of non-flex widgets first, to determine the amount of space
     /// available for the flex widgets.
     ///
+    /// Forgetting to visit children is a logic error and may lead to debug panics.
+    /// All the children returned by `children_ids` should be visited.
+    ///
     /// For efficiency, a container should only invoke layout of a child widget
     /// once, though there is nothing enforcing this.
     ///
@@ -130,17 +134,18 @@ pub trait Widget: AsAny {
 
     fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut NodeBuilder);
 
-    /// Return references to this widget's children.
+    /// Return ids of this widget's children.
     ///
-    /// Leaf widgets return an empty array. Container widgets return references to
+    /// Leaf widgets return an empty array. Container widgets return ids of
     /// their children.
     ///
-    /// This methods has some validity invariants. A widget's children list must be
+    /// The list returned by this method is considered the "canonical" list of children
+    /// by Masonry.
+    ///
+    /// This method has some validity invariants. A widget's children list must be
     /// consistent. If children are added or removed, the parent widget should call
-    /// `children_changed` on one of the Ctx parameters. Container widgets are also
-    /// responsible for calling the main methods (`on_event`, `lifecycle`, `layout`,
-    /// `paint`) on their children.
-    /// TODO - Update this doc
+    /// `children_changed` on one of the Ctx parameters. Container widgets are
+    /// responsible for visiting all their children during `layout` and `register_children`.
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]>;
 
     // TODO - Rename


### PR DESCRIPTION
This gives a beginner-friendly error in cases where Masonry detects that `register_children()` was improperly implemented.