### PR TITLE
Remove potential interactivity from `Label`

### DIFF
--- a/masonry/src/widget/button.rs
+++ b/masonry/src/widget/button.rs
@@ -58,7 +58,7 @@ impl Button {
     /// ```
     pub fn from_label(label: Label) -> Button {
         Button {
-            label: WidgetPod::new(label.with_pointer_interaction(false)),
+            label: WidgetPod::new(label),
         }
     }
 }

--- a/masonry/src/widget/checkbox.rs
+++ b/masonry/src/widget/checkbox.rs
@@ -29,7 +29,7 @@ impl Checkbox {
     pub fn new(checked: bool, text: impl Into<ArcStr>) -> Checkbox {
         Checkbox {
             checked,
-            label: WidgetPod::new(Label::new(text).with_pointer_interaction(false)),
+            label: WidgetPod::new(Label::new(text)),
         }
     }
 
@@ -37,7 +37,7 @@ impl Checkbox {
     pub fn from_label(checked: bool, label: Label) -> Checkbox {
         Checkbox {
             checked,
-            label: WidgetPod::new(label.with_pointer_interaction(false)),
+            label: WidgetPod::new(label),
         }
     }
 }

--- a/masonry/src/widget/label.rs
+++ b/masonry/src/widget/label.rs
@@ -34,7 +34,10 @@ pub enum LineBreaking {
     Overflow,
 }
 
-/// A widget displaying non-editable text.
+/// A widget displaying non-interactive text.
+///
+/// This is useful for creating interactive widgets which internally
+/// need support for displaying text, such as a button.
 pub struct Label {
     text: ArcStr,
     text_changed: bool,
@@ -42,7 +45,6 @@ pub struct Label {
     line_break_mode: LineBreaking,
     show_disabled: bool,
     brush: TextBrush,
-    interactive: bool,
 }
 
 // --- MARK: BUILDERS ---
@@ -56,16 +58,7 @@ impl Label {
             line_break_mode: LineBreaking::Overflow,
             show_disabled: true,
             brush: crate::theme::TEXT_COLOR.into(),
-            interactive: true,
         }
-    }
-
-    /// Sets the value returned by [`accepts_pointer_interaction`].
-    ///
-    /// True by default.
-    pub fn with_pointer_interaction(mut self, interactive: bool) -> Self {
-        self.interactive = interactive;
-        self
     }
 
     pub fn text(&self) -> &ArcStr {
@@ -166,41 +159,15 @@ impl WidgetMut<'_, Label> {
 
 // --- MARK: IMPL WIDGET ---
 impl Widget for Label {
-    fn on_pointer_event(&mut self, _ctx: &mut EventCtx, event: &PointerEvent) {
-        match event {
-            PointerEvent::PointerMove(_point) => {
-                // TODO: Set cursor if over link
-            }
-            PointerEvent::PointerDown(_button, _state) => {
-                // TODO: Start tracking currently pressed
-                // (i.e. don't press)
-            }
-            PointerEvent::PointerUp(_button, _state) => {
-                // TODO: Follow link (if not now dragging ?)
-            }
-            _ => {}
-        }
-    }
+    fn on_pointer_event(&mut self, _ctx: &mut EventCtx, _event: &PointerEvent) {}
 
-    fn on_text_event(&mut self, _ctx: &mut EventCtx, _event: &TextEvent) {
-        // If focused on a link and enter pressed, follow it?
-        // TODO: This sure looks like each link needs its own widget, although I guess the challenge there is
-        // that the bounding boxes can go e.g. across line boundaries?
-    }
+    fn on_text_event(&mut self, _ctx: &mut EventCtx, _event: &TextEvent) {}
 
     fn on_access_event(&mut self, _ctx: &mut EventCtx, _event: &AccessEvent) {}
 
     fn register_children(&mut self, _ctx: &mut RegisterCtx) {}
 
-    #[allow(missing_docs)]
-    fn on_status_change(&mut self, _ctx: &mut UpdateCtx, event: &StatusChange) {
-        match event {
-            StatusChange::FocusChanged(_) => {
-                // TODO: Focus on first link
-            }
-            _ => {}
-        }
-    }
+    fn on_status_change(&mut self, _ctx: &mut UpdateCtx, _event: &StatusChange) {}
 
     fn update(&mut self, ctx: &mut UpdateCtx, event: &Update) {
         match event {
@@ -279,7 +246,7 @@ impl Widget for Label {
     }
 
     fn accepts_pointer_interaction(&self) -> bool {
-        self.interactive
+        false
     }
 
     fn make_trace_span(&self) -> Span {

--- a/masonry/src/widget/tests/status_change.rs
+++ b/masonry/src/widget/tests/status_change.rs
@@ -5,7 +5,7 @@ use assert_matches::assert_matches;
 
 use crate::event::{PointerButton, PointerEvent, PointerState};
 use crate::testing::{widget_ids, Record, Recording, TestHarness, TestWidgetExt as _};
-use crate::widget::{Button, Flex, Label, SizedBox};
+use crate::widget::{Button, Flex, SizedBox};
 use crate::*;
 
 fn next_pointer_event(recording: &Recording) -> Option<PointerEvent> {
@@ -138,23 +138,23 @@ fn propagate_hovered() {
 
 #[test]
 fn update_hovered_on_mouse_leave() {
-    let [label_id] = widget_ids();
+    let [button_id] = widget_ids();
 
-    let label_rec = Recording::default();
+    let button_rec = Recording::default();
 
-    let widget = Label::new("hello").with_id(label_id).record(&label_rec);
+    let widget = Button::new("hello").with_id(button_id).record(&button_rec);
 
     let mut harness = TestHarness::create(widget);
 
-    harness.mouse_move_to(label_id);
-    assert!(is_hovered(&harness, label_id));
+    harness.mouse_move_to(button_id);
+    assert!(is_hovered(&harness, button_id));
 
-    label_rec.clear();
+    button_rec.clear();
     println!("leaving");
     harness.process_pointer_event(PointerEvent::PointerLeave(PointerState::empty()));
 
-    assert!(!is_hovered(&harness, label_id));
-    assert_eq!(next_hovered_changed(&label_rec), Some(false));
+    assert!(!is_hovered(&harness, button_id));
+    assert_eq!(next_hovered_changed(&button_rec), Some(false));
 }
 
 // TODO - https://github.com/PoignardAzur/masonry-rs/issues/58


### PR DESCRIPTION
The whole reason the Label widget exists is as a non-interactive text holder for higher-level widgets. Therefore, it isn't meaningful for it to have interactivity.

More concretely, there is no interactivity currently implemented