### PR TITLE
Add needs_rewrite_passes and content_changed methods

### DIFF
--- a/masonry/src/app_driver.rs
+++ b/masonry/src/app_driver.rs
@@ -32,4 +32,12 @@ impl<'a> DriverCtx<'a> {
     pub fn get_root<W: Widget>(&mut self) -> WidgetMut<'_, W> {
         self.main_root_widget.downcast()
     }
+
+    pub fn needs_rewrite_passes(&self) -> bool {
+        self.main_root_widget
+            .ctx
+            .widget_state
+            .needs_rewrite_passes()
+            || self.main_root_widget.ctx.global_state.focus_changed()
+    }
 }

--- a/masonry/src/app_driver.rs
+++ b/masonry/src/app_driver.rs
@@ -33,7 +33,7 @@ impl<'a> DriverCtx<'a> {
         self.main_root_widget.downcast()
     }
 
-    pub fn needs_rewrite_passes(&self) -> bool {
+    pub fn content_changed(&self) -> bool {
         self.main_root_widget
             .ctx
             .widget_state

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -604,12 +604,21 @@ impl RenderRoot {
     pub(crate) fn focus_chain(&mut self) -> &[WidgetId] {
         &self.root_state().focus_chain
     }
+
+    #[allow(dead_code)]
+    pub(crate) fn needs_rewrite_passes(&mut self) -> bool {
+        self.root_state().needs_rewrite_passes() || self.state.focus_changed()
+    }
 }
 
 impl RenderRootState {
     /// Send a signal to the runner of this app, which allows global actions to be triggered by a widget.
     pub(crate) fn emit_signal(&mut self, signal: RenderRootSignal) {
         self.signal_queue.push_back(signal);
+    }
+
+    pub(crate) fn focus_changed(&self) -> bool {
+        self.focused_widget != self.next_focused_widget
     }
 }
 

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -312,6 +312,16 @@ impl WidgetState {
     pub(crate) fn window_origin(&self) -> Point {
         self.window_origin
     }
+
+    pub(crate) fn needs_rewrite_passes(&self) -> bool {
+        self.needs_layout
+            || self.needs_compose
+            || self.needs_paint
+            || self.needs_accessibility
+            || self.needs_anim
+            || self.needs_update_disabled
+            || self.needs_update_stashed
+    }
 }
 
 impl Clone for VisitBool {

--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -118,10 +118,10 @@ where
                 &mut self.ctx,
                 root.child_mut(),
             );
-            if cfg!(debug_assertions) && !self.ctx.view_tree_changed {
-                tracing::debug!("Nothing changed as result of action");
-            }
             self.current_view = next_view;
+        }
+        if cfg!(debug_assertions) && rebuild && !masonry_ctx.content_changed() {
+            tracing::debug!("Nothing changed as result of action");
         }
     }
     fn on_start(&mut self, state: &mut event_loop_runner::MasonryState) {

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -131,7 +131,6 @@ where
         let mut ctx = ViewCtx {
             widget_map: WidgetMap::default(),
             id_path: Vec::new(),
-            view_tree_changed: false,
             proxy,
             runtime: self.runtime,
         };
@@ -241,7 +240,6 @@ pub struct ViewCtx {
     /// This includes only the widgets which might send actions
     widget_map: WidgetMap,
     id_path: Vec<ViewId>,
-    view_tree_changed: bool,
     proxy: Arc<dyn RawProxy>,
     runtime: tokio::runtime::Runtime,
 }
@@ -270,12 +268,6 @@ impl ViewCtx {
     pub fn boxed_pod<W: Widget>(&mut self, pod: Pod<W>) -> Pod<Box<dyn Widget>> {
         Pod {
             inner: pod.inner.boxed(),
-        }
-    }
-
-    pub fn mark_changed(&mut self) {
-        if cfg!(debug_assertions) {
-            self.view_tree_changed = true;
         }
     }
 

--- a/xilem/src/view/button.rs
+++ b/xilem/src/view/button.rs
@@ -57,12 +57,11 @@ where
         &self,
         prev: &Self,
         _: &mut Self::ViewState,
-        ctx: &mut ViewCtx,
+        _ctx: &mut ViewCtx,
         mut element: Mut<'el, Self::Element>,
     ) -> Mut<'el, Self::Element> {
         if prev.label != self.label {
             element.set_text(self.label.clone());
-            ctx.mark_changed();
         }
         element
     }

--- a/xilem/src/view/checkbox.rs
+++ b/xilem/src/view/checkbox.rs
@@ -48,16 +48,14 @@ where
         &self,
         prev: &Self,
         (): &mut Self::ViewState,
-        ctx: &mut ViewCtx,
+        _ctx: &mut ViewCtx,
         mut element: Mut<'el, Self::Element>,
     ) -> Mut<'el, Self::Element> {
         if prev.label != self.label {
             element.set_text(self.label.clone());
-            ctx.mark_changed();
         }
         if prev.checked != self.checked {
             element.set_checked(self.checked);
-            ctx.mark_changed();
         }
         element
     }

--- a/xilem/src/view/flex.rs
+++ b/xilem/src/view/flex.rs
@@ -127,23 +127,18 @@ where
     ) -> Mut<'el, Self::Element> {
         if prev.axis != self.axis {
             element.set_direction(self.axis);
-            ctx.mark_changed();
         }
         if prev.cross_axis_alignment != self.cross_axis_alignment {
             element.set_cross_axis_alignment(self.cross_axis_alignment);
-            ctx.mark_changed();
         }
         if prev.main_axis_alignment != self.main_axis_alignment {
             element.set_main_axis_alignment(self.main_axis_alignment);
-            ctx.mark_changed();
         }
         if prev.fill_major_axis != self.fill_major_axis {
             element.set_must_fill_main_axis(self.fill_major_axis);
-            ctx.mark_changed();
         }
         if prev.gap != self.gap {
             element.set_raw_gap(self.gap);
-            ctx.mark_changed();
         }
         // TODO: Re-use scratch space?
         let mut splice = FlexSplice::new(element);

