### PR TITLE
Create on_anim method

### DIFF
--- a/masonry/src/event.rs
+++ b/masonry/src/event.rs
@@ -243,6 +243,7 @@ pub enum WindowTheme {
 /// widget has been added then.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
+#[allow(variant_size_differences)]
 pub enum Update {
     /// Sent to a `Widget` when it is added to the widget tree. This should be
     /// the first message that each widget receives.
@@ -260,18 +261,6 @@ pub enum Update {
     /// children with the system; this is required for things like correct routing
     /// of events.
     WidgetAdded,
-
-    /// Called at the beginning of a new animation frame.
-    ///
-    /// On the first frame when transitioning from idle to animating, `interval`
-    /// will be 0. (This logic is presently per-window but might change to
-    /// per-widget to make it more consistent). Otherwise it is in nanoseconds.
-    ///
-    /// The `paint` method will be called shortly after this event is finished.
-    /// As a result, you should try to avoid doing anything computationally
-    /// intensive in response to an `AnimFrame` event: it might make the app miss
-    /// the monitor's refresh, causing lag or jerky animations.
-    AnimFrame(u64),
 
     /// Called when the Disabled state of the widget is changed.
     ///
@@ -485,7 +474,6 @@ impl Update {
     pub fn short_name(&self) -> &str {
         match self {
             Update::WidgetAdded => "WidgetAdded",
-            Update::AnimFrame(_) => "AnimFrame",
             Update::DisabledChanged(_) => "DisabledChanged",
             Update::StashedChanged(_) => "StashedChanged",
             Update::RequestPanToChild(_) => "RequestPanToChild",

--- a/masonry/src/passes/anim.rs
+++ b/masonry/src/passes/anim.rs
@@ -6,7 +6,7 @@ use tracing::info_span;
 use crate::passes::recurse_on_children;
 use crate::render_root::{RenderRoot, RenderRootState};
 use crate::tree_arena::ArenaMut;
-use crate::{Update, UpdateCtx, Widget, WidgetState};
+use crate::{UpdateCtx, Widget, WidgetState};
 
 // --- MARK: UPDATE ANIM ---
 fn update_anim_for_widget(
@@ -33,7 +33,7 @@ fn update_anim_for_widget(
             widget_state_children: state.children.reborrow_mut(),
             widget_children: widget.children.reborrow_mut(),
         };
-        widget.item.update(&mut ctx, &Update::AnimFrame(elapsed_ns));
+        widget.item.on_anim_frame(&mut ctx, elapsed_ns);
     }
 
     let id = state.item.id;
@@ -61,5 +61,3 @@ pub(crate) fn run_update_anim_pass(root: &mut RenderRoot, elapsed_ns: u64) {
         elapsed_ns,
     );
 }
-
-// ----------------

--- a/masonry/src/testing/helper_widgets.rs
+++ b/masonry/src/testing/helper_widgets.rs
@@ -30,6 +30,7 @@ use crate::*;
 pub type PointerEventFn<S> = dyn FnMut(&mut S, &mut EventCtx, &PointerEvent);
 pub type TextEventFn<S> = dyn FnMut(&mut S, &mut EventCtx, &TextEvent);
 pub type AccessEventFn<S> = dyn FnMut(&mut S, &mut EventCtx, &AccessEvent);
+pub type AnimFrameFn<S> = dyn FnMut(&mut S, &mut UpdateCtx, u64);
 pub type RegisterChildrenFn<S> = dyn FnMut(&mut S, &mut RegisterCtx);
 pub type StatusChangeFn<S> = dyn FnMut(&mut S, &mut UpdateCtx, &StatusChange);
 pub type UpdateFn<S> = dyn FnMut(&mut S, &mut UpdateCtx, &Update);
@@ -54,6 +55,7 @@ pub struct ModularWidget<S> {
     on_pointer_event: Option<Box<PointerEventFn<S>>>,
     on_text_event: Option<Box<TextEventFn<S>>>,
     on_access_event: Option<Box<AccessEventFn<S>>>,
+    on_anim_frame: Option<Box<AnimFrameFn<S>>>,
     register_children: Option<Box<RegisterChildrenFn<S>>>,
     on_status_change: Option<Box<StatusChangeFn<S>>>,
     update: Option<Box<UpdateFn<S>>>,
@@ -105,9 +107,10 @@ pub enum Record {
     PE(PointerEvent),
     TE(TextEvent),
     AE(AccessEvent),
-    RegisterChildren,
+    AF(u64),
+    RC,
     SC(StatusChange),
-    L(Update),
+    U(Update),
     Layout(Size),
     Compose,
     Paint,
@@ -140,6 +143,7 @@ impl<S> ModularWidget<S> {
             on_pointer_event: None,
             on_text_event: None,
             on_access_event: None,
+            on_anim_frame: None,
             register_children: None,
             on_status_change: None,
             update: None,
@@ -188,6 +192,11 @@ impl<S> ModularWidget<S> {
         f: impl FnMut(&mut S, &mut EventCtx, &AccessEvent) + 'static,
     ) -> Self {
         self.on_access_event = Some(Box::new(f));
+        self
+    }
+
+    pub fn anim_frame_fn(mut self, f: impl FnMut(&mut S, &mut UpdateCtx, u64) + 'static) -> Self {
+        self.on_anim_frame = Some(Box::new(f));
         self
     }
 
@@ -269,6 +278,12 @@ impl<S: 'static> Widget for ModularWidget<S> {
     fn on_access_event(&mut self, ctx: &mut EventCtx, event: &AccessEvent) {
         if let Some(f) = self.on_access_event.as_mut() {
             f(&mut self.state, ctx, event);
+        }
+    }
+
+    fn on_anim_frame(&mut self, ctx: &mut UpdateCtx, interval: u64) {
+        if let Some(f) = self.on_anim_frame.as_mut() {
+            f(&mut self.state, ctx, interval);
         }
     }
 
@@ -489,9 +504,9 @@ impl<W: Widget> Widget for Recorder<W> {
         self.child.on_access_event(ctx, event);
     }
 
-    fn register_children(&mut self, ctx: &mut RegisterCtx) {
-        self.recording.push(Record::RegisterChildren);
-        self.child.register_children(ctx);
+    fn on_anim_frame(&mut self, ctx: &mut UpdateCtx, interval: u64) {
+        self.recording.push(Record::AF(interval));
+        self.child.on_anim_frame(ctx, interval);
     }
 
     fn on_status_change(&mut self, ctx: &mut UpdateCtx, event: &StatusChange) {
@@ -499,8 +514,13 @@ impl<W: Widget> Widget for Recorder<W> {
         self.child.on_status_change(ctx, event);
     }
 
+    fn register_children(&mut self, ctx: &mut RegisterCtx) {
+        self.recording.push(Record::RC);
+        self.child.register_children(ctx);
+    }
+
     fn update(&mut self, ctx: &mut UpdateCtx, event: &Update) {
-        self.recording.push(Record::L(event.clone()));
+        self.recording.push(Record::U(event.clone()));
         self.child.update(ctx, event);
     }
 

--- a/masonry/src/testing/helper_widgets.rs
+++ b/masonry/src/testing/helper_widgets.rs
@@ -87,8 +87,8 @@ pub struct ReplaceChild {
 /// let widget = Label::new("Hello").record(&recording);
 ///
 /// TestHarness::create(widget);
-/// assert_matches!(recording.next().unwrap(), Record::RegisterChildren);
-/// assert_matches!(recording.next().unwrap(), Record::L(Update::WidgetAdded));
+/// assert_matches!(recording.next().unwrap(), Record::RC);
+/// assert_matches!(recording.next().unwrap(), Record::U(Update::WidgetAdded));
 /// ```
 pub struct Recorder<W> {
     recording: Recording,

--- a/masonry/src/widget/spinner.rs
+++ b/masonry/src/widget/spinner.rs
@@ -77,6 +77,15 @@ impl Widget for Spinner {
 
     fn on_access_event(&mut self, _ctx: &mut EventCtx, _event: &AccessEvent) {}
 
+    fn on_anim_frame(&mut self, ctx: &mut UpdateCtx, interval: u64) {
+        self.t += (interval as f64) * 1e-9;
+        if self.t >= 1.0 {
+            self.t = self.t.rem_euclid(1.0);
+        }
+        ctx.request_anim_frame();
+        ctx.request_paint_only();
+    }
+
     fn register_children(&mut self, _ctx: &mut RegisterCtx) {}
 
     fn on_status_change(&mut self, _ctx: &mut UpdateCtx, _event: &StatusChange) {}
@@ -85,14 +94,6 @@ impl Widget for Spinner {
         match event {
             Update::WidgetAdded => {
                 ctx.request_anim_frame();
-            }
-            Update::AnimFrame(interval) => {
-                self.t += (*interval as f64) * 1e-9;
-                if self.t >= 1.0 {
-                    self.t = self.t.rem_euclid(1.0);
-                }
-                ctx.request_anim_frame();
-                ctx.request_paint_only();
             }
             _ => (),
         }

--- a/masonry/src/widget/tests/snapshots/masonry__widget__tests__lifecycle_basic__app_creation.snap
+++ b/masonry/src/widget/tests/snapshots/masonry__widget__tests__lifecycle_basic__app_creation.snap
@@ -4,8 +4,8 @@ assertion_line: 22
 expression: record
 ---
 [
-    RegisterChildren,
-    L(
+    RC,
+    U(
         WidgetAdded,
     ),
     Layout(

--- a/masonry/src/widget/variable_label.rs
+++ b/masonry/src/widget/variable_label.rs
@@ -307,6 +307,16 @@ impl Widget for VariableLabel {
 
     fn on_access_event(&mut self, _ctx: &mut EventCtx, _event: &AccessEvent) {}
 
+    fn on_anim_frame(&mut self, ctx: &mut UpdateCtx, interval: u64) {
+        let millis = (interval as f64 / 1_000_000.) as f32;
+        let result = self.weight.advance(millis);
+        self.text_layout.invalidate();
+        if !result.is_completed() {
+            ctx.request_anim_frame();
+        }
+        ctx.request_layout();
+    }
+
     fn register_children(&mut self, _ctx: &mut RegisterCtx) {}
 
     #[allow(missing_docs)]
@@ -331,15 +341,6 @@ impl Widget for VariableLabel {
                     }
                 }
                 // TODO: Parley seems to require a relayout when colours change
-                ctx.request_layout();
-            }
-            Update::AnimFrame(time) => {
-                let millis = (*time as f64 / 1_000_000.) as f32;
-                let result = self.weight.advance(millis);
-                self.text_layout.invalidate();
-                if !result.is_completed() {
-                    ctx.request_anim_frame();
-                }
                 ctx.request_layout();
             }
             _ => {}

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -79,6 +79,18 @@ pub trait Widget: AsAny {
     /// Handle an event from the platform's accessibility API.
     fn on_access_event(&mut self, ctx: &mut EventCtx, event: &AccessEvent) {}
 
+    /// Called at the beginning of a new animation frame.
+    ///
+    /// On the first frame when transitioning from idle to animating, `interval`
+    /// will be 0. (This logic is presently per-window but might change to
+    /// per-widget to make it more consistent). Otherwise it is in nanoseconds.
+    ///
+    /// The `paint` method will be called shortly after this event is finished.
+    /// As a result, you should try to avoid doing anything computationally
+    /// intensive in response to an `AnimFrame` event: it might make the app miss
+    /// the monitor's refresh, causing lag or jerky animations.
+    fn on_anim_frame(&mut self, ctx: &mut UpdateCtx, interval: u64) {}
+
     #[allow(missing_docs)]
     fn on_status_change(&mut self, ctx: &mut UpdateCtx, event: &StatusChange);
 
@@ -380,6 +392,10 @@ impl Widget for Box<dyn Widget> {
 
     fn on_access_event(&mut self, ctx: &mut EventCtx, event: &AccessEvent) {
         self.deref_mut().on_access_event(ctx, event);
+    }
+
+    fn on_anim_frame(&mut self, ctx: &mut UpdateCtx, interval: u64) {
+        self.deref_mut().on_anim_frame(ctx, interval);
     }
 
     fn register_children(&mut self, ctx: &mut RegisterCtx) {


### PR DESCRIPTION
This marks animation as something that's somewhere between an event (it's triggered externally, it can't be requested synchronously as part of rewrite passes) and an update (it takes the same context type, and isn't tied to a user interaction).