### PR TITLE
Refactor safety rails for layout pass

### DIFF
--- a/masonry/examples/calc_masonry.rs
+++ b/masonry/examples/calc_masonry.rs
@@ -181,7 +181,6 @@ impl Widget for CalcButton {
                 _ => {}
             }
         }
-        ctx.skip_child(&mut self.inner);
     }
 
     fn on_status_change(&mut self, ctx: &mut LifeCycleCtx, event: &StatusChange) {

--- a/masonry/src/box_constraints.rs
+++ b/masonry/src/box_constraints.rs
@@ -115,6 +115,26 @@ impl BoxConstraints {
             return;
         }
 
+        if self.min.width.is_nan() {
+            debug_panic!("Minimum width constraint passed to {name} is NaN");
+        }
+        if self.min.height.is_nan() {
+            debug_panic!("Minimum height constraint passed to {name} is NaN");
+        }
+        if self.max.width.is_nan() {
+            debug_panic!("Maxium width constraint passed to {name} is NaN");
+        }
+        if self.max.height.is_nan() {
+            debug_panic!("Maxium height constraint passed to {name} is NaN");
+        }
+
+        if self.min.width.is_infinite() {
+            debug_panic!("Infinite minimum width constraint passed to {name}");
+        }
+        if self.min.height.is_infinite() {
+            debug_panic!("Infinite minimum height constraint passed to {name}");
+        }
+
         if !(0.0 <= self.min.width
             && self.min.width <= self.max.width
             && 0.0 <= self.min.height
@@ -122,16 +142,7 @@ impl BoxConstraints {
             && self.min.expand() == self.min
             && self.max.expand() == self.max)
         {
-            tracing::warn!("Bad BoxConstraints passed to {}:", name);
-            tracing::warn!("{:?}", self);
-        }
-
-        if self.min.width.is_infinite() {
-            tracing::warn!("Infinite minimum width constraint passed to {}:", name);
-        }
-
-        if self.min.height.is_infinite() {
-            tracing::warn!("Infinite minimum height constraint passed to {}:", name);
+            debug_panic!("Bad BoxConstraints passed to {name}: {self:?}",);
         }
     }
 

--- a/masonry/src/box_constraints.rs
+++ b/masonry/src/box_constraints.rs
@@ -122,10 +122,10 @@ impl BoxConstraints {
             debug_panic!("Minimum height constraint passed to {name} is NaN");
         }
         if self.max.width.is_nan() {
-            debug_panic!("Maxium width constraint passed to {name} is NaN");
+            debug_panic!("Maximum width constraint passed to {name} is NaN");
         }
         if self.max.height.is_nan() {
-            debug_panic!("Maxium height constraint passed to {name} is NaN");
+            debug_panic!("Maximum height constraint passed to {name} is NaN");
         }
 
         if self.min.width.is_infinite() {

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -146,18 +146,6 @@ impl_context_method!(
             self.widget_state.id
         }
 
-        /// Skip iterating over the given child.
-        ///
-        /// Normally, container widgets are supposed to iterate over each of their
-        /// child widgets in their methods. By default, the framework treats not
-        /// doing so as a mistake, and panics if debug assertions are on.
-        ///
-        /// This tells the framework that a child was deliberately skipped.
-        // TODO - see event flow tutorial - See https://github.com/linebender/xilem/issues/376
-        pub fn skip_child(&self, child: &mut WidgetPod<impl Widget>) {
-            self.get_child_state(child).mark_as_visited(true);
-        }
-
         #[allow(dead_code)]
         /// Helper method to get a direct reference to a child widget from its `WidgetPod`.
         fn get_child<Child: Widget>(&self, child: &'_ WidgetPod<Child>) -> &'_ Child {
@@ -910,12 +898,6 @@ impl LayoutCtx<'_> {
         self.get_child_state(child).needs_layout
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn mark_as_visited(&self, visited: bool) {
-        #[cfg(debug_assertions)]
-        self.widget_state.mark_as_visited(visited);
-    }
-
     /// The distance from the bottom of the given widget to the baseline.
     ///
     /// ## Panics
@@ -971,9 +953,7 @@ impl LayoutCtx<'_> {
     /// This may be removed in the future. Currently it's useful for
     /// stashed children and children whose layout is cached.
     pub fn skip_layout(&mut self, child: &mut WidgetPod<impl Widget>) {
-        #[cfg(debug_assertions)]
-        self.get_child_state(child).mark_as_visited(true);
-        self.get_child_state_mut(child).needs_layout = false;
+        self.get_child_state_mut(child).request_layout = false;
     }
 
     /// Gives the widget a clip path.
@@ -1017,6 +997,19 @@ impl LayoutCtx<'_> {
     #[track_caller]
     pub fn place_child<W: Widget>(&mut self, child: &mut WidgetPod<W>, origin: Point) {
         self.assert_layout_done(child, "place_child");
+        if origin.x.is_nan()
+            || origin.x.is_infinite()
+            || origin.y.is_nan()
+            || origin.y.is_infinite()
+        {
+            debug_panic!(
+                "Error in {}: trying to call 'place_child' with child '{}' {} with invalid origin {:?}",
+                self.widget_id(),
+                self.get_child(child).short_type_name(),
+                child.id(),
+                origin,
+            );
+        }
         if origin != self.get_child_state_mut(child).origin {
             self.get_child_state_mut(child).origin = origin;
             self.get_child_state_mut(child).translation_changed = true;
@@ -1044,6 +1037,19 @@ impl ComposeCtx<'_> {
         child: &mut WidgetPod<W>,
         translation: Vec2,
     ) {
+        if translation.x.is_nan()
+            || translation.x.is_infinite()
+            || translation.y.is_nan()
+            || translation.y.is_infinite()
+        {
+            debug_panic!(
+                "Error in {}: trying to call 'set_child_translation' with child '{}' {} with invalid translation {:?}",
+                self.widget_id(),
+                self.get_child(child).short_type_name(),
+                child.id(),
+                translation,
+            );
+        }
         let child = self.get_child_state_mut(child);
         if translation != child.translation {
             child.translation = translation;

--- a/masonry/src/passes/layout.rs
+++ b/masonry/src/passes/layout.rs
@@ -110,6 +110,7 @@ pub(crate) fn run_layout_on<W: Widget>(
 
     #[cfg(debug_assertions)]
     {
+        let name = widget.short_type_name();
         for child_id in widget.children_ids() {
             let child_id = child_id.to_raw();
             let child_state = state_mut.children.get_child_mut(child_id).unwrap().item;
@@ -121,7 +122,7 @@ pub(crate) fn run_layout_on<W: Widget>(
             if child_state.request_layout {
                 debug_panic!(
                     "Error in '{}' {}: LayoutCtx::run_layout() was not called with child widget '{}' {}.",
-                    widget.short_type_name(),
+                    name,
                     pod.id(),
                     child_state.widget_name,
                     child_state.id,
@@ -131,7 +132,7 @@ pub(crate) fn run_layout_on<W: Widget>(
             if child_state.is_expecting_place_child_call {
                 debug_panic!(
                     "Error in '{}' {}: LayoutCtx::place_child() was not called with child widget '{}' {}.",
-                    widget.short_type_name(),
+                    name,
                     pod.id(),
                     child_state.widget_name,
                     child_state.id,
@@ -143,7 +144,7 @@ pub(crate) fn run_layout_on<W: Widget>(
             if !state.local_paint_rect.contains_rect(child_rect) && state.clip.is_none() {
                 debug_panic!(
                     "Error in '{}' {}: paint_rect {:?} doesn't contain paint_rect {:?} of child widget '{}' {}",
-                    widget.short_type_name(),
+                    name,
                     pod.id(),
                     state.local_paint_rect,
                     child_rect,
@@ -157,37 +158,17 @@ pub(crate) fn run_layout_on<W: Widget>(
         if children_ids != new_children_ids && !state.children_changed {
             debug_panic!(
                 "Error in '{}' {}: children changed during layout pass",
-                widget.short_type_name(),
+                name,
                 pod.id(),
             );
         }
 
-        if new_size.width.is_infinite() {
+        if !new_size.width.is_finite() || !new_size.height.is_finite() {
             debug_panic!(
-                "Error in '{}' {}: width is infinite",
-                widget.short_type_name(),
+                "Error in '{}' {}: invalid size {}",
+                name,
                 pod.id(),
-            );
-        }
-        if new_size.width.is_nan() {
-            debug_panic!(
-                "Error in '{}' {}: width is NaN",
-                widget.short_type_name(),
-                pod.id(),
-            );
-        }
-        if new_size.height.is_infinite() {
-            debug_panic!(
-                "Error in '{}' {}: height is infinite",
-                widget.short_type_name(),
-                pod.id(),
-            );
-        }
-        if new_size.height.is_nan() {
-            debug_panic!(
-                "Error in '{}' {}: height is NaN",
-                widget.short_type_name(),
-                pod.id(),
+                new_size
             );
         }
     }

--- a/masonry/src/passes/update.rs
+++ b/masonry/src/passes/update.rs
@@ -371,6 +371,11 @@ fn update_stashed_for_widget(
         state.item.needs_accessibility = true;
         // TODO - Remove once accessibility can be composed, same as above.
         state.item.request_accessibility = true;
+        // A stashed child doesn't need layout. We assumed that a child that just got
+        // un-stashed will need relayout.
+        // TODO - Handle this interaction more elegantly.
+        state.item.needs_layout = !stashed;
+        state.item.request_layout = !stashed;
     }
 
     state.item.needs_update_stashed = false;

--- a/masonry/src/tree_arena.rs
+++ b/masonry/src/tree_arena.rs
@@ -277,15 +277,6 @@ impl<'a, Item> ArenaRefChildren<'a, Item> {
             .map(|child| child.arena_ref(self.id, self.parents_map.parents_map))
     }
 
-    // TODO - This method could not be implemented with an actual arena design.
-    // It's currently used for some sanity-checking of widget code, but will
-    // likely be removed.
-    pub(crate) fn iter_children(&self) -> impl Iterator<Item = ArenaRef<'_, Item>> {
-        self.children
-            .iter()
-            .map(|child| child.arena_ref(self.id, self.parents_map.parents_map))
-    }
-
     /// Find an arena item among descendants (this node not included).
     ///
     /// Returns a shared reference to the item if present.
@@ -361,15 +352,6 @@ impl<'a, Item> ArenaMutChildren<'a, Item> {
             .iter_mut()
             .find(|child| child.id == id)
             .map(|child| child.arena_mut(self.id, self.parents_map.parents_map))
-    }
-
-    // TODO - This method could not be implemented with an actual arena design.
-    // It's currently used for some sanity-checking of widget code, but will
-    // likely be removed.
-    pub(crate) fn iter_children(&self) -> impl Iterator<Item = ArenaRef<'_, Item>> {
-        self.children
-            .iter()
-            .map(|child| child.arena_ref(self.id, self.parents_map.parents_map))
     }
 
     // TODO - Remove the child_id argument once creation of Widgets is figured out.

--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -932,7 +932,8 @@ impl Widget for Flex {
         // Measure non-flex children.
         let mut major_non_flex = total_gap;
         // We start with a small value to avoid divide-by-zero errors.
-        let mut flex_sum = 0.001;
+        const MIN_FLEX_SUM: f64 = 0.0001;
+        let mut flex_sum = MIN_FLEX_SUM;
         for child in &mut self.children {
             match child {
                 Child::Fixed { widget, alignment } => {
@@ -1126,7 +1127,7 @@ impl Widget for Flex {
             major -= gap;
         }
 
-        if flex_sum > 0.0 {
+        if flex_sum > MIN_FLEX_SUM {
             major = total_major;
         }
 
@@ -1589,5 +1590,14 @@ mod tests {
         });
 
         // TODO - test out-of-bounds access?
+    }
+
+    #[test]
+    fn divide_by_zero() {
+        let widget = Flex::column().with_flex_spacer(0.0);
+
+        // Running layout should not panic when the flex sum is zero.
+        let mut harness = TestHarness::create(widget);
+        harness.render();
     }
 }

--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -931,7 +931,8 @@ impl Widget for Flex {
         let total_gap = self.children.len().saturating_sub(1) as f64 * gap;
         // Measure non-flex children.
         let mut major_non_flex = total_gap;
-        let mut flex_sum = 0.0;
+        // We start with a small value to avoid divide-by-zero errors.
+        let mut flex_sum = 0.001;
         for child in &mut self.children {
             match child {
                 Child::Fixed { widget, alignment } => {

--- a/masonry/src/widget/grid.rs
+++ b/masonry/src/widget/grid.rs
@@ -248,6 +248,12 @@ impl Widget for Grid {
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size {
         let total_size = bc.max();
+        if !total_size.is_finite() {
+            debug_panic!(
+                "Error while computing layout for grid; infinite BoxConstraint max provided {}",
+                total_size
+            );
+        }
         let width_unit = (total_size.width + self.grid_spacing) / (self.grid_width as f64);
         let height_unit = (total_size.height + self.grid_spacing) / (self.grid_height as f64);
         for child in &mut self.children {

--- a/masonry/src/widget/grid.rs
+++ b/masonry/src/widget/grid.rs
@@ -248,12 +248,6 @@ impl Widget for Grid {
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size {
         let total_size = bc.max();
-        if !total_size.is_finite() {
-            debug_panic!(
-                "Error while computing layout for grid; infinite BoxConstraint provided {}",
-                total_size
-            );
-        }
         let width_unit = (total_size.width + self.grid_spacing) / (self.grid_width as f64);
         let height_unit = (total_size.height + self.grid_spacing) / (self.grid_height as f64);
         for child in &mut self.children {

--- a/masonry/src/widget/grid.rs
+++ b/masonry/src/widget/grid.rs
@@ -248,12 +248,18 @@ impl Widget for Grid {
 
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size {
         let total_size = bc.max();
+        if !total_size.is_finite() {
+            debug_panic!(
+                "Error while computing layout for grid; infinite BoxConstraint provided {}",
+                total_size
+            );
+        }
         let width_unit = (total_size.width + self.grid_spacing) / (self.grid_width as f64);
         let height_unit = (total_size.height + self.grid_spacing) / (self.grid_height as f64);
         for child in &mut self.children {
             let cell_size = Size::new(
-                child.width as f64 * width_unit - self.grid_spacing,
-                child.height as f64 * height_unit - self.grid_spacing,
+                (child.width as f64 * width_unit - self.grid_spacing).max(0.0),
+                (child.height as f64 * height_unit - self.grid_spacing).max(0.0),
             );
             let child_bc = BoxConstraints::new(cell_size, cell_size);
             let _ = ctx.run_layout(&mut child.widget, &child_bc);

--- a/masonry/src/widget/tests/safety_rails.rs
+++ b/masonry/src/widget/tests/safety_rails.rs
@@ -129,7 +129,7 @@ fn check_pointer_capture_text_event() {
     harness.keyboard_type_chars("a");
 }
 
-#[should_panic(expected = "not visited in method layout")]
+#[should_panic(expected = "LayoutCtx::run_layout() was not called")]
 #[test]
 #[cfg_attr(
     not(debug_assertions),
@@ -144,7 +144,7 @@ fn check_forget_to_recurse_layout() {
     let _harness = TestHarness::create(widget);
 }
 
-#[should_panic(expected = "missing call to place_child method for child widget")]
+#[should_panic(expected = "LayoutCtx::place_child() was not called")]
 #[test]
 #[cfg_attr(
     not(debug_assertions),


### PR DESCRIPTION
Merge call_widget_method_with_checks, run_layout_inner and run_layout_on.
Remove needs_visit flag.
Add checks for invalid values in place_child, set_child_translation and run_layout.