### PR TITLE
Replace WidgetMut methods with free functions.

### DIFF
--- a/masonry/README.md
+++ b/masonry/README.md
@@ -51,9 +51,9 @@ impl AppDriver for Driver {
         match action {
             Action::ButtonPressed(_) => {
                 let mut root: WidgetMut<RootWidget<Portal<Flex>>> = ctx.get_root();
-                let mut root = root.child_mut();
-                let mut flex = root.child_mut();
-                flex.add_child(Label::new(self.next_task.clone()));
+                let mut portal = RootWidget::child_mut(&mut root);
+                let mut flex = Portal::child_mut(&mut portal);
+                Flex::add_child(&mut flex, Label::new(self.next_task.clone()));
             }
             Action::TextChanged(new_text) => {
                 self.next_task = new_text.clone();

--- a/masonry/examples/calc_masonry.rs
+++ b/masonry/examples/calc_masonry.rs
@@ -147,7 +147,7 @@ impl Widget for CalcButton {
                     let color = self.active_color;
                     // See on_status_change for why we use `mutate_later` here.
                     ctx.mutate_later(&mut self.inner, move |mut inner| {
-                        inner.set_background(color);
+                        SizedBox::set_background(&mut inner, color);
                     });
                     ctx.capture_pointer();
                     trace!("CalcButton {:?} pressed", ctx.widget_id());
@@ -158,7 +158,7 @@ impl Widget for CalcButton {
                     let color = self.base_color;
                     // See on_status_change for why we use `mutate_later` here.
                     ctx.mutate_later(&mut self.inner, move |mut inner| {
-                        inner.set_background(color);
+                        SizedBox::set_background(&mut inner, color);
                     });
                     ctx.submit_action(Action::Other(Box::new(self.action)));
                     trace!("CalcButton {:?} released", ctx.widget_id());
@@ -190,7 +190,7 @@ impl Widget for CalcButton {
         match event {
             Update::HoveredChanged(true) => {
                 ctx.mutate_later(&mut self.inner, move |mut inner| {
-                    inner.set_border(Color::WHITE, 3.0);
+                    SizedBox::set_border(&mut inner, Color::WHITE, 3.0);
                 });
                 // FIXME - This is a monkey-patch for a problem where the mutate pass isn't run after this.
                 // Should be fixed once the pass spec RFC is implemented.
@@ -198,7 +198,7 @@ impl Widget for CalcButton {
             }
             Update::HoveredChanged(false) => {
                 ctx.mutate_later(&mut self.inner, move |mut inner| {
-                    inner.set_border(Color::TRANSPARENT, 3.0);
+                    SizedBox::set_border(&mut inner, Color::TRANSPARENT, 3.0);
                 });
                 // FIXME - This is a monkey-patch for a problem where the mutate pass isn't run after this.
                 // Should be fixed once the pass spec RFC is implemented.
@@ -254,12 +254,11 @@ impl AppDriver for CalcState {
             _ => unreachable!(),
         }
 
-        ctx.get_root::<RootWidget<Flex>>()
-            .child_mut()
-            .child_mut(1)
-            .unwrap()
-            .downcast::<Label>()
-            .set_text(&*self.value);
+        let mut root = ctx.get_root::<RootWidget<Flex>>();
+        let mut flex = RootWidget::child_mut(&mut root);
+        let mut label = Flex::child_mut(&mut flex, 1).unwrap();
+        let mut label = label.downcast::<Label>();
+        Label::set_text(&mut label, &*self.value);
     }
 }
 

--- a/masonry/examples/grid_masonry.rs
+++ b/masonry/examples/grid_masonry.rs
@@ -28,9 +28,9 @@ impl AppDriver for Driver {
                 self.grid_spacing += 0.5;
             }
 
-            ctx.get_root::<RootWidget<Grid>>()
-                .child_mut()
-                .set_spacing(self.grid_spacing);
+            let mut root = ctx.get_root::<RootWidget<Grid>>();
+            let mut grid = RootWidget::child_mut(&mut root);
+            Grid::set_spacing(&mut grid, self.grid_spacing);
         }
     }
 }

--- a/masonry/examples/to_do_list.rs
+++ b/masonry/examples/to_do_list.rs
@@ -24,15 +24,15 @@ impl AppDriver for Driver {
         match action {
             Action::ButtonPressed(_) => {
                 let mut root: WidgetMut<RootWidget<Portal<Flex>>> = ctx.get_root();
-                let mut root = root.child_mut();
-                let mut flex = root.child_mut();
-                flex.add_child(Label::new(self.next_task.clone()));
+                let mut portal = RootWidget::child_mut(&mut root);
+                let mut flex = Portal::child_mut(&mut portal);
+                Flex::add_child(&mut flex, Label::new(self.next_task.clone()));
 
-                let mut first_row = flex.child_mut(0).unwrap();
+                let mut first_row = Flex::child_mut(&mut flex, 0).unwrap();
                 let mut first_row = first_row.downcast::<Flex>();
-                let mut textbox = first_row.child_mut(0).unwrap();
+                let mut textbox = Flex::child_mut(&mut first_row, 0).unwrap();
                 let mut textbox = textbox.downcast::<Textbox>();
-                textbox.reset_text(String::new());
+                Textbox::reset_text(&mut textbox, String::new());
             }
             Action::TextChanged(new_text) => {
                 self.next_task = new_text.clone();

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -34,9 +34,9 @@
 //!         match action {
 //!             Action::ButtonPressed(_) => {
 //!                 let mut root: WidgetMut<RootWidget<Portal<Flex>>> = ctx.get_root();
-//!                 let mut root = root.child_mut();
-//!                 let mut flex = root.child_mut();
-//!                 flex.add_child(Label::new(self.next_task.clone()));
+//!                 let mut portal = RootWidget::child_mut(&mut root);
+//!                 let mut flex = Portal::child_mut(&mut portal);
+//!                 Flex::add_child(&mut flex, Label::new(self.next_task.clone()));
 //!             }
 //!             Action::TextChanged(new_text) => {
 //!                 self.next_task = new_text.clone();

--- a/masonry/src/widget/button.rs
+++ b/masonry/src/widget/button.rs
@@ -63,14 +63,14 @@ impl Button {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, Button> {
+impl Button {
     /// Set the text.
-    pub fn set_text(&mut self, new_text: impl Into<ArcStr>) {
-        self.label_mut().set_text(new_text);
+    pub fn set_text(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
+        Label::set_text(&mut Self::label_mut(this), new_text);
     }
 
-    pub fn label_mut(&mut self) -> WidgetMut<'_, Label> {
-        self.ctx.get_mut(&mut self.widget.label)
+    pub fn label_mut<'w>(this: &'w mut WidgetMut<'_, Self>) -> WidgetMut<'w, Label> {
+        this.ctx.get_mut(&mut this.widget.label)
     }
 }
 
@@ -263,10 +263,10 @@ mod tests {
 
             harness.edit_root_widget(|mut button| {
                 let mut button = button.downcast::<Button>();
-                button.set_text("The quick brown fox jumps over the lazy dog");
+                Button::set_text(&mut button, "The quick brown fox jumps over the lazy dog");
 
-                let mut label = button.label_mut();
-                label.set_text_properties(|props| {
+                let mut label = Button::label_mut(&mut button);
+                Label::set_text_properties(&mut label, |props| {
                     props.set_brush(PRIMARY_LIGHT);
                     props.set_text_size(20.0);
                 });

--- a/masonry/src/widget/button.rs
+++ b/masonry/src/widget/button.rs
@@ -69,7 +69,7 @@ impl Button {
         Label::set_text(&mut Self::label_mut(this), new_text);
     }
 
-    pub fn label_mut<'w>(this: &'w mut WidgetMut<'_, Self>) -> WidgetMut<'w, Label> {
+    pub fn label_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
         this.ctx.get_mut(&mut this.widget.label)
     }
 }

--- a/masonry/src/widget/checkbox.rs
+++ b/masonry/src/widget/checkbox.rs
@@ -56,7 +56,7 @@ impl Checkbox {
         Label::set_text(&mut Checkbox::label_mut(this), new_text);
     }
 
-    pub fn label_mut<'w>(this: &'w mut WidgetMut<'_, Self>) -> WidgetMut<'w, Label> {
+    pub fn label_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
         this.ctx.get_mut(&mut this.widget.label)
     }
 }

--- a/masonry/src/widget/checkbox.rs
+++ b/masonry/src/widget/checkbox.rs
@@ -42,22 +42,22 @@ impl Checkbox {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, Checkbox> {
-    pub fn set_checked(&mut self, checked: bool) {
-        self.widget.checked = checked;
+impl Checkbox {
+    pub fn set_checked(this: &mut WidgetMut<'_, Self>, checked: bool) {
+        this.widget.checked = checked;
         // Checked state impacts appearance and accessibility node
-        self.ctx.request_render();
+        this.ctx.request_render();
     }
 
     /// Set the text.
     ///
     /// We enforce this to be an `ArcStr` to make the allocation explicit.
-    pub fn set_text(&mut self, new_text: ArcStr) {
-        self.label_mut().set_text(new_text);
+    pub fn set_text(this: &mut WidgetMut<'_, Self>, new_text: ArcStr) {
+        Label::set_text(&mut Checkbox::label_mut(this), new_text);
     }
 
-    pub fn label_mut(&mut self) -> WidgetMut<'_, Label> {
-        self.ctx.get_mut(&mut self.widget.label)
+    pub fn label_mut<'w>(this: &'w mut WidgetMut<'_, Self>) -> WidgetMut<'w, Label> {
+        this.ctx.get_mut(&mut this.widget.label)
     }
 }
 
@@ -285,12 +285,15 @@ mod tests {
 
             harness.edit_root_widget(|mut checkbox| {
                 let mut checkbox = checkbox.downcast::<Checkbox>();
-                checkbox.set_checked(true);
-                checkbox.set_text(ArcStr::from("The quick brown fox jumps over the lazy dog"));
+                Checkbox::set_checked(&mut checkbox, true);
+                Checkbox::set_text(
+                    &mut checkbox,
+                    ArcStr::from("The quick brown fox jumps over the lazy dog"),
+                );
 
-                let mut label = checkbox.label_mut();
-                label.set_text_brush(PRIMARY_LIGHT);
-                label.set_text_size(20.0);
+                let mut label = Checkbox::label_mut(&mut checkbox);
+                Label::set_text_brush(&mut label, PRIMARY_LIGHT);
+                Label::set_text_size(&mut label, 20.0);
             });
 
             harness.render()

--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -542,10 +542,10 @@ impl Flex {
     }
 
     // FIXME - Remove Box
-    pub fn child_mut<'w>(
-        this: &'w mut WidgetMut<'_, Self>,
+    pub fn child_mut<'t>(
+        this: &'t mut WidgetMut<'_, Self>,
         idx: usize,
-    ) -> Option<WidgetMut<'w, Box<dyn Widget>>> {
+    ) -> Option<WidgetMut<'t, Box<dyn Widget>>> {
         let child = match &mut this.widget.children[idx] {
             Child::Fixed { widget, .. } | Child::Flex { widget, .. } => widget,
             Child::FixedSpacer(..) => return None,

--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -303,30 +303,30 @@ impl Flex {
 }
 
 // --- MARK: WIDGETMUT---
-impl<'a> WidgetMut<'a, Flex> {
+impl Flex {
     /// Set the flex direction (see [`Axis`]).
-    pub fn set_direction(&mut self, direction: Axis) {
-        self.widget.direction = direction;
-        self.ctx.request_layout();
+    pub fn set_direction(this: &mut WidgetMut<'_, Self>, direction: Axis) {
+        this.widget.direction = direction;
+        this.ctx.request_layout();
     }
 
     /// Set the childrens' [`CrossAxisAlignment`].
-    pub fn set_cross_axis_alignment(&mut self, alignment: CrossAxisAlignment) {
-        self.widget.cross_alignment = alignment;
-        self.ctx.request_layout();
+    pub fn set_cross_axis_alignment(this: &mut WidgetMut<'_, Self>, alignment: CrossAxisAlignment) {
+        this.widget.cross_alignment = alignment;
+        this.ctx.request_layout();
     }
 
     /// Set the childrens' [`MainAxisAlignment`].
-    pub fn set_main_axis_alignment(&mut self, alignment: MainAxisAlignment) {
-        self.widget.main_alignment = alignment;
-        self.ctx.request_layout();
+    pub fn set_main_axis_alignment(this: &mut WidgetMut<'_, Self>, alignment: MainAxisAlignment) {
+        this.widget.main_alignment = alignment;
+        this.ctx.request_layout();
     }
 
     /// Set whether the container must expand to fill the available space on
     /// its main axis.
-    pub fn set_must_fill_main_axis(&mut self, fill: bool) {
-        self.widget.fill_major_axis = fill;
-        self.ctx.request_layout();
+    pub fn set_must_fill_main_axis(this: &mut WidgetMut<'_, Self>, fill: bool) {
+        this.widget.fill_major_axis = fill;
+        this.ctx.request_layout();
     }
 
     /// Set the spacing along the major axis between any two elements in logical pixels.
@@ -341,13 +341,13 @@ impl<'a> WidgetMut<'a, Flex> {
     /// If `gap` is not a non-negative finite value.
     ///
     /// See also [`use_default_gap`](Self::use_default_gap).
-    pub fn set_gap(&mut self, gap: f64) {
+    pub fn set_gap(this: &mut WidgetMut<'_, Self>, gap: f64) {
         if gap.is_finite() && gap >= 0.0 {
-            self.widget.gap = Some(gap);
+            this.widget.gap = Some(gap);
         } else {
             panic!("Invalid `gap` {gap}, expected a non-negative finite value.")
         }
-        self.ctx.request_layout();
+        this.ctx.request_layout();
     }
 
     /// Use the default gap value.
@@ -359,18 +359,18 @@ impl<'a> WidgetMut<'a, Flex> {
     ///
     /// [`WIDGET_PADDING_VERTICAL`]: crate::theme::WIDGET_PADDING_VERTICAL
     /// [`WIDGET_PADDING_HORIZONTAL`]: crate::theme::WIDGET_PADDING_VERTICAL
-    pub fn use_default_gap(&mut self) {
-        self.widget.gap = None;
-        self.ctx.request_layout();
+    pub fn use_default_gap(this: &mut WidgetMut<'_, Self>) {
+        this.widget.gap = None;
+        this.ctx.request_layout();
     }
 
     /// Equivalent to [`set_gap`](Self::set_gap) if `gap` is `Some`, or
     /// [`use_default_gap`](Self::use_default_gap) otherwise.
     ///
     /// Does not perform validation of the provided value.
-    pub fn set_raw_gap(&mut self, gap: Option<f64>) {
-        self.widget.gap = gap;
-        self.ctx.request_layout();
+    pub fn set_raw_gap(this: &mut WidgetMut<'_, Self>, gap: Option<f64>) {
+        this.widget.gap = gap;
+        this.ctx.request_layout();
     }
 
     /// Add a non-flex child widget.
@@ -378,41 +378,45 @@ impl<'a> WidgetMut<'a, Flex> {
     /// See also [`with_child`].
     ///
     /// [`with_child`]: Flex::with_child
-    pub fn add_child(&mut self, child: impl Widget) {
+    pub fn add_child(this: &mut WidgetMut<'_, Self>, child: impl Widget) {
         let child = Child::Fixed {
             widget: WidgetPod::new(Box::new(child)),
             alignment: None,
         };
-        self.widget.children.push(child);
-        self.ctx.children_changed();
+        this.widget.children.push(child);
+        this.ctx.children_changed();
     }
 
-    pub fn add_child_id(&mut self, child: impl Widget, id: WidgetId) {
+    pub fn add_child_id(this: &mut WidgetMut<'_, Self>, child: impl Widget, id: WidgetId) {
         let child = Child::Fixed {
             widget: WidgetPod::new_with_id(Box::new(child), id),
             alignment: None,
         };
-        self.widget.children.push(child);
-        self.ctx.children_changed();
+        this.widget.children.push(child);
+        this.ctx.children_changed();
     }
 
     /// Add a flexible child widget.
-    pub fn add_flex_child(&mut self, child: impl Widget, params: impl Into<FlexParams>) {
+    pub fn add_flex_child(
+        this: &mut WidgetMut<'_, Self>,
+        child: impl Widget,
+        params: impl Into<FlexParams>,
+    ) {
         let params = params.into();
         let child = new_flex_child(params, WidgetPod::new(Box::new(child)));
 
-        self.widget.children.push(child);
-        self.ctx.children_changed();
+        this.widget.children.push(child);
+        this.ctx.children_changed();
     }
 
     /// Add a spacer widget with a standard size.
     ///
     /// The actual value of this spacer depends on whether this container is
     /// a row or column, as well as theme settings.
-    pub fn add_default_spacer(&mut self) {
-        let key = axis_default_spacer(self.widget.direction);
-        self.add_spacer(key);
-        self.ctx.request_layout();
+    pub fn add_default_spacer(this: &mut WidgetMut<'_, Self>) {
+        let key = axis_default_spacer(this.widget.direction);
+        Flex::add_spacer(this, key);
+        this.ctx.request_layout();
     }
 
     /// Add an empty spacer widget with the given size.
@@ -421,19 +425,19 @@ impl<'a> WidgetMut<'a, Flex> {
     /// generally prefer to use [`add_default_spacer`].
     ///
     /// [`add_default_spacer`]: WidgetMut::add_default_spacer
-    pub fn add_spacer(&mut self, mut len: f64) {
+    pub fn add_spacer(this: &mut WidgetMut<'_, Self>, mut len: f64) {
         if len < 0.0 {
             tracing::warn!("add_spacer called with negative length: {}", len);
         }
         len = len.clamp(0.0, f64::MAX);
 
         let new_child = Child::FixedSpacer(len, 0.0);
-        self.widget.children.push(new_child);
-        self.ctx.request_layout();
+        this.widget.children.push(new_child);
+        this.ctx.request_layout();
     }
 
     /// Add an empty spacer widget with a specific `flex` factor.
-    pub fn add_flex_spacer(&mut self, flex: f64) {
+    pub fn add_flex_spacer(this: &mut WidgetMut<'_, Self>, flex: f64) {
         let flex = if flex >= 0.0 {
             flex
         } else {
@@ -441,8 +445,8 @@ impl<'a> WidgetMut<'a, Flex> {
             0.0
         };
         let new_child = Child::FlexedSpacer(flex, 0.0);
-        self.widget.children.push(new_child);
-        self.ctx.request_layout();
+        this.widget.children.push(new_child);
+        this.ctx.request_layout();
     }
 
     /// Add a non-flex child widget.
@@ -450,38 +454,42 @@ impl<'a> WidgetMut<'a, Flex> {
     /// See also [`with_child`].
     ///
     /// [`with_child`]: Flex::with_child
-    pub fn insert_child(&mut self, idx: usize, child: impl Widget) {
-        self.insert_child_pod(idx, WidgetPod::new(Box::new(child)));
+    pub fn insert_child(this: &mut WidgetMut<'_, Self>, idx: usize, child: impl Widget) {
+        Self::insert_child_pod(this, idx, WidgetPod::new(Box::new(child)));
     }
 
     /// Add a non-flex child widget.
-    pub fn insert_child_pod(&mut self, idx: usize, widget: WidgetPod<Box<dyn Widget>>) {
+    pub fn insert_child_pod(
+        this: &mut WidgetMut<'_, Self>,
+        idx: usize,
+        widget: WidgetPod<Box<dyn Widget>>,
+    ) {
         let child = Child::Fixed {
             widget,
             alignment: None,
         };
-        self.widget.children.insert(idx, child);
-        self.ctx.children_changed();
+        this.widget.children.insert(idx, child);
+        this.ctx.children_changed();
     }
 
     pub fn insert_flex_child(
-        &mut self,
+        this: &mut WidgetMut<'_, Self>,
         idx: usize,
         child: impl Widget,
         params: impl Into<FlexParams>,
     ) {
-        self.insert_flex_child_pod(idx, WidgetPod::new(Box::new(child)), params);
+        Self::insert_flex_child_pod(this, idx, WidgetPod::new(Box::new(child)), params);
     }
 
     pub fn insert_flex_child_pod(
-        &mut self,
+        this: &mut WidgetMut<'_, Self>,
         idx: usize,
         child: WidgetPod<Box<dyn Widget>>,
         params: impl Into<FlexParams>,
     ) {
         let child = new_flex_child(params.into(), child);
-        self.widget.children.insert(idx, child);
-        self.ctx.children_changed();
+        this.widget.children.insert(idx, child);
+        this.ctx.children_changed();
     }
 
     // TODO - remove
@@ -489,10 +497,10 @@ impl<'a> WidgetMut<'a, Flex> {
     ///
     /// The actual value of this spacer depends on whether this container is
     /// a row or column, as well as theme settings.
-    pub fn insert_default_spacer(&mut self, idx: usize) {
-        let key = axis_default_spacer(self.widget.direction);
-        self.insert_spacer(idx, key);
-        self.ctx.request_layout();
+    pub fn insert_default_spacer(this: &mut WidgetMut<'_, Self>, idx: usize) {
+        let key = axis_default_spacer(this.widget.direction);
+        Self::insert_spacer(this, idx, key);
+        this.ctx.request_layout();
     }
 
     /// Add an empty spacer widget with the given size.
@@ -501,19 +509,19 @@ impl<'a> WidgetMut<'a, Flex> {
     /// generally prefer to use [`add_default_spacer`].
     ///
     /// [`add_default_spacer`]: WidgetMut::add_default_spacer
-    pub fn insert_spacer(&mut self, idx: usize, mut len: f64) {
+    pub fn insert_spacer(this: &mut WidgetMut<'_, Self>, idx: usize, mut len: f64) {
         if len < 0.0 {
             tracing::warn!("add_spacer called with negative length: {}", len);
         }
         len = len.clamp(0.0, f64::MAX);
 
         let new_child = Child::FixedSpacer(len, 0.0);
-        self.widget.children.insert(idx, new_child);
-        self.ctx.request_layout();
+        this.widget.children.insert(idx, new_child);
+        this.ctx.request_layout();
     }
 
     /// Add an empty spacer widget with a specific `flex` factor.
-    pub fn insert_flex_spacer(&mut self, idx: usize, flex: f64) {
+    pub fn insert_flex_spacer(this: &mut WidgetMut<'_, Self>, idx: usize, flex: f64) {
         let flex = if flex >= 0.0 {
             flex
         } else {
@@ -521,27 +529,30 @@ impl<'a> WidgetMut<'a, Flex> {
             0.0
         };
         let new_child = Child::FlexedSpacer(flex, 0.0);
-        self.widget.children.insert(idx, new_child);
-        self.ctx.request_layout();
+        this.widget.children.insert(idx, new_child);
+        this.ctx.request_layout();
     }
 
-    pub fn remove_child(&mut self, idx: usize) {
-        let child = self.widget.children.remove(idx);
+    pub fn remove_child(this: &mut WidgetMut<'_, Self>, idx: usize) {
+        let child = this.widget.children.remove(idx);
         if let Child::Fixed { widget, .. } | Child::Flex { widget, .. } = child {
-            self.ctx.remove_child(widget);
+            this.ctx.remove_child(widget);
         }
-        self.ctx.request_layout();
+        this.ctx.request_layout();
     }
 
     // FIXME - Remove Box
-    pub fn child_mut(&mut self, idx: usize) -> Option<WidgetMut<'_, Box<dyn Widget>>> {
-        let child = match &mut self.widget.children[idx] {
+    pub fn child_mut<'w>(
+        this: &'w mut WidgetMut<'_, Self>,
+        idx: usize,
+    ) -> Option<WidgetMut<'w, Box<dyn Widget>>> {
+        let child = match &mut this.widget.children[idx] {
             Child::Fixed { widget, .. } | Child::Flex { widget, .. } => widget,
             Child::FixedSpacer(..) => return None,
             Child::FlexedSpacer(..) => return None,
         };
 
-        Some(self.ctx.get_mut(child))
+        Some(this.ctx.get_mut(child))
     }
 
     /// Updates the flex parameters for the child at `idx`,
@@ -549,8 +560,12 @@ impl<'a> WidgetMut<'a, Flex> {
     /// # Panics
     ///
     /// Panics if the element at `idx` is not a widget.
-    pub fn update_child_flex_params(&mut self, idx: usize, params: impl Into<FlexParams>) {
-        let child = &mut self.widget.children[idx];
+    pub fn update_child_flex_params(
+        this: &mut WidgetMut<'_, Self>,
+        idx: usize,
+        params: impl Into<FlexParams>,
+    ) {
+        let child = &mut this.widget.children[idx];
         let child_val = std::mem::replace(child, Child::FixedSpacer(0.0, 0.0));
         let widget = match child_val {
             Child::Fixed { widget, .. } | Child::Flex { widget, .. } => widget,
@@ -560,7 +575,7 @@ impl<'a> WidgetMut<'a, Flex> {
         };
         let new_child = new_flex_child(params.into(), widget);
         *child = new_child;
-        self.ctx.children_changed();
+        this.ctx.children_changed();
     }
 
     /// Updates the spacer at `idx`, if the spacer was a fixed spacer, it will be overwritten with a flex spacer
@@ -568,8 +583,8 @@ impl<'a> WidgetMut<'a, Flex> {
     /// # Panics
     ///
     /// Panics if the element at `idx` is not a spacer.
-    pub fn update_spacer_flex(&mut self, idx: usize, flex: f64) {
-        let child = &mut self.widget.children[idx];
+    pub fn update_spacer_flex(this: &mut WidgetMut<'_, Self>, idx: usize, flex: f64) {
+        let child = &mut this.widget.children[idx];
 
         match *child {
             Child::FixedSpacer(_, _) | Child::FlexedSpacer(_, _) => {
@@ -579,7 +594,7 @@ impl<'a> WidgetMut<'a, Flex> {
                 panic!("Can't update spacer parameters of a non-spacer element");
             }
         };
-        self.ctx.children_changed();
+        this.ctx.children_changed();
     }
 
     /// Updates the spacer at `idx`, if the spacer was a flex spacer, it will be overwritten with a fixed spacer
@@ -587,8 +602,8 @@ impl<'a> WidgetMut<'a, Flex> {
     /// # Panics
     ///
     /// Panics if the element at `idx` is not a spacer.
-    pub fn update_spacer_fixed(&mut self, idx: usize, len: f64) {
-        let child = &mut self.widget.children[idx];
+    pub fn update_spacer_fixed(this: &mut WidgetMut<'_, Self>, idx: usize, len: f64) {
+        let child = &mut this.widget.children[idx];
 
         match *child {
             Child::FixedSpacer(_, _) | Child::FlexedSpacer(_, _) => {
@@ -598,16 +613,16 @@ impl<'a> WidgetMut<'a, Flex> {
                 panic!("Can't update spacer parameters of a non-spacer element");
             }
         };
-        self.ctx.children_changed();
+        this.ctx.children_changed();
     }
 
-    pub fn clear(&mut self) {
-        if !self.widget.children.is_empty() {
-            self.ctx.request_layout();
+    pub fn clear(this: &mut WidgetMut<'_, Self>) {
+        if !this.widget.children.is_empty() {
+            this.ctx.request_layout();
 
-            for child in self.widget.children.drain(..) {
+            for child in this.widget.children.drain(..) {
                 if let Child::Fixed { widget, .. } | Child::Flex { widget, .. } = child {
-                    self.ctx.remove_child(widget);
+                    this.ctx.remove_child(widget);
                 }
             }
         }
@@ -1301,31 +1316,31 @@ mod tests {
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_cross_axis_alignment(CrossAxisAlignment::Start);
+            Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Start);
         });
         assert_render_snapshot!(harness, "row_cross_axis_start");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_cross_axis_alignment(CrossAxisAlignment::Center);
+            Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Center);
         });
         assert_render_snapshot!(harness, "row_cross_axis_center");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_cross_axis_alignment(CrossAxisAlignment::End);
+            Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::End);
         });
         assert_render_snapshot!(harness, "row_cross_axis_end");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_cross_axis_alignment(CrossAxisAlignment::Baseline);
+            Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Baseline);
         });
         assert_render_snapshot!(harness, "row_cross_axis_baseline");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_cross_axis_alignment(CrossAxisAlignment::Fill);
+            Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Fill);
         });
         assert_render_snapshot!(harness, "row_cross_axis_fill");
     }
@@ -1347,37 +1362,37 @@ mod tests {
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_main_axis_alignment(MainAxisAlignment::Start);
+            Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::Start);
         });
         assert_render_snapshot!(harness, "row_main_axis_start");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_main_axis_alignment(MainAxisAlignment::Center);
+            Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::Center);
         });
         assert_render_snapshot!(harness, "row_main_axis_center");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_main_axis_alignment(MainAxisAlignment::End);
+            Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::End);
         });
         assert_render_snapshot!(harness, "row_main_axis_end");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_main_axis_alignment(MainAxisAlignment::SpaceBetween);
+            Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::SpaceBetween);
         });
         assert_render_snapshot!(harness, "row_main_axis_spaceBetween");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_main_axis_alignment(MainAxisAlignment::SpaceEvenly);
+            Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::SpaceEvenly);
         });
         assert_render_snapshot!(harness, "row_main_axis_spaceEvenly");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_main_axis_alignment(MainAxisAlignment::SpaceAround);
+            Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::SpaceAround);
         });
         assert_render_snapshot!(harness, "row_main_axis_spaceAround");
 
@@ -1386,7 +1401,7 @@ mod tests {
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_must_fill_main_axis(true);
+            Flex::set_must_fill_main_axis(&mut flex, true);
         });
         assert_render_snapshot!(harness, "row_fill_main_axis");
     }
@@ -1406,31 +1421,31 @@ mod tests {
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_cross_axis_alignment(CrossAxisAlignment::Start);
+            Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Start);
         });
         assert_render_snapshot!(harness, "col_cross_axis_start");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_cross_axis_alignment(CrossAxisAlignment::Center);
+            Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Center);
         });
         assert_render_snapshot!(harness, "col_cross_axis_center");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_cross_axis_alignment(CrossAxisAlignment::End);
+            Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::End);
         });
         assert_render_snapshot!(harness, "col_cross_axis_end");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_cross_axis_alignment(CrossAxisAlignment::Baseline);
+            Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Baseline);
         });
         assert_render_snapshot!(harness, "col_cross_axis_baseline");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_cross_axis_alignment(CrossAxisAlignment::Fill);
+            Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Fill);
         });
         assert_render_snapshot!(harness, "col_cross_axis_fill");
     }
@@ -1452,37 +1467,37 @@ mod tests {
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_main_axis_alignment(MainAxisAlignment::Start);
+            Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::Start);
         });
         assert_render_snapshot!(harness, "col_main_axis_start");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_main_axis_alignment(MainAxisAlignment::Center);
+            Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::Center);
         });
         assert_render_snapshot!(harness, "col_main_axis_center");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_main_axis_alignment(MainAxisAlignment::End);
+            Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::End);
         });
         assert_render_snapshot!(harness, "col_main_axis_end");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_main_axis_alignment(MainAxisAlignment::SpaceBetween);
+            Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::SpaceBetween);
         });
         assert_render_snapshot!(harness, "col_main_axis_spaceBetween");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_main_axis_alignment(MainAxisAlignment::SpaceEvenly);
