### PR TITLE
Remove debug_validate method

### DIFF
--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -389,7 +389,6 @@ impl RenderRoot {
         run_update_pointer_pass(self);
 
         self.run_rewrite_passes();
-        self.get_root_widget().debug_validate(false);
 
         handled
     }
@@ -404,7 +403,6 @@ impl RenderRoot {
         run_update_focus_pass(self);
 
         self.run_rewrite_passes();
-        self.get_root_widget().debug_validate(false);
 
         handled
     }
@@ -423,7 +421,6 @@ impl RenderRoot {
         root_on_access_event(self, &event, WidgetId(id));
 
         self.run_rewrite_passes();
-        self.get_root_widget().debug_validate(false);
     }
 
     // --- MARK: PAINT ---

--- a/masonry/src/widget/widget_ref.rs
+++ b/masonry/src/widget/widget_ref.rs
@@ -184,37 +184,6 @@ impl<'w> WidgetRef<'w, dyn Widget> {
 
         Some(innermost_widget)
     }
-
-    /// Recursively check that the Widget tree upholds various invariants.
-    ///
-    /// Can only be called after `on_event` and `lifecycle`.
-    pub fn debug_validate(&self, after_layout: bool) {
-        if cfg!(not(debug_assertions)) {
-            return;
-        }
-
-        // TODO
-        #[cfg(FALSE)]
-        if self.ctx.widget_state.is_new {
-            debug_panic!(
-                "Widget '{}' {} is invalid: widget did not receive WidgetAdded",
-                self.deref().short_type_name(),
-                self.ctx.widget_state.id,
-            );
-        }
-
-        if after_layout && self.ctx.widget_state.needs_layout {
-            debug_panic!(
-                "Widget '{}' {} is invalid: widget layout state not cleared",
-                self.deref().short_type_name(),
-                self.ctx.widget_state.id,
-            );
-        }
-
-        for child in self.children() {
-            child.debug_validate(after_layout);
-        }
-    }
 }
 
 // --- MARK: TESTS ---


### PR DESCRIPTION
I'm pretty sure this method never caught a single bug.

I think the idea of a "safety net" that checks invariants are upheld by passes (without trusting pass code) has merit, but it should be based on a survey of previous bugs in pass code.