### PR TITLE
Remove the dead `links` field from TextLayout

### DIFF
--- a/masonry/src/text/text_layout.rs
+++ b/masonry/src/text/text_layout.rs
@@ -4,7 +4,6 @@
 //! A type for laying out, drawing, and interacting with text.
 
 use std::collections::{HashMap, HashSet};
-use std::rc::Rc;
 
 use accesskit::{NodeBuilder, NodeId, Role, TreeUpdate};
 use parley::context::RangedBuilder;
@@ -13,7 +12,7 @@ use parley::layout::{Alignment, Cursor};
 use parley::style::{FontFamily, FontStack, GenericFamily, StyleProperty};
 use parley::{FontContext, Layout, LayoutContext};
 use unicode_segmentation::UnicodeSegmentation;
-use vello::kurbo::{Affine, Line, Point, Rect, Size};
+use vello::kurbo::{Affine, Line, Point, Size};
 use vello::peniko::{self, Color, Gradient};
 use vello::Scene;
 
@@ -53,8 +52,6 @@ pub struct TextLayout {
 
     alignment: Alignment,
     max_advance: Option<f32>,
-
-    links: Rc<[(Rect, usize)]>,
 
     needs_layout: bool,
     needs_line_breaks: bool,
@@ -184,8 +181,6 @@ impl TextLayout {
 
             max_advance: None,
             alignment: Default::default(),
-
-            links: Rc::new([]),
 
             needs_layout: true,
             needs_line_breaks: true,
@@ -445,11 +440,6 @@ impl TextLayout {
             self.needs_line_breaks = false;
             self.layout
                 .break_all_lines(self.max_advance, self.alignment);
-
-            // TODO:
-            // self.links = text
-            //     .links()
-            // ...
         }
     }
 
@@ -586,7 +576,6 @@ impl std::fmt::Debug for TextLayout {
             .field("outdated?", &self.needs_rebuild())
             .field("width", &self.layout.width())
             .field("height", &self.layout.height())
-            .field("links", &self.links)
             .finish_non_exhaustive()
     }
 }


### PR DESCRIPTION
cc for awareness @mwcampbell.

That field was dead code left behind when we removed previous links support. On that struct is probably not the right field for links to live, since `Label` also uses `TextLayout`, but can't meaningfully support links as part of a different interactive widget.