--- a/xilem/src/view/grid.rs
+++ b/xilem/src/view/grid.rs
@@ -86,15 +86,12 @@ where
     ) -> Mut<'el, Self::Element> {
         if prev.height != self.height {
             element.set_height(self.height);
-            ctx.mark_changed();
         }
         if prev.width != self.width {
             element.set_width(self.width);
-            ctx.mark_changed();
         }
         if prev.spacing != self.spacing {
             element.set_spacing(self.spacing);
-            ctx.mark_changed();
         }
 
         let mut splice = GridSplice::new(element);

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -62,24 +62,20 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
         &self,
         prev: &Self,
         (): &mut Self::ViewState,
-        ctx: &mut ViewCtx,
+        _ctx: &mut ViewCtx,
         mut element: Mut<'el, Self::Element>,
     ) -> Mut<'el, Self::Element> {
         if prev.label != self.label {
             element.set_text(self.label.clone());
-            ctx.mark_changed();
         }
         if prev.text_brush != self.text_brush {
             element.set_text_brush(self.text_brush.clone());
-            ctx.mark_changed();
         }
         if prev.alignment != self.alignment {
             element.set_alignment(self.alignment);
-            ctx.mark_changed();
         }
         if prev.text_size != self.text_size {
             element.set_text_size(self.text_size);
-            ctx.mark_changed();
         }
         element
     }

--- a/xilem/src/view/progress_bar.rs
+++ b/xilem/src/view/progress_bar.rs
@@ -29,12 +29,11 @@ impl<State, Action> View<State, Action, ViewCtx> for ProgressBar {
         &self,
         prev: &Self,
         (): &mut Self::ViewState,
-        ctx: &mut ViewCtx,
+        _ctx: &mut ViewCtx,
         mut element: Mut<'el, Self::Element>,
     ) -> Mut<'el, Self::Element> {
         if prev.progress != self.progress {
             element.set_progress(self.progress);
-            ctx.mark_changed();
         }
         element
     }

--- a/xilem/src/view/prose.rs
+++ b/xilem/src/view/prose.rs
@@ -63,24 +63,20 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
         &self,
         prev: &Self,
         (): &mut Self::ViewState,
-        ctx: &mut ViewCtx,
+        _ctx: &mut ViewCtx,
         mut element: Mut<'el, Self::Element>,
     ) -> Mut<'el, Self::Element> {
         if prev.content != self.content {
             element.set_text(self.content.clone());
-            ctx.mark_changed();
         }
         if prev.text_brush != self.text_brush {
             element.set_text_brush(self.text_brush.clone());
-            ctx.mark_changed();
         }
         if prev.alignment != self.alignment {
             element.set_alignment(self.alignment);
-            ctx.mark_changed();
         }
         if prev.text_size != self.text_size {
             element.set_text_size(self.text_size);
-            ctx.mark_changed();
         }
         element
     }

--- a/xilem/src/view/textbox.rs
+++ b/xilem/src/view/textbox.rs
@@ -82,7 +82,7 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
         &self,
         prev: &Self,
         _: &mut Self::ViewState,
-        ctx: &mut ViewCtx,
+        _ctx: &mut ViewCtx,
         mut element: Mut<'el, Self::Element>,
     ) -> Mut<'el, Self::Element> {
         // Unlike the other properties, we don't compare to the previous value;
@@ -94,16 +94,13 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
         // This is probably not the right behaviour, but determining what is the right behaviour is hard
         if self.contents != element.text() {
             element.reset_text(self.contents.clone());
-            ctx.mark_changed();
         }
 
         if prev.text_brush != self.text_brush {
             element.set_text_brush(self.text_brush.clone());
-            ctx.mark_changed();
         }
         if prev.alignment != self.alignment {
             element.set_alignment(self.alignment);
-            ctx.mark_changed();
         }
         element
     }

--- a/xilem/src/view/variable_label.rs
+++ b/xilem/src/view/variable_label.rs
@@ -117,34 +117,28 @@ impl<State, Action> View<State, Action, ViewCtx> for VariableLabel {
         &self,
         prev: &Self,
         (): &mut Self::ViewState,
-        ctx: &mut ViewCtx,
+        _ctx: &mut ViewCtx,
         mut element: Mut<'el, Self::Element>,
     ) -> Mut<'el, Self::Element> {
         if prev.label != self.label {
             element.set_text(self.label.clone());
-            ctx.mark_changed();
         }
         if prev.text_brush != self.text_brush {
             element.set_text_brush(self.text_brush.clone());
-            ctx.mark_changed();
         }
         if prev.alignment != self.alignment {
             element.set_alignment(self.alignment);
-            ctx.mark_changed();
         }
         if prev.text_size != self.text_size {
             element.set_text_size(self.text_size);
-            ctx.mark_changed();
         }
         if prev.target_weight != self.target_weight {
             element.set_target_weight(self.target_weight.value(), self.over_millis);
-            ctx.mark_changed();
         }
         // First perform a fast filter, then perform a full comparison if that suggests a possible change.
         let fonts_eq = fonts_eq_fastpath(prev.font, self.font) || prev.font == self.font;
         if !fonts_eq {
             element.set_font(self.font);
-            ctx.mark_changed();
         }
         element
     }


### PR DESCRIPTION
These methods will be used with #639 to implement a fixpoint loop for rewrite passes.

This also lets us remove `mark_changed`, since we can use `content_changed` for the same purpose.