+            Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::SpaceEvenly);
         });
         assert_render_snapshot!(harness, "col_main_axis_spaceEvenly");
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_main_axis_alignment(MainAxisAlignment::SpaceAround);
+            Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::SpaceAround);
         });
         assert_render_snapshot!(harness, "col_main_axis_spaceAround");
 
@@ -1491,7 +1506,7 @@ mod tests {
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
-            flex.set_must_fill_main_axis(true);
+            Flex::set_must_fill_main_axis(&mut flex, true);
         });
         assert_render_snapshot!(harness, "col_fill_main_axis");
     }
@@ -1511,27 +1526,27 @@ mod tests {
             harness.edit_root_widget(|mut flex| {
                 let mut flex = flex.downcast::<Flex>();
 
-                flex.remove_child(1);
+                Flex::remove_child(&mut flex, 1);
                 // -> acd
-                flex.add_child(Label::new("x"));
+                Flex::add_child(&mut flex, Label::new("x"));
                 // -> acdx
-                flex.add_flex_child(Label::new("y"), 2.0);
+                Flex::add_flex_child(&mut flex, Label::new("y"), 2.0);
                 // -> acdxy
-                flex.add_default_spacer();
+                Flex::add_default_spacer(&mut flex);
                 // -> acdxy_
-                flex.add_spacer(5.0);
+                Flex::add_spacer(&mut flex, 5.0);
                 // -> acdxy__
-                flex.add_flex_spacer(1.0);
+                Flex::add_flex_spacer(&mut flex, 1.0);
                 // -> acdxy___
-                flex.insert_child(2, Label::new("i"));
+                Flex::insert_child(&mut flex, 2, Label::new("i"));
                 // -> acidxy___
-                flex.insert_flex_child(2, Label::new("j"), 2.0);
+                Flex::insert_flex_child(&mut flex, 2, Label::new("j"), 2.0);
                 // -> acjidxy___
-                flex.insert_default_spacer(2);
+                Flex::insert_default_spacer(&mut flex, 2);
                 // -> ac_jidxy___
-                flex.insert_spacer(2, 5.0);
+                Flex::insert_spacer(&mut flex, 2, 5.0);
                 // -> ac__jidxy___
-                flex.insert_flex_spacer(2, 1.0);
+                Flex::insert_flex_spacer(&mut flex, 2, 1.0);
             });
 
             harness.render()
@@ -1572,7 +1587,7 @@ mod tests {
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
 
-            let mut child = flex.child_mut(1).unwrap();
+            let mut child = Flex::child_mut(&mut flex, 1).unwrap();
             assert_eq!(
                 child
                     .try_downcast::<Label>()
@@ -1584,7 +1599,7 @@ mod tests {
             );
             std::mem::drop(child);
 
-            assert!(flex.child_mut(2).is_none());
+            assert!(Flex::child_mut(&mut flex, 2).is_none());
         });
 
         // TODO - test out-of-bounds access?

--- a/masonry/src/widget/grid.rs
+++ b/masonry/src/widget/grid.rs
@@ -212,10 +212,10 @@ impl Grid {
         this.ctx.request_layout();
     }
 
-    pub fn child_mut<'w>(
-        this: &'w mut WidgetMut<'_, Self>,
+    pub fn child_mut<'t>(
+        this: &'t mut WidgetMut<'_, Self>,
         idx: usize,
-    ) -> Option<WidgetMut<'w, Box<dyn Widget>>> {
+    ) -> Option<WidgetMut<'t, Box<dyn Widget>>> {
         let child = match this.widget.children[idx].widget_mut() {
             Some(widget) => widget,
             None => return None,

--- a/masonry/src/widget/image.rs
+++ b/masonry/src/widget/image.rs
@@ -53,19 +53,19 @@ impl Image {
 }
 
 // --- MARK: WIDGETMUT ---
-impl<'a> WidgetMut<'a, Image> {
+impl Image {
     /// Modify the widget's object fit.
     #[inline]
-    pub fn set_fit_mode(&mut self, new_object_fit: ObjectFit) {
-        self.widget.object_fit = new_object_fit;
-        self.ctx.request_layout();
+    pub fn set_fit_mode(this: &mut WidgetMut<'_, Self>, new_object_fit: ObjectFit) {
+        this.widget.object_fit = new_object_fit;
+        this.ctx.request_layout();
     }
 
     /// Set new `ImageBuf`.
     #[inline]
-    pub fn set_image_data(&mut self, image_data: ImageBuf) {
-        self.widget.image_data = image_data;
-        self.ctx.request_layout();
+    pub fn set_image_data(this: &mut WidgetMut<'_, Self>, image_data: ImageBuf) {
+        this.widget.image_data = image_data;
+        this.ctx.request_layout();
     }
 }
 
@@ -201,7 +201,7 @@ mod tests {
 
             harness.edit_root_widget(|mut image| {
                 let mut image = image.downcast::<Image>();
-                image.set_image_data(image_data);
+                Image::set_image_data(&mut image, image_data);
             });
 
             harness.render()

--- a/masonry/src/widget/label.rs
+++ b/masonry/src/widget/label.rs
@@ -107,53 +107,52 @@ impl Label {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, Label> {
-    pub fn text(&self) -> &ArcStr {
-        &self.widget.text
-    }
-
-    pub fn set_text_properties<R>(&mut self, f: impl FnOnce(&mut TextLayout) -> R) -> R {
-        let ret = f(&mut self.widget.text_layout);
-        if self.widget.text_layout.needs_rebuild() {
-            self.ctx.request_layout();
+impl Label {
+    pub fn set_text_properties<R>(
+        this: &mut WidgetMut<'_, Self>,
+        f: impl FnOnce(&mut TextLayout) -> R,
+    ) -> R {
+        let ret = f(&mut this.widget.text_layout);
+        if this.widget.text_layout.needs_rebuild() {
+            this.ctx.request_layout();
         }
         ret
     }
 
-    pub fn set_text(&mut self, new_text: impl Into<ArcStr>) {
+    pub fn set_text(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
         let new_text = new_text.into();
-        self.widget.text = new_text;
-        self.widget.text_changed = true;
-        self.ctx.request_layout();
+        this.widget.text = new_text;
+        this.widget.text_changed = true;
+        this.ctx.request_layout();
     }
 
     #[doc(alias = "set_text_color")]
-    pub fn set_text_brush(&mut self, brush: impl Into<TextBrush>) {
+    pub fn set_text_brush(this: &mut WidgetMut<'_, Self>, brush: impl Into<TextBrush>) {
         let brush = brush.into();
-        self.widget.brush = brush;
-        if !self.ctx.is_disabled() {
-            let brush = self.widget.brush.clone();
-            self.set_text_properties(|layout| layout.set_brush(brush));
+        this.widget.brush = brush;
+        if !this.ctx.is_disabled() {
+            let brush = this.widget.brush.clone();
+            Self::set_text_properties(this, |layout| layout.set_brush(brush));
         }
     }
-    pub fn set_text_size(&mut self, size: f32) {
-        self.set_text_properties(|layout| layout.set_text_size(size));
+    pub fn set_text_size(this: &mut WidgetMut<'_, Self>, size: f32) {
+        Self::set_text_properties(this, |layout| layout.set_text_size(size));
     }
-    pub fn set_weight(&mut self, weight: Weight) {
-        self.set_text_properties(|layout| layout.set_weight(weight));
+    pub fn set_weight(this: &mut WidgetMut<'_, Self>, weight: Weight) {
+        Self::set_text_properties(this, |layout| layout.set_weight(weight));
     }
-    pub fn set_alignment(&mut self, alignment: Alignment) {
-        self.set_text_properties(|layout| layout.set_text_alignment(alignment));
+    pub fn set_alignment(this: &mut WidgetMut<'_, Self>, alignment: Alignment) {
+        Self::set_text_properties(this, |layout| layout.set_text_alignment(alignment));
     }
-    pub fn set_font(&mut self, font_stack: FontStack<'static>) {
-        self.set_text_properties(|layout| layout.set_font(font_stack));
+    pub fn set_font(this: &mut WidgetMut<'_, Self>, font_stack: FontStack<'static>) {
+        Self::set_text_properties(this, |layout| layout.set_font(font_stack));
     }
-    pub fn set_font_family(&mut self, family: FontFamily<'static>) {
-        self.set_font(FontStack::Single(family));
+    pub fn set_font_family(this: &mut WidgetMut<'_, Self>, family: FontFamily<'static>) {
+        Self::set_font(this, FontStack::Single(family));
     }
-    pub fn set_line_break_mode(&mut self, line_break_mode: LineBreaking) {
-        self.widget.line_break_mode = line_break_mode;
-        self.ctx.request_layout();
+    pub fn set_line_break_mode(this: &mut WidgetMut<'_, Self>, line_break_mode: LineBreaking) {
+        this.widget.line_break_mode = line_break_mode;
+        this.ctx.request_layout();
     }
 }
 
@@ -350,12 +349,12 @@ mod tests {
 
             harness.edit_root_widget(|mut label| {
                 let mut label = label.downcast::<Label>();
-                label.set_text("The quick brown fox jumps over the lazy dog");
-                label.set_text_brush(PRIMARY_LIGHT);
-                label.set_font_family(FontFamily::Generic(GenericFamily::Monospace));
-                label.set_text_size(20.0);
-                label.set_line_break_mode(LineBreaking::WordWrap);
-                label.set_alignment(Alignment::Middle);
+                Label::set_text(&mut label, "The quick brown fox jumps over the lazy dog");
+                Label::set_text_brush(&mut label, PRIMARY_LIGHT);
+                Label::set_font_family(&mut label, FontFamily::Generic(GenericFamily::Monospace));
+                Label::set_text_size(&mut label, 20.0);
+                Label::set_line_break_mode(&mut label, LineBreaking::WordWrap);
+                Label::set_alignment(&mut label, Alignment::Middle);
             });
 
             harness.render()

--- a/masonry/src/widget/portal.rs
+++ b/masonry/src/widget/portal.rs
@@ -168,19 +168,19 @@ impl<W: Widget> Portal<W> {
 
 // --- MARK: WIDGETMUT ---
 impl<W: Widget> Portal<W> {
-    pub fn child_mut<'s>(this: &'s mut WidgetMut<'_, Self>) -> WidgetMut<'s, W> {
+    pub fn child_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, W> {
         this.ctx.get_mut(&mut this.widget.child)
     }
 
-    pub fn horizontal_scrollbar_mut<'s>(
-        this: &'s mut WidgetMut<'_, Self>,
-    ) -> WidgetMut<'s, ScrollBar> {
+    pub fn horizontal_scrollbar_mut<'t>(
+        this: &'t mut WidgetMut<'_, Self>,
+    ) -> WidgetMut<'t, ScrollBar> {
         this.ctx.get_mut(&mut this.widget.scrollbar_horizontal)
     }
 
-    pub fn vertical_scrollbar_mut<'s>(
-        this: &'s mut WidgetMut<'_, Self>,
-    ) -> WidgetMut<'s, ScrollBar> {
+    pub fn vertical_scrollbar_mut<'t>(
+        this: &'t mut WidgetMut<'_, Self>,
+    ) -> WidgetMut<'t, ScrollBar> {
         this.ctx.get_mut(&mut this.widget.scrollbar_vertical)
     }
 

--- a/masonry/src/widget/progress_bar.rs
+++ b/masonry/src/widget/progress_bar.rs
@@ -36,7 +36,7 @@ impl ProgressBar {
     /// Otherwise, the input will be clamped to [0, 1].
     pub fn new(progress: Option<f64>) -> Self {
         let mut out = Self::new_indefinite();
-        out.set_progress(progress);
+        out.set_progress_inner(progress);
         out
     }
     fn new_indefinite() -> Self {
@@ -47,7 +47,7 @@ impl ProgressBar {
         }
     }
 
-    fn set_progress(&mut self, mut progress: Option<f64>) {
+    fn set_progress_inner(&mut self, mut progress: Option<f64>) {
         clamp_progress(&mut progress);
         // check to see if we can avoid doing work
         if self.progress != progress {
@@ -74,11 +74,11 @@ impl ProgressBar {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, ProgressBar> {
-    pub fn set_progress(&mut self, progress: Option<f64>) {
-        self.widget.set_progress(progress);
-        self.ctx.request_layout();
-        self.ctx.request_render();
+impl ProgressBar {
+    pub fn set_progress(this: &mut WidgetMut<'_, Self>, progress: Option<f64>) {
+        this.widget.set_progress_inner(progress);
+        this.ctx.request_layout();
+        this.ctx.request_render();
     }
 }
 
@@ -208,6 +208,8 @@ mod tests {
     use super::*;
     use crate::assert_render_snapshot;
     use crate::testing::{widget_ids, TestHarness, TestWidgetExt};
+
+    // TODO - Add WidgetMut test
 
     #[test]
     fn indeterminate_progressbar() {

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -81,18 +81,14 @@ impl Prose {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, Prose> {
-    pub fn text(&self) -> &ArcStr {
-        self.widget.text_layout.text()
-    }
-
+impl Prose {
     pub fn set_text_properties<R>(
-        &mut self,
+        this: &mut WidgetMut<'_, Self>,
         f: impl FnOnce(&mut TextWithSelection<ArcStr>) -> R,
     ) -> R {
-        let ret = f(&mut self.widget.text_layout);
-        if self.widget.text_layout.needs_rebuild() {
-            self.ctx.request_layout();
+        let ret = f(&mut this.widget.text_layout);
+        if this.widget.text_layout.needs_rebuild() {
+            this.ctx.request_layout();
         }
         ret
     }
@@ -100,39 +96,39 @@ impl WidgetMut<'_, Prose> {
     /// Change the text. If the user currently has a selection in the box, this will delete that selection.
     ///
     /// We enforce this to be an `ArcStr` to make the allocation explicit.
-    pub fn set_text(&mut self, new_text: ArcStr) {
-        if self.ctx.is_focused() {
+    pub fn set_text(this: &mut WidgetMut<'_, Self>, new_text: ArcStr) {
+        if this.ctx.is_focused() {
             tracing::info!(
                 "Called reset_text on a focused `Prose`. This will lose the user's current selection"
             );
         }
-        self.set_text_properties(|layout| layout.set_text(new_text));
+        Self::set_text_properties(this, |layout| layout.set_text(new_text));
     }
 
     #[doc(alias = "set_text_color")]
-    pub fn set_text_brush(&mut self, brush: impl Into<TextBrush>) {
+    pub fn set_text_brush(this: &mut WidgetMut<'_, Self>, brush: impl Into<TextBrush>) {
         let brush = brush.into();
-        self.widget.brush = brush;
-        if !self.ctx.is_disabled() {
-            let brush = self.widget.brush.clone();
-            self.set_text_properties(|layout| layout.set_brush(brush));
+        this.widget.brush = brush;
+        if !this.ctx.is_disabled() {
+            let brush = this.widget.brush.clone();
+            Self::set_text_properties(this, |layout| layout.set_brush(brush));
         }
     }
-    pub fn set_text_size(&mut self, size: f32) {
-        self.set_text_properties(|layout| layout.set_text_size(size));
+    pub fn set_text_size(this: &mut WidgetMut<'_, Self>, size: f32) {
+        Self::set_text_properties(this, |layout| layout.set_text_size(size));
     }
-    pub fn set_alignment(&mut self, alignment: Alignment) {
-        self.set_text_properties(|layout| layout.set_text_alignment(alignment));
+    pub fn set_alignment(this: &mut WidgetMut<'_, Self>, alignment: Alignment) {
+        Self::set_text_properties(this, |layout| layout.set_text_alignment(alignment));
     }
-    pub fn set_font(&mut self, font_stack: FontStack<'static>) {
-        self.set_text_properties(|layout| layout.set_font(font_stack));
+    pub fn set_font(this: &mut WidgetMut<'_, Self>, font_stack: FontStack<'static>) {
+        Self::set_text_properties(this, |layout| layout.set_font(font_stack));
     }
-    pub fn set_font_family(&mut self, family: FontFamily<'static>) {
-        self.set_font(FontStack::Single(family));
+    pub fn set_font_family(this: &mut WidgetMut<'_, Self>, family: FontFamily<'static>) {
+        Self::set_font(this, FontStack::Single(family));
     }
-    pub fn set_line_break_mode(&mut self, line_break_mode: LineBreaking) {
-        self.widget.line_break_mode = line_break_mode;
-        self.ctx.request_layout();
+    pub fn set_line_break_mode(this: &mut WidgetMut<'_, Self>, line_break_mode: LineBreaking) {
+        this.widget.line_break_mode = line_break_mode;
+        this.ctx.request_layout();
     }
 }
 
@@ -290,3 +286,5 @@ impl Widget for Prose {
         Some(self.text_layout.text().as_ref().chars().take(100).collect())
     }
 }
+
+// TODO - Add tests

--- a/masonry/src/widget/root_widget.rs
+++ b/masonry/src/widget/root_widget.rs
@@ -33,7 +33,7 @@ impl<W: Widget> RootWidget<W> {
 }
 
 impl<W: Widget> RootWidget<W> {
-    pub fn child_mut<'s>(this: &'s mut WidgetMut<'_, Self>) -> WidgetMut<'s, W> {
+    pub fn child_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, W> {
         this.ctx.get_mut(&mut this.widget.pod)
     }
 }

--- a/masonry/src/widget/root_widget.rs
+++ b/masonry/src/widget/root_widget.rs
@@ -32,9 +32,9 @@ impl<W: Widget> RootWidget<W> {
     }
 }
 
-impl<W: Widget> WidgetMut<'_, RootWidget<W>> {
-    pub fn child_mut(&mut self) -> WidgetMut<'_, W> {
-        self.ctx.get_mut(&mut self.widget.pod)
+impl<W: Widget> RootWidget<W> {
+    pub fn child_mut<'s>(this: &'s mut WidgetMut<'_, Self>) -> WidgetMut<'s, W> {
+        this.ctx.get_mut(&mut this.widget.pod)
     }
 }
 

--- a/masonry/src/widget/scroll_bar.rs
+++ b/masonry/src/widget/scroll_bar.rs
@@ -103,19 +103,19 @@ impl ScrollBar {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, ScrollBar> {
+impl ScrollBar {
     // TODO - Remove?
-    pub fn set_sizes(&mut self, portal_size: f64, content_size: f64) {
-        self.widget.portal_size = portal_size;
-        self.widget.content_size = content_size;
-        self.ctx.request_render();
+    pub fn set_sizes(this: &mut WidgetMut<'_, Self>, portal_size: f64, content_size: f64) {
+        this.widget.portal_size = portal_size;
+        this.widget.content_size = content_size;
+        this.ctx.request_render();
     }
 
     // TODO - Remove?
-    pub fn set_content_size(&mut self, content_size: f64) {
+    pub fn set_content_size(this: &mut WidgetMut<'_, Self>, content_size: f64) {
         // TODO - cursor_progress
-        self.widget.content_size = content_size;
-        self.ctx.request_render();
+        this.widget.content_size = content_size;
+        this.ctx.request_render();
     }
 }
 

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -184,44 +184,44 @@ impl SizedBox {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, SizedBox> {
-    pub fn set_child(&mut self, child: impl Widget) {
-        if let Some(child) = self.widget.child.take() {
-            self.ctx.remove_child(child);
+impl SizedBox {
+    pub fn set_child(this: &mut WidgetMut<'_, Self>, child: impl Widget) {
+        if let Some(child) = this.widget.child.take() {
+            this.ctx.remove_child(child);
         }
-        self.widget.child = Some(WidgetPod::new(child).boxed());
-        self.ctx.children_changed();
-        self.ctx.request_layout();
+        this.widget.child = Some(WidgetPod::new(child).boxed());
+        this.ctx.children_changed();
+        this.ctx.request_layout();
     }
 
-    pub fn remove_child(&mut self) {
-        if let Some(child) = self.widget.child.take() {
-            self.ctx.remove_child(child);
+    pub fn remove_child(this: &mut WidgetMut<'_, Self>) {
+        if let Some(child) = this.widget.child.take() {
+            this.ctx.remove_child(child);
         }
     }
 
     /// Set container's width.
-    pub fn set_width(&mut self, width: f64) {
-        self.widget.width = Some(width);
-        self.ctx.request_layout();
+    pub fn set_width(this: &mut WidgetMut<'_, Self>, width: f64) {
+        this.widget.width = Some(width);
+        this.ctx.request_layout();
     }
 
     /// Set container's height.
-    pub fn set_height(&mut self, height: f64) {
-        self.widget.height = Some(height);
-        self.ctx.request_layout();
+    pub fn set_height(this: &mut WidgetMut<'_, Self>, height: f64) {
+        this.widget.height = Some(height);
+        this.ctx.request_layout();
     }
 
     /// Set container's width.
-    pub fn unset_width(&mut self) {
-        self.widget.width = None;
-        self.ctx.request_layout();
+    pub fn unset_width(this: &mut WidgetMut<'_, Self>) {
+        this.widget.width = None;
+        this.ctx.request_layout();
     }
 
     /// Set container's height.
-    pub fn unset_height(&mut self) {
-        self.widget.height = None;
-        self.ctx.request_layout();
+    pub fn unset_height(this: &mut WidgetMut<'_, Self>) {
+        this.widget.height = None;
+        this.ctx.request_layout();
     }
 
     /// Set the background for this widget.
@@ -230,42 +230,48 @@ impl WidgetMut<'_, SizedBox> {
     /// notably, it can be any [`Color`], any gradient, or an [`Image`].
     ///
     /// [`Image`]: vello::peniko::Image
-    pub fn set_background(&mut self, brush: impl Into<Brush>) {
-        self.widget.background = Some(brush.into());
-        self.ctx.request_paint_only();
+    pub fn set_background(this: &mut WidgetMut<'_, Self>, brush: impl Into<Brush>) {
+        this.widget.background = Some(brush.into());
+        this.ctx.request_paint_only();
     }
 
     /// Clears background.
-    pub fn clear_background(&mut self) {
-        self.widget.background = None;
-        self.ctx.request_paint_only();
+    pub fn clear_background(this: &mut WidgetMut<'_, Self>) {
+        this.widget.background = None;
+        this.ctx.request_paint_only();
     }
 
     /// Paint a border around the widget with a color and width.
-    pub fn set_border(&mut self, color: impl Into<Color>, width: impl Into<f64>) {
-        self.widget.border = Some(BorderStyle {
+    pub fn set_border(
+        this: &mut WidgetMut<'_, Self>,
+        color: impl Into<Color>,
+        width: impl Into<f64>,
+    ) {
+        this.widget.border = Some(BorderStyle {
             color: color.into(),
             width: width.into(),
         });
-        self.ctx.request_layout();
+        this.ctx.request_layout();
     }
 
     /// Clears border.
-    pub fn clear_border(&mut self) {
-        self.widget.border = None;
-        self.ctx.request_layout();
+    pub fn clear_border(this: &mut WidgetMut<'_, Self>) {
+        this.widget.border = None;
+        this.ctx.request_layout();
     }
 
     /// Round off corners of this container by setting a corner radius
-    pub fn set_rounded(&mut self, radius: impl Into<RoundedRectRadii>) {
-        self.widget.corner_radius = radius.into();
-        self.ctx.request_paint_only();
+    pub fn set_rounded(this: &mut WidgetMut<'_, Self>, radius: impl Into<RoundedRectRadii>) {
+        this.widget.corner_radius = radius.into();
+        this.ctx.request_paint_only();
     }
 
     // TODO - Doc
-    pub fn child_mut(&mut self) -> Option<WidgetMut<'_, Box<dyn Widget>>> {
-        let child = self.widget.child.as_mut()?;
-        Some(self.ctx.get_mut(child))
+    pub fn child_mut<'s>(
+        this: &'s mut WidgetMut<'_, Self>,
+    ) -> Option<WidgetMut<'s, Box<dyn Widget>>> {
+        let child = this.widget.child.as_mut()?;
+        Some(this.ctx.get_mut(child))
     }
 }
 
@@ -400,8 +406,6 @@ impl Widget for SizedBox {
     }
 }
 
-// --- Tests ---
-
 // --- MARK: TESTS ---
 #[cfg(test)]
 mod tests {
@@ -412,6 +416,8 @@ mod tests {
     use crate::assert_render_snapshot;
     use crate::testing::TestHarness;
     use crate::widget::Label;
+
+    // TODO - Add WidgetMut tests
 
     #[test]
     fn expand() {

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -267,9 +267,9 @@ impl SizedBox {
     }
 
     // TODO - Doc
-    pub fn child_mut<'s>(
-        this: &'s mut WidgetMut<'_, Self>,
-    ) -> Option<WidgetMut<'s, Box<dyn Widget>>> {
+    pub fn child_mut<'t>(
+        this: &'t mut WidgetMut<'_, Self>,
+    ) -> Option<WidgetMut<'t, Box<dyn Widget>>> {
         let child = this.widget.child.as_mut()?;
         Some(this.ctx.get_mut(child))
     }

--- a/masonry/src/widget/spinner.rs
+++ b/masonry/src/widget/spinner.rs
@@ -17,7 +17,6 @@ use crate::{
     PointerEvent, RegisterCtx, Size, TextEvent, Update, UpdateCtx, Vec2, Widget, WidgetId,
 };
 
-// TODO - Set color
 /// An animated spinner widget for showing a loading state.
 ///
 /// To customize the spinner's size, you can place it inside a [`SizedBox`]
@@ -55,16 +54,16 @@ impl Default for Spinner {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, Spinner> {
+impl Spinner {
     /// Set the spinner's color.
-    pub fn set_color(&mut self, color: impl Into<Color>) {
-        self.widget.color = color.into();
-        self.ctx.request_paint_only();
+    pub fn set_color(this: &mut WidgetMut<'_, Self>, color: impl Into<Color>) {
+        this.widget.color = color.into();
+        this.ctx.request_paint_only();
     }
 
     /// Reset the spinner's color to its default value.
-    pub fn reset_color(&mut self) {
-        self.set_color(DEFAULT_SPINNER_COLOR);
+    pub fn reset_color(this: &mut WidgetMut<'_, Self>) {
+        Self::set_color(this, DEFAULT_SPINNER_COLOR);
     }
 }
 
@@ -191,7 +190,7 @@ mod tests {
 
             harness.edit_root_widget(|mut spinner| {
                 let mut spinner = spinner.downcast::<Spinner>();
-                spinner.set_color(Color::PURPLE);
+                Spinner::set_color(&mut spinner, Color::PURPLE);
             });
 
             harness.render()

--- a/masonry/src/widget/split.rs
+++ b/masonry/src/widget/split.rs
@@ -297,29 +297,29 @@ impl Split {
 // FIXME - Add unit tests for WidgetMut<Split>
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, Split> {
+impl Split {
     /// Set the split point as a fraction of the split axis.
     ///
     /// The value must be between `0.0` and `1.0`, inclusive.
     /// The default split point is `0.5`.
-    pub fn set_split_point(&mut self, split_point: f64) {
+    pub fn set_split_point(this: &mut WidgetMut<'_, Self>, split_point: f64) {
         assert!(
             (0.0..=1.0).contains(&split_point),
             "split_point must be in the range [0.0-1.0]!"
         );
-        self.widget.split_point_chosen = split_point;
-        self.ctx.request_layout();
+        this.widget.split_point_chosen = split_point;
+        this.ctx.request_layout();
     }
 
     /// Set the minimum size for both sides of the split axis.
     ///
     /// The value must be greater than or equal to `0.0`.
     /// The value will be rounded up to the nearest integer.
-    pub fn set_min_size(&mut self, first: f64, second: f64) {
+    pub fn set_min_size(this: &mut WidgetMut<'_, Self>, first: f64, second: f64) {
         assert!(first >= 0.0);
         assert!(second >= 0.0);
-        self.widget.min_size = (first.ceil(), second.ceil());
-        self.ctx.request_layout();
+        this.widget.min_size = (first.ceil(), second.ceil());
+        this.ctx.request_layout();
     }
 
     /// Set the size of the splitter bar.
@@ -327,10 +327,10 @@ impl WidgetMut<'_, Split> {
     /// The value must be positive or zero.
     /// The value will be rounded up to the nearest integer.
     /// The default splitter bar size is `6.0`.
-    pub fn set_bar_size(&mut self, bar_size: f64) {
+    pub fn set_bar_size(this: &mut WidgetMut<'_, Self>, bar_size: f64) {
         assert!(bar_size >= 0.0, "bar_size must be 0.0 or greater!");
-        self.widget.bar_size = bar_size.ceil();
-        self.ctx.request_layout();
+        this.widget.bar_size = bar_size.ceil();
+        this.ctx.request_layout();
     }
 
     /// Set the minimum size of the splitter bar area.
@@ -345,27 +345,27 @@ impl WidgetMut<'_, Split> {
     /// The value must be positive or zero.
     /// The value will be rounded up to the nearest integer.
     /// The default minimum splitter bar area is `6.0`.
-    pub fn set_min_bar_area(&mut self, min_bar_area: f64) {
+    pub fn set_min_bar_area(this: &mut WidgetMut<'_, Self>, min_bar_area: f64) {
         assert!(min_bar_area >= 0.0, "min_bar_area must be 0.0 or greater!");
-        self.widget.min_bar_area = min_bar_area.ceil();
-        self.ctx.request_layout();
+        this.widget.min_bar_area = min_bar_area.ceil();
+        this.ctx.request_layout();
     }
 
     /// Set whether the split point can be changed by dragging.
-    pub fn set_draggable(&mut self, draggable: bool) {
-        self.widget.draggable = draggable;
+    pub fn set_draggable(this: &mut WidgetMut<'_, Self>, draggable: bool) {
+        this.widget.draggable = draggable;
         // Bar mutability impacts appearance, but not accessibility node
         // TODO - This might change in a future implementation
-        self.ctx.request_paint_only();
+        this.ctx.request_paint_only();
     }
 
     /// Set whether the splitter bar is drawn as a solid rectangle.
     ///
     /// If this is `false` (the default), the bar will be drawn as two parallel lines.
-    pub fn set_bar_solid(&mut self, solid: bool) {
-        self.widget.solid = solid;
+    pub fn set_bar_solid(this: &mut WidgetMut<'_, Self>, solid: bool) {
+        this.widget.solid = solid;
         // Bar solidity impacts appearance, but not accessibility node
-        self.ctx.request_paint_only();
+        this.ctx.request_paint_only();
     }
 }
 
@@ -635,11 +635,11 @@ mod tests {
             harness.edit_root_widget(|mut splitter| {
                 let mut splitter = splitter.downcast::<Split>();
 
-                splitter.set_split_point(0.3);
-                splitter.set_min_size(40.0, 10.0);
-                splitter.set_bar_size(12.0);
-                splitter.set_draggable(true);
-                splitter.set_bar_solid(true);
+                Split::set_split_point(&mut splitter, 0.3);
+                Split::set_min_size(&mut splitter, 40.0, 10.0);
+                Split::set_bar_size(&mut splitter, 12.0);
+                Split::set_draggable(&mut splitter, true);
+                Split::set_bar_solid(&mut splitter, true);
             });
 
             harness.render()

--- a/masonry/src/widget/tests/widget_tree.rs
+++ b/masonry/src/widget/tests/widget_tree.rs
@@ -21,7 +21,7 @@ fn access_grandchild_widget() {
     dbg!(harness.root_widget());
     harness.edit_widget(id_label, |mut label| {
         let mut label = label.downcast::<Label>();
-        label.set_text("New text");
+        Label::set_text(&mut label, "New text");
     });
 
     assert_debug_snapshot!(harness.root_widget());

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -94,18 +94,14 @@ impl Textbox {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, Textbox> {
-    pub fn text(&self) -> &str {
-        self.widget.editor.text()
-    }
-
+impl Textbox {
     pub fn set_text_properties<R>(
-        &mut self,
+        this: &mut WidgetMut<'_, Self>,
         f: impl FnOnce(&mut TextWithSelection<String>) -> R,
     ) -> R {
-        let ret = f(&mut self.widget.editor);
-        if self.widget.editor.needs_rebuild() {
-            self.ctx.request_layout();
+        let ret = f(&mut this.widget.editor);
+        if this.widget.editor.needs_rebuild() {
+            this.ctx.request_layout();
         }
         ret
     }
@@ -117,40 +113,40 @@ impl WidgetMut<'_, Textbox> {
     // FIXME - it's not clear whether this is the right behaviour, or if there even
     // is one.
     // TODO: Create a method which sets the text and the cursor selection to be used if focused?
-    pub fn reset_text(&mut self, new_text: String) {
-        if self.ctx.is_focused() {
+    pub fn reset_text(this: &mut WidgetMut<'_, Self>, new_text: String) {
+        if this.ctx.is_focused() {
             tracing::warn!(
                 "Called reset_text on a focused `Textbox`. This will lose the user's current selection and cursor"
             );
         }
-        self.widget.editor.reset_preedit();
-        self.set_text_properties(|layout| layout.set_text(new_text));
+        this.widget.editor.reset_preedit();
+        Self::set_text_properties(this, |layout| layout.set_text(new_text));
     }
 
     #[doc(alias = "set_text_color")]
-    pub fn set_text_brush(&mut self, brush: impl Into<TextBrush>) {
+    pub fn set_text_brush(this: &mut WidgetMut<'_, Self>, brush: impl Into<TextBrush>) {
         let brush = brush.into();
-        self.widget.brush = brush;
-        if !self.ctx.is_disabled() {
-            let brush = self.widget.brush.clone();
-            self.set_text_properties(|layout| layout.set_brush(brush));
+        this.widget.brush = brush;
+        if !this.ctx.is_disabled() {
+            let brush = this.widget.brush.clone();
+            Self::set_text_properties(this, |layout| layout.set_brush(brush));
         }
     }
-    pub fn set_text_size(&mut self, size: f32) {
-        self.set_text_properties(|layout| layout.set_text_size(size));
+    pub fn set_text_size(this: &mut WidgetMut<'_, Self>, size: f32) {
+        Self::set_text_properties(this, |layout| layout.set_text_size(size));
     }
-    pub fn set_alignment(&mut self, alignment: Alignment) {
-        self.set_text_properties(|layout| layout.set_text_alignment(alignment));
+    pub fn set_alignment(this: &mut WidgetMut<'_, Self>, alignment: Alignment) {
+        Self::set_text_properties(this, |layout| layout.set_text_alignment(alignment));
     }
-    pub fn set_font(&mut self, font_stack: FontStack<'static>) {
-        self.set_text_properties(|layout| layout.set_font(font_stack));
+    pub fn set_font(this: &mut WidgetMut<'_, Self>, font_stack: FontStack<'static>) {
+        Self::set_text_properties(this, |layout| layout.set_font(font_stack));
     }
-    pub fn set_font_family(&mut self, family: FontFamily<'static>) {
-        self.set_font(FontStack::Single(family));
+    pub fn set_font_family(this: &mut WidgetMut<'_, Self>, family: FontFamily<'static>) {
+        Self::set_font(this, FontStack::Single(family));
     }
-    pub fn set_line_break_mode(&mut self, line_break_mode: LineBreaking) {
-        self.widget.line_break_mode = line_break_mode;
-        self.ctx.request_render();
+    pub fn set_line_break_mode(this: &mut WidgetMut<'_, Self>, line_break_mode: LineBreaking) {
+        this.widget.line_break_mode = line_break_mode;
+        this.ctx.request_render();
     }
 }
 
@@ -344,3 +340,5 @@ impl Widget for Textbox {
         Some(self.editor.text().chars().take(100).collect())
     }
 }
+
+// TODO - Add tests

--- a/masonry/src/widget/variable_label.rs
+++ b/masonry/src/widget/variable_label.rs
@@ -217,67 +217,65 @@ impl VariableLabel {
 }
 
 // --- MARK: WIDGETMUT ---
-impl WidgetMut<'_, VariableLabel> {
-    /// Read the text.
-    pub fn text(&self) -> &ArcStr {
-        &self.widget.text
-    }
-
+impl VariableLabel {
     /// Set a property on the underlying text.
     ///
     /// This cannot be used to set attributes.
-    pub fn set_text_properties<R>(&mut self, f: impl FnOnce(&mut TextLayout) -> R) -> R {
-        let ret = f(&mut self.widget.text_layout);
-        if self.widget.text_layout.needs_rebuild() {
-            self.ctx.request_layout();
+    pub fn set_text_properties<R>(
+        this: &mut WidgetMut<'_, Self>,
+        f: impl FnOnce(&mut TextLayout) -> R,
+    ) -> R {
+        let ret = f(&mut this.widget.text_layout);
+        if this.widget.text_layout.needs_rebuild() {
+            this.ctx.request_layout();
         }
         ret
     }
 
     /// Modify the underlying text.
-    pub fn set_text(&mut self, new_text: impl Into<ArcStr>) {
+    pub fn set_text(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
         let new_text = new_text.into();
-        self.widget.text = new_text;
-        self.widget.text_changed = true;
-        self.ctx.request_layout();
+        this.widget.text = new_text;
+        this.widget.text_changed = true;
+        this.ctx.request_layout();
     }
 
     #[doc(alias = "set_text_color")]
     /// Set the brush of the text, normally used for the colour.
-    pub fn set_text_brush(&mut self, brush: impl Into<TextBrush>) {
+    pub fn set_text_brush(this: &mut WidgetMut<'_, Self>, brush: impl Into<TextBrush>) {
         let brush = brush.into();
-        self.widget.brush = brush;
-        if !self.ctx.is_disabled() {
-            self.widget.text_layout.invalidate();
-            self.ctx.request_layout();
+        this.widget.brush = brush;
+        if !this.ctx.is_disabled() {
+            this.widget.text_layout.invalidate();
+            this.ctx.request_layout();
         }
     }
     /// Set the font size for this text.
-    pub fn set_text_size(&mut self, size: f32) {
-        self.set_text_properties(|layout| layout.set_text_size(size));
+    pub fn set_text_size(this: &mut WidgetMut<'_, Self>, size: f32) {
+        Self::set_text_properties(this, |layout| layout.set_text_size(size));
     }
     /// Set the text alignment of the contained text
-    pub fn set_alignment(&mut self, alignment: Alignment) {
-        self.set_text_properties(|layout| layout.set_text_alignment(alignment));
+    pub fn set_alignment(this: &mut WidgetMut<'_, Self>, alignment: Alignment) {
+        Self::set_text_properties(this, |layout| layout.set_text_alignment(alignment));
     }
     /// Set the font (potentially with fallbacks) which will be used for this text.
-    pub fn set_font(&mut self, font_stack: FontStack<'static>) {
-        self.set_text_properties(|layout| layout.set_font(font_stack));
+    pub fn set_font(this: &mut WidgetMut<'_, Self>, font_stack: FontStack<'static>) {
+        Self::set_text_properties(this, |layout| layout.set_font(font_stack));
     }
     /// A helper method to use a single font family.
-    pub fn set_font_family(&mut self, family: FontFamily<'static>) {
-        self.set_font(FontStack::Single(family));
+    pub fn set_font_family(this: &mut WidgetMut<'_, Self>, family: FontFamily<'static>) {
+        Self::set_font(this, FontStack::Single(family));
     }
     /// How to handle overflowing lines.
-    pub fn set_line_break_mode(&mut self, line_break_mode: LineBreaking) {
-        self.widget.line_break_mode = line_break_mode;
-        self.ctx.request_layout();
+    pub fn set_line_break_mode(this: &mut WidgetMut<'_, Self>, line_break_mode: LineBreaking) {
+        this.widget.line_break_mode = line_break_mode;
+        this.ctx.request_layout();
     }
     /// Set the weight which this font will target.
-    pub fn set_target_weight(&mut self, target: f32, over_millis: f32) {
-        self.widget.weight.move_to(target, over_millis);
-        self.ctx.request_layout();
-        self.ctx.request_anim_frame();
+    pub fn set_target_weight(this: &mut WidgetMut<'_, Self>, target: f32, over_millis: f32) {
+        this.widget.weight.move_to(target, over_millis);
+        this.ctx.request_layout();
+        this.ctx.request_anim_frame();
     }
 }
 
@@ -424,4 +422,6 @@ impl Widget for VariableLabel {
 
 // --- MARK: TESTS ---
 #[cfg(test)]
-mod tests {}
+mod tests {
+    // TODO - Add tests
+}

--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -114,7 +114,7 @@ where
                 &self.current_view,
                 &mut self.view_state,
                 &mut self.ctx,
-                root.child_mut(),
+                RootWidget::child_mut(&mut root),
             );
             self.current_view = next_view;
         }

--- a/xilem/src/view/button.rs
+++ b/xilem/src/view/button.rs
@@ -59,7 +59,7 @@ where
         mut element: Mut<Self::Element>,
     ) {
         if prev.label != self.label {
-            element.set_text(self.label.clone());
+            widget::Button::set_text(&mut element, self.label.clone());
         }
     }
 

--- a/xilem/src/view/checkbox.rs
+++ b/xilem/src/view/checkbox.rs
@@ -52,10 +52,10 @@ where
         mut element: Mut<Self::Element>,
     ) {
         if prev.label != self.label {
-            element.set_text(self.label.clone());
+            widget::Checkbox::set_text(&mut element, self.label.clone());
         }
         if prev.checked != self.checked {
-            element.set_checked(self.checked);
+            widget::Checkbox::set_checked(&mut element, self.checked);
         }
     }
 

--- a/xilem/src/view/flex.rs
+++ b/xilem/src/view/flex.rs
@@ -251,10 +251,10 @@ impl ElementSplice<FlexElement> for FlexSplice<'_> {
                 );
             }
             FlexElement::FixedSpacer(len) => {
-                widget::Flex::insert_spacer(&mut self.element, self.idx, len)
+                widget::Flex::insert_spacer(&mut self.element, self.idx, len);
             }
             FlexElement::FlexSpacer(len) => {
-                widget::Flex::insert_flex_spacer(&mut self.element, self.idx, len)
+                widget::Flex::insert_flex_spacer(&mut self.element, self.idx, len);
             }
         };
         self.idx += 1;
@@ -273,10 +273,10 @@ impl ElementSplice<FlexElement> for FlexSplice<'_> {
                     );
                 }
                 FlexElement::FixedSpacer(len) => {
-                    widget::Flex::insert_spacer(&mut self.element, self.idx, len)
+                    widget::Flex::insert_spacer(&mut self.element, self.idx, len);
                 }
                 FlexElement::FlexSpacer(len) => {
-                    widget::Flex::insert_flex_spacer(&mut self.element, self.idx, len)
+                    widget::Flex::insert_flex_spacer(&mut self.element, self.idx, len);
                 }
             };
             self.idx += 1;
@@ -539,10 +539,10 @@ impl<State, Action> View<State, Action, ViewCtx> for FlexSpacer {
         if self != prev {
             match self {
                 FlexSpacer::Fixed(len) => {
-                    widget::Flex::update_spacer_fixed(&mut element.parent, element.idx, *len)
+                    widget::Flex::update_spacer_fixed(&mut element.parent, element.idx, *len);
                 }
                 FlexSpacer::Flex(flex) => {
-                    widget::Flex::update_spacer_flex(&mut element.parent, element.idx, *flex)
+                    widget::Flex::update_spacer_flex(&mut element.parent, element.idx, *flex);
                 }
             };
         }
@@ -708,10 +708,10 @@ where
                 let (spacer_element, ()) = View::<(), (), ViewCtx>::build(new_spacer, ctx);
                 match spacer_element {
                     FlexElement::FixedSpacer(len) => {
-                        widget::Flex::insert_spacer(&mut element.parent, element.idx, len)
+                        widget::Flex::insert_spacer(&mut element.parent, element.idx, len);
                     }
                     FlexElement::FlexSpacer(len) => {
-                        widget::Flex::insert_flex_spacer(&mut element.parent, element.idx, len)
+                        widget::Flex::insert_flex_spacer(&mut element.parent, element.idx, len);
                     }
                     FlexElement::Child(_, _) => unreachable!(),
                 };

--- a/xilem/src/view/grid.rs
+++ b/xilem/src/view/grid.rs
@@ -82,13 +82,13 @@ where
         mut element: Mut<Self::Element>,
     ) {
         if prev.height != self.height {
-            element.set_height(self.height);
+            widget::Grid::set_height(&mut element, self.height);
         }
         if prev.width != self.width {
-            element.set_width(self.width);
+            widget::Grid::set_width(&mut element, self.width);
         }
         if prev.spacing != self.spacing {
-            element.set_spacing(self.spacing);
+            widget::Grid::set_spacing(&mut element, self.spacing);
         }
 
         let mut splice = GridSplice::new(element);
@@ -162,9 +162,7 @@ impl<W: Widget> SuperElement<Pod<W>, ViewCtx> for GridElement {
         f: impl FnOnce(Mut<Pod<W>>) -> R,
     ) -> (Mut<Self>, R) {
         let ret = {
-            let mut child = this
-                .parent
-                .child_mut(this.idx)
+            let mut child = widget::Grid::child_mut(&mut this.parent, this.idx)
                 .expect("This is supposed to be a widget");
             let downcast = child.downcast();
             f(downcast)
@@ -181,8 +179,12 @@ impl ElementSplice<GridElement> for GridSplice<'_> {
         for element in self.scratch.drain() {
             match element {
                 GridElement::Child(child, params) => {
-                    self.element
-                        .insert_grid_child_pod(self.idx, child.inner, params);
+                    widget::Grid::insert_grid_child_pod(
+                        &mut self.element,
+                        self.idx,
+                        child.inner,
+                        params,
+                    );
                 }
             };
             self.idx += 1;
@@ -193,8 +195,12 @@ impl ElementSplice<GridElement> for GridSplice<'_> {
     fn insert(&mut self, element: GridElement) {
         match element {
             GridElement::Child(child, params) => {
-                self.element
-                    .insert_grid_child_pod(self.idx, child.inner, params);
+                widget::Grid::insert_grid_child_pod(
+                    &mut self.element,
+                    self.idx,
+                    child.inner,
+                    params,
+                );
             }
         };
         self.idx += 1;
@@ -222,7 +228,7 @@ impl ElementSplice<GridElement> for GridSplice<'_> {
             };
             f(child)
         };
-        self.element.remove_child(self.idx);
+        widget::Grid::remove_child(&mut self.element, self.idx);
         ret
     }
 }
@@ -369,13 +375,13 @@ where
     ) {
         {
             if self.params != prev.params {
-                element
-                    .parent
-                    .update_child_grid_params(element.idx, self.params);
+                widget::Grid::update_child_grid_params(
+                    &mut element.parent,
+                    element.idx,
+                    self.params,
+                );
             }
-            let mut child = element
-                .parent
-                .child_mut(element.idx)
+            let mut child = widget::Grid::child_mut(&mut element.parent, element.idx)
                 .expect("GridWrapper always has a widget child");
             self.view
                 .rebuild(&prev.view, view_state, ctx, child.downcast());
@@ -388,9 +394,7 @@ where
         ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        let mut child = element
-            .parent
-            .child_mut(element.idx)
+        let mut child = widget::Grid::child_mut(&mut element.parent, element.idx)
             .expect("GridWrapper always has a widget child");
         self.view.teardown(view_state, ctx, child.downcast());
     }

--- a/xilem/src/view/image.rs
+++ b/xilem/src/view/image.rs
@@ -61,10 +61,10 @@ impl<State, Action> View<State, Action, ViewCtx> for Image {
         mut element: Mut<Self::Element>,
     ) {
         if prev.object_fit != self.object_fit {
-            element.set_fit_mode(self.object_fit);
+            widget::Image::set_fit_mode(&mut element, self.object_fit);
         }
         if prev.image != self.image {
-            element.set_image_data(self.image.clone());
+            widget::Image::set_image_data(&mut element, self.image.clone());
         }
     }
 

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -75,19 +75,19 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
         mut element: Mut<Self::Element>,
     ) {
         if prev.label != self.label {
-            element.set_text(self.label.clone());
+            widget::Label::set_text(&mut element, self.label.clone());
         }
         if prev.text_brush != self.text_brush {
-            element.set_text_brush(self.text_brush.clone());
+            widget::Label::set_text_brush(&mut element, self.text_brush.clone());
         }
         if prev.alignment != self.alignment {
-            element.set_alignment(self.alignment);
+            widget::Label::set_alignment(&mut element, self.alignment);
         }
         if prev.text_size != self.text_size {
-            element.set_text_size(self.text_size);
+            widget::Label::set_text_size(&mut element, self.text_size);
         }
         if prev.weight != self.weight {
-            element.set_weight(self.weight);
+            widget::Label::set_weight(&mut element, self.weight);
         }
     }
 

--- a/xilem/src/view/portal.rs
+++ b/xilem/src/view/portal.rs
@@ -51,7 +51,7 @@ where
         ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        let child_element = element.child_mut();
+        let child_element = widget::Portal::child_mut(&mut element);
         self.child
             .rebuild(&prev.child, view_state, ctx, child_element);
     }
@@ -62,7 +62,7 @@ where
         ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        let child_element = element.child_mut();
+        let child_element = widget::Portal::child_mut(&mut element);
         self.child.teardown(view_state, ctx, child_element);
     }
 

--- a/xilem/src/view/progress_bar.rs
+++ b/xilem/src/view/progress_bar.rs
@@ -33,7 +33,7 @@ impl<State, Action> View<State, Action, ViewCtx> for ProgressBar {
         mut element: Mut<Self::Element>,
     ) {
         if prev.progress != self.progress {
-            element.set_progress(self.progress);
+            widget::ProgressBar::set_progress(&mut element, self.progress);
         }
     }
 

--- a/xilem/src/view/prose.rs
+++ b/xilem/src/view/prose.rs
@@ -68,16 +68,16 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
         mut element: Mut<Self::Element>,
     ) {
         if prev.content != self.content {
-            element.set_text(self.content.clone());
+            widget::Prose::set_text(&mut element, self.content.clone());
         }
         if prev.text_brush != self.text_brush {
-            element.set_text_brush(self.text_brush.clone());
+            widget::Prose::set_text_brush(&mut element, self.text_brush.clone());
         }
         if prev.alignment != self.alignment {
-            element.set_alignment(self.alignment);
+            widget::Prose::set_alignment(&mut element, self.alignment);
         }
         if prev.text_size != self.text_size {
-            element.set_text_size(self.text_size);
+            widget::Prose::set_text_size(&mut element, self.text_size);
         }
     }
 

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -157,7 +157,7 @@ where
         if self.background != prev.background {
             match &self.background {
                 Some(background) => {
-                    widget::SizedBox::set_background(&mut element, background.clone())
+                    widget::SizedBox::set_background(&mut element, background.clone());
                 }
                 None => widget::SizedBox::clear_background(&mut element),
             }
@@ -165,7 +165,7 @@ where
         if self.border != prev.border {
             match &self.border {
                 Some(border) => {
-                    widget::SizedBox::set_border(&mut element, border.color, border.width)
+                    widget::SizedBox::set_border(&mut element, border.color, border.width);
                 }
                 None => widget::SizedBox::clear_border(&mut element),
             }

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -144,34 +144,37 @@ where
     ) {
         if self.width != prev.width {
             match self.width {
-                Some(width) => element.set_width(width),
-                None => element.unset_width(),
+                Some(width) => widget::SizedBox::set_width(&mut element, width),
+                None => widget::SizedBox::unset_width(&mut element),
             }
         }
         if self.height != prev.height {
             match self.height {
-                Some(height) => element.set_height(height),
-                None => element.unset_height(),
+                Some(height) => widget::SizedBox::set_height(&mut element, height),
+                None => widget::SizedBox::unset_height(&mut element),
             }
         }
         if self.background != prev.background {
             match &self.background {
-                Some(background) => element.set_background(background.clone()),
-                None => element.clear_background(),
+                Some(background) => {
+                    widget::SizedBox::set_background(&mut element, background.clone())
+                }
+                None => widget::SizedBox::clear_background(&mut element),
             }
         }
         if self.border != prev.border {
             match &self.border {
-                Some(border) => element.set_border(border.color, border.width),
-                None => element.clear_border(),
+                Some(border) => {
+                    widget::SizedBox::set_border(&mut element, border.color, border.width)
+                }
+                None => widget::SizedBox::clear_border(&mut element),
             }
         }
         if self.corner_radius != prev.corner_radius {
-            element.set_rounded(self.corner_radius);
+            widget::SizedBox::set_rounded(&mut element, self.corner_radius);
         }
         {
-            let mut child = element
-                .child_mut()
+            let mut child = widget::SizedBox::child_mut(&mut element)
                 .expect("We only create SizedBox with a child");
             self.inner
                 .rebuild(&prev.inner, view_state, ctx, child.downcast());
@@ -184,8 +187,7 @@ where
         ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        let mut child = element
-            .child_mut()
+        let mut child = widget::SizedBox::child_mut(&mut element)
             .expect("We only create SizedBox with a child");
         self.inner.teardown(view_state, ctx, child.downcast());
     }

--- a/xilem/src/view/spinner.rs
+++ b/xilem/src/view/spinner.rs
@@ -68,8 +68,8 @@ impl<State, Action> View<State, Action, ViewCtx> for Spinner {
     ) {
         if prev.color != self.color {
             match self.color {
-                Some(color) => element.set_color(color),
-                None => element.reset_color(),
+                Some(color) => widget::Spinner::set_color(&mut element, color),
+                None => widget::Spinner::reset_color(&mut element),
             };
         }
     }

--- a/xilem/src/view/textbox.rs
+++ b/xilem/src/view/textbox.rs
@@ -93,15 +93,15 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
         // without calling `set_text`.
 
         // This is probably not the right behaviour, but determining what is the right behaviour is hard
-        if self.contents != element.text() {
-            element.reset_text(self.contents.clone());
+        if self.contents != element.widget.text() {
+            widget::Textbox::reset_text(&mut element, self.contents.clone());
         }
 
         if prev.text_brush != self.text_brush {
-            element.set_text_brush(self.text_brush.clone());
+            widget::Textbox::set_text_brush(&mut element, self.text_brush.clone());
         }
         if prev.alignment != self.alignment {
-            element.set_alignment(self.alignment);
+            widget::Textbox::set_alignment(&mut element, self.alignment);
         }
     }
 

--- a/xilem/src/view/variable_label.rs
+++ b/xilem/src/view/variable_label.rs
@@ -117,24 +117,28 @@ impl<State, Action> View<State, Action, ViewCtx> for VariableLabel {
         mut element: Mut<Self::Element>,
     ) {
         if prev.label != self.label {
-            element.set_text(self.label.clone());
+            widget::VariableLabel::set_text(&mut element, self.label.clone());
         }
         if prev.text_brush != self.text_brush {
-            element.set_text_brush(self.text_brush.clone());
+            widget::VariableLabel::set_text_brush(&mut element, self.text_brush.clone());
         }
         if prev.alignment != self.alignment {
-            element.set_alignment(self.alignment);
+            widget::VariableLabel::set_alignment(&mut element, self.alignment);
         }
         if prev.text_size != self.text_size {
-            element.set_text_size(self.text_size);
+            widget::VariableLabel::set_text_size(&mut element, self.text_size);
         }
         if prev.target_weight != self.target_weight {
-            element.set_target_weight(self.target_weight.value(), self.over_millis);
+            widget::VariableLabel::set_target_weight(
+                &mut element,
+                self.target_weight.value(),
+                self.over_millis,
+            );
         }
         // First perform a fast filter, then perform a full comparison if that suggests a possible change.
         let fonts_eq = fonts_eq_fastpath(prev.font, self.font) || prev.font == self.font;
         if !fonts_eq {
-            element.set_font(self.font);
+            widget::VariableLabel::set_font(&mut element, self.font);
         }
     }
 


### PR DESCRIPTION
See discussion here https://github.com/linebender/xilem/pull/663 and [on zulip](https://xi.zulipchat.com/#narrow/channel/317477-masonry/topic/Improving.20docs.20for.20WidgetMut).

Basically, previous code was using `WidgetMut<MyWidget>` as a receiver. This can be done when WidgetMut is a local type, but external users wouldn't be able to do it. The result would be that users importing Masonry as a dependency but copy-pasting code from one of our widgets would get compile errors.

This PR switches to a syntax that external crates will be able to use when declaring widgets. It's a more verbose, less readable syntax, but it's unambiguous and doesn't require clever tricks.

We can consider switching back to WidgetMut-as-a-receiver when `#![feature(arbitrary_self_types)]` or some equivalent gets stabilized. See https://github.com/rust-lang/rust/issues/44874#issuecomment-2122179688 for current progress.