### PR TITLE
Reorder update passes

### DIFF
--- a/masonry/src/passes/anim.rs
+++ b/masonry/src/passes/anim.rs
@@ -1,0 +1,67 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use tracing::info_span;
+
+use crate::passes::recurse_on_children;
+use crate::render_root::{RenderRoot, RenderRootState};
+use crate::tree_arena::ArenaMut;
+use crate::{LifeCycle, LifeCycleCtx, Widget, WidgetState};
+
+// --- MARK: UPDATE ANIM ---
+fn update_anim_for_widget(
+    global_state: &mut RenderRootState,
+    mut widget: ArenaMut<'_, Box<dyn Widget>>,
+    mut state: ArenaMut<'_, WidgetState>,
+    elapsed_ns: u64,
+) {
+    let _span = widget.item.make_trace_span().entered();
+
+    if !state.item.needs_anim {
+        return;
+    }
+    state.item.needs_anim = false;
+
+    // Most passes reset their `needs` and `request` flags after the call to
+    // the widget method, but it's valid and expected for `request_anim` to be
+    // set in response to `AnimFrame`.
+    if state.item.request_anim {
+        state.item.request_anim = false;
+        let mut ctx = LifeCycleCtx {
+            global_state,
+            widget_state: state.item,
+            widget_state_children: state.children.reborrow_mut(),
+            widget_children: widget.children.reborrow_mut(),
+        };
+        widget
+            .item
+            .lifecycle(&mut ctx, &LifeCycle::AnimFrame(elapsed_ns));
+    }
+
+    let id = state.item.id;
+    let parent_state = state.item;
+    recurse_on_children(
+        id,
+        widget.reborrow_mut(),
+        state.children,
+        |widget, mut state| {
+            update_anim_for_widget(global_state, widget, state.reborrow_mut(), elapsed_ns);
+            parent_state.merge_up(state.item);
+        },
+    );
+}
+
+/// Run the animation pass.
+pub(crate) fn run_update_anim_pass(root: &mut RenderRoot, elapsed_ns: u64) {
+    let _span = info_span!("update_anim").entered();
+
+    let (root_widget, mut root_state) = root.widget_arena.get_pair_mut(root.root.id());
+    update_anim_for_widget(
+        &mut root.state,
+        root_widget,
+        root_state.reborrow_mut(),
+        elapsed_ns,
+    );
+}
+
+// ----------------

--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -76,8 +76,6 @@ fn run_event_pass<E>(
     Handled::from(is_handled)
 }
 
-// TODO - Send synthetic MouseLeave events
-
 // --- MARK: POINTER_EVENT ---
 pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEvent) -> Handled {
     let _span = info_span!("pointer_event").entered();

--- a/masonry/src/passes/mod.rs
+++ b/masonry/src/passes/mod.rs
@@ -5,13 +5,14 @@ use crate::tree_arena::{ArenaMut, ArenaMutChildren};
 use crate::widget::WidgetArena;
 use crate::{Widget, WidgetId, WidgetState};
 
-pub mod accessibility;
-pub mod compose;
-pub mod event;
-pub mod layout;
-pub mod mutate;
-pub mod paint;
-pub mod update;
+pub(crate) mod accessibility;
+pub(crate) mod anim;
+pub(crate) mod compose;
+pub(crate) mod event;
+pub(crate) mod layout;
+pub(crate) mod mutate;
+pub(crate) mod paint;
+pub(crate) mod update;
 
 pub(crate) fn recurse_on_children(
     id: WidgetId,

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -19,6 +19,7 @@ use crate::debug_logger::DebugLogger;
 use crate::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use crate::event::{PointerEvent, TextEvent, WindowEvent};
 use crate::passes::accessibility::run_accessibility_pass;
+use crate::passes::anim::run_update_anim_pass;
 use crate::passes::compose::run_compose_pass;
 use crate::passes::event::{
     run_on_access_event_pass, run_on_pointer_event_pass, run_on_text_event_pass,
@@ -28,9 +29,9 @@ use crate::passes::mutate::{mutate_widget, run_mutate_pass};
 use crate::passes::paint::run_paint_pass;
 use crate::passes::recurse_on_children;
 use crate::passes::update::{
-    run_update_anim_pass, run_update_disabled_pass, run_update_focus_chain_pass,
-    run_update_focus_pass, run_update_pointer_pass, run_update_scroll_pass,
-    run_update_stashed_pass, run_update_widget_tree_pass,
+    run_update_disabled_pass, run_update_focus_chain_pass, run_update_focus_pass,
+    run_update_pointer_pass, run_update_scroll_pass, run_update_stashed_pass,
+    run_update_widget_tree_pass,
 };
 use crate::text::TextBrush;
 use crate::tree_arena::{ArenaMut, TreeArena};

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -21,7 +21,7 @@ use winit::event::Ime;
 use crate::action::Action;
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::event::{PointerButton, PointerEvent, PointerState, TextEvent, WindowEvent};
-use crate::passes::update::run_update_anim_pass;
+use crate::passes::anim::run_update_anim_pass;
 use crate::render_root::{RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy};
 use crate::testing::{screenshots::get_image_diff, snapshot_utils::get_cargo_workspace};
 use crate::tracing_backend::try_init_test_tracing;


### PR DESCRIPTION
Reorder update passes so their code is in the same order as they're run.
Split out anim pass to a separate file (since it's not run with the other passes).
This is strictly cut-and-paste, no code has been changed.