### PR TITLE
Improve WidgetMut documentation

### DIFF
--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -100,6 +100,8 @@
 #![cfg_attr(not(debug_assertions), allow(unused))]
 // False-positive with dev-dependencies only used in examples
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
+// Needed because of the SelfMut macro
+#![allow(clippy::needless_arbitrary_self_type)]
 
 // TODO - Add logo
 

--- a/masonry/src/widget/button.rs
+++ b/masonry/src/widget/button.rs
@@ -14,8 +14,8 @@ use crate::paint_scene_helpers::{fill_lin_gradient, stroke, UnitPoint};
 use crate::widget::{Label, WidgetMut, WidgetPod};
 
 use crate::{
-    theme, AccessCtx, AccessEvent, ArcStr, BoxConstraints, EventCtx, Insets, LayoutCtx,
-    LifeCycleCtx, PaintCtx, PointerEvent, Size, StatusChange, TextEvent, Widget, WidgetId,
+    theme, AccessCtx, AccessEvent, ArcStr, BoxConstraints, EventCtx, ImplMut, Insets, LayoutCtx,
+    LifeCycleCtx, PaintCtx, PointerEvent, SelfMut, Size, StatusChange, TextEvent, Widget, WidgetId,
 };
 
 // the minimum padding added to a button.
