### PR TITLE
Refactor tracing handling for events

### DIFF
--- a/masonry/src/event.rs
+++ b/masonry/src/event.rs
@@ -384,6 +384,7 @@ impl PointerEvent {
 impl TextEvent {
     pub fn short_name(&self) -> &'static str {
         match self {
+            TextEvent::KeyboardKey(KeyEvent { repeat: true, .. }, _) => "KeyboardKey (repeat)",
             TextEvent::KeyboardKey(_, _) => "KeyboardKey",
             TextEvent::Ime(Ime::Disabled) => "Ime::Disabled",
             TextEvent::Ime(Ime::Enabled) => "Ime::Enabled",
@@ -397,7 +398,7 @@ impl TextEvent {
 
     pub fn is_high_density(&self) -> bool {
         match self {
-            TextEvent::KeyboardKey(event, _) => event.repeat,
+            TextEvent::KeyboardKey(_, _) => false,
             TextEvent::Ime(_) => false,
             // Basically every mouse click/scroll event seems to produce a modifier change event.
             TextEvent::ModifierChange(_) => true,

--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -5,7 +5,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use accesskit_winit::Adapter;
-use tracing::{debug, warn};
+use tracing::{debug, info_span, warn};
 use vello::kurbo::Affine;
 use vello::peniko::Color;
 use vello::util::{RenderContext, RenderSurface};
@@ -458,6 +458,7 @@ impl MasonryState<'_> {
                     .handle_window_event(WindowEvent::Rescale(scale_factor));
             }
             WinitWindowEvent::RedrawRequested => {
+                let _span = info_span!("redraw");
                 self.render_root.handle_window_event(WindowEvent::AnimFrame);
                 let (scene, tree_update) = self.render_root.redraw();
                 self.render(scene);

--- a/masonry/src/passes/update.rs
+++ b/masonry/src/passes/update.rs
@@ -587,7 +587,9 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
                 let is_hovered = hovered_set.contains(&ctx.widget_id());
 
                 if ctx.widget_state.is_hovered != is_hovered {
-                    widget.on_status_change(ctx, &StatusChange::HoveredChanged(is_hovered));
+                    widget.update(ctx, &Update::HoveredChanged(is_hovered));
+                    ctx.widget_state.request_accessibility = true;
+                    ctx.widget_state.needs_accessibility = true;
                 }
                 ctx.widget_state.is_hovered = is_hovered;
             });

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, VecDeque};
 use accesskit::{ActionRequest, TreeUpdate};
 use parley::fontique::{self, Collection, CollectionOptions};
 use parley::{FontContext, LayoutContext};
-use tracing::warn;
+use tracing::{info_span, warn};
 use vello::kurbo::{self, Rect};
 use vello::Scene;
 
@@ -242,6 +242,7 @@ impl RenderRoot {
 
     // --- MARK: PUB FUNCTIONS ---
     pub fn handle_pointer_event(&mut self, event: PointerEvent) -> Handled {
+        let _span = info_span!("pointer_event");
         let handled = run_on_pointer_event_pass(self, &event);
         run_update_pointer_pass(self);
         self.run_rewrite_passes();
@@ -250,6 +251,7 @@ impl RenderRoot {
     }
 
     pub fn handle_text_event(&mut self, event: TextEvent) -> Handled {
+        let _span = info_span!("text_event");
         let handled = run_on_text_event_pass(self, &event);
         run_update_focus_pass(self);
         self.run_rewrite_passes();
@@ -258,6 +260,7 @@ impl RenderRoot {
     }
 
     pub fn handle_access_event(&mut self, event: ActionRequest) {
+        let _span = info_span!("access_event");
         let Ok(id) = event.target.0.try_into() else {
             warn!("Received ActionRequest with id 0. This shouldn't be possible.");
             return;

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -196,6 +196,7 @@ pub trait Widget: AsAny {
     /// As methods recurse through the widget tree, trace spans are added for each child
     /// widget visited, and popped when control flow goes back to the parent. This method
     /// returns a static span (that you can use to filter traces and logs).
+    // TODO: Make include the widget's id?
     fn make_trace_span(&self) -> Span {
         trace_span!("Widget", r#type = self.short_type_name())
     }


### PR DESCRIPTION
Inspired by #687, I thought some more tidying up of the log file was in order.

The main differences are:
1) Higher-scale spans exist for key operations
2) Something is always logged for each event, but less for high-density eventskey 
3) Less is logged for high-density events
4) Key repeats are no longer treated as high density
5) We no longer do extra work if the hover and focus paths haven't changed (which also means less logging)

This PR *does not* depend on #687 