### PR TITLE
Make WidgetState private

### DIFF
--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -239,6 +239,14 @@ impl_context_method!(
             self.widget_state.window_origin()
         }
 
+        pub fn window_layout_rect(&self) -> Rect {
+            self.widget_state.window_layout_rect()
+        }
+
+        pub fn paint_rect(&self) -> Rect {
+            self.widget_state.paint_rect()
+        }
+
         /// The clip path of the widget, if any was set.
         ///
         /// For more information, see
@@ -1219,6 +1227,11 @@ mod private {
     pub trait Sealed {}
 }
 
+// TODO - Rethink RawWrapper API
+// We're exporting a trait with a method that returns a private type.
+// It's mostly fine because the trait is sealed anyway, but it's not great for documentation.
+
+#[allow(private_interfaces)]
 pub trait IsContext: private::Sealed {
     fn get_widget_state(&mut self) -> &mut WidgetState;
 }
@@ -1227,6 +1240,7 @@ macro_rules! impl_context_trait {
     ($SomeCtx:tt) => {
         impl private::Sealed for $SomeCtx<'_> {}
 
+        #[allow(private_interfaces)]
         impl IsContext for $SomeCtx<'_> {
             fn get_widget_state(&mut self) -> &mut WidgetState {
                 self.widget_state

--- a/masonry/src/debug_logger.rs
+++ b/masonry/src/debug_logger.rs
@@ -164,14 +164,14 @@ impl DebugLogger {
         if !self.activated {
             return;
         }
-        let widget_id = widget.state().id.to_raw() as u32;
+        let widget_id = widget.ctx().widget_state.id.to_raw() as u32;
         let layout_info = LayoutInfo {
-            layout_rect: widget.state().layout_rect(),
+            layout_rect: widget.ctx().widget_state.layout_rect(),
             typename: widget.deref().short_type_name().into(),
             children: widget
                 .children()
                 .into_iter()
-                .map(|child| child.state().id.to_raw() as u32)
+                .map(|child| child.ctx().widget_state.id.to_raw() as u32)
                 .collect(),
         };
 
@@ -186,7 +186,7 @@ impl DebugLogger {
 
     pub fn get_widget_state(widget: WidgetRef<'_, dyn Widget>) -> StateTree {
         let mut state = StateTree::default();
-        let w_state = widget.state();
+        let w_state = widget.ctx().widget_state;
 
         // TODO
         #[cfg(debug_assertions)]
@@ -220,18 +220,18 @@ impl DebugLogger {
             widget: WidgetRef<'_, dyn Widget>,
         ) {
             let mut layout_info = LayoutInfo {
-                layout_rect: widget.state().layout_rect(),
+                layout_rect: widget.ctx().widget_state.layout_rect(),
                 typename: widget.deref().short_type_name().into(),
                 children: Default::default(),
             };
 
             for child in widget.children() {
-                let child_id = child.state().id.to_raw() as u32;
+                let child_id = child.ctx().widget_state.id.to_raw() as u32;
                 layout_info.children.insert(child_id);
                 add_to_tree(widgets_map, widget_states, child);
             }
 
-            let id = widget.state().id.to_raw() as u32;
+            let id = widget.ctx().widget_state.id.to_raw() as u32;
             widgets_map.insert(id, layout_info);
             widget_states.insert(id, DebugLogger::get_widget_state(widget));
         }
@@ -242,7 +242,7 @@ impl DebugLogger {
 
         (
             LayoutTree {
-                root: Some(root_widget.state().id.to_raw() as u32),
+                root: Some(root_widget.ctx().widget_state.id.to_raw() as u32),
                 widgets: Arc::new(widgets_map),
             },
             widget_states,

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -147,6 +147,8 @@ pub use parley::layout::Alignment as TextAlignment;
 pub use util::{AsAny, Handled};
 pub use vello::peniko::{Color, Gradient};
 pub use widget::widget::{AllowRawMut, Widget, WidgetId};
-pub use widget::{WidgetPod, WidgetState};
+pub use widget::WidgetPod;
 
 pub use text::ArcStr;
+
+pub(crate) use widget::WidgetState;

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -240,7 +240,7 @@ impl TestHarness {
     }
 
     fn process_state_after_event(&mut self) {
-        if self.root_widget().state().needs_layout {
+        if self.root_widget().ctx.widget_state.needs_layout {
             self.render_root.root_layout();
         }
     }
@@ -389,7 +389,7 @@ impl TestHarness {
     ///
     /// Combines [`mouse_move`](Self::mouse_move), [`mouse_button_press`](Self::mouse_button_press), and [`mouse_button_release`](Self::mouse_button_release).
     pub fn mouse_click_on(&mut self, id: WidgetId) {
-        let widget_rect = self.get_widget(id).state().window_layout_rect();
+        let widget_rect = self.get_widget(id).ctx().window_layout_rect();
         let widget_center = widget_rect.center();
 
         self.mouse_move(widget_center);
@@ -401,7 +401,7 @@ impl TestHarness {
     pub fn mouse_move_to(&mut self, id: WidgetId) {
         // FIXME - handle case where the widget isn't visible
         // FIXME - assert that the widget correctly receives the event otherwise?
-        let widget_rect = self.get_widget(id).state().window_layout_rect();
+        let widget_rect = self.get_widget(id).ctx().window_layout_rect();
         let widget_center = widget_rect.center();
 
         self.mouse_move(widget_center);

--- a/masonry/src/widget/mod.rs
+++ b/masonry/src/widget/mod.rs
@@ -52,9 +52,9 @@ pub use variable_label::VariableLabel;
 pub use widget_mut::WidgetMut;
 pub use widget_pod::WidgetPod;
 pub use widget_ref::WidgetRef;
-pub use widget_state::WidgetState;
 
 pub(crate) use widget_arena::WidgetArena;
+pub(crate) use widget_state::WidgetState;
 
 use crate::{Affine, Size};
 

--- a/masonry/src/widget/portal.rs
+++ b/masonry/src/widget/portal.rs
@@ -205,11 +205,11 @@ impl<W: Widget> WidgetMut<'_, Portal<W>> {
     }
 
     pub fn set_viewport_pos(&mut self, position: Point) -> bool {
-        let portal_size = self.state().layout_rect().size();
+        let portal_size = self.ctx.layout_rect().size();
         let content_size = self
             .ctx
             .get_mut(&mut self.widget.child)
-            .state()
+            .ctx
             .layout_rect()
             .size();
 
@@ -537,7 +537,7 @@ mod tests {
 
         assert_render_snapshot!(harness, "button_list_scrolled");
 
-        let item_3_rect = harness.get_widget(item_3_id).state().layout_rect();
+        let item_3_rect = harness.get_widget(item_3_id).ctx().layout_rect();
         harness.edit_root_widget(|mut portal| {
             let mut portal = portal.downcast::<Portal<Flex>>();
             portal.pan_viewport_to(item_3_rect);
@@ -545,7 +545,7 @@ mod tests {
 
         assert_render_snapshot!(harness, "button_list_scroll_to_item_3");
 
-        let item_13_rect = harness.get_widget(item_13_id).state().layout_rect();
+        let item_13_rect = harness.get_widget(item_13_id).ctx().layout_rect();
         harness.edit_root_widget(|mut portal| {
             let mut portal = portal.downcast::<Portal<Flex>>();
             portal.pan_viewport_to(item_13_rect);

--- a/masonry/src/widget/tests/layout.rs
+++ b/masonry/src/widget/tests/layout.rs
@@ -25,8 +25,8 @@ fn layout_simple() {
 
     let harness = TestHarness::create(widget);
 
-    let first_box_rect = harness.get_widget(id_1).state().layout_rect();
-    let first_box_paint_rect = harness.get_widget(id_1).state().paint_rect();
+    let first_box_rect = harness.get_widget(id_1).ctx().layout_rect();
+    let first_box_paint_rect = harness.get_widget(id_1).ctx().paint_rect();
 
     assert_eq!(first_box_rect.x0, 0.0);
     assert_eq!(first_box_rect.y0, 0.0);
@@ -55,8 +55,8 @@ fn layout_insets() {
 
     let harness = TestHarness::create(parent_widget);
 
-    let child_paint_rect = harness.get_widget(child_id).state().paint_rect();
-    let parent_paint_rect = harness.get_widget(parent_id).state().paint_rect();
+    let child_paint_rect = harness.get_widget(child_id).ctx().paint_rect();
+    let parent_paint_rect = harness.get_widget(parent_id).ctx().paint_rect();
 
     assert_eq!(child_paint_rect.x0, 0.0);
     assert_eq!(child_paint_rect.y0, -20.0);

--- a/masonry/src/widget/tests/status_change.rs
+++ b/masonry/src/widget/tests/status_change.rs
@@ -21,7 +21,7 @@ fn next_pointer_event(recording: &Recording) -> Option<PointerEvent> {
 }
 
 fn is_hovered(harness: &TestHarness, id: WidgetId) -> bool {
-    harness.get_widget(id).state().is_hovered
+    harness.get_widget(id).ctx().is_hovered()
 }
 
 fn next_hovered_changed(recording: &Recording) -> Option<bool> {
@@ -62,7 +62,7 @@ fn propagate_hovered() {
     padding_rec.clear();
     button_rec.clear();
 
-    harness.inspect_widgets(|widget| assert!(!widget.state().is_hovered));
+    harness.inspect_widgets(|widget| assert!(!widget.ctx().is_hovered()));
 
     // What we are doing here is moving the mouse to different widgets,
     // and verifying both the widget's `is_hovered` status and also that
@@ -72,10 +72,10 @@ fn propagate_hovered() {
 
     harness.mouse_move_to(empty);
 
-    dbg!(harness.get_widget(button).state().window_layout_rect());
-    dbg!(harness.get_widget(pad).state().window_layout_rect());
-    dbg!(harness.get_widget(root).state().window_layout_rect());
-    dbg!(harness.get_widget(empty).state().window_layout_rect());
+    dbg!(harness.get_widget(button).ctx().window_layout_rect());
+    dbg!(harness.get_widget(pad).ctx().window_layout_rect());
+    dbg!(harness.get_widget(root).ctx().window_layout_rect());
+    dbg!(harness.get_widget(empty).ctx().window_layout_rect());
 
     eprintln!("root: {root:?}");
     eprintln!("empty: {empty:?}");

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -216,12 +216,12 @@ pub trait Widget: AsAny {
         for child_id in self.children_ids().iter().rev() {
             let child = ctx.get(*child_id);
 
-            let relative_pos = pos - child.state().window_origin().to_vec2();
+            let relative_pos = pos - child.ctx().window_origin().to_vec2();
             // The position must be inside the child's layout and inside the child's clip path (if
             // any).
-            if !child.state().is_stashed
+            if !child.ctx().is_stashed()
                 && !child.widget.skip_pointer()
-                && child.state().window_layout_rect().contains(pos)
+                && child.ctx().window_layout_rect().contains(pos)
             {
                 return Some(child);
             }

--- a/masonry/src/widget/widget_mut.rs
+++ b/masonry/src/widget/widget_mut.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::contexts::MutateCtx;
-use crate::{Widget, WidgetState};
+use crate::Widget;
 
 // TODO - Document extension trait workaround.
 // See https://xi.zulipchat.com/#narrow/stream/317477-masonry/topic/Thoughts.20on.20simplifying.20WidgetMut/near/436478885
@@ -39,12 +39,6 @@ impl<W: Widget> Drop for WidgetMut<'_, W> {
 }
 
 impl<'w, W: Widget> WidgetMut<'w, W> {
-    // TODO - Replace with individual methods from WidgetState
-    /// Get the [`WidgetState`] of the current widget.
-    pub fn state(&self) -> &WidgetState {
-        self.ctx.widget_state
-    }
-
     /// Get a `WidgetMut` for the same underlying widget with a shorter lifetime.
     pub fn reborrow_mut(&mut self) -> WidgetMut<'_, W> {
         let widget = &mut self.widget;

--- a/masonry/src/widget/widget_ref.rs
+++ b/masonry/src/widget/widget_ref.rs
@@ -168,7 +168,7 @@ impl<'w> WidgetRef<'w, dyn Widget> {
     pub fn find_widget_at_pos(&self, pos: Point) -> Option<WidgetRef<'_, dyn Widget>> {
         let mut innermost_widget = *self;
 
-        if !self.ctx.widget_state.window_layout_rect().contains(pos) {
+        if !self.ctx.window_layout_rect().contains(pos) {
             return None;
         }
 

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -37,7 +37,7 @@ use crate::{CursorIcon, WidgetId};
 /// [`paint`]: crate::Widget::paint
 /// [`WidgetPod`]: crate::WidgetPod
 #[derive(Clone, Debug)]
-pub struct WidgetState {
+pub(crate) struct WidgetState {
     pub(crate) id: WidgetId,
 
     // --- LAYOUT ---


### PR DESCRIPTION
This enforces a pattern in the codebase where that WidgetState can only be accessed through pass contexts, which prevents invalidation bugs.