@@ -64,13 +64,13 @@ impl Button {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, Button> {
+impl ImplMut!('_, Button) {
     /// Set the text.
-    pub fn set_text(&mut self, new_text: impl Into<ArcStr>) {
+    pub fn set_text(self: SelfMut!('_, Button), new_text: impl Into<ArcStr>) {
         self.label_mut().set_text(new_text);
     }
 
-    pub fn label_mut(&mut self) -> WidgetMut<'_, Label> {
+    pub fn label_mut(self: SelfMut!('_, Button)) -> WidgetMut<'_, Label> {
         self.ctx.get_mut(&mut self.widget.label)
     }
 }

--- a/masonry/src/widget/checkbox.rs
+++ b/masonry/src/widget/checkbox.rs
@@ -43,8 +43,9 @@ impl Checkbox {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, Checkbox> {
-    pub fn set_checked(&mut self, checked: bool) {
+use crate::{ImplMut, SelfMut};
+impl ImplMut!('_, Checkbox) {
+    pub fn set_checked(self: SelfMut!('_, Checkbox), checked: bool) {
         self.widget.checked = checked;
         self.ctx.request_paint();
         self.ctx.request_accessibility_update();
@@ -53,11 +54,11 @@ impl WidgetMut<'_, Checkbox> {
     /// Set the text.
     ///
     /// We enforce this to be an `ArcStr` to make the allocation explicit.
-    pub fn set_text(&mut self, new_text: ArcStr) {
+    pub fn set_text(self: SelfMut!('_, Checkbox), new_text: ArcStr) {
         self.label_mut().set_text(new_text);
     }
 
-    pub fn label_mut(&mut self) -> WidgetMut<'_, Label> {
+    pub fn label_mut(self: SelfMut!('_, Checkbox)) -> WidgetMut<'_, Label> {
         self.ctx.get_mut(&mut self.widget.label)
     }
 }

--- a/masonry/src/widget/grid.rs
+++ b/masonry/src/widget/grid.rs
@@ -143,24 +143,34 @@ impl GridParams {
 }
 
 // --- MARK: WIDGETMUT---
-impl<'a> WidgetMut<'a, Grid> {
+use crate::{ImplMut, SelfMut};
+impl ImplMut!('_, Grid) {
     /// Add a child widget.
     ///
     /// See also [`with_child`].
     ///
     /// [`with_child`]: Grid::with_child
-    pub fn add_child(&mut self, child: impl Widget, params: GridParams) {
+    pub fn add_child(self: SelfMut!('_, Grid), child: impl Widget, params: GridParams) {
         let child_pod: WidgetPod<Box<dyn Widget>> = WidgetPod::new(Box::new(child));
         self.insert_child_pod(child_pod, params);
     }
 
-    pub fn add_child_id(&mut self, child: impl Widget, id: WidgetId, params: GridParams) {
+    pub fn add_child_id(
+        self: SelfMut!('_, Grid),
+        child: impl Widget,
+        id: WidgetId,
+        params: GridParams,
+    ) {
         let child_pod: WidgetPod<Box<dyn Widget>> = WidgetPod::new_with_id(Box::new(child), id);
         self.insert_child_pod(child_pod, params);
     }
 
     /// Add a child widget.
-    pub fn insert_child_pod(&mut self, widget: WidgetPod<Box<dyn Widget>>, params: GridParams) {
+    pub fn insert_child_pod(
+        self: SelfMut!('_, Grid),
+        widget: WidgetPod<Box<dyn Widget>>,
+        params: GridParams,
+    ) {
         let child = new_grid_child(params, widget);
         self.widget.children.push(child);
         self.ctx.children_changed();
@@ -168,7 +178,7 @@ impl<'a> WidgetMut<'a, Grid> {
     }
 
     pub fn insert_grid_child_at(
-        &mut self,
+        self: SelfMut!('_, Grid),
         idx: usize,
         child: impl Widget,
         params: impl Into<GridParams>,
@@ -177,7 +187,7 @@ impl<'a> WidgetMut<'a, Grid> {
     }
 
     pub fn insert_grid_child_pod(
-        &mut self,
+        self: SelfMut!('_, Grid),
         idx: usize,
         child: WidgetPod<Box<dyn Widget>>,
         params: impl Into<GridParams>,
@@ -188,22 +198,25 @@ impl<'a> WidgetMut<'a, Grid> {
         self.ctx.request_layout();
     }
 
-    pub fn set_spacing(&mut self, spacing: f64) {
+    pub fn set_spacing(self: SelfMut!('_, Grid), spacing: f64) {
         self.widget.grid_spacing = spacing;
         self.ctx.request_layout();
     }
 
-    pub fn set_width(&mut self, width: i32) {
+    pub fn set_width(self: SelfMut!('_, Grid), width: i32) {
         self.widget.grid_width = width;
         self.ctx.request_layout();
     }
 
-    pub fn set_height(&mut self, height: i32) {
+    pub fn set_height(self: SelfMut!('_, Grid), height: i32) {
         self.widget.grid_height = height;
         self.ctx.request_layout();
     }
 
-    pub fn child_mut(&mut self, idx: usize) -> Option<WidgetMut<'_, Box<dyn Widget>>> {
+    pub fn child_mut(
+        self: SelfMut!('_, Grid),
+        idx: usize,
+    ) -> Option<WidgetMut<'_, Box<dyn Widget>>> {
         let child = match self.widget.children[idx].widget_mut() {
             Some(widget) => widget,
             None => return None,
@@ -217,13 +230,13 @@ impl<'a> WidgetMut<'a, Grid> {
     /// # Panics
     ///
     /// Panics if the element at `idx` is not a widget.
-    pub fn update_child_grid_params(&mut self, idx: usize, params: GridParams) {
+    pub fn update_child_grid_params(self: SelfMut!('_, Grid), idx: usize, params: GridParams) {
         let child = &mut self.widget.children[idx];
         child.update_params(params);
         self.ctx.request_layout();
     }
 
-    pub fn remove_child(&mut self, idx: usize) {
+    pub fn remove_child(self: SelfMut!('_, Grid), idx: usize) {
         let child = self.widget.children.remove(idx);
         self.ctx.remove_child(child.widget);
         self.ctx.request_layout();

--- a/masonry/src/widget/image.rs
+++ b/masonry/src/widget/image.rs
@@ -53,7 +53,7 @@ impl Image {
 }
 
 // --- MARK: WIDGETMUT ---
-impl<'a> WidgetMut<'a, Image> {
+impl WidgetMut<'_, Image> {
     /// Modify the widget's object fit.
     #[inline]
     pub fn set_fit_mode(&mut self, new_object_fit: ObjectFit) {

--- a/masonry/src/widget/label.rs
+++ b/masonry/src/widget/label.rs
@@ -107,12 +107,16 @@ impl Label {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, Label> {
+use crate::{ImplMut, SelfMut};
+impl ImplMut!('_, Label) {
     pub fn text(&self) -> &ArcStr {
         self.widget.text_layout.text()
     }
 
-    pub fn set_text_properties<R>(&mut self, f: impl FnOnce(&mut TextLayout<ArcStr>) -> R) -> R {
+    pub fn set_text_properties<R>(
+        self: SelfMut!('_, Label),
+        f: impl FnOnce(&mut TextLayout<ArcStr>) -> R,
+    ) -> R {
         let ret = f(&mut self.widget.text_layout);
         if self.widget.text_layout.needs_rebuild() {
             self.ctx.request_layout();
@@ -120,13 +124,13 @@ impl WidgetMut<'_, Label> {
         ret
     }
 
-    pub fn set_text(&mut self, new_text: impl Into<ArcStr>) {
+    pub fn set_text(self: SelfMut!('_, Label), new_text: impl Into<ArcStr>) {
         let new_text = new_text.into();
         self.set_text_properties(|layout| layout.set_text(new_text));
     }
 
     #[doc(alias = "set_text_color")]
-    pub fn set_text_brush(&mut self, brush: impl Into<TextBrush>) {
+    pub fn set_text_brush(self: SelfMut!('_, Label), brush: impl Into<TextBrush>) {
         let brush = brush.into();
         self.widget.brush = brush;
         if !self.ctx.is_disabled() {
@@ -134,19 +138,19 @@ impl WidgetMut<'_, Label> {
             self.set_text_properties(|layout| layout.set_brush(brush));
         }
     }
-    pub fn set_text_size(&mut self, size: f32) {
+    pub fn set_text_size(self: SelfMut!('_, Label), size: f32) {
         self.set_text_properties(|layout| layout.set_text_size(size));
     }
-    pub fn set_alignment(&mut self, alignment: Alignment) {
+    pub fn set_alignment(self: SelfMut!('_, Label), alignment: Alignment) {
         self.set_text_properties(|layout| layout.set_text_alignment(alignment));
     }
-    pub fn set_font(&mut self, font_stack: FontStack<'static>) {
+    pub fn set_font(self: SelfMut!('_, Label), font_stack: FontStack<'static>) {
         self.set_text_properties(|layout| layout.set_font(font_stack));
     }
-    pub fn set_font_family(&mut self, family: FontFamily<'static>) {
+    pub fn set_font_family(self: SelfMut!('_, Label), family: FontFamily<'static>) {
         self.set_font(FontStack::Single(family));
     }
-    pub fn set_line_break_mode(&mut self, line_break_mode: LineBreaking) {
+    pub fn set_line_break_mode(self: SelfMut!('_, Label), line_break_mode: LineBreaking) {
         self.widget.line_break_mode = line_break_mode;
         self.ctx.request_paint();
     }

--- a/masonry/src/widget/mod.rs
+++ b/masonry/src/widget/mod.rs
@@ -115,3 +115,38 @@ impl ObjectFit {
         Affine::new([scalex, 0., 0., scaley, origin_x, origin_y])
     }
 }
+
+// --- MARK: RECEIVER ---
+
+#[cfg(FALSE)]
+mod example {
+    // This:
+
+    impl ImplMut!('_, Button) {
+        /// Set the text.
+        pub fn set_text(self: SelfMut!('_, Button), new_text: impl Into<ArcStr>) {
+            self.label_mut().set_text(new_text);
+        }
+
+        pub fn label_mut(&mut self) -> WidgetMut<'_, Label> {
+            self.ctx.get_mut(&mut self.widget.label)
+        }
+    }
+
+    // Will resolve to this if cfg(doc):
+    impl Button {
+        /// Set the text.
+        pub fn set_text(self: WidgetMut<'_, Button>, new_text: impl Into<ArcStr>) {
+            self.label_mut().set_text(new_text);
+        }
+    }
+
+    // Else resolve to this
+    use crate::ImplMut;
+    impl ImplMut!('_, Button) {
+        /// Set the text.
+        pub fn set_text(self: &mut Self, new_text: impl Into<ArcStr>) {
+            self.label_mut().set_text(new_text);
+        }
+    }
+}

--- a/masonry/src/widget/portal.rs
+++ b/masonry/src/widget/portal.rs
@@ -167,28 +167,30 @@ impl<W: Widget> Portal<W> {
 }
 
 // --- MARK: WIDGETMUT ---
-impl<W: Widget> WidgetMut<'_, Portal<W>> {
-    pub fn child_mut(&mut self) -> WidgetMut<'_, W> {
+
+use crate::{ImplMut, SelfMut};
+impl<W: Widget> ImplMut!('_, Portal<W>) {
+    pub fn child_mut(self: SelfMut!('_, Portal<W>)) -> WidgetMut<'_, W> {
         self.ctx.get_mut(&mut self.widget.child)
     }
 
-    pub fn horizontal_scrollbar_mut(&mut self) -> WidgetMut<'_, ScrollBar> {
+    pub fn horizontal_scrollbar_mut(self: SelfMut!('_, Portal<W>)) -> WidgetMut<'_, ScrollBar> {
         self.ctx.get_mut(&mut self.widget.scrollbar_horizontal)
     }
 
-    pub fn vertical_scrollbar_mut(&mut self) -> WidgetMut<'_, ScrollBar> {
+    pub fn vertical_scrollbar_mut(self: SelfMut!('_, Portal<W>)) -> WidgetMut<'_, ScrollBar> {
         self.ctx.get_mut(&mut self.widget.scrollbar_vertical)
     }
 
     // TODO - rewrite doc
     /// Set whether to constrain the child horizontally.
-    pub fn set_constrain_horizontal(&mut self, constrain: bool) {
+    pub fn set_constrain_horizontal(self: SelfMut!('_, Portal<W>), constrain: bool) {
         self.widget.constrain_horizontal = constrain;
         self.ctx.request_layout();
     }
 
     /// Set whether to constrain the child vertically.
-    pub fn set_constrain_vertical(&mut self, constrain: bool) {
+    pub fn set_constrain_vertical(self: SelfMut!('_, Portal<W>), constrain: bool) {
         self.widget.constrain_vertical = constrain;
         self.ctx.request_layout();
     }
@@ -199,12 +201,12 @@ impl<W: Widget> WidgetMut<'_, Portal<W>> {
     /// See [`content_must_fill`] for more details.
     ///
     /// [`content_must_fill`]: ClipBox::content_must_fill
-    pub fn set_content_must_fill(&mut self, must_fill: bool) {
+    pub fn set_content_must_fill(self: SelfMut!('_, Portal<W>), must_fill: bool) {
         self.widget.must_fill = must_fill;
         self.ctx.request_layout();
     }
 
-    pub fn set_viewport_pos(&mut self, position: Point) -> bool {
+    pub fn set_viewport_pos(self: SelfMut!('_, Portal<W>), position: Point) -> bool {
         let portal_size = self.ctx.layout_rect().size();
         let content_size = self
             .ctx
@@ -228,12 +230,12 @@ impl<W: Widget> WidgetMut<'_, Portal<W>> {
         pos_changed
     }
 
-    pub fn pan_viewport_by(&mut self, translation: Vec2) -> bool {
+    pub fn pan_viewport_by(self: SelfMut!('_, Portal<W>), translation: Vec2) -> bool {
         self.set_viewport_pos(self.widget.viewport_pos + translation)
     }
 
     // Note - Rect is in child coordinates
-    pub fn pan_viewport_to(&mut self, target: Rect) -> bool {
+    pub fn pan_viewport_to(self: SelfMut!('_, Portal<W>), target: Rect) -> bool {
         let viewport = Rect::from_origin_size(self.widget.viewport_pos, self.ctx.widget_state.size);
 
         let new_pos_x = compute_pan_range(

--- a/masonry/src/widget/progress_bar.rs
+++ b/masonry/src/widget/progress_bar.rs
@@ -79,8 +79,9 @@ impl ProgressBar {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, ProgressBar> {
-    pub fn set_progress(&mut self, progress: Option<f64>) {
+use crate::{ImplMut, SelfMut};
+impl ImplMut!('_, ProgressBar) {
+    pub fn set_progress(self: SelfMut!('_, ProgressBar), progress: Option<f64>) {
         self.widget.set_progress(progress);
         self.ctx.request_layout();
         self.ctx.request_accessibility_update();

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -85,13 +85,14 @@ impl Prose {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, Prose> {
+use crate::{ImplMut, SelfMut};
+impl ImplMut!('_, Prose) {
     pub fn text(&self) -> &ArcStr {
         self.widget.text_layout.text()
     }
 
     pub fn set_text_properties<R>(
-        &mut self,
+        self: SelfMut!('_, Prose),
         f: impl FnOnce(&mut TextWithSelection<ArcStr>) -> R,
     ) -> R {
         let ret = f(&mut self.widget.text_layout);
@@ -104,7 +105,7 @@ impl WidgetMut<'_, Prose> {
     /// Change the text. If the user currently has a selection in the box, this will delete that selection.
     ///
     /// We enforce this to be an `ArcStr` to make the allocation explicit.
-    pub fn set_text(&mut self, new_text: ArcStr) {
+    pub fn set_text(self: SelfMut!('_, Prose), new_text: ArcStr) {
         if self.ctx.is_focused() {
             tracing::info!(
                 "Called reset_text on a focused `Prose`. This will lose the user's current selection"
@@ -114,7 +115,7 @@ impl WidgetMut<'_, Prose> {
     }
 
     #[doc(alias = "set_text_color")]
-    pub fn set_text_brush(&mut self, brush: impl Into<TextBrush>) {
+    pub fn set_text_brush(self: SelfMut!('_, Prose), brush: impl Into<TextBrush>) {
         let brush = brush.into();
         self.widget.brush = brush;
         if !self.ctx.is_disabled() {
@@ -122,19 +123,19 @@ impl WidgetMut<'_, Prose> {
             self.set_text_properties(|layout| layout.set_brush(brush));
         }
     }
-    pub fn set_text_size(&mut self, size: f32) {
+    pub fn set_text_size(self: SelfMut!('_, Prose), size: f32) {
         self.set_text_properties(|layout| layout.set_text_size(size));
     }
-    pub fn set_alignment(&mut self, alignment: Alignment) {
+    pub fn set_alignment(self: SelfMut!('_, Prose), alignment: Alignment) {
         self.set_text_properties(|layout| layout.set_text_alignment(alignment));
     }
-    pub fn set_font(&mut self, font_stack: FontStack<'static>) {
+    pub fn set_font(self: SelfMut!('_, Prose), font_stack: FontStack<'static>) {
         self.set_text_properties(|layout| layout.set_font(font_stack));
     }
-    pub fn set_font_family(&mut self, family: FontFamily<'static>) {
+    pub fn set_font_family(self: SelfMut!('_, Prose), family: FontFamily<'static>) {
         self.set_font(FontStack::Single(family));
     }
-    pub fn set_line_break_mode(&mut self, line_break_mode: LineBreaking) {
+    pub fn set_line_break_mode(self: SelfMut!('_, Prose), line_break_mode: LineBreaking) {
         self.widget.line_break_mode = line_break_mode;
         self.ctx.request_paint();
     }

--- a/masonry/src/widget/root_widget.rs
+++ b/masonry/src/widget/root_widget.rs
@@ -32,8 +32,9 @@ impl<W: Widget> RootWidget<W> {
     }
 }
 
-impl<W: Widget> WidgetMut<'_, RootWidget<W>> {
-    pub fn child_mut(&mut self) -> WidgetMut<'_, W> {
+use crate::{ImplMut, SelfMut};
+impl<W: Widget> ImplMut!('_, RootWidget<W>) {
+    pub fn child_mut(self: SelfMut!('_, RootWidget<W>)) -> WidgetMut<'_, W> {
         self.ctx.get_mut(&mut self.widget.pod)
     }
 }

--- a/masonry/src/widget/scroll_bar.rs
+++ b/masonry/src/widget/scroll_bar.rs
@@ -104,16 +104,17 @@ impl ScrollBar {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, ScrollBar> {
+use crate::{ImplMut, SelfMut};
+impl ImplMut!('_, ScrollBar) {
     // TODO - Remove?
-    pub fn set_sizes(&mut self, portal_size: f64, content_size: f64) {
+    pub fn set_sizes(self: SelfMut!('_, ScrollBar), portal_size: f64, content_size: f64) {
         self.widget.portal_size = portal_size;
         self.widget.content_size = content_size;
         self.ctx.request_paint();
     }
 
     // TODO - Remove?
-    pub fn set_content_size(&mut self, content_size: f64) {
+    pub fn set_content_size(self: SelfMut!('_, ScrollBar), content_size: f64) {
         // TODO - cursor_progress
         self.widget.content_size = content_size;
         self.ctx.request_paint();

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -184,8 +184,9 @@ impl SizedBox {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, SizedBox> {
-    pub fn set_child(&mut self, child: impl Widget) {
+use crate::{ImplMut, SelfMut};
+impl ImplMut!('_, SizedBox) {
+    pub fn set_child(self: SelfMut!('_, SizedBox), child: impl Widget) {
         if let Some(child) = self.widget.child.take() {
             self.ctx.remove_child(child);
         }
@@ -194,32 +195,32 @@ impl WidgetMut<'_, SizedBox> {
         self.ctx.request_layout();
     }
 
-    pub fn remove_child(&mut self) {
+    pub fn remove_child(self: SelfMut!('_, SizedBox)) {
         if let Some(child) = self.widget.child.take() {
             self.ctx.remove_child(child);
         }
     }
 
     /// Set container's width.
-    pub fn set_width(&mut self, width: f64) {
+    pub fn set_width(self: SelfMut!('_, SizedBox), width: f64) {
         self.widget.width = Some(width);
         self.ctx.request_layout();
     }
 
     /// Set container's height.
-    pub fn set_height(&mut self, height: f64) {
+    pub fn set_height(self: SelfMut!('_, SizedBox), height: f64) {
         self.widget.height = Some(height);
         self.ctx.request_layout();
     }
 
     /// Set container's width.
-    pub fn unset_width(&mut self) {
+    pub fn unset_width(self: SelfMut!('_, SizedBox)) {
         self.widget.width = None;
         self.ctx.request_layout();
     }
 
     /// Set container's height.
-    pub fn unset_height(&mut self) {
+    pub fn unset_height(self: SelfMut!('_, SizedBox)) {
         self.widget.height = None;
         self.ctx.request_layout();
     }
@@ -230,19 +231,23 @@ impl WidgetMut<'_, SizedBox> {
     /// notably, it can be any [`Color`], any gradient, or an [`Image`].
     ///
     /// [`Image`]: vello::peniko::Image
-    pub fn set_background(&mut self, brush: impl Into<Brush>) {
+    pub fn set_background(self: SelfMut!('_, SizedBox), brush: impl Into<Brush>) {
         self.widget.background = Some(brush.into());
         self.ctx.request_paint();
     }
 
     /// Clears background.
-    pub fn clear_background(&mut self) {
+    pub fn clear_background(self: SelfMut!('_, SizedBox)) {
         self.widget.background = None;
         self.ctx.request_paint();
     }
 
     /// Paint a border around the widget with a color and width.
-    pub fn set_border(&mut self, color: impl Into<Color>, width: impl Into<f64>) {
+    pub fn set_border(
+        self: SelfMut!('_, SizedBox),
+        color: impl Into<Color>,
+        width: impl Into<f64>,
+    ) {
         self.widget.border = Some(BorderStyle {
             color: color.into(),
             width: width.into(),
@@ -251,19 +256,19 @@ impl WidgetMut<'_, SizedBox> {
     }
 
     /// Clears border.
-    pub fn clear_border(&mut self) {
+    pub fn clear_border(self: SelfMut!('_, SizedBox)) {
         self.widget.border = None;
         self.ctx.request_layout();
     }
 
     /// Round off corners of this container by setting a corner radius
-    pub fn set_rounded(&mut self, radius: impl Into<RoundedRectRadii>) {
+    pub fn set_rounded(self: SelfMut!('_, SizedBox), radius: impl Into<RoundedRectRadii>) {
         self.widget.corner_radius = radius.into();
         self.ctx.request_paint();
     }
 
     // TODO - Doc
-    pub fn child_mut(&mut self) -> Option<WidgetMut<'_, Box<dyn Widget>>> {
+    pub fn child_mut(self: SelfMut!('_, SizedBox)) -> Option<WidgetMut<'_, Box<dyn Widget>>> {
         let child = self.widget.child.as_mut()?;
         Some(self.ctx.get_mut(child))
     }

--- a/masonry/src/widget/spinner.rs
+++ b/masonry/src/widget/spinner.rs
@@ -56,15 +56,16 @@ impl Default for Spinner {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, Spinner> {
+use crate::{ImplMut, SelfMut};
+impl ImplMut!('_, Spinner) {
     /// Set the spinner's color.
-    pub fn set_color(&mut self, color: impl Into<Color>) {
+    pub fn set_color(self: SelfMut!('_, Spinner), color: impl Into<Color>) {
         self.widget.color = color.into();
         self.ctx.request_paint();
     }
 
     /// Reset the spinner's color to its default value.
-    pub fn reset_color(&mut self) {
+    pub fn reset_color(self: SelfMut!('_, Spinner)) {
         self.set_color(DEFAULT_SPINNER_COLOR);
     }
 }

--- a/masonry/src/widget/split.rs
+++ b/masonry/src/widget/split.rs
@@ -298,12 +298,13 @@ impl Split {
 // FIXME - Add unit tests for WidgetMut<Split>
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, Split> {
+use crate::{ImplMut, SelfMut};
+impl ImplMut!('_, Split) {
     /// Set the split point as a fraction of the split axis.
     ///
     /// The value must be between `0.0` and `1.0`, inclusive.
     /// The default split point is `0.5`.
-    pub fn set_split_point(&mut self, split_point: f64) {
+    pub fn set_split_point(self: SelfMut!('_, Split), split_point: f64) {
         assert!(
             (0.0..=1.0).contains(&split_point),
             "split_point must be in the range [0.0-1.0]!"
@@ -316,7 +317,7 @@ impl WidgetMut<'_, Split> {
     ///
     /// The value must be greater than or equal to `0.0`.
     /// The value will be rounded up to the nearest integer.
-    pub fn set_min_size(&mut self, first: f64, second: f64) {
+    pub fn set_min_size(self: SelfMut!('_, Split), first: f64, second: f64) {
         assert!(first >= 0.0);
         assert!(second >= 0.0);
         self.widget.min_size = (first.ceil(), second.ceil());
@@ -328,7 +329,7 @@ impl WidgetMut<'_, Split> {
     /// The value must be positive or zero.
     /// The value will be rounded up to the nearest integer.
     /// The default splitter bar size is `6.0`.
-    pub fn set_bar_size(&mut self, bar_size: f64) {
+    pub fn set_bar_size(self: SelfMut!('_, Split), bar_size: f64) {
         assert!(bar_size >= 0.0, "bar_size must be 0.0 or greater!");
         self.widget.bar_size = bar_size.ceil();
         self.ctx.request_layout();
@@ -346,14 +347,14 @@ impl WidgetMut<'_, Split> {
     /// The value must be positive or zero.
     /// The value will be rounded up to the nearest integer.
     /// The default minimum splitter bar area is `6.0`.
-    pub fn set_min_bar_area(&mut self, min_bar_area: f64) {
+    pub fn set_min_bar_area(self: SelfMut!('_, Split), min_bar_area: f64) {
         assert!(min_bar_area >= 0.0, "min_bar_area must be 0.0 or greater!");
         self.widget.min_bar_area = min_bar_area.ceil();
         self.ctx.request_layout();
     }
 
     /// Set whether the split point can be changed by dragging.
-    pub fn set_draggable(&mut self, draggable: bool) {
+    pub fn set_draggable(self: SelfMut!('_, Split), draggable: bool) {
         self.widget.draggable = draggable;
         self.ctx.request_paint();
     }
@@ -361,7 +362,7 @@ impl WidgetMut<'_, Split> {
     /// Set whether the splitter bar is drawn as a solid rectangle.
     ///
     /// If this is `false` (the default), the bar will be drawn as two parallel lines.
-    pub fn set_bar_solid(&mut self, solid: bool) {
+    pub fn set_bar_solid(self: SelfMut!('_, Split), solid: bool) {
         self.widget.solid = solid;
         self.ctx.request_paint();
     }

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -98,13 +98,14 @@ impl Textbox {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, Textbox> {
+use crate::{ImplMut, SelfMut};
+impl ImplMut!('_, Textbox) {
     pub fn text(&self) -> &str {
         self.widget.editor.text()
     }
 
     pub fn set_text_properties<R>(
-        &mut self,
+        self: SelfMut!('_, Textbox),
         f: impl FnOnce(&mut TextWithSelection<String>) -> R,
     ) -> R {
         let ret = f(&mut self.widget.editor);
@@ -121,7 +122,7 @@ impl WidgetMut<'_, Textbox> {
     // FIXME - it's not clear whether this is the right behaviour, or if there even
     // is one.
     // TODO: Create a method which sets the text and the cursor selection to be used if focused?
-    pub fn reset_text(&mut self, new_text: String) {
+    pub fn reset_text(self: SelfMut!('_, Textbox), new_text: String) {
         if self.ctx.is_focused() {
             tracing::warn!(
                 "Called reset_text on a focused `Textbox`. This will lose the user's current selection and cursor"
@@ -132,7 +133,7 @@ impl WidgetMut<'_, Textbox> {
     }
 
     #[doc(alias = "set_text_color")]
-    pub fn set_text_brush(&mut self, brush: impl Into<TextBrush>) {
+    pub fn set_text_brush(self: SelfMut!('_, Textbox), brush: impl Into<TextBrush>) {
         let brush = brush.into();
         self.widget.brush = brush;
         if !self.ctx.is_disabled() {
@@ -140,19 +141,19 @@ impl WidgetMut<'_, Textbox> {
             self.set_text_properties(|layout| layout.set_brush(brush));
         }
     }
-    pub fn set_text_size(&mut self, size: f32) {
+    pub fn set_text_size(self: SelfMut!('_, Textbox), size: f32) {
         self.set_text_properties(|layout| layout.set_text_size(size));
     }
-    pub fn set_alignment(&mut self, alignment: Alignment) {
+    pub fn set_alignment(self: SelfMut!('_, Textbox), alignment: Alignment) {
         self.set_text_properties(|layout| layout.set_text_alignment(alignment));
     }
-    pub fn set_font(&mut self, font_stack: FontStack<'static>) {
+    pub fn set_font(self: SelfMut!('_, Textbox), font_stack: FontStack<'static>) {
         self.set_text_properties(|layout| layout.set_font(font_stack));
     }
-    pub fn set_font_family(&mut self, family: FontFamily<'static>) {
+    pub fn set_font_family(self: SelfMut!('_, Textbox), family: FontFamily<'static>) {
         self.set_font(FontStack::Single(family));
     }
-    pub fn set_line_break_mode(&mut self, line_break_mode: LineBreaking) {
+    pub fn set_line_break_mode(self: SelfMut!('_, Textbox), line_break_mode: LineBreaking) {
         self.widget.line_break_mode = line_break_mode;
         self.ctx.request_paint();
         self.ctx.request_accessibility_update();

--- a/masonry/src/widget/variable_label.rs
+++ b/masonry/src/widget/variable_label.rs
@@ -213,7 +213,8 @@ impl VariableLabel {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, VariableLabel> {
+use crate::{ImplMut, SelfMut};
+impl ImplMut!('_, VariableLabel) {
     /// Read the text.
     pub fn text(&self) -> &ArcStr {
         self.widget.text_layout.text()
@@ -222,7 +223,10 @@ impl WidgetMut<'_, VariableLabel> {
     /// Set a property on the underlying text.
     ///
     /// This cannot be used to set attributes.
-    pub fn set_text_properties<R>(&mut self, f: impl FnOnce(&mut TextLayout<ArcStr>) -> R) -> R {
+    pub fn set_text_properties<R>(
+        self: SelfMut!('_, VariableLabel),
+        f: impl FnOnce(&mut TextLayout<ArcStr>) -> R,
+    ) -> R {
         let ret = f(&mut self.widget.text_layout);
         if self.widget.text_layout.needs_rebuild() {
             self.ctx.request_layout();
@@ -231,14 +235,14 @@ impl WidgetMut<'_, VariableLabel> {
     }
 
     /// Modify the underlying text.
-    pub fn set_text(&mut self, new_text: impl Into<ArcStr>) {
+    pub fn set_text(self: SelfMut!('_, VariableLabel), new_text: impl Into<ArcStr>) {
         let new_text = new_text.into();
         self.set_text_properties(|layout| layout.set_text(new_text));
     }
 
     #[doc(alias = "set_text_color")]
     /// Set the brush of the text, normally used for the colour.
-    pub fn set_text_brush(&mut self, brush: impl Into<TextBrush>) {
+    pub fn set_text_brush(self: SelfMut!('_, VariableLabel), brush: impl Into<TextBrush>) {
         let brush = brush.into();
         self.widget.brush = brush;
         if !self.ctx.is_disabled() {
@@ -247,28 +251,28 @@ impl WidgetMut<'_, VariableLabel> {
         }
     }
     /// Set the font size for this text.
-    pub fn set_text_size(&mut self, size: f32) {
+    pub fn set_text_size(self: SelfMut!('_, VariableLabel), size: f32) {
         self.set_text_properties(|layout| layout.set_text_size(size));
     }
     /// Set the text alignment of the contained text
-    pub fn set_alignment(&mut self, alignment: Alignment) {
+    pub fn set_alignment(self: SelfMut!('_, VariableLabel), alignment: Alignment) {
         self.set_text_properties(|layout| layout.set_text_alignment(alignment));
     }
     /// Set the font (potentially with fallbacks) which will be used for this text.
-    pub fn set_font(&mut self, font_stack: FontStack<'static>) {
+    pub fn set_font(self: SelfMut!('_, VariableLabel), font_stack: FontStack<'static>) {
         self.set_text_properties(|layout| layout.set_font(font_stack));
     }
     /// A helper method to use a single font family.
-    pub fn set_font_family(&mut self, family: FontFamily<'static>) {
+    pub fn set_font_family(self: SelfMut!('_, VariableLabel), family: FontFamily<'static>) {
         self.set_font(FontStack::Single(family));
     }
     /// How to handle overflowing lines.
-    pub fn set_line_break_mode(&mut self, line_break_mode: LineBreaking) {
+    pub fn set_line_break_mode(self: SelfMut!('_, VariableLabel), line_break_mode: LineBreaking) {
         self.widget.line_break_mode = line_break_mode;
         self.ctx.request_layout();
     }
     /// Set the weight which this font will target.
-    pub fn set_target_weight(&mut self, target: f32, over_millis: f32) {
+    pub fn set_target_weight(self: SelfMut!('_, VariableLabel), target: f32, over_millis: f32) {
         self.widget.weight.move_to(target, over_millis);
         self.ctx.request_layout();
         self.ctx.request_anim_frame();

--- a/masonry/src/widget/widget_mut.rs
+++ b/masonry/src/widget/widget_mut.rs
@@ -82,4 +82,87 @@ impl<'a> WidgetMut<'a, Box<dyn Widget>> {
     }
 }
 
+// --- MARK: RECEIVER ---
+
+#[cfg(FALSE)]
+mod example {
+    // This:
+
+    impl ImplMut!('_, Button) {
+        /// Set the text.
+        pub fn set_text(self: SelfMut!('_, Button), new_text: impl Into<ArcStr>) {
+            self.label_mut().set_text(new_text);
+        }
+
+        pub fn label_mut(&mut self) -> WidgetMut<'_, Label> {
+            self.ctx.get_mut(&mut self.widget.label)
+        }
+    }
+
+    // Will resolve to this if cfg(doc):
+    impl Button {
+        /// Set the text.
+        pub fn set_text(self: WidgetMut<'_, Button>, new_text: impl Into<ArcStr>) {
+            self.label_mut().set_text(new_text);
+        }
+    }
+
+    // Else resolve to this
+    use crate::ImplMut;
+    impl ImplMut!('_, Button) {
+        /// Set the text.
+        pub fn set_text(self: &mut Self, new_text: impl Into<ArcStr>) {
+            self.label_mut().set_text(new_text);
+        }
+    }
+}
+
+#[cfg(doc)]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! ImplMut {
+    ($lifetime:lifetime, $widget:ty) => {
+        $widget
+    };
+}
+
+#[cfg(not(doc))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! ImplMut {
+    ($lifetime:lifetime, $widget:ty) => {
+        WidgetMut<$lifetime, $widget>
+    };
+}
+
+#[cfg(doc)]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! SelfMut {
+    ($lifetime:lifetime, $widget:ty) => {
+        &'_ mut WidgetMut<$lifetime, $widget>
+    };
+}
+
+#[cfg(not(doc))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! SelfMut {
+    ($lifetime:lifetime, $widget:ty) => {
+        &mut Self
+    };
+}
+
+#[cfg(doc)]
+impl<W: Widget> std::ops::Deref for WidgetMut<'_, W> {
+    type Target = W;
+
+    fn deref(&self) -> &Self::Target {
+        &self.widget
+    }
+}
+
+#[cfg(doc)]
+impl<W: Widget> std::ops::Receiver for WidgetMut<'_, W> {}
+
 // TODO - unit tests


### PR DESCRIPTION
This PR introduces an `ImplMut` macro and a `SelfMut` macro which resolve to different types depending on whether we're generating doc. The doc version uses the unstable receiver trait.

For details, see [this zulip thread](https://xi.zulipchat.com/#narrow/stream/317477-masonry/topic/Improving.20docs.20for.20WidgetMut).

> As far I know, the doc is generated using a nightly compiler, so that should be fine. It means we are using unstable features to generate our docs. And not only that, unstable features that are scheduled to be broken fairly soon (the receiver trait syntax above works with a current nightly compiler, but it's not the one promoted by the latest RFC).
>
> But since this can only cause breakage when uploading a new version and not, like, when people download masonry as a dependency, I think it's a worthwhile tradeoff.

I'm not quite sure how to document this yet. It's a pretty far-ranging change.

Also, because I want to avoid merge conflicts with other PRs in the pipeline, imports in this PR are still messy.

Leaving this PR as a draft for now.