### PR TITLE
Rename pass functions from root_xxx to run_xxx_pass

### DIFF
--- a/masonry/src/passes/accessibility.rs
+++ b/masonry/src/passes/accessibility.rs
@@ -129,7 +129,7 @@ fn to_accesskit_rect(r: Rect, scale_factor: f64) -> accesskit::Rect {
 }
 
 // --- MARK: ROOT ---
-pub(crate) fn root_accessibility(
+pub(crate) fn run_accessibility_pass(
     root: &mut RenderRoot,
     rebuild_all: bool,
     scale_factor: f64,

--- a/masonry/src/passes/compose.rs
+++ b/masonry/src/passes/compose.rs
@@ -72,7 +72,7 @@ fn compose_widget(
 }
 
 // --- MARK: ROOT ---
-pub(crate) fn root_compose(root: &mut RenderRoot) {
+pub(crate) fn run_compose_pass(root: &mut RenderRoot) {
     let _span = info_span!("compose").entered();
 
     let (root_widget, root_state) = root.widget_arena.get_pair_mut(root.root.id());

--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -79,7 +79,7 @@ fn run_event_pass<E>(
 // TODO - Send synthetic MouseLeave events
 
 // --- MARK: POINTER_EVENT ---
-pub(crate) fn root_on_pointer_event(root: &mut RenderRoot, event: &PointerEvent) -> Handled {
+pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEvent) -> Handled {
     let _span = info_span!("pointer_event").entered();
     if !event.is_high_density() {
         debug!("Running ON_POINTER_EVENT pass with {}", event.short_name());
@@ -126,7 +126,7 @@ pub(crate) fn root_on_pointer_event(root: &mut RenderRoot, event: &PointerEvent)
 // - If a Widget has focus, then none of its parents is hidden
 
 // --- MARK: TEXT EVENT ---
-pub(crate) fn root_on_text_event(root: &mut RenderRoot, event: &TextEvent) -> Handled {
+pub(crate) fn run_on_text_event_pass(root: &mut RenderRoot, event: &TextEvent) -> Handled {
     let _span = info_span!("text_event").entered();
     if !event.is_high_density() {
         debug!("Running ON_TEXT_EVENT pass with {}", event.short_name());
@@ -165,7 +165,7 @@ pub(crate) fn root_on_text_event(root: &mut RenderRoot, event: &TextEvent) -> Ha
 }
 
 // --- MARK: ACCESS EVENT ---
-pub(crate) fn root_on_access_event(
+pub(crate) fn run_on_access_event_pass(
     root: &mut RenderRoot,
     event: &AccessEvent,
     target: WidgetId,

--- a/masonry/src/passes/layout.rs
+++ b/masonry/src/passes/layout.rs
@@ -205,7 +205,7 @@ pub(crate) fn run_layout_on<W: Widget>(
 }
 
 // --- MARK: ROOT ---
-pub(crate) fn root_layout(root: &mut RenderRoot) {
+pub(crate) fn run_layout_pass(root: &mut RenderRoot) {
     if !root.root_state().needs_layout {
         return;
     }

--- a/masonry/src/passes/paint.rs
+++ b/masonry/src/passes/paint.rs
@@ -100,7 +100,7 @@ fn paint_widget(
 }
 
 // --- MARK: ROOT ---
-pub(crate) fn root_paint(root: &mut RenderRoot) -> Scene {
+pub(crate) fn run_paint_pass(root: &mut RenderRoot) -> Scene {
     let _span = info_span!("paint").entered();
 
     let debug_paint = std::env::var("MASONRY_DEBUG_PAINT").is_ok_and(|it| !it.is_empty());

--- a/masonry/src/passes/update.rs
+++ b/masonry/src/passes/update.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use cursor_icon::CursorIcon;
 use tracing::{info_span, trace};
 
-use crate::passes::event::root_on_pointer_event;
+use crate::passes::event::run_on_pointer_event_pass;
 use crate::passes::{merge_state_up, recurse_on_children};
 use crate::render_root::{RenderRoot, RenderRootSignal, RenderRootState};
 use crate::tree_arena::ArenaMut;
@@ -85,7 +85,7 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
     if let Some(id) = root.state.pointer_capture_target {
         if !root.is_still_interactive(id) {
             root.state.pointer_capture_target = None;
-            root_on_pointer_event(root, &PointerEvent::new_pointer_leave());
+            run_on_pointer_event_pass(root, &PointerEvent::new_pointer_leave());
         }
     }
 


### PR DESCRIPTION
This means all the pass functions now have the same naming convention, which makes the code more grep-able.