### PR TITLE
Stop storing text in TextLayout

### DIFF
--- a/masonry/src/text/text_layout.rs
+++ b/masonry/src/text/text_layout.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use parley::context::RangedBuilder;
 use parley::fontique::{Style, Weight};
 use parley::layout::{Alignment, Cursor};
-use parley::style::{Brush as BrushTrait, FontFamily, FontStack, GenericFamily, StyleProperty};
+use parley::style::{FontFamily, FontStack, GenericFamily, StyleProperty};
 use parley::{FontContext, Layout, LayoutContext};
 use vello::kurbo::{Affine, Line, Point, Rect, Size};
 use vello::peniko::{self, Color, Gradient};
@@ -37,8 +37,7 @@ use crate::text::render_text;
 ///
 /// TODO: Update docs to mentionParley
 #[derive(Clone)]
-pub struct TextLayout<T> {
-    text: T,
+pub struct TextLayout {
     // TODO: Find a way to let this use borrowed data
     scale: f32,
 
@@ -57,6 +56,8 @@ pub struct TextLayout<T> {
     needs_line_breaks: bool,
     layout: Layout<TextBrush>,
     scratch_scene: Scene,
+    // TODO - Add field to check whether text has changed since last layout
+    // #[cfg(debug_assertions)] last_text_start: String,
 }
 
 /// Whether a section of text should be hinted.
@@ -101,7 +102,7 @@ impl TextBrush {
     }
 }
 
-impl BrushTrait for TextBrush {}
+impl parley::style::Brush for TextBrush {}
 
 impl From<peniko::Brush> for TextBrush {
     fn from(value: peniko::Brush) -> Self {
@@ -140,11 +141,10 @@ pub struct LayoutMetrics {
     //TODO: add inking_rect
 }
 
-impl<T> TextLayout<T> {
+impl TextLayout {
     /// Create a new `TextLayout` object.
-    pub fn new(text: T, text_size: f32) -> Self {
+    pub fn new(text_size: f32) -> Self {
         TextLayout {
-            text,
             scale: 1.0,
 
             brush: crate::theme::TEXT_COLOR.into(),
@@ -264,48 +264,20 @@ impl<T> TextLayout<T> {
     pub fn needs_rebuild(&self) -> bool {
         self.needs_layout || self.needs_line_breaks
     }
-
-    // TODO: What are the valid use cases for this, where we shouldn't use a run-specific check instead?
-    // /// Returns `true` if this layout's text appears to be right-to-left.
-    // ///
-    // /// See [`piet::util::first_strong_rtl`] for more information.
-    // ///
-    // /// [`piet::util::first_strong_rtl`]: crate::piet::util::first_strong_rtl
-    // pub fn text_is_rtl(&self) -> bool {
-    //     self.text_is_rtl
-    // }
 }
 
-impl<T: AsRef<str> + Eq> TextLayout<T> {
+impl TextLayout {
     #[track_caller]
     fn assert_rebuilt(&self, method: &str) {
         if self.needs_layout || self.needs_line_breaks {
-            debug_panic!(
-                "TextLayout::{method} called without rebuilding layout object. Text was '{}'",
-                self.text.as_ref().chars().take(250).collect::<String>()
-            );
+            if cfg!(debug_assertions) {
+                // TODO - Include self.last_text_start
+                #[cfg(debug_assertions)]
+                panic!("TextLayout::{method} called without rebuilding layout object.");
+            } else {
+                tracing::error!("TextLayout::{method} called without rebuilding layout object.",);
+            };
         }
-    }
-
-    /// Set the text to display.
-    pub fn set_text(&mut self, text: T) {
-        if self.text != text {
-            self.text = text;
-            self.invalidate();
-        }
-    }
-
-    /// Returns the string backing this layout, if it exists.
-    pub fn text(&self) -> &T {
-        &self.text
-    }
-
-    /// Returns the string backing this layout, if it exists.
-    ///
-    /// Invalidates the layout and so should only be used when definitely applying an edit
-    pub fn text_mut(&mut self) -> &mut T {
-        self.invalidate();
-        &mut self.text
     }
 
     /// Returns the inner Parley [`Layout`] value.
@@ -359,90 +331,45 @@ impl<T: AsRef<str> + Eq> TextLayout<T> {
     }
 
     /// Given the utf-8 position of a character boundary in the underlying text,
-    /// return the `Point` (relative to this object's origin) representing the
-    /// boundary of the containing grapheme.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `text_pos` is not a character boundary.
-    ///
-    /// This is not meaningful until [`Self::rebuild`] has been called.
-    pub fn cursor_for_text_position(&self, text_pos: usize) -> Cursor {
-        self.assert_rebuilt("cursor_for_text_position");
-
-        // TODO: As a reminder, `is_leading` is not very useful to us; we don't know this ahead of time
-        // We're going to need to do quite a bit of remedial work on these
-        // e.g. to handle a inside a ligature made of multiple (unicode) grapheme clusters
-        // https://raphlinus.github.io/text/2020/10/26/text-layout.html#shaping-cluster
-        // But we're choosing to defer this work
-        // This also needs to handle affinity.
-        Cursor::from_position(&self.layout, text_pos, true)
-    }
-
-    /// Given the utf-8 position of a character boundary in the underlying text,
-    /// return the `Point` (relative to this object's origin) representing the
-    /// boundary of the containing grapheme.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `text_pos` is not a character boundary.
-    ///
-    /// This is not meaningful until [`Self::rebuild`] has been called.
-    pub fn point_for_text_position(&self, text_pos: usize) -> Point {
-        let cursor = self.cursor_for_text_position(text_pos);
-        Point::new(
-            cursor.advance as f64,
-            (cursor.baseline + cursor.offset) as f64,
-        )
-    }
-
-    // TODO: needed for text selection
-    // /// Given a utf-8 range in the underlying text, return a `Vec` of `Rect`s
-    // /// representing the nominal bounding boxes of the text in that range.
-    // ///
-    // /// # Panics
-    // ///
-    // /// Panics if the range start or end is not a character boundary.
-    // pub fn rects_for_range(&self, range: Range<usize>) -> Vec<Rect> {
-    //     self.layout.rects_for_range(range)
-    // }
-
-    /// Given the utf-8 position of a character boundary in the underlying text,
     /// return a `Line` suitable for drawing a vertical cursor at that boundary.
     ///
     /// This is not meaningful until [`Self::rebuild`] has been called.
-    // TODO: This is too simplistic. See https://raphlinus.github.io/text/2020/10/26/text-layout.html#shaping-cluster
-    // for example. This would break in a `fi` ligature
-    pub fn cursor_line_for_text_position(&self, text_pos: usize) -> Line {
-        let from_position = self.cursor_for_text_position(text_pos);
+    pub fn caret_line_from_byte_index(&self, byte_index: usize) -> Option<Line> {
+        // TODO - Handle affinity
+        // For now we give is_leading: true, which means the caret is before
+        // the character at byte_index, which matches how we interpret character boundaries.
+        let caret = Cursor::from_position(&self.layout, byte_index, true);
 
-        let line = from_position.path.line(&self.layout).unwrap();
+        let line = caret.path.line(&self.layout)?;
         let line_metrics = line.metrics();
 
         let baseline = line_metrics.baseline + line_metrics.descent;
-        let p1 = (from_position.offset as f64, baseline as f64);
-        let p2 = (
-            from_position.offset as f64,
-            (baseline - line_metrics.size()) as f64,
-        );
-        Line::new(p1, p2)
+        let line_size = line_metrics.size();
+        let p1 = (caret.offset as f64, baseline as f64);
+        let p2 = (caret.offset as f64, (baseline - line_size) as f64);
+        Some(Line::new(p1, p2))
     }
 
     /// Rebuild the inner layout as needed.
     ///
     /// This `TextLayout` object manages a lower-level layout object that may
-    /// need to be rebuilt in response to changes to the text or attributes
-    /// like the font.
+    /// need to be rebuilt in response to changes to text attributes like the font.
     ///
     /// This method should be called whenever any of these things may have changed.
     /// A simple way to ensure this is correct is to always call this method
     /// as part of your widget's [`layout`][crate::Widget::layout] method.
+    ///
+    /// The `text_changed` parameter should be set to `true` if the text changed since
+    /// the last rebuild. Always setting it to true may lead to redundant work, wrongly
+    /// setting it to false may lead to invalidation bugs.
     pub fn rebuild(
         &mut self,
         font_ctx: &mut FontContext,
         layout_ctx: &mut LayoutContext<TextBrush>,
+        text: &str,
+        text_changed: bool,
     ) {
-        self.rebuild_with_attributes(font_ctx, layout_ctx, |builder| builder);
+        self.rebuild_with_attributes(font_ctx, layout_ctx, text, text_changed, |builder| builder);
     }
 
     /// Rebuild the inner layout as needed, adding attributes to the underlying layout.
@@ -452,14 +379,21 @@ impl<T: AsRef<str> + Eq> TextLayout<T> {
         &mut self,
         font_ctx: &mut FontContext,
         layout_ctx: &mut LayoutContext<TextBrush>,
+        text: &str,
+        text_changed: bool,
         attributes: impl for<'b> FnOnce(
             RangedBuilder<'b, TextBrush, &'b str>,
         ) -> RangedBuilder<'b, TextBrush, &'b str>,
     ) {
-        if self.needs_layout {
+        // TODO - check against self.last_text_start
+
+        if self.needs_layout || text_changed {
             self.needs_layout = false;
 
-            let mut builder = layout_ctx.ranged_builder(font_ctx, self.text.as_ref(), self.scale);
+            // Workaround for how parley treats empty lines.
+            //let text = if !text.is_empty() { text } else { " " };
+
+            let mut builder = layout_ctx.ranged_builder(font_ctx, text, self.scale);
             builder.push_default(&StyleProperty::Brush(self.brush.clone()));
             builder.push_default(&StyleProperty::FontSize(self.text_size));
             builder.push_default(&StyleProperty::FontStack(self.font));
@@ -474,7 +408,7 @@ impl<T: AsRef<str> + Eq> TextLayout<T> {
 
             self.needs_line_breaks = true;
         }
-        if self.needs_line_breaks {
+        if self.needs_line_breaks || text_changed {
             self.needs_line_breaks = false;
             self.layout
                 .break_all_lines(self.max_advance, self.alignment);
@@ -505,10 +439,9 @@ impl<T: AsRef<str> + Eq> TextLayout<T> {
     }
 }
 
-impl<T: AsRef<str> + Eq> std::fmt::Debug for TextLayout<T> {
+impl std::fmt::Debug for TextLayout {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("TextLayout")
-            .field("text", &self.text.as_ref())
             .field("scale", &self.scale)
             .field("brush", &self.brush)
             .field("font", &self.font)
@@ -525,8 +458,8 @@ impl<T: AsRef<str> + Eq> std::fmt::Debug for TextLayout<T> {
     }
 }
 
-impl<T: AsRef<str> + Eq + Default> Default for TextLayout<T> {
+impl Default for TextLayout {
     fn default() -> Self {
-        Self::new(Default::default(), crate::theme::TEXT_SIZE_NORMAL as f32)
+        Self::new(crate::theme::TEXT_SIZE_NORMAL as f32)
     }
 }

--- a/masonry/src/widget/label.rs
+++ b/masonry/src/widget/label.rs
@@ -35,11 +35,9 @@ pub enum LineBreaking {
 
 /// A widget displaying non-editable text.
 pub struct Label {
-    // We hardcode the underlying storage type as `ArcStr` for `Label`
-    // More advanced use cases will almost certainly need a custom widget, anyway
-    // (Rich text is not yet fully integrated, and so the architecture by which a label
-    // has rich text properties specified still needs to be designed)
-    text_layout: TextLayout<ArcStr>,
+    text: ArcStr,
+    text_changed: bool,
+    text_layout: TextLayout,
     line_break_mode: LineBreaking,
     show_disabled: bool,
     brush: TextBrush,
@@ -51,7 +49,9 @@ impl Label {
     /// Create a new label.
     pub fn new(text: impl Into<ArcStr>) -> Self {
         Self {
-            text_layout: TextLayout::new(text.into(), crate::theme::TEXT_SIZE_NORMAL as f32),
+            text: text.into(),
+            text_changed: false,
+            text_layout: TextLayout::new(crate::theme::TEXT_SIZE_NORMAL as f32),
             line_break_mode: LineBreaking::Overflow,
             show_disabled: true,
             brush: crate::theme::TEXT_COLOR.into(),
@@ -67,7 +67,7 @@ impl Label {
     }
 
     pub fn text(&self) -> &ArcStr {
-        self.text_layout.text()
+        &self.text
     }
 
     #[doc(alias = "with_text_color")]
@@ -109,10 +109,10 @@ impl Label {
 // --- MARK: WIDGETMUT ---
 impl WidgetMut<'_, Label> {
     pub fn text(&self) -> &ArcStr {
-        self.widget.text_layout.text()
+        &self.widget.text
     }
 
-    pub fn set_text_properties<R>(&mut self, f: impl FnOnce(&mut TextLayout<ArcStr>) -> R) -> R {
+    pub fn set_text_properties<R>(&mut self, f: impl FnOnce(&mut TextLayout) -> R) -> R {
         let ret = f(&mut self.widget.text_layout);
         if self.widget.text_layout.needs_rebuild() {
             self.ctx.request_layout();
@@ -122,7 +122,9 @@ impl WidgetMut<'_, Label> {
 
     pub fn set_text(&mut self, new_text: impl Into<ArcStr>) {
         let new_text = new_text.into();
-        self.set_text_properties(|layout| layout.set_text(new_text));
+        self.widget.text = new_text;
+        self.widget.text_changed = true;
+        self.ctx.request_layout();
     }
 
     #[doc(alias = "set_text_color")]
@@ -221,9 +223,11 @@ impl Widget for Label {
             None
         };
         self.text_layout.set_max_advance(max_advance);
-        if self.text_layout.needs_rebuild() {
+        if self.text_layout.needs_rebuild() || self.text_changed {
             let (font_ctx, layout_ctx) = ctx.text_contexts();
-            self.text_layout.rebuild(font_ctx, layout_ctx);
+            self.text_layout
+                .rebuild(font_ctx, layout_ctx, &self.text, self.text_changed);
+            self.text_changed = false;
         }
         // We ignore trailing whitespace for a label
         let text_size = self.text_layout.size();
@@ -236,7 +240,10 @@ impl Widget for Label {
 
     fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
         if self.text_layout.needs_rebuild() {
-            debug_panic!("Called Label paint before layout");
+            debug_panic!(
+                "Called {name}::paint with invalid layout",
+                name = self.short_type_name()
+            );
         }
         if self.line_break_mode == LineBreaking::Clip {
             let clip_rect = ctx.size().to_rect();
@@ -271,7 +278,7 @@ impl Widget for Label {
     }
 
     fn get_debug_text(&self) -> Option<String> {
-        Some(self.text_layout.text().as_ref().to_string())
+        Some(self.text.to_string())
     }
 }
 

--- a/masonry/src/widget/progress_bar.rs
+++ b/masonry/src/widget/progress_bar.rs
@@ -117,7 +117,7 @@ impl Widget for ProgressBar {
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size {
         const DEFAULT_WIDTH: f64 = 400.;
 
-        if self.label.needs_rebuild() {
+        if self.label.needs_rebuild() || self.progress_changed {
             let (font_ctx, layout_ctx) = ctx.text_contexts();
             self.label
                 .rebuild(font_ctx, layout_ctx, &self.value(), self.progress_changed);

--- a/masonry/src/widget/progress_bar.rs
+++ b/masonry/src/widget/progress_bar.rs
@@ -25,7 +25,8 @@ pub struct ProgressBar {
     /// `None` variant can be used to show a progress bar without a percentage.
     /// It is also used if an invalid float (outside of [0, 1]) is passed.
     progress: Option<f64>,
-    label: TextLayout<ArcStr>,
+    progress_changed: bool,
+    label: TextLayout,
 }
 
 impl ProgressBar {
@@ -39,11 +40,11 @@ impl ProgressBar {
         out.set_progress(progress);
         out
     }
-
     fn new_indefinite() -> Self {
         Self {
             progress: None,
-            label: TextLayout::new("".into(), crate::theme::TEXT_SIZE_NORMAL as f32),
+            progress_changed: false,
+            label: TextLayout::new(crate::theme::TEXT_SIZE_NORMAL as f32),
         }
     }
 
@@ -52,13 +53,8 @@ impl ProgressBar {
         // check to see if we can avoid doing work
         if self.progress != progress {
             self.progress = progress;
-            self.update_text();
+            self.progress_changed = true;
         }
-    }
-
-    /// Updates the text layout with the current part-complete value
-    fn update_text(&mut self) {
-        self.label.set_text(self.value());
     }
 
     fn value(&self) -> ArcStr {
@@ -123,7 +119,9 @@ impl Widget for ProgressBar {
 
         if self.label.needs_rebuild() {
             let (font_ctx, layout_ctx) = ctx.text_contexts();
-            self.label.rebuild(font_ctx, layout_ctx);
+            self.label
+                .rebuild(font_ctx, layout_ctx, &self.value(), self.progress_changed);
+            self.progress_changed = false;
         }
         let label_size = self.label.size();
 

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -260,7 +260,10 @@ impl Widget for Prose {
 
     fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
         if self.text_layout.needs_rebuild() {
-            debug_panic!("Called Label paint before layout");
+            debug_panic!(
+                "Called {name}::paint with invalid layout",
+                name = self.short_type_name()
+            );
         }
         if self.line_break_mode == LineBreaking::Clip {
             let clip_rect = ctx.size().to_rect();

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -299,7 +299,10 @@ impl Widget for Textbox {
 
     fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
         if self.editor.needs_rebuild() {
-            debug_panic!("Called Label paint before layout");
+            debug_panic!(
+                "Called {name}::paint with invalid layout",
+                name = self.short_type_name()
+            );
         }
         if self.line_break_mode == LineBreaking::Clip {
             let clip_rect = ctx.size().to_rect();

--- a/masonry/src/widget/variable_label.rs
+++ b/masonry/src/widget/variable_label.rs
@@ -134,7 +134,9 @@ impl AnimationStatus {
 // TODO: Make this a wrapper (around `Label`?)
 /// A widget displaying non-editable text, with a variable [weight](parley::style::FontWeight).
 pub struct VariableLabel {
-    text_layout: TextLayout<ArcStr>,
+    text: ArcStr,
+    text_changed: bool,
+    text_layout: TextLayout,
     line_break_mode: LineBreaking,
     show_disabled: bool,
     brush: TextBrush,
@@ -146,7 +148,9 @@ impl VariableLabel {
     /// Create a new label.
     pub fn new(text: impl Into<ArcStr>) -> Self {
         Self {
-            text_layout: TextLayout::new(text.into(), crate::theme::TEXT_SIZE_NORMAL as f32),
+            text: text.into(),
+            text_changed: false,
+            text_layout: TextLayout::new(crate::theme::TEXT_SIZE_NORMAL as f32),
             line_break_mode: LineBreaking::Overflow,
             show_disabled: true,
             brush: crate::theme::TEXT_COLOR.into(),
@@ -155,7 +159,7 @@ impl VariableLabel {
     }
 
     pub fn text(&self) -> &ArcStr {
-        self.text_layout.text()
+        &self.text
     }
 
     #[doc(alias = "with_text_color")]
@@ -216,13 +220,13 @@ impl VariableLabel {
 impl WidgetMut<'_, VariableLabel> {
     /// Read the text.
     pub fn text(&self) -> &ArcStr {
-        self.widget.text_layout.text()
+        &self.widget.text
     }
 
     /// Set a property on the underlying text.
     ///
     /// This cannot be used to set attributes.
-    pub fn set_text_properties<R>(&mut self, f: impl FnOnce(&mut TextLayout<ArcStr>) -> R) -> R {
+    pub fn set_text_properties<R>(&mut self, f: impl FnOnce(&mut TextLayout) -> R) -> R {
         let ret = f(&mut self.widget.text_layout);
         if self.widget.text_layout.needs_rebuild() {
             self.ctx.request_layout();
@@ -233,7 +237,9 @@ impl WidgetMut<'_, VariableLabel> {
     /// Modify the underlying text.
     pub fn set_text(&mut self, new_text: impl Into<ArcStr>) {
         let new_text = new_text.into();
-        self.set_text_properties(|layout| layout.set_text(new_text));
+        self.widget.text = new_text;
+        self.widget.text_changed = true;
+        self.ctx.request_layout();
     }
 
     #[doc(alias = "set_text_color")]
@@ -356,8 +362,12 @@ impl Widget for VariableLabel {
             self.text_layout
                 .set_brush(self.brush(ctx.widget_state.is_disabled));
             let (font_ctx, layout_ctx) = ctx.text_contexts();
-            self.text_layout
-                .rebuild_with_attributes(font_ctx, layout_ctx, |mut builder| {
+            self.text_layout.rebuild_with_attributes(
+                font_ctx,
+                layout_ctx,
+                &self.text,
+                self.text_changed,
+                |mut builder| {
                     builder.push_default(&parley::style::StyleProperty::FontWeight(Weight::new(
                         self.weight.value,
                     )));
@@ -365,7 +375,9 @@ impl Widget for VariableLabel {
                     //     parley::style::FontSettings::List(&[]),
                     // ));
                     builder
-                });
+                },
+            );
+            self.text_changed = false;
         }
         // We ignore trailing whitespace for a label
         let text_size = self.text_layout.size();
@@ -378,7 +390,10 @@ impl Widget for VariableLabel {
 
     fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
         if self.text_layout.needs_rebuild() {
-            debug_panic!("Called Label paint before layout");
+            debug_panic!(
+                "Called {name}::paint with invalid layout",
+                name = self.short_type_name()
+            );
         }
         if self.line_break_mode == LineBreaking::Clip {
             let clip_rect = ctx.size().to_rect();
@@ -409,7 +424,7 @@ impl Widget for VariableLabel {
     }
 
     fn get_debug_text(&self) -> Option<String> {
-        Some(self.text_layout.text().as_ref().to_string())
+        Some(self.text.to_string())
     }
 }
 


### PR DESCRIPTION
Remove type parameter from TextLayout.
Tweak error message in text widgets.

This makes the TextLayout code slightly simpler (though with more invariants) in anticipation of splitting it into its own crate.