### PR TITLE
Refactor rewrite passes

### DIFF
--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -235,6 +235,7 @@ impl MasonryState<'_> {
                     use_system_fonts: true,
                     size_policy: WindowSizePolicy::User,
                     scale_factor,
+                    test_font: None,
                 },
             ),
             renderer: None,

--- a/masonry/src/passes/compose.rs
+++ b/masonry/src/passes/compose.rs
@@ -72,11 +72,9 @@ fn compose_widget(
 }
 
 // --- MARK: ROOT ---
-pub(crate) fn root_compose(root: &mut RenderRoot, global_root_state: &mut WidgetState) {
+pub(crate) fn root_compose(root: &mut RenderRoot) {
     let _span = info_span!("compose").entered();
 
     let (root_widget, root_state) = root.widget_arena.get_pair_mut(root.root.id());
     compose_widget(&mut root.state, root_widget, root_state, false, Vec2::ZERO);
-
-    global_root_state.merge_up(root.widget_arena.get_state_mut(root.root.id()).item);
 }

--- a/masonry/src/passes/layout.rs
+++ b/masonry/src/passes/layout.rs
@@ -314,7 +314,11 @@ pub(crate) fn run_layout_on<W: Widget>(
 }
 
 // --- MARK: ROOT ---
-pub(crate) fn root_layout(root: &mut RenderRoot) -> Size {
+pub(crate) fn root_layout(root: &mut RenderRoot) {
+    if !root.root_state().needs_layout {
+        return;
+    }
+
     let _span = info_span!("layout").entered();
 
     let window_size = root.get_kurbo_size();
@@ -343,6 +347,4 @@ pub(crate) fn root_layout(root: &mut RenderRoot) -> Size {
             root.state.emit_signal(RenderRootSignal::SetSize(new_size));
         }
     }
-
-    size
 }

--- a/masonry/src/passes/mutate.rs
+++ b/masonry/src/passes/mutate.rs
@@ -6,7 +6,7 @@ use tracing::info_span;
 use crate::passes::merge_state_up;
 use crate::render_root::RenderRoot;
 use crate::widget::WidgetMut;
-use crate::{MutateCtx, Widget, WidgetId, WidgetState};
+use crate::{MutateCtx, Widget, WidgetId};
 
 pub(crate) fn mutate_widget<R>(
     root: &mut RenderRoot,
@@ -44,15 +44,9 @@ pub(crate) fn mutate_widget<R>(
 
 // TODO - Add link to mutate pass documentation
 /// Apply any deferred mutations (created using [`...Ctx::mutate_later`](crate::LayoutCtx::mutate_later)).
-pub(crate) fn run_mutate_pass(root: &mut RenderRoot, root_state: &mut WidgetState) {
-    // TODO - Factor out into a "pre-event" function?
-    // root.state.next_focused_widget = root.state.focused_widget;
-
+pub(crate) fn run_mutate_pass(root: &mut RenderRoot) {
     let callbacks = std::mem::take(&mut root.state.mutate_callbacks);
     for callback in callbacks {
         mutate_widget(root, callback.id, callback.callback);
     }
-
-    root_state.merge_up(root.widget_arena.get_state_mut(root.root.id()).item);
-    // root.post_event_processing(&mut root_state);
 }

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -466,7 +466,7 @@ impl RenderRoot {
         // Note: this code doesn't do any short-circuiting, because each pass is
         // expected to have its own early exits.
         // Calling a run_xxx_pass (or root_xxx) should always be very fast if
-        // the passes don't need to do anything.
+        // the pass doesn't need to do anything.
 
         run_mutate_pass(self);
         run_update_widget_tree_pass(self);

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -27,16 +27,14 @@ use crate::passes::paint::root_paint;
 use crate::passes::recurse_on_children;
 use crate::passes::update::{
     run_update_anim_pass, run_update_disabled_pass, run_update_focus_chain_pass,
-    run_update_focus_pass, run_update_new_widgets_pass, run_update_pointer_pass,
-    run_update_scroll_pass, run_update_stashed_pass,
+    run_update_focus_pass, run_update_pointer_pass, run_update_scroll_pass,
+    run_update_stashed_pass, run_update_widget_tree_pass,
 };
 use crate::text::TextBrush;
 use crate::tree_arena::{ArenaMut, TreeArena};
 use crate::widget::WidgetArena;
 use crate::widget::{WidgetMut, WidgetRef, WidgetState};
-use crate::{
-    AccessEvent, Action, BoxConstraints, CursorIcon, Handled, QueryCtx, Widget, WidgetId, WidgetPod,
-};
+use crate::{AccessEvent, Action, CursorIcon, Handled, QueryCtx, Widget, WidgetId, WidgetPod};
 
 // --- MARK: STRUCTS ---
 
@@ -160,15 +158,7 @@ impl RenderRoot {
         };
 
         // We run a set of passes to initialize the widget tree
-        run_update_new_widgets_pass(&mut root);
-        // TODO - Remove this line
-        let mut dummy_state = WidgetState::synthetic(root.root.id(), root.get_kurbo_size());
-        root.post_event_processing(&mut dummy_state);
-
-        // We run a layout pass right away to have a SetSize signal ready
-        if size_policy == WindowSizePolicy::Content {
-            root.root_layout();
-        }
+        root.run_rewrite_passes();
 
         root
     }
@@ -192,6 +182,7 @@ impl RenderRoot {
             }
             WindowEvent::Resize(size) => {
                 self.size = size;
+                self.root_state().request_layout = true;
                 self.root_state().needs_layout = true;
                 self.state.emit_signal(RenderRootSignal::RequestRedraw);
                 Handled::Yes
@@ -205,7 +196,8 @@ impl RenderRoot {
                 let last = self.last_anim.take();
                 let elapsed_ns = last.map(|t| now.duration_since(t).as_nanos()).unwrap_or(0) as u64;
 
-                self.root_anim_frame(elapsed_ns);
+                run_update_anim_pass(self, elapsed_ns);
+                self.run_rewrite_passes();
 
                 // If this animation will continue, store the time.
                 // If a new animation starts, then it will have zero reported elapsed time.
@@ -229,13 +221,6 @@ impl RenderRoot {
 
     pub fn handle_text_event(&mut self, event: TextEvent) -> Handled {
         self.root_on_text_event(event)
-    }
-
-    pub(crate) fn root_anim_frame(&mut self, elapsed_ns: u64) {
-        run_update_anim_pass(self, elapsed_ns);
-
-        let mut root_state = self.widget_arena.get_state_mut(self.root.id()).item.clone();
-        self.post_event_processing(&mut root_state);
     }
 
     /// Registers all fonts that exist in the given data.
@@ -273,7 +258,7 @@ impl RenderRoot {
 
     pub fn redraw(&mut self) -> (Scene, TreeUpdate) {
         if self.root_state().needs_layout {
-            self.root_layout();
+            root_layout(self);
         }
         if self.root_state().needs_layout {
             warn!("Widget requested layout during layout pass");
@@ -379,8 +364,7 @@ impl RenderRoot {
             f(widget_mut)
         });
 
-        let mut root_state = self.widget_arena.get_state_mut(self.root.id()).item.clone();
-        self.post_event_processing(&mut root_state);
+        self.run_rewrite_passes();
 
         res
     }
@@ -395,20 +379,17 @@ impl RenderRoot {
     ) -> R {
         let res = mutate_widget(self, id, f);
 
-        let mut root_state = self.widget_arena.get_state_mut(self.root.id()).item.clone();
-        self.post_event_processing(&mut root_state);
+        self.run_rewrite_passes();
 
         res
     }
 
     // --- MARK: POINTER_EVENT ---
     fn root_on_pointer_event(&mut self, event: PointerEvent) -> Handled {
-        let mut dummy_state = WidgetState::synthetic(self.root.id(), self.get_kurbo_size());
+        let handled = root_on_pointer_event(self, &event);
+        run_update_pointer_pass(self);
 
-        let handled = root_on_pointer_event(self, &mut dummy_state, &event);
-        run_update_pointer_pass(self, &mut dummy_state);
-
-        self.post_event_processing(&mut dummy_state);
+        self.run_rewrite_passes();
         self.get_root_widget().debug_validate(false);
 
         handled
@@ -416,16 +397,14 @@ impl RenderRoot {
 
     // --- MARK: TEXT_EVENT ---
     fn root_on_text_event(&mut self, event: TextEvent) -> Handled {
-        let mut dummy_state = WidgetState::synthetic(self.root.id(), self.get_kurbo_size());
-
         if matches!(event, TextEvent::FocusChange(false)) {
-            root_on_pointer_event(self, &mut dummy_state, &PointerEvent::new_pointer_leave());
+            root_on_pointer_event(self, &PointerEvent::new_pointer_leave());
         }
 
-        let handled = root_on_text_event(self, &mut dummy_state, &event);
-        run_update_focus_pass(self, &mut dummy_state);
+        let handled = root_on_text_event(self, &event);
+        run_update_focus_pass(self);
 
-        self.post_event_processing(&mut dummy_state);
+        self.run_rewrite_passes();
         self.get_root_widget().debug_validate(false);
 
         handled
@@ -433,8 +412,6 @@ impl RenderRoot {
 
     // --- MARK: ACCESS_EVENT ---
     pub fn root_on_access_event(&mut self, event: ActionRequest) {
-        let mut dummy_state = WidgetState::synthetic(self.root.id(), self.get_kurbo_size());
-
         let Ok(id) = event.target.0.try_into() else {
             warn!("Received ActionRequest with id 0. This shouldn't be possible.");
             return;
@@ -445,34 +422,10 @@ impl RenderRoot {
             data: event.data,
         };
 
-        root_on_access_event(self, &mut dummy_state, &event);
+        root_on_access_event(self, &event);
 
-        self.post_event_processing(&mut dummy_state);
+        self.run_rewrite_passes();
         self.get_root_widget().debug_validate(false);
-    }
-
-    // --- MARK: LAYOUT ---
-    pub(crate) fn root_layout(&mut self) {
-        let window_size = self.get_kurbo_size();
-        let bc = match self.size_policy {
-            WindowSizePolicy::User => BoxConstraints::tight(window_size),
-            WindowSizePolicy::Content => BoxConstraints::UNBOUNDED,
-        };
-
-        let mut dummy_state = WidgetState::synthetic(self.root.id(), self.get_kurbo_size());
-        let size = root_layout(self, &mut dummy_state, &bc);
-
-        if let WindowSizePolicy::Content = self.size_policy {
-            let new_size = LogicalSize::new(size.width, size.height).to_physical(self.scale_factor);
-            if self.size != new_size {
-                self.size = new_size;
-                self.state.emit_signal(RenderRootSignal::SetSize(new_size));
-            }
-        }
-
-        run_update_pointer_pass(self, &mut dummy_state);
-
-        self.post_event_processing(&mut dummy_state);
     }
 
     // --- MARK: PAINT ---
@@ -501,44 +454,22 @@ impl RenderRoot {
         kurbo::Size::new(size.width, size.height)
     }
 
-    // --- MARK: POST-EVENT ---
-    fn post_event_processing(&mut self, widget_state: &mut WidgetState) {
-        // If children are changed during the handling of an event,
-        // we need to send RouteWidgetAdded now, so that they are ready for update/layout.
-        if widget_state.children_changed {
-            run_update_new_widgets_pass(self);
-        }
+    // --- MARK: REWRITE PASSES ---
+    pub(crate) fn run_rewrite_passes(&mut self) {
+        // TODO - Rerun passes if invalidation flags are still set
 
-        if self.state.debug_logger.layout_tree.root.is_none() {
-            self.state.debug_logger.layout_tree.root = Some(self.root.id().to_raw() as u32);
-        }
+        run_mutate_pass(self);
+        run_update_widget_tree_pass(self);
+        run_update_disabled_pass(self);
+        run_update_stashed_pass(self);
+        run_update_focus_chain_pass(self);
+        run_update_focus_pass(self);
+        root_layout(self);
+        run_update_scroll_pass(self);
+        root_compose(self);
+        run_update_pointer_pass(self);
 
-        if !self.state.scroll_request_targets.is_empty() {
-            run_update_scroll_pass(self);
-        }
-
-        if self.root_state().needs_compose && !self.root_state().needs_layout {
-            root_compose(self, widget_state);
-        }
-
-        // Update the disabled and stashed state if necessary
-        // Always do this before updating the focus-chain
-        if self.root_state().needs_update_disabled {
-            run_update_disabled_pass(self);
-        }
-        if self.root_state().needs_update_stashed {
-            run_update_stashed_pass(self);
-        }
-
-        // Update the focus-chain if necessary
-        // Always do this before sending focus change, since this event updates the focus chain.
-        if self.root_state().update_focus_chain {
-            run_update_focus_chain_pass(self);
-        }
-
-        run_update_focus_pass(self, widget_state);
-
-        if self.root_state().request_anim {
+        if self.root_state().needs_anim {
             self.state.emit_signal(RenderRootSignal::RequestAnimFrame);
         }
 
@@ -552,8 +483,6 @@ impl RenderRoot {
         {
             self.state.emit_signal(RenderRootSignal::RequestRedraw);
         }
-
-        run_mutate_pass(self, widget_state);
     }
 
     pub(crate) fn request_render_all(&mut self) {

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -183,7 +183,7 @@ impl RenderRoot {
         root
     }
 
-    fn root_state(&mut self) -> &mut WidgetState {
+    pub(crate) fn root_state(&mut self) -> &mut WidgetState {
         self.widget_arena
             .widget_states
             .root_token_mut()
@@ -454,6 +454,12 @@ impl RenderRoot {
     }
 
     // --- MARK: REWRITE PASSES ---
+    /// Run all rewrite passes on widget tree.
+    ///
+    /// Rewrite passes are passes which occur after external events, and
+    /// update flags and internal values to a consistent state.
+    ///
+    /// See Pass Spec RFC for details. (TODO - Link to doc instead.)
     pub(crate) fn run_rewrite_passes(&mut self) {
         // TODO - Rerun passes if invalidation flags are still set
 

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -463,6 +463,11 @@ impl RenderRoot {
     pub(crate) fn run_rewrite_passes(&mut self) {
         // TODO - Rerun passes if invalidation flags are still set
 
+        // Note: this code doesn't do any short-circuiting, because each pass is
+        // expected to have its own early exits.
+        // Calling a run_xxx_pass (or root_xxx) should always be very fast if
+        // the passes don't need to do anything.
+
         run_mutate_pass(self);
         run_update_widget_tree_pass(self);
         run_update_disabled_pass(self);

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -207,8 +207,8 @@ impl TestHarness {
     /// as will any resulting commands. Commands created as a result of this event
     /// will also be dispatched.
     pub fn process_window_event(&mut self, event: WindowEvent) -> Handled {
-        let handled = self.render_root.handle_window_event(event);
-        handled
+        
+        self.render_root.handle_window_event(event)
     }
 
     /// Send an event to the widget.
@@ -217,8 +217,8 @@ impl TestHarness {
     /// as will any resulting commands. Commands created as a result of this event
     /// will also be dispatched.
     pub fn process_pointer_event(&mut self, event: PointerEvent) -> Handled {
-        let handled = self.render_root.handle_pointer_event(event);
-        handled
+        
+        self.render_root.handle_pointer_event(event)
     }
 
     /// Send an event to the widget.
@@ -227,8 +227,8 @@ impl TestHarness {
     /// as will any resulting commands. Commands created as a result of this event
     /// will also be dispatched.
     pub fn process_text_event(&mut self, event: TextEvent) -> Handled {
-        let handled = self.render_root.handle_text_event(event);
-        handled
+        
+        self.render_root.handle_text_event(event)
     }
 
     // --- MARK: RENDER ---
@@ -501,8 +501,8 @@ impl TestHarness {
         &mut self,
         f: impl FnOnce(WidgetMut<'_, Box<dyn Widget>>) -> R,
     ) -> R {
-        let res = self.render_root.edit_root_widget(f);
-        res
+        
+        self.render_root.edit_root_widget(f)
     }
 
     /// Get a [`WidgetMut`] to a specific widget.
@@ -513,8 +513,8 @@ impl TestHarness {
         id: WidgetId,
         f: impl FnOnce(WidgetMut<'_, Box<dyn Widget>>) -> R,
     ) -> R {
-        let res = self.render_root.edit_widget(id, f);
-        res
+        
+        self.render_root.edit_widget(id, f)
     }
 
     /// Pop next action from the queue

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -207,7 +207,6 @@ impl TestHarness {
     /// as will any resulting commands. Commands created as a result of this event
     /// will also be dispatched.
     pub fn process_window_event(&mut self, event: WindowEvent) -> Handled {
-        
         self.render_root.handle_window_event(event)
     }
 
@@ -217,7 +216,6 @@ impl TestHarness {
     /// as will any resulting commands. Commands created as a result of this event
     /// will also be dispatched.
     pub fn process_pointer_event(&mut self, event: PointerEvent) -> Handled {
-        
         self.render_root.handle_pointer_event(event)
     }
 
@@ -227,7 +225,6 @@ impl TestHarness {
     /// as will any resulting commands. Commands created as a result of this event
     /// will also be dispatched.
     pub fn process_text_event(&mut self, event: TextEvent) -> Handled {
-        
         self.render_root.handle_text_event(event)
     }
 
@@ -501,7 +498,6 @@ impl TestHarness {
         &mut self,
         f: impl FnOnce(WidgetMut<'_, Box<dyn Widget>>) -> R,
     ) -> R {
-        
         self.render_root.edit_root_widget(f)
     }
 
@@ -513,7 +509,6 @@ impl TestHarness {
         id: WidgetId,
         f: impl FnOnce(WidgetMut<'_, Box<dyn Widget>>) -> R,
     ) -> R {
-        
         self.render_root.edit_widget(id, f)
     }
 

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -174,6 +174,12 @@ impl TestHarness {
         // harnesses.
         let _ = try_init_test_tracing();
 
+        const ROBOTO: &[u8] = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/resources/fonts/roboto/Roboto-Regular.ttf"
+        ));
+        let data = ROBOTO.to_vec();
+
         let mut harness = TestHarness {
             render_root: RenderRoot::new(
                 root_widget,
@@ -181,18 +187,13 @@ impl TestHarness {
                     use_system_fonts: false,
                     size_policy: WindowSizePolicy::User,
                     scale_factor: 1.0,
+                    test_font: Some(data),
                 },
             ),
             mouse_state,
             window_size,
             background_color,
         };
-        const ROBOTO: &[u8] = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/resources/fonts/roboto/Roboto-Regular.ttf"
-        ));
-        let data = ROBOTO.to_vec();
-        harness.render_root.add_test_font(data);
         harness.process_window_event(WindowEvent::Resize(window_size));
 
         harness

--- a/masonry/src/widget/tests/snapshots/masonry__widget__tests__lifecycle_basic__app_creation.snap
+++ b/masonry/src/widget/tests/snapshots/masonry__widget__tests__lifecycle_basic__app_creation.snap
@@ -15,4 +15,8 @@ expression: record
         0.0W×0.0H,
     ),
     Compose,
+    Layout(
+        400.0W×400.0H,
+    ),
+    Compose,
 ]

--- a/masonry/src/widget/tests/snapshots/masonry__widget__tests__lifecycle_basic__app_creation.snap
+++ b/masonry/src/widget/tests/snapshots/masonry__widget__tests__lifecycle_basic__app_creation.snap
@@ -12,7 +12,7 @@ expression: record
         BuildFocusChain,
     ),
     Layout(
-        400.0W×400.0H,
+        0.0W×0.0H,
     ),
     Compose,
 ]


### PR DESCRIPTION
Create run_rewrite_passes function.
Remove redundant uses of synthetic WidgetState.
Small bugfixes.
Move RenderRoot::root_layout code into the layout pass. Rename update_new_widgets pass to update_widget_tree.