### PR TITLE
Clippy pass, cosmetic fixes, and `rust-version.workspace=true` for web examples

### DIFF
--- a/masonry/src/action.rs
+++ b/masonry/src/action.rs
@@ -9,7 +9,6 @@ use crate::event::PointerButton;
 
 // TODO - TextCursor changed, ImeChanged, EnterKey, MouseEnter
 #[non_exhaustive]
-#[allow(missing_docs)]
 /// Events from UI elements.
 ///
 /// Note: Actions are still a WIP feature.

--- a/masonry/src/app_driver.rs
+++ b/masonry/src/app_driver.rs
@@ -19,7 +19,7 @@ pub trait AppDriver {
     fn on_action(&mut self, ctx: &mut DriverCtx<'_>, widget_id: WidgetId, action: Action);
 
     #[allow(unused_variables)]
-    // reason: otherwise `state` would need to be named `_state` which behaves badly when using rust-analyzer to implent the trait
+    // reason: otherwise `state` would need to be named `_state` which behaves badly when using rust-analyzer to implement the trait
     /// A hook which will be executed when the application starts, to allow initial configuration of the `MasonryState`.
     ///
     /// Use cases include loading fonts.

--- a/masonry/src/app_driver.rs
+++ b/masonry/src/app_driver.rs
@@ -18,7 +18,8 @@ pub struct DriverCtx<'a> {
 pub trait AppDriver {
     fn on_action(&mut self, ctx: &mut DriverCtx<'_>, widget_id: WidgetId, action: Action);
 
-    #[allow(unused_variables)] // reason: otherwise `state` would need to be named `_state` which behaves badly when using rust-analyzer to implent the trait
+    #[allow(unused_variables)]
+    // reason: otherwise `state` would need to be named `_state` which behaves badly when using rust-analyzer to implent the trait
     /// A hook which will be executed when the application starts, to allow initial configuration of the `MasonryState`.
     ///
     /// Use cases include loading fonts.

--- a/masonry/src/app_driver.rs
+++ b/masonry/src/app_driver.rs
@@ -18,7 +18,7 @@ pub struct DriverCtx<'a> {
 pub trait AppDriver {
     fn on_action(&mut self, ctx: &mut DriverCtx<'_>, widget_id: WidgetId, action: Action);
 
-    #[allow(unused_variables)]
+    #[allow(unused_variables)] // reason: otherwise `state` would need to be named `_state` which behaves badly when using rust-analyzer to implent the trait
     /// A hook which will be executed when the application starts, to allow initial configuration of the `MasonryState`.
     ///
     /// Use cases include loading fonts.

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -1236,6 +1236,7 @@ impl<'a, Ctx: IsContext, W> Drop for RawWrapperMut<'a, Ctx, W> {
 }
 
 mod private {
+    #[allow(unnameable_types)] // reason: see https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/
     pub trait Sealed {}
 }
 
@@ -1243,7 +1244,7 @@ mod private {
 // We're exporting a trait with a method that returns a private type.
 // It's mostly fine because the trait is sealed anyway, but it's not great for documentation.
 
-#[allow(private_interfaces)]
+#[allow(private_interfaces)] // reason: see https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/
 pub trait IsContext: private::Sealed {
     fn get_widget_state(&mut self) -> &mut WidgetState;
 }
@@ -1252,7 +1253,7 @@ macro_rules! impl_context_trait {
     ($SomeCtx:tt) => {
         impl private::Sealed for $SomeCtx<'_> {}
 
-        #[allow(private_interfaces)]
+        #[allow(private_interfaces)] // reason: see https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/
         impl IsContext for $SomeCtx<'_> {
             fn get_widget_state(&mut self) -> &mut WidgetState {
                 self.widget_state

--- a/xilem/src/one_of.rs
+++ b/xilem/src/one_of.rs
@@ -146,7 +146,7 @@ impl crate::core::one_of::PhantomElementCtx for ViewCtx {
     type PhantomElement = Pod<Box<dyn Widget>>;
 }
 
-#[allow(unnameable_types)] // Public because of trait visibility rules, but has no public API.
+#[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
 pub enum OneOfWidget<A, B, C, D, E, F, G, H, I> {
     A(WidgetPod<A>),
     B(WidgetPod<B>),
@@ -175,7 +175,7 @@ impl<
     fn on_text_event(&mut self, _ctx: &mut EventCtx, _event: &TextEvent) {}
     fn on_access_event(&mut self, _ctx: &mut EventCtx, _event: &AccessEvent) {}
 
-    #[allow(missing_docs)]
+    #[allow(missing_docs)] // reason: Doesn't do anything and is not available publicly
     fn on_status_change(&mut self, _: &mut UpdateCtx, _: &StatusChange) {
         // Intentionally do nothing
     }

--- a/xilem_core/src/any_view.rs
+++ b/xilem_core/src/any_view.rs
@@ -166,6 +166,7 @@ where
 
 /// The state used by [`AnyView`].
 #[doc(hidden)]
+#[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
 pub struct AnyViewState {
     inner_state: Box<dyn Any>,
     /// The generation is the value which is shown

--- a/xilem_core/src/sequence.rs
+++ b/xilem_core/src/sequence.rs
@@ -199,7 +199,7 @@ where
 }
 
 /// The state used to implement `ViewSequence` for `Option<impl ViewSequence>`
-#[allow(unnameable_types)] // Public because of trait visibility rules, but has no public API.
+#[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
 pub struct OptionSeqState<InnerState> {
     /// The current state.
     ///
@@ -342,7 +342,8 @@ where
 /// to the index, and the other half used for the generation.
 ///
 // This is managed in [`create_vector_view_id`] and [`view_id_to_index_generation`]
-#[doc(hidden)] // Implementation detail, public because of trait visibility rules
+#[doc(hidden)]
+#[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
 pub struct VecViewState<InnerState> {
     inner_states: Vec<InnerState>,
 

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -203,6 +203,7 @@ where
     }
 }
 
+#[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
 pub struct ArcState<ViewState> {
     view_state: ViewState,
     dirty: bool,

--- a/xilem_core/src/views/adapt.rs
+++ b/xilem_core/src/views/adapt.rs
@@ -21,7 +21,6 @@ pub struct Adapt<
 > {
     proxy_fn: ProxyFn,
     child: ChildView,
-    #[allow(clippy::type_complexity)]
     phantom: PhantomData<
         fn() -> (
             ParentState,

--- a/xilem_core/src/views/memoize.rs
+++ b/xilem_core/src/views/memoize.rs
@@ -58,6 +58,7 @@ where
     }
 }
 
+#[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
 pub struct MemoizeState<V, VState> {
     view: V,
     view_state: VState,

--- a/xilem_core/src/views/one_of.rs
+++ b/xilem_core/src/views/one_of.rs
@@ -524,7 +524,7 @@ mod hidden {
 
     use super::PhantomElementCtx;
 
-    #[allow(unreachable_pub)]
+    #[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
     pub enum Never {}
 
     impl ViewMarker for Never {}
@@ -564,7 +564,7 @@ mod hidden {
         }
     }
     /// The state used to implement `View` for `OneOfN`
-    #[allow(unreachable_pub)]
+    #[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
     pub struct OneOfState<A, B, C, D, E, F, G, H, I> {
         /// The current state of the inner view or view sequence.
         pub(super) inner_state: super::OneOf<A, B, C, D, E, F, G, H, I>,

--- a/xilem_web/src/app.rs
+++ b/xilem_web/src/app.rs
@@ -73,7 +73,7 @@ where
 impl<State, Fragment: DomFragment<State>, InitFragment: FnMut(&mut State) -> Fragment>
     AppInner<State, Fragment, InitFragment>
 {
-    pub fn new(root: web_sys::Node, data: State, app_logic: InitFragment) -> Self {
+    fn new(root: web_sys::Node, data: State, app_logic: InitFragment) -> Self {
         let ctx = ViewCtx::default();
         AppInner {
             data,

--- a/xilem_web/src/concurrent/interval.rs
+++ b/xilem_web/src/concurrent/interval.rs
@@ -57,6 +57,7 @@ where
     }
 }
 
+#[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
 pub struct IntervalState {
     // Closures are retained so they can be called by environment
     interval_fn: Closure<dyn FnMut()>,

--- a/xilem_web/src/concurrent/memoized_await.rs
+++ b/xilem_web/src/concurrent/memoized_await.rs
@@ -101,6 +101,7 @@ where
 }
 
 #[derive(Default)]
+#[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
 pub struct MemoizedAwaitState {
     generation: u64,
     schedule_update: bool,

--- a/xilem_web/src/concurrent/task.rs
+++ b/xilem_web/src/concurrent/task.rs
@@ -102,6 +102,7 @@ pub struct Task<F, H, M> {
     message: PhantomData<fn() -> M>,
 }
 
+#[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
 pub struct TaskState {
     abort_handle: Option<AbortHandle>,
 }

--- a/xilem_web/src/elements.rs
+++ b/xilem_web/src/elements.rs
@@ -153,14 +153,15 @@ impl<'a, 'b, 'c, 'd> DomChildrenSplice<'a, 'b, 'c, 'd> {
 impl<'a, 'b, 'c, 'd> ElementSplice<AnyPod> for DomChildrenSplice<'a, 'b, 'c, 'd> {
     fn with_scratch<R>(&mut self, f: impl FnOnce(&mut AppendVec<AnyPod>) -> R) -> R {
         let ret = f(self.scratch);
-        #[allow(unused_assignments, unused_mut)]
-        let mut add_dom_children_to_parent = true;
-        #[cfg(feature = "hydration")]
-        {
-            add_dom_children_to_parent = !self.in_hydration;
-        }
-
         if !self.scratch.is_empty() {
+            #[allow(unused_assignments, unused_mut)]
+            // reason: when the feature "hydration" is enabled/disabled, avoid warnings
+            let mut add_dom_children_to_parent = true;
+            #[cfg(feature = "hydration")]
+            {
+                add_dom_children_to_parent = !self.in_hydration;
+            }
+
             for element in self.scratch.drain() {
                 if add_dom_children_to_parent {
                     self.fragment

--- a/xilem_web/src/events.rs
+++ b/xilem_web/src/events.rs
@@ -107,12 +107,17 @@ fn remove_event_listener(
         .unwrap_throw();
 }
 
-/// State for the `OnEvent` view.
-pub struct OnEventState<S> {
-    #[allow(unused)]
-    child_state: S,
-    callback: Closure<dyn FnMut(web_sys::Event)>,
+mod hidden {
+    use wasm_bindgen::prelude::Closure;
+    #[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
+    /// State for the `OnEvent` view.
+    pub struct OnEventState<S> {
+        pub(crate) child_state: S,
+        pub(crate) callback: Closure<dyn FnMut(web_sys::Event)>,
+    }
 }
+
+use hidden::OnEventState;
 
 // These (boilerplatey) functions are there to reduce the boilerplate created by the macro-expansion below.
 
@@ -143,7 +148,7 @@ where
     })
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)] // reason: This is only used to avoid more boilerplate in macros, also so that rust-analyzer can be of help here.
 fn rebuild_event_listener<State, Action, V, Event>(
     element_view: &V,
     prev_element_view: &V,
@@ -519,7 +524,7 @@ pub struct OnResize<V, State, Action, Callback> {
 
 pub struct OnResizeState<VState> {
     child_state: VState,
-    // Closures are retained so they can be called by environment
+    // reason: Closures are retained so they can be called by environment
     #[allow(unused)]
     callback: Closure<dyn FnMut(js_sys::Array)>,
     observer: web_sys::ResizeObserver,

--- a/xilem_web/src/lib.rs
+++ b/xilem_web/src/lib.rs
@@ -48,9 +48,9 @@ mod vecmap;
 
 pub mod concurrent;
 pub mod elements;
+pub mod events;
 pub mod interfaces;
 pub mod svg;
-pub mod events;
 
 pub use self::{
     after_update::{

--- a/xilem_web/src/lib.rs
+++ b/xilem_web/src/lib.rs
@@ -35,7 +35,6 @@ mod class;
 mod context;
 mod dom_helpers;
 mod element_props;
-mod events;
 mod message;
 mod one_of;
 mod optional_action;
@@ -51,6 +50,7 @@ pub mod concurrent;
 pub mod elements;
 pub mod interfaces;
 pub mod svg;
+pub mod events;
 
 pub use self::{
     after_update::{

--- a/xilem_web/src/message.rs
+++ b/xilem_web/src/message.rs
@@ -51,7 +51,7 @@ impl dyn Message {
     /// If the message contained within `self` is not of type `T`, returns `self`
     /// (so that e.g. a different type can be used)
     pub fn downcast<T: Message>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
-        // The panic is unreachable
+        // reason: The panic is unreachable
         #![allow(clippy::missing_panics_doc)]
         if self.deref().as_any().is::<T>() {
             Ok(self

--- a/xilem_web/src/one_of.rs
+++ b/xilem_web/src/one_of.rs
@@ -183,6 +183,7 @@ where
     }
 }
 
+#[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
 pub enum Noop {}
 
 impl PhantomElementCtx for ViewCtx {

--- a/xilem_web/src/optional_action.rs
+++ b/xilem_web/src/optional_action.rs
@@ -13,6 +13,7 @@ pub trait OptionalAction<A>: sealed::Sealed {
     fn action(self) -> Option<A>;
 }
 mod sealed {
+    #[allow(unnameable_types)] // reason: see https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/
     pub trait Sealed {}
 }
 

--- a/xilem_web/src/pointer.rs
+++ b/xilem_web/src/pointer.rs
@@ -19,8 +19,9 @@ pub struct Pointer<V, T, A, F> {
     phantom: PhantomData<fn() -> (T, A)>,
 }
 
+#[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
 pub struct PointerState<S> {
-    // Closures are retained so they can be called by environment
+    // reason: Closures are retained so they can be called by environment
     #[allow(unused)]
     down_closure: Closure<dyn FnMut(PointerEvent)>,
     #[allow(unused)]

--- a/xilem_web/src/svg/common_attrs.rs
+++ b/xilem_web/src/svg/common_attrs.rs
@@ -142,6 +142,7 @@ where
     }
 }
 
+#[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
 pub struct StrokeState<ChildState> {
     brush_svg_repr: Option<AttributeValue>,
     stroke_dash_pattern_svg_repr: Option<AttributeValue>,

--- a/xilem_web/src/templated.rs
+++ b/xilem_web/src/templated.rs
@@ -11,6 +11,7 @@ use wasm_bindgen::UnwrapThrowExt;
 /// This view creates an internally cached deep-clone of the underlying DOM node. When the inner view is created again, this will be done more efficiently.
 pub struct Templated<E>(Rc<E>);
 
+#[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
 pub struct TemplatedState<ViewState> {
     view_state: ViewState,
     dirty: bool,

--- a/xilem_web/src/vecmap.rs
+++ b/xilem_web/src/vecmap.rs
@@ -140,7 +140,6 @@ impl<K, V> VecMap<K, V> {
     /// assert_eq!((*first_key, *first_value), (1, "a"));
     /// ```
     pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
-        #[allow(clippy::map_identity)]
         self.0.iter().map(|(k, v)| (k, v))
     }
 

--- a/xilem_web/web_examples/counter/Cargo.toml
+++ b/xilem_web/web_examples/counter/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 publish = false
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/xilem_web/web_examples/counter_custom_element/Cargo.toml
+++ b/xilem_web/web_examples/counter_custom_element/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 publish = false
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/xilem_web/web_examples/elm/Cargo.toml
+++ b/xilem_web/web_examples/elm/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0" # not versioned
 publish = false
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/xilem_web/web_examples/fetch/Cargo.toml
+++ b/xilem_web/web_examples/fetch/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 publish = false
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/xilem_web/web_examples/mathml_svg/Cargo.toml
+++ b/xilem_web/web_examples/mathml_svg/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 publish = false
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/xilem_web/web_examples/raw_dom_access/Cargo.toml
+++ b/xilem_web/web_examples/raw_dom_access/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 publish = false
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 console_error_panic_hook = "0.1"

--- a/xilem_web/web_examples/spawn_tasks/Cargo.toml
+++ b/xilem_web/web_examples/spawn_tasks/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0" # not versioned
 publish = false
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/xilem_web/web_examples/spawn_tasks/src/main.rs
+++ b/xilem_web/web_examples/spawn_tasks/src/main.rs
@@ -35,7 +35,10 @@ async fn create_ping_task(proxy: TaskProxy, shutdown_signal: ShutdownSignal) {
     log::debug!("Start ping task");
     let mut abort = shutdown_signal.into_future().fuse();
 
-    #[allow(clippy::infinite_loop)]
+    #[allow(
+        clippy::infinite_loop,
+        // reason = "False-Positive of clippy, not recognizing that the loop will be aborted"
+    )]
     loop {
         let mut timeout = TimeoutFuture::new(1_000).fuse();
 

--- a/xilem_web/web_examples/svgtoy/Cargo.toml
+++ b/xilem_web/web_examples/svgtoy/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 publish = false
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/xilem_web/web_examples/todomvc/Cargo.toml
+++ b/xilem_web/web_examples/todomvc/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 publish = false
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/xilem_web/web_examples/todomvc/src/state.rs
+++ b/xilem_web/web_examples/todomvc/src/state.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::UnwrapThrowExt;
 const KEY: &str = "todomvc_persist";
 
 #[derive(Default, Debug, Serialize, Deserialize)]
-pub struct AppState {
+pub(crate) struct AppState {
     #[serde(skip)]
     pub new_todo: String,
     pub todos: Vec<Todo>,
@@ -21,7 +21,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn create_todo(&mut self) {
+    pub(crate) fn create_todo(&mut self) {
         if self.new_todo.is_empty() {
             return;
         }
@@ -39,13 +39,13 @@ impl AppState {
     }
 
     /// Are all the todos complete?
-    pub fn are_all_complete(&self) -> bool {
+    pub(crate) fn are_all_complete(&self) -> bool {
         self.todos.iter().all(|todo| todo.completed)
     }
 
     /// If all TODOs are complete, then mark them all not complete,
     /// else mark them all complete.
-    pub fn toggle_all_complete(&mut self) {
+    pub(crate) fn toggle_all_complete(&mut self) {
         if self.are_all_complete() {
             for todo in self.todos.iter_mut() {
                 todo.completed = false;
@@ -58,7 +58,7 @@ impl AppState {
         self.save();
     }
 
-    pub fn visible_todos(&mut self) -> impl Iterator<Item = (usize, &mut Todo)> {
+    pub(crate) fn visible_todos(&mut self) -> impl Iterator<Item = (usize, &mut Todo)> {
         self.todos
             .iter_mut()
             .enumerate()
@@ -69,12 +69,12 @@ impl AppState {
             })
     }
 
-    pub fn update_new_todo(&mut self, new_text: &str) {
+    pub(crate) fn update_new_todo(&mut self, new_text: &str) {
         self.new_todo.clear();
         self.new_todo.push_str(new_text);
     }
 
-    pub fn start_editing(&mut self, id: u64) {
+    pub(crate) fn start_editing(&mut self, id: u64) {
         if let Some(ref mut todo) = self.todos.iter_mut().find(|todo| todo.id == id) {
             todo.title_editing.clear();
             todo.title_editing.push_str(&todo.title);
@@ -83,7 +83,7 @@ impl AppState {
     }
 
     /// Load the current state from local storage, or use the default.
-    pub fn load() -> Self {
+    pub(crate) fn load() -> Self {
         let Some(raw) = storage().get_item(KEY).unwrap_throw() else {
             return Default::default();
         };
@@ -97,14 +97,14 @@ impl AppState {
     }
 
     /// Save the current state to local storage
-    pub fn save(&self) {
+    pub(crate) fn save(&self) {
         let raw = serde_json::to_string(self).unwrap_throw();
         storage().set_item(KEY, &raw).unwrap_throw();
     }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Todo {
+pub(crate) struct Todo {
     pub id: u64,
     pub title: String,
     #[serde(skip)]
@@ -113,7 +113,7 @@ pub struct Todo {
 }
 
 impl Todo {
-    pub fn new(title: String, id: u64) -> Self {
+    pub(crate) fn new(title: String, id: u64) -> Self {
         let title_editing = title.clone();
         Self {
             id,
@@ -123,14 +123,14 @@ impl Todo {
         }
     }
 
-    pub fn save_editing(&mut self) {
+    pub(crate) fn save_editing(&mut self) {
         self.title.clear();
         self.title.push_str(&self.title_editing);
     }
 }
 
 #[derive(Debug, Default, PartialEq, Copy, Clone)]
-pub enum Filter {
+pub(crate) enum Filter {
     #[default]
     All,
     Active,


### PR DESCRIPTION
Phew, fixing (future) clippy-lints is grunt-work (I enabled `unnameable_types` for this), this is by far not complete, mostly xilem-side, but at least a small step towards enabling more of our lint set.

There's a few "drive-by fixes" like hiding `View::ViewState` types in Xilem (I don't think we generally want to expose these), or exposing event types in xilem_web.

I would suggest disabling the `allow_attributes_without_reason` lint for now, so that we can update the rust version. I feel like adding comments next to these is just unnecessary extra-work. I think adding more reasons should probably be a separate pass, after a rust version update, so that `#[allow(..., reason="")]` is supported.