### PR TITLE
Remove tracing boilerplate from widget code

### DIFF
--- a/masonry/src/passes/layout.rs
+++ b/masonry/src/passes/layout.rs
@@ -198,6 +198,12 @@ pub(crate) fn run_layout_inner<W: Widget>(
             pod.id(),
         );
     }
+    trace!(
+        "Computed layout: size={}, baseline={}, insets={:?}",
+        new_size,
+        state.baseline_offset,
+        state.paint_insets,
+    );
 
     state.needs_layout = false;
     state.is_expecting_place_child_call = true;

--- a/masonry/src/widget/align.rs
+++ b/masonry/src/widget/align.rs
@@ -10,7 +10,7 @@
 
 use accesskit::{NodeBuilder, Role};
 use smallvec::{smallvec, SmallVec};
-use tracing::{trace, trace_span, Span};
+use tracing::{trace_span, Span};
 use vello::Scene;
 
 use crate::contexts::AccessCtx;
@@ -135,12 +135,6 @@ impl Widget for Align {
             }
         }
 
-        trace!(
-            "Computed layout: origin={}, size={}, insets={:?}",
-            origin,
-            my_size,
-            my_insets
-        );
         my_size
     }
 

--- a/masonry/src/widget/button.rs
+++ b/masonry/src/widget/button.rs
@@ -140,7 +140,6 @@ impl Widget for Button {
         let label_offset = (button_size.to_vec2() - label_size.to_vec2()) / 2.0;
         ctx.place_child(&mut self.label, label_offset.to_point());
 
-        trace!("Computed button size: {}", button_size);
         button_size
     }
 

--- a/masonry/src/widget/checkbox.rs
+++ b/masonry/src/widget/checkbox.rs
@@ -125,7 +125,6 @@ impl Widget for Checkbox {
         let baseline =
             ctx.child_baseline_offset(&self.label) + (our_size.height - label_size.height);
         ctx.set_baseline_offset(baseline);
-        trace!("Computed layout: size={}, baseline={}", our_size, baseline);
         our_size
     }
 

--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -5,7 +5,7 @@
 
 use accesskit::{NodeBuilder, Role};
 use smallvec::SmallVec;
-use tracing::{trace, trace_span, Span};
+use tracing::{trace_span, Span};
 use vello::kurbo::{common::FloatExt, Affine, Line, Stroke, Vec2};
 use vello::Scene;
 
@@ -1158,11 +1158,6 @@ impl Widget for Flex {
         };
 
         ctx.set_baseline_offset(baseline_offset);
-        trace!(
-            "Computed layout: size={}, baseline_offset={}",
-            my_size,
-            baseline_offset
-        );
         my_size
     }
 

--- a/masonry/src/widget/image.rs
+++ b/masonry/src/widget/image.rs
@@ -6,7 +6,7 @@
 
 use accesskit::{NodeBuilder, Role};
 use smallvec::SmallVec;
-use tracing::{trace, trace_span, Span};
+use tracing::{trace_span, Span};
 use vello::kurbo::Affine;
 use vello::peniko::{BlendMode, Image as ImageBuf};
 use vello::Scene;
@@ -90,11 +90,10 @@ impl Widget for Image {
         let image_size = Size::new(self.image_data.width as f64, self.image_data.height as f64);
         if image_size.is_empty() {
             let size = bc.min();
-            trace!("Computed size: {}", size);
             return size;
         }
         let image_aspect_ratio = image_size.height / image_size.width;
-        let size = match self.object_fit {
+        match self.object_fit {
             ObjectFit::Contain => bc.constrain_aspect_ratio(image_aspect_ratio, image_size.width),
             ObjectFit::Cover => Size::new(bc.max().width, bc.max().width * image_aspect_ratio),
             ObjectFit::Fill => bc.max(),
@@ -112,9 +111,7 @@ impl Widget for Image {
 
                 size
             }
-        };
-        trace!("Computed size: {}", size);
-        size
+        }
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {

--- a/masonry/src/widget/label.rs
+++ b/masonry/src/widget/label.rs
@@ -7,7 +7,7 @@ use accesskit::{NodeBuilder, Role};
 use parley::layout::Alignment;
 use parley::style::{FontFamily, FontStack};
 use smallvec::SmallVec;
-use tracing::{trace, trace_span, Span};
+use tracing::{trace_span, Span};
 use vello::kurbo::{Affine, Point, Size};
 use vello::peniko::BlendMode;
 use vello::Scene;
@@ -231,14 +231,7 @@ impl Widget for Label {
             height: text_size.height,
             width: text_size.width + 2. * LABEL_X_PADDING,
         };
-        let size = bc.constrain(label_size);
-        trace!(
-            "Computed layout: max={:?}. w={}, h={}",
-            max_advance,
-            size.width,
-            size.height,
-        );
-        size
+        bc.constrain(label_size)
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {

--- a/masonry/src/widget/progress_bar.rs
+++ b/masonry/src/widget/progress_bar.rs
@@ -6,7 +6,7 @@
 use crate::Point;
 use accesskit::{NodeBuilder, Role};
 use smallvec::{smallvec, SmallVec};
-use tracing::{trace, trace_span, Span};
+use tracing::{trace_span, Span};
 use vello::Scene;
 
 use crate::kurbo::Size;
@@ -131,9 +131,7 @@ impl Widget for ProgressBar {
             DEFAULT_WIDTH.max(label_size.width),
             crate::theme::BASIC_WIDGET_HEIGHT.max(label_size.height),
         );
-        let our_size = bc.constrain(desired_size);
-        trace!("Computed layout: size={}", our_size);
-        our_size
+        bc.constrain(desired_size)
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -7,7 +7,7 @@ use parley::{
     style::{FontFamily, FontStack},
 };
 use smallvec::SmallVec;
-use tracing::{trace, trace_span, Span};
+use tracing::{trace_span, Span};
 use vello::{
     kurbo::{Affine, Point, Size},
     peniko::BlendMode,
@@ -255,14 +255,7 @@ impl Widget for Prose {
             height: text_size.height,
             width: text_size.width + 2. * LABEL_X_PADDING,
         };
-        let size = bc.constrain(label_size);
-        trace!(
-            "Computed layout: max={:?}. w={}, h={}",
-            max_advance,
-            size.width,
-            size.height,
-        );
-        size
+        bc.constrain(label_size)
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -5,7 +5,7 @@
 
 use accesskit::{NodeBuilder, Role};
 use smallvec::{smallvec, SmallVec};
-use tracing::{trace, trace_span, warn, Span};
+use tracing::{trace_span, warn, Span};
 use vello::kurbo::{Affine, RoundedRectRadii};
 use vello::peniko::{Brush, Color, Fill};
 use vello::Scene;
@@ -344,8 +344,6 @@ impl Widget for SizedBox {
 
         // TODO - figure out paint insets
         // TODO - figure out baseline offset
-
-        trace!("Computed size: {}", size);
 
         if size.width.is_infinite() {
             warn!("SizedBox is returning an infinite width.");

--- a/masonry/src/widget/spinner.rs
+++ b/masonry/src/widget/spinner.rs
@@ -7,7 +7,7 @@ use std::f64::consts::PI;
 
 use accesskit::{NodeBuilder, Role};
 use smallvec::SmallVec;
-use tracing::{trace, trace_span, Span};
+use tracing::{trace_span, Span};
 use vello::kurbo::{Affine, Cap, Line, Stroke};
 use vello::Scene;
 
@@ -117,7 +117,6 @@ impl Widget for Spinner {
             ))
         };
 
-        trace!("Computed size: {}", size);
         size
     }
 

--- a/masonry/src/widget/spinner.rs
+++ b/masonry/src/widget/spinner.rs
@@ -108,8 +108,6 @@ impl Widget for Spinner {
     }
 
     fn layout(&mut self, _ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size {
-        
-
         if bc.is_width_bounded() && bc.is_height_bounded() {
             bc.max()
         } else {

--- a/masonry/src/widget/spinner.rs
+++ b/masonry/src/widget/spinner.rs
@@ -108,16 +108,16 @@ impl Widget for Spinner {
     }
 
     fn layout(&mut self, _ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size {
-        let size = if bc.is_width_bounded() && bc.is_height_bounded() {
+        
+
+        if bc.is_width_bounded() && bc.is_height_bounded() {
             bc.max()
         } else {
             bc.constrain(Size::new(
                 theme::BASIC_WIDGET_HEIGHT,
                 theme::BASIC_WIDGET_HEIGHT,
             ))
-        };
-
-        size
+        }
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {

--- a/masonry/src/widget/split.rs
+++ b/masonry/src/widget/split.rs
@@ -5,7 +5,7 @@
 
 use accesskit::{NodeBuilder, Role};
 use smallvec::{smallvec, SmallVec};
-use tracing::{trace, trace_span, warn, Span};
+use tracing::{trace_span, warn, Span};
 use vello::Scene;
 
 use crate::dpi::LogicalPosition;
@@ -543,7 +543,6 @@ impl Widget for Split {
         let insets = paint_rect - my_size.to_rect();
         ctx.set_paint_insets(insets);
 
-        trace!("Computed layout: size={}, insets={:?}", my_size, insets);
         my_size
     }
 

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -7,7 +7,7 @@ use parley::{
     style::{FontFamily, FontStack},
 };
 use smallvec::SmallVec;
-use tracing::{trace, trace_span, Span};
+use tracing::{trace_span, Span};
 use vello::{
     kurbo::{Affine, Point, Size, Stroke},
     peniko::{BlendMode, Color},
@@ -294,14 +294,7 @@ impl Widget for Textbox {
             // TODO: Better heuristic here?
             width,
         };
-        let size = bc.constrain(label_size);
-        trace!(
-            "Computed layout: max={:?}. w={}, h={}",
-            max_advance,
-            size.width,
-            size.height,
-        );
-        size
+        bc.constrain(label_size)
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {

--- a/masonry/src/widget/variable_label.rs
+++ b/masonry/src/widget/variable_label.rs
@@ -10,7 +10,7 @@ use parley::fontique::Weight;
 use parley::layout::Alignment;
 use parley::style::{FontFamily, FontStack};
 use smallvec::SmallVec;
-use tracing::{trace, trace_span, Span};
+use tracing::{trace_span, Span};
 use vello::kurbo::{Affine, Point, Size};
 use vello::peniko::BlendMode;
 use vello::Scene;
@@ -373,14 +373,7 @@ impl Widget for VariableLabel {
             height: text_size.height,
             width: text_size.width + 2. * LABEL_X_PADDING,
         };
-        let size = bc.constrain(label_size);
-        trace!(
-            "Computed layout: max={:?}. w={}, h={}",
-            max_advance,
-            size.width,
-            size.height,
-        );
-        size
+        bc.constrain(label_size)
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {


### PR DESCRIPTION
Each widget implementation was doing its own bespoke tracing in layout. This removes the bespoke tracing and adds a trace inside the layout pass logging the same information in a more centralized way.