### PR TITLE
xilem_web: Add a few boolean attribute modifiers for `HtmlInputElement` and factor element state flags out of these modifiers into `ElementFlags`

### DIFF
--- a/xilem_web/src/elements.rs
+++ b/xilem_web/src/elements.rs
@@ -11,7 +11,7 @@ use wasm_bindgen::{JsCast, UnwrapThrowExt};
 use crate::{
     core::{AppendVec, ElementSplice, MessageResult, Mut, View, ViewId, ViewMarker},
     document,
-    modifiers::{Children, With},
+    modifiers::{Children, WithModifier},
     vec_splice::VecSplice,
     AnyPod, DomFragment, DomNode, DynMessage, FromWithContext, Pod, ViewCtx, HTML_NS,
 };
@@ -262,11 +262,11 @@ pub(crate) fn rebuild_element<State, Action, Element>(
     State: 'static,
     Action: 'static,
     Element: 'static,
-    Element: DomNode<Props: With<Children>>,
+    Element: DomNode<Props: WithModifier<Children>>,
 {
     let mut dom_children_splice = DomChildrenSplice::new(
         &mut state.append_scratch,
-        With::<Children>::modifier(element.props).modifier,
+        WithModifier::<Children>::modifier(element.props).modifier,
         &mut state.vec_splice_scratch,
         element.node.as_ref(),
         ctx.fragment.clone(),
@@ -290,11 +290,11 @@ pub(crate) fn teardown_element<State, Action, Element>(
     State: 'static,
     Action: 'static,
     Element: 'static,
-    Element: DomNode<Props: With<Children>>,
+    Element: DomNode<Props: WithModifier<Children>>,
 {
     let mut dom_children_splice = DomChildrenSplice::new(
         &mut state.append_scratch,
-        With::<Children>::modifier(element.props).modifier,
+        WithModifier::<Children>::modifier(element.props).modifier,
         &mut state.vec_splice_scratch,
         element.node.as_ref(),
         ctx.fragment.clone(),

--- a/xilem_web/src/elements.rs
+++ b/xilem_web/src/elements.rs
@@ -266,7 +266,7 @@ pub(crate) fn rebuild_element<State, Action, Element>(
 {
     let mut dom_children_splice = DomChildrenSplice::new(
         &mut state.append_scratch,
-        With::<Children>::modifier(element.props),
+        With::<Children>::modifier(element.props).modifier,
         &mut state.vec_splice_scratch,
         element.node.as_ref(),
         ctx.fragment.clone(),
@@ -294,7 +294,7 @@ pub(crate) fn teardown_element<State, Action, Element>(
 {
     let mut dom_children_splice = DomChildrenSplice::new(
         &mut state.append_scratch,
-        With::<Children>::modifier(element.props),
+        With::<Children>::modifier(element.props).modifier,
         &mut state.vec_splice_scratch,
         element.node.as_ref(),
         ctx.fragment.clone(),

--- a/xilem_web/src/interfaces.rs
+++ b/xilem_web/src/interfaces.rs
@@ -830,7 +830,7 @@ pub trait HtmlInputElement<State, Action = ()>:
     /// use xilem_web::{interfaces::{Element, HtmlInputElement}, elements::html::input};
     ///
     /// # fn component() -> impl HtmlInputElement<()> {
-    /// input(()).required(true) // results in <input required></input>
+    /// input(()).multiple(true) // results in <input multiple></input>
     /// # }
     /// ```
     fn multiple(self, required: bool) -> html_input_element::view::Multiple<Self, State, Action> {

--- a/xilem_web/src/interfaces.rs
+++ b/xilem_web/src/interfaces.rs
@@ -833,8 +833,8 @@ pub trait HtmlInputElement<State, Action = ()>:
     /// input(()).multiple(true) // results in <input multiple></input>
     /// # }
     /// ```
-    fn multiple(self, required: bool) -> html_input_element::view::Multiple<Self, State, Action> {
-        html_input_element::view::Multiple::new(self, required)
+    fn multiple(self, multiple: bool) -> html_input_element::view::Multiple<Self, State, Action> {
+        html_input_element::view::Multiple::new(self, multiple)
     }
 }
 

--- a/xilem_web/src/interfaces.rs
+++ b/xilem_web/src/interfaces.rs
@@ -766,6 +766,7 @@ pub trait HtmlInputElement<State, Action = ()>:
     Action,
     DomNode: DomNode<
         Props: With<html_input_element::Checked>
+                   + With<html_input_element::DefaultChecked>
                    + With<html_input_element::Disabled>
                    + With<html_input_element::Required>
                    + With<html_input_element::Multiple>,
@@ -857,6 +858,7 @@ where
     T: HtmlElement<State, Action>,
     T::DomNode: AsRef<web_sys::HtmlInputElement>,
     <T::DomNode as DomNode>::Props: With<html_input_element::Checked>
+        + With<html_input_element::DefaultChecked>
         + With<html_input_element::Disabled>
         + With<html_input_element::Required>
         + With<html_input_element::Multiple>,

--- a/xilem_web/src/interfaces.rs
+++ b/xilem_web/src/interfaces.rs
@@ -16,10 +16,8 @@ use std::borrow::Cow;
 
 use crate::{
     events,
-    modifiers::{
-        Attr, Attributes, Class, ClassIter, Classes, Rotate, Scale, ScaleValue, Style, StyleIter,
-        Styles, With,
-    },
+    modifiers::{Attr, Class, ClassIter, Rotate, Scale, ScaleValue, Style, StyleIter},
+    props::{WithElementProps, WithHtmlInputElementProps},
     DomNode, DomView, IntoAttributeValue, OptionalAction, Pointer, PointerMsg,
 };
 use wasm_bindgen::JsCast;
@@ -51,13 +49,7 @@ macro_rules! event_handler_mixin {
 }
 
 pub trait Element<State, Action = ()>:
-    Sized
-    + DomView<
-        State,
-        Action,
-        DomNode: DomNode<Props: With<Attributes> + With<Classes> + With<Styles>>
-                     + AsRef<web_sys::Element>,
-    >
+    Sized + DomView<State, Action, DomNode: DomNode<Props: WithElementProps> + AsRef<web_sys::Element>>
 {
     /// Set an attribute for an [`Element`]
     ///
@@ -331,7 +323,7 @@ pub trait Element<State, Action = ()>:
 impl<State, Action, T> Element<State, Action> for T
 where
     T: DomView<State, Action>,
-    <T::DomNode as DomNode>::Props: With<Attributes> + With<Classes> + With<Styles>,
+    <T::DomNode as DomNode>::Props: WithElementProps,
     T::DomNode: AsRef<web_sys::Element>,
 {
 }
@@ -764,13 +756,7 @@ pub trait HtmlInputElement<State, Action = ()>:
     HtmlElement<
     State,
     Action,
-    DomNode: DomNode<
-        Props: With<html_input_element::Checked>
-                   + With<html_input_element::DefaultChecked>
-                   + With<html_input_element::Disabled>
-                   + With<html_input_element::Required>
-                   + With<html_input_element::Multiple>,
-    > + AsRef<web_sys::HtmlInputElement>,
+    DomNode: DomNode<Props: WithHtmlInputElementProps> + AsRef<web_sys::HtmlInputElement>,
 >
 {
     /// See <https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/checked> for more details.
@@ -857,11 +843,7 @@ impl<State, Action, T> HtmlInputElement<State, Action> for T
 where
     T: HtmlElement<State, Action>,
     T::DomNode: AsRef<web_sys::HtmlInputElement>,
-    <T::DomNode as DomNode>::Props: With<html_input_element::Checked>
-        + With<html_input_element::DefaultChecked>
-        + With<html_input_element::Disabled>
-        + With<html_input_element::Required>
-        + With<html_input_element::Multiple>,
+    <T::DomNode as DomNode>::Props: WithHtmlInputElementProps,
 {
 }
 

--- a/xilem_web/src/interfaces.rs
+++ b/xilem_web/src/interfaces.rs
@@ -758,10 +758,97 @@ where
 {
 }
 
+use crate::modifiers::html_input_element;
 // #[cfg(feature = "HtmlInputElement")]
 pub trait HtmlInputElement<State, Action = ()>:
-    HtmlElement<State, Action, DomNode: AsRef<web_sys::HtmlInputElement>>
+    HtmlElement<
+    State,
+    Action,
+    DomNode: DomNode<
+        Props: With<html_input_element::Checked>
+                   + With<html_input_element::Disabled>
+                   + With<html_input_element::Required>
+                   + With<html_input_element::Multiple>,
+    > + AsRef<web_sys::HtmlInputElement>,
+>
 {
+    /// See <https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/checked> for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xilem_web::{interfaces::{Element, HtmlInputElement}, elements::html::input};
+    ///
+    /// # fn component() -> impl HtmlInputElement<()> {
+    /// input(()).attr("type", "checkbox").checked(true) // results in <input type="checkbox" checked></input>
+    /// # }
+    /// ```
+    fn checked(self, checked: bool) -> html_input_element::view::Checked<Self, State, Action> {
+        html_input_element::view::Checked::new(self, checked)
+    }
+
+    /// See <https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/checked> for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xilem_web::{interfaces::{Element, HtmlInputElement}, elements::html::input};
+    ///
+    /// # fn component() -> impl HtmlInputElement<()> {
+    /// input(()).attr("type", "radio").default_checked(true) // results in <input type="radio" checked></input>
+    /// # }
+    /// ```
+    fn default_checked(
+        self,
+        default_checked: bool,
+    ) -> html_input_element::view::DefaultChecked<Self, State, Action> {
+        html_input_element::view::DefaultChecked::new(self, default_checked)
+    }
+
+    /// See <https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/disabled> for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xilem_web::{interfaces::{Element, HtmlInputElement}, elements::html::input};
+    ///
+    /// # fn component() -> impl HtmlInputElement<()> {
+    /// input(()).disabled(true) // results in <input disabled></input>
+    /// # }
+    /// ```
+    fn disabled(self, disabled: bool) -> html_input_element::view::Disabled<Self, State, Action> {
+        html_input_element::view::Disabled::new(self, disabled)
+    }
+
+    /// See <https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/disabled> for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xilem_web::{interfaces::{Element, HtmlInputElement}, elements::html::input};
+    ///
+    /// # fn component() -> impl HtmlInputElement<()> {
+    /// input(()).required(true) // results in <input required></input>
+    /// # }
+    /// ```
+    fn required(self, required: bool) -> html_input_element::view::Required<Self, State, Action> {
+        html_input_element::view::Required::new(self, required)
+    }
+
+    /// See <https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/multiple> for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xilem_web::{interfaces::{Element, HtmlInputElement}, elements::html::input};
+    ///
+    /// # fn component() -> impl HtmlInputElement<()> {
+    /// input(()).required(true) // results in <input required></input>
+    /// # }
+    /// ```
+    fn multiple(self, required: bool) -> html_input_element::view::Multiple<Self, State, Action> {
+        html_input_element::view::Multiple::new(self, required)
+    }
 }
 
 // #[cfg(feature = "HtmlInputElement")]
@@ -769,6 +856,10 @@ impl<State, Action, T> HtmlInputElement<State, Action> for T
 where
     T: HtmlElement<State, Action>,
     T::DomNode: AsRef<web_sys::HtmlInputElement>,
+    <T::DomNode as DomNode>::Props: With<html_input_element::Checked>
+        + With<html_input_element::Disabled>
+        + With<html_input_element::Required>
+        + With<html_input_element::Multiple>,
 {
 }
 

--- a/xilem_web/src/modifiers/attribute.rs
+++ b/xilem_web/src/modifiers/attribute.rs
@@ -110,7 +110,7 @@ impl Attributes {
     #[inline]
     /// Pushes `modifier` at the end of the current modifiers.
     ///
-    /// Must only be used when `self.was_created() == true`.
+    /// Must only be used when `this.flags.was_created() == true`.
     pub fn push(this: &mut Modifier<'_, Self>, modifier: impl Into<AttributeModifier>) {
         debug_assert!(
             this.flags.was_created(),
@@ -124,7 +124,7 @@ impl Attributes {
     #[inline]
     /// Inserts `modifier` at the current index.
     ///
-    /// Must only be used when `self.was_created() == false`.
+    /// Must only be used when `this.flags.was_created() == false`.
     pub fn insert(this: &mut Modifier<'_, Self>, modifier: impl Into<AttributeModifier>) {
         debug_assert!(
             !this.flags.was_created(),
@@ -143,7 +143,7 @@ impl Attributes {
     #[inline]
     /// Mutates the next modifier.
     ///
-    /// Must only be used when `self.was_created() == false`.
+    /// Must only be used when `this.flags.was_created() == false`.
     pub fn mutate<R>(
         this: &mut Modifier<'_, Self>,
         f: impl FnOnce(&mut AttributeModifier) -> R,
@@ -167,7 +167,7 @@ impl Attributes {
 
     /// Skips the next `count` modifiers.
     ///
-    /// Must only be used when `self.was_created() == false`.
+    /// Must only be used when `this.flags.was_created() == false`.
     pub fn skip(this: &mut Modifier<'_, Self>, count: usize) {
         debug_assert!(
             !this.flags.was_created(),
@@ -178,7 +178,7 @@ impl Attributes {
 
     /// Deletes the next `count` modifiers.
     ///
-    /// Must only be used when `self.was_created() == false`.
+    /// Must only be used when `this.flags.was_created() == false`.
     pub fn delete(this: &mut Modifier<'_, Self>, count: usize) {
         debug_assert!(
             !this.flags.was_created(),

--- a/xilem_web/src/modifiers/attribute.rs
+++ b/xilem_web/src/modifiers/attribute.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     core::{MessageResult, Mut, View, ViewElement, ViewId, ViewMarker},
-    modifiers::{Modifier, With},
+    modifiers::{Modifier, WithModifier},
     vecmap::VecMap,
     AttributeValue, DomView, DynMessage, IntoAttributeValue, ViewCtx,
 };
@@ -102,7 +102,7 @@ impl Attributes {
     #[inline]
     /// Rebuilds the current element, while ensuring that the order of the modifiers stays correct.
     /// Any children should be rebuilt in inside `f`, *before* modifying any other properties of [`Attributes`].
-    pub fn rebuild<E: With<Self>>(mut element: E, prev_len: usize, f: impl FnOnce(E)) {
+    pub fn rebuild<E: WithModifier<Self>>(mut element: E, prev_len: usize, f: impl FnOnce(E)) {
         element.modifier().modifier.idx -= prev_len;
         f(element);
     }
@@ -302,8 +302,8 @@ impl<V, State, Action> View<State, Action, ViewCtx, DynMessage> for Attr<V, Stat
 where
     State: 'static,
     Action: 'static,
-    V: DomView<State, Action, Element: With<Attributes>>,
-    for<'a> <V::Element as ViewElement>::Mut<'a>: With<Attributes>,
+    V: DomView<State, Action, Element: WithModifier<Attributes>>,
+    for<'a> <V::Element as ViewElement>::Mut<'a>: WithModifier<Attributes>,
 {
     type Element = V::Element;
 

--- a/xilem_web/src/modifiers/class.rs
+++ b/xilem_web/src/modifiers/class.rs
@@ -4,7 +4,7 @@
 use crate::{
     core::{MessageResult, Mut, View, ViewElement, ViewId, ViewMarker},
     diff::{diff_iters, Diff},
-    modifiers::{Modifier, With},
+    modifiers::{Modifier, WithModifier},
     vecmap::VecMap,
     DomView, DynMessage, ViewCtx,
 };
@@ -147,7 +147,7 @@ impl Classes {
     #[inline]
     /// Rebuilds the current element, while ensuring that the order of the modifiers stays correct.
     /// Any children should be rebuilt in inside `f`, *before* modifying any other properties of [`Classes`].
-    pub fn rebuild<E: With<Self>>(mut element: E, prev_len: usize, f: impl FnOnce(E)) {
+    pub fn rebuild<E: WithModifier<Self>>(mut element: E, prev_len: usize, f: impl FnOnce(E)) {
         element.modifier().modifier.idx -= prev_len as u16;
         f(element);
     }
@@ -337,8 +337,8 @@ where
     State: 'static,
     Action: 'static,
     C: ClassIter,
-    V: DomView<State, Action, Element: With<Classes>>,
-    for<'a> <V::Element as ViewElement>::Mut<'a>: With<Classes>,
+    V: DomView<State, Action, Element: WithModifier<Classes>>,
+    for<'a> <V::Element as ViewElement>::Mut<'a>: WithModifier<Classes>,
 {
     type Element = V::Element;
 

--- a/xilem_web/src/modifiers/class.rs
+++ b/xilem_web/src/modifiers/class.rs
@@ -155,7 +155,7 @@ impl Classes {
     #[inline]
     /// Pushes `modifier` at the end of the current modifiers.
     ///
-    /// Must only be used when `self.was_created() == true`
+    /// Must only be used when `this.flags.was_created() == true`
     pub fn push(this: &mut Modifier<'_, Self>, modifier: ClassModifier) {
         debug_assert!(
             this.flags.was_created(),
@@ -170,7 +170,7 @@ impl Classes {
     #[inline]
     /// Inserts `modifier` at the current index.
     ///
-    /// Must only be used when `self.was_created() == false`
+    /// Must only be used when `this.flags.was_created() == false`
     pub fn insert(this: &mut Modifier<'_, Self>, modifier: ClassModifier) {
         debug_assert!(
             !this.flags.was_created(),
@@ -191,7 +191,7 @@ impl Classes {
     #[inline]
     /// Mutates the next modifier.
     ///
-    /// Must only be used when `self.was_created() == false`
+    /// Must only be used when `this.flags.was_created() == false`
     pub fn mutate<R>(this: &mut Modifier<'_, Self>, f: impl FnOnce(&mut ClassModifier) -> R) -> R {
         debug_assert!(
             !this.flags.was_created(),
@@ -208,7 +208,7 @@ impl Classes {
     #[inline]
     /// Skips the next `count` modifiers.
     ///
-    /// Must only be used when `self.was_created() == false`
+    /// Must only be used when `this.flags.was_created() == false`
     pub fn skip(this: &mut Modifier<'_, Self>, count: usize) {
         debug_assert!(
             !this.flags.was_created(),
@@ -220,7 +220,7 @@ impl Classes {
     #[inline]
     /// Deletes the next `count` modifiers.
     ///
-    /// Must only be used when `self.was_created() == false`
+    /// Must only be used when `this.flags.was_created() == false`
     pub fn delete(this: &mut Modifier<'_, Self>, count: usize) {
         debug_assert!(
             !this.flags.was_created(),
@@ -235,7 +235,7 @@ impl Classes {
     #[inline]
     /// Extends the current modifiers with an iterator of modifiers. Returns the count of `modifiers`.
     ///
-    /// Must only be used when `self.was_created() == true`
+    /// Must only be used when `this.flags.was_created() == true`
     pub fn extend(
         this: &mut Modifier<'_, Self>,
         modifiers: impl Iterator<Item = ClassModifier>,
@@ -256,7 +256,7 @@ impl Classes {
     #[inline]
     /// Diffs between two iterators, and updates the underlying modifiers if they have changed, returns the `next` iterator count.
     ///
-    /// Must only be used when `self.was_created() == false`
+    /// Must only be used when `this.flags.was_created() == false`
     pub fn apply_diff<T: Iterator<Item = ClassModifier>>(
         this: &mut Modifier<'_, Self>,
         prev: T,

--- a/xilem_web/src/modifiers/class.rs
+++ b/xilem_web/src/modifiers/class.rs
@@ -6,7 +6,7 @@ use crate::{
     diff::{diff_iters, Diff},
     modifiers::With,
     vecmap::VecMap,
-    DomView, DynMessage, ElementProps, ViewCtx,
+    DomView, DynMessage, ViewCtx,
 };
 use std::{fmt::Debug, marker::PhantomData};
 use wasm_bindgen::{JsCast, UnwrapThrowExt};
@@ -96,12 +96,6 @@ pub struct Classes {
     dirty: bool,
     /// This is to avoid an additional alignment word with 2 booleans, it contains the two `IN_HYDRATION` and `WAS_CREATED` flags
     flags: u8,
-}
-
-impl With<Classes> for ElementProps {
-    fn modifier(&mut self) -> &mut Classes {
-        self.classes()
-    }
 }
 
 impl Classes {

--- a/xilem_web/src/modifiers/elements.rs
+++ b/xilem_web/src/modifiers/elements.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod html_input_element {
     use crate::overwrite_bool_modifier;
     overwrite_bool_modifier!(Checked);

--- a/xilem_web/src/modifiers/elements.rs
+++ b/xilem_web/src/modifiers/elements.rs
@@ -7,7 +7,6 @@ pub mod html_input_element {
     overwrite_bool_modifier!(Multiple);
 
     pub mod view {
-        use crate::modifiers::With;
         use crate::overwrite_bool_modifier_view;
         overwrite_bool_modifier_view!(Checked);
         overwrite_bool_modifier_view!(DefaultChecked);

--- a/xilem_web/src/modifiers/elements/mod.rs
+++ b/xilem_web/src/modifiers/elements/mod.rs
@@ -1,0 +1,18 @@
+pub mod html_input_element {
+    use crate::overwrite_bool_modifier;
+    overwrite_bool_modifier!(Checked);
+    overwrite_bool_modifier!(DefaultChecked);
+    overwrite_bool_modifier!(Disabled);
+    overwrite_bool_modifier!(Required);
+    overwrite_bool_modifier!(Multiple);
+
+    pub mod view {
+        use crate::modifiers::With;
+        use crate::overwrite_bool_modifier_view;
+        overwrite_bool_modifier_view!(Checked);
+        overwrite_bool_modifier_view!(DefaultChecked);
+        overwrite_bool_modifier_view!(Disabled);
+        overwrite_bool_modifier_view!(Required);
+        overwrite_bool_modifier_view!(Multiple);
+    }
+}

--- a/xilem_web/src/modifiers/mod.rs
+++ b/xilem_web/src/modifiers/mod.rs
@@ -63,6 +63,12 @@ pub use class::*;
 mod style;
 pub use style::*;
 
+mod overwrite;
+pub use overwrite::*;
+
+mod elements;
+pub use elements::*;
+
 use crate::{AnyPod, DomNode, Pod, PodMut};
 
 /// This is basically equivalent to [`AsMut`], it's intended to give access to modifiers of a [`ViewElement`](crate::core::ViewElement).

--- a/xilem_web/src/modifiers/mod.rs
+++ b/xilem_web/src/modifiers/mod.rs
@@ -69,23 +69,35 @@ pub use overwrite::*;
 mod elements;
 pub use elements::*;
 
-use crate::{AnyPod, DomNode, Pod, PodMut};
+use crate::{props::ElementFlags, AnyPod, DomNode, Pod, PodMut};
 
-/// This is basically equivalent to [`AsMut`], it's intended to give access to modifiers of a [`ViewElement`](crate::core::ViewElement).
+/// This struct is a container, with the current Element state (e.g. whether it was created/hydrated or generally needs an update), and the modifier itself.
+pub struct Modifier<'a, M> {
+    pub modifier: &'a mut M,
+    pub flags: &'a mut ElementFlags,
+}
+
+impl<'a, M> Modifier<'a, M> {
+    pub fn new(modifier: &'a mut M, flags: &'a mut ElementFlags) -> Self {
+        Self { modifier, flags }
+    }
+}
+
+/// This trait is intended to give access to modifiers of a [`ViewElement`](crate::core::ViewElement).
 ///
 /// The name is chosen, such that it reads nicely, e.g. in a trait bound: [`DomView<T, A, Element: With<Classes>>`](crate::DomView), while not behaving differently as [`AsRef`] on [`Pod`] and [`PodMut`].
 pub trait With<M> {
-    fn modifier(&mut self) -> &mut M;
+    fn modifier(&mut self) -> Modifier<'_, M>;
 }
 
 impl<T, N: DomNode<Props: With<T>>> With<T> for Pod<N> {
-    fn modifier(&mut self) -> &mut T {
+    fn modifier(&mut self) -> Modifier<'_, T> {
         <N::Props as With<T>>::modifier(&mut self.props)
     }
 }
 
 impl<T, N: DomNode<Props: With<T>>> With<T> for PodMut<'_, N> {
-    fn modifier(&mut self) -> &mut T {
+    fn modifier(&mut self) -> Modifier<'_, T> {
         <N::Props as With<T>>::modifier(self.props)
     }
 }

--- a/xilem_web/src/modifiers/mod.rs
+++ b/xilem_web/src/modifiers/mod.rs
@@ -84,21 +84,19 @@ impl<'a, M> Modifier<'a, M> {
 }
 
 /// This trait is intended to give access to modifiers of a [`ViewElement`](crate::core::ViewElement).
-///
-/// The name is chosen, such that it reads nicely, e.g. in a trait bound: [`DomView<T, A, Element: With<Classes>>`](crate::DomView), while not behaving differently as [`AsRef`] on [`Pod`] and [`PodMut`].
-pub trait With<M> {
+pub trait WithModifier<M> {
     fn modifier(&mut self) -> Modifier<'_, M>;
 }
 
-impl<T, N: DomNode<Props: With<T>>> With<T> for Pod<N> {
+impl<T, N: DomNode<Props: WithModifier<T>>> WithModifier<T> for Pod<N> {
     fn modifier(&mut self) -> Modifier<'_, T> {
-        <N::Props as With<T>>::modifier(&mut self.props)
+        <N::Props as WithModifier<T>>::modifier(&mut self.props)
     }
 }
 
-impl<T, N: DomNode<Props: With<T>>> With<T> for PodMut<'_, N> {
+impl<T, N: DomNode<Props: WithModifier<T>>> WithModifier<T> for PodMut<'_, N> {
     fn modifier(&mut self) -> Modifier<'_, T> {
-        <N::Props as With<T>>::modifier(self.props)
+        <N::Props as WithModifier<T>>::modifier(self.props)
     }
 }
 

--- a/xilem_web/src/modifiers/overwrite.rs
+++ b/xilem_web/src/modifiers/overwrite.rs
@@ -196,16 +196,20 @@ macro_rules! overwrite_bool_modifier_view {
         where
             State: 'static,
             Action: 'static,
-            V: $crate::DomView<State, Action, Element: $crate::modifiers::With<super::$modifier>>,
+            V: $crate::DomView<
+                State,
+                Action,
+                Element: $crate::modifiers::WithModifier<super::$modifier>,
+            >,
             for<'a> <V::Element as $crate::core::ViewElement>::Mut<'a>:
-                $crate::modifiers::With<super::$modifier>,
+                $crate::modifiers::WithModifier<super::$modifier>,
         {
             type Element = V::Element;
 
             type ViewState = V::ViewState;
 
             fn build(&self, ctx: &mut $crate::ViewCtx) -> (Self::Element, Self::ViewState) {
-                use $crate::modifiers::With;
+                use $crate::modifiers::WithModifier;
                 let (mut el, state) =
                     ctx.with_size_hint::<super::$modifier, _>(1, |ctx| self.inner.build(ctx));
                 let modifier = &mut super::$modifier::as_overwrite_bool_modifier(el.modifier());
@@ -220,7 +224,7 @@ macro_rules! overwrite_bool_modifier_view {
                 ctx: &mut $crate::ViewCtx,
                 mut element: $crate::core::Mut<Self::Element>,
             ) {
-                use $crate::modifiers::With;
+                use $crate::modifiers::WithModifier;
                 element.modifier().modifier.0.rebuild(1);
                 self.inner
                     .rebuild(&prev.inner, view_state, ctx, element.reborrow_mut());

--- a/xilem_web/src/modifiers/overwrite.rs
+++ b/xilem_web/src/modifiers/overwrite.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use super::Modifier;
 
 /// A specialized optimized boolean overwrite modifier, with support of up to 32 boolean elements, to avoid allocations.

--- a/xilem_web/src/modifiers/overwrite.rs
+++ b/xilem_web/src/modifiers/overwrite.rs
@@ -33,9 +33,7 @@ macro_rules! assert_overflow {
 }
 
 impl OverwriteBool {
-    /// Creates a new `Attributes` modifier.
-    ///
-    /// `size_hint` is used to avoid unnecessary allocations while traversing up the view-tree when adding modifiers in [`View::build`].
+    /// Creates a new [`OverwriteBool`] modifier, which is usually wrapped with a separate type for boolean (DOM) attributes.
     pub(crate) fn new(size_hint: usize) -> Self {
         assert_overflow!(size_hint);
         Self {
@@ -71,7 +69,7 @@ impl OverwriteBool {
     #[inline]
     /// Pushes `modifier` at the end of the current modifiers.
     ///
-    /// Must only be used when `self.was_created() == true`.
+    /// Must only be used when `this.flags.was_created() == true`.
     pub fn push(this: &mut Modifier<'_, Self>, modifier: bool) {
         debug_assert!(
             this.flags.was_created(),
@@ -88,7 +86,7 @@ impl OverwriteBool {
     #[inline]
     /// Mutates the next modifier.
     ///
-    /// Must only be used when `self.was_created() == false`.
+    /// Must only be used when `this.flags.was_created() == false`.
     pub fn mutate<R>(this: &mut Modifier<'_, Self>, f: impl FnOnce(&mut bool) -> R) -> R {
         debug_assert!(
             !this.flags.was_created(),
@@ -108,7 +106,7 @@ impl OverwriteBool {
     #[inline]
     /// Skips the next `count` modifiers.
     ///
-    /// Must only be used when `self.was_created() == false`.
+    /// Must only be used when `this.flags.was_created() == false`.
     pub fn skip(this: &mut Modifier<'_, Self>, count: u8) {
         debug_assert!(
             !this.flags.was_created(),
@@ -134,7 +132,7 @@ impl OverwriteBool {
     #[inline]
     /// Applies potential changes with `f`.
     ///
-    /// First argument of `f` is `in_hydration`, the second the new value, if it is set (i.e. is `Some(_)`). When previously modifiers existed, but were deleted it uses `None` as value.
+    /// Argument of `f` is the new value, `Some(_)` if set, and `None` if all values were deleted.
     pub fn apply_changes(&mut self, f: impl FnOnce(Option<bool>)) {
         let needs_update = self.needs_update;
         self.needs_update = false;
@@ -148,7 +146,7 @@ impl OverwriteBool {
 }
 
 #[macro_export]
-/// A macro to create a boolean attribute modifier.
+/// A macro to create a boolean overwrite modifier.
 macro_rules! overwrite_bool_modifier {
     ($modifier: ident) => {
         pub struct $modifier($crate::modifiers::OverwriteBool);
@@ -172,7 +170,7 @@ macro_rules! overwrite_bool_modifier {
 }
 
 #[macro_export]
-/// A macro to create a boolean attribute modifier view for a modifier that's in the parent module with the same name,
+/// A macro to create a boolean overwrite modifier view for a modifier that's in the parent module with the same name.
 macro_rules! overwrite_bool_modifier_view {
     ($modifier: ident) => {
         pub struct $modifier<V, State, Action> {

--- a/xilem_web/src/modifiers/overwrite.rs
+++ b/xilem_web/src/modifiers/overwrite.rs
@@ -1,0 +1,446 @@
+const IN_HYDRATION: u8 = 1 << 0;
+const WAS_CREATED: u8 = 1 << 1;
+
+/// A specialized optimized boolean overwrite modifier, with support of up to 32 boolean elements, to avoid allocations.
+///
+/// It is intended for just overwriting a possibly previous set value.
+/// For example `input_el.checked(true).checked(false)` will set the `checked` attribute to `false`.
+/// This will usually be used for boolean attributes such as `input.checked`, or `button.disabled`
+/// If used for more than 32 it will panic.
+pub struct OverwriteBool {
+    /// The underlying boolean flags encoded as bitflags.
+    modifiers: u32,
+    /// the current index of the modifiers. After reconciliation it should equal `len`. In rebuild it is decremented with [`OverwriteBool::rebuild`]
+    pub(crate) idx: u8,
+    /// The amount of boolean flags used in this modifier.
+    len: u8,
+    /// To avoid an extra alignment, the boolean flags [`IN_HYDRATION`] and [`WAS_CREATED`] are packed here together.
+    flags: u8,
+    /// A dirty flag, to indicate whether `apply_changes` should update (i.e. call `f`) the underlying value.
+    needs_update: bool,
+}
+
+macro_rules! assert_overflow {
+    ($index: expr) => {
+        debug_assert!(
+            $index < 32,
+            "If you ever see this,\
+             please open an issue at https://github.com/linebender/xilem/, \
+             we would appreciate to know what caused this. There are known solutions.\
+             This is currently limited to 32 booleans to be more efficient."
+        );
+    };
+}
+
+impl OverwriteBool {
+    /// Creates a new `Attributes` modifier.
+    ///
+    /// `size_hint` is used to avoid unnecessary allocations while traversing up the view-tree when adding modifiers in [`View::build`].
+    pub(crate) fn new(size_hint: usize, in_hydration: bool) -> Self {
+        assert_overflow!(size_hint);
+        let mut flags = WAS_CREATED;
+        if in_hydration {
+            flags |= IN_HYDRATION;
+        }
+        Self {
+            modifiers: 0,
+            needs_update: false,
+            flags,
+            idx: 0,
+            len: 0,
+        }
+    }
+
+    #[inline]
+    pub fn rebuild(&mut self, prev_len: u8) {
+        self.idx -= prev_len;
+    }
+
+    #[inline]
+    /// Returns whether the underlying element has been built or rebuilt, this could e.g. happen, when `OneOf` changes a variant to a different element.
+    pub fn was_created(&self) -> bool {
+        self.flags & WAS_CREATED != 0
+    }
+
+    #[inline]
+    /// Returns whether the underlying element has been built or rebuilt, this could e.g. happen, when `OneOf` changes a variant to a different element.
+    pub fn in_hydration(&self) -> bool {
+        self.flags & IN_HYDRATION != 0
+    }
+
+    /// Returns if `modifier` has changed.
+    fn set(&mut self, modifier: bool) -> bool {
+        let before = self.modifiers & (1 << self.idx);
+        if modifier {
+            self.modifiers |= 1 << self.idx;
+        } else {
+            self.modifiers &= !(1 << self.idx);
+        }
+        (self.modifiers & (1 << self.idx)) != before
+    }
+
+    /// Returns the current boolean modifier (at `self.idx`)
+    fn get(&self) -> bool {
+        let bit = 1 << self.idx;
+        self.modifiers & bit == bit
+    }
+
+    #[inline]
+    /// Pushes `modifier` at the end of the current modifiers.
+    ///
+    /// Must only be used when `self.was_created() == true`.
+    pub fn push(&mut self, modifier: bool) {
+        debug_assert!(
+            self.was_created(),
+            "This should never be called, when the underlying element wasn't (re)created."
+        );
+        self.set(modifier);
+        self.needs_update = true;
+        self.idx += 1;
+        self.len += 1;
+        assert_overflow!(self.len);
+    }
+
+    #[inline]
+    /// Mutates the next modifier.
+    ///
+    /// Must only be used when `self.was_created() == false`.
+    pub fn mutate<R>(&mut self, f: impl FnOnce(&mut bool) -> R) -> R {
+        debug_assert!(
+            !self.was_created(),
+            "This should never be called, when the underlying element was (re)created."
+        );
+        let mut modifier = self.get();
+        let retval = f(&mut modifier);
+        let dirty = self.set(modifier);
+        self.idx += 1;
+        self.needs_update |= self.len == self.idx && dirty;
+        retval
+    }
+
+    #[inline]
+    /// Skips the next `count` modifiers.
+    ///
+    /// Must only be used when `self.was_created() == false`.
+    pub fn skip(&mut self, count: u8) {
+        debug_assert!(
+            !self.was_created(),
+            "This should never be called, when the underlying element was (re)created."
+        );
+        self.idx += count;
+    }
+
+    #[inline]
+    /// Updates the next modifier, based on the diff of `prev` and `next`.
+    ///
+    /// It can also be used when the underlying element was recreated.
+    pub fn update(&mut self, prev: bool, next: bool) {
+        if self.was_created() {
+            self.push(next);
+        } else if next != prev {
+            self.mutate(|modifier| *modifier = next);
+        } else {
+            self.skip(1);
+        }
+    }
+
+    #[inline]
+    /// Applies potential changes with `f`.
+    ///
+    /// First argument of `f` is `in_hydration`, the second the new value, if it is set (i.e. is `Some(_)`). When previously modifiers existed, but were deleted it uses `None` as value.
+    pub fn apply_changes(&mut self, f: impl FnOnce(bool, Option<bool>)) {
+        self.flags = 0;
+        let needs_update = self.needs_update;
+        self.needs_update = false;
+        if needs_update {
+            let bit = 1 << (self.idx - 1);
+            let modifier = (self.len > 0).then_some(self.modifiers & bit == bit);
+            f(self.in_hydration(), modifier);
+        }
+    }
+    // TODO implement delete etc.
+}
+
+#[macro_export]
+/// A macro to create a boolean attribute modifier.
+macro_rules! overwrite_bool_modifier {
+    ($modifier: ident) => {
+        pub struct $modifier($crate::modifiers::OverwriteBool);
+
+        impl $modifier {
+            pub(crate) fn new(size_hint: usize, in_hydration: bool) -> Self {
+                $modifier($crate::modifiers::OverwriteBool::new(
+                    size_hint,
+                    in_hydration,
+                ))
+            }
+
+            pub fn apply_changes(&mut self, f: impl FnOnce(bool, Option<bool>)) {
+                self.0.apply_changes(f);
+            }
+        }
+    };
+}
+
+#[macro_export]
+/// A macro to create a boolean attribute modifier view for a modifier that's in the parent module with the same name,
+macro_rules! overwrite_bool_modifier_view {
+    ($modifier: ident) => {
+        pub struct $modifier<V, State, Action> {
+            value: bool,
+            inner: V,
+            phantom: std::marker::PhantomData<fn() -> (State, Action)>,
+        }
+
+        impl<V, State, Action> $modifier<V, State, Action> {
+            pub fn new(inner: V, value: bool) -> Self {
+                $modifier {
+                    inner,
+                    value,
+                    phantom: std::marker::PhantomData,
+                }
+            }
+        }
+
+        impl<V, State, Action> $crate::core::ViewMarker for $modifier<V, State, Action> {}
+        impl<V, State, Action>
+            $crate::core::View<State, Action, $crate::ViewCtx, $crate::DynMessage>
+            for $modifier<V, State, Action>
+        where
+            State: 'static,
+            Action: 'static,
+            V: $crate::DomView<State, Action, Element: $crate::modifiers::With<super::$modifier>>,
+            for<'a> <V::Element as $crate::core::ViewElement>::Mut<'a>:
+                $crate::modifiers::With<super::$modifier>,
+        {
+            type Element = V::Element;
+
+            type ViewState = V::ViewState;
+
+            fn build(&self, ctx: &mut $crate::ViewCtx) -> (Self::Element, Self::ViewState) {
+                let (mut el, state) =
+                    ctx.with_size_hint::<super::$modifier, _>(1, |ctx| self.inner.build(ctx));
+                el.modifier().0.push(self.value);
+                (el, state)
+            }
+
+            fn rebuild(
+                &self,
+                prev: &Self,
+                view_state: &mut Self::ViewState,
+                ctx: &mut $crate::ViewCtx,
+                mut element: $crate::core::Mut<Self::Element>,
+            ) {
+                element.modifier().0.rebuild(1);
+                self.inner
+                    .rebuild(&prev.inner, view_state, ctx, element.reborrow_mut());
+                element.modifier().0.update(prev.value, self.value);
+            }
+
+            fn teardown(
+                &self,
+                view_state: &mut Self::ViewState,
+                ctx: &mut $crate::ViewCtx,
+                element: $crate::core::Mut<Self::Element>,
+            ) {
+                self.inner.teardown(view_state, ctx, element);
+            }
+
+            fn message(
+                &self,
+                view_state: &mut Self::ViewState,
+                id_path: &[$crate::core::ViewId],
+                message: $crate::DynMessage,
+                app_state: &mut State,
+            ) -> $crate::core::MessageResult<Action, $crate::DynMessage> {
+                self.inner.message(view_state, id_path, message, app_state)
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overwrite_bool_push() {
+        let mut modifier = OverwriteBool::new(2, false);
+        assert!(!modifier.needs_update);
+        modifier.push(true);
+        assert!(modifier.needs_update);
+        assert_eq!(modifier.len, 1);
+        modifier.push(false);
+        assert!(modifier.needs_update);
+        assert_eq!(modifier.len, 2);
+        assert_eq!(modifier.idx, 2);
+        let mut was_applied = false;
+        modifier.apply_changes(|_, value| {
+            was_applied = true;
+            assert_eq!(value, Some(false));
+        });
+        assert!(was_applied);
+        assert!(!modifier.needs_update);
+    }
+
+    #[test]
+    fn overwrite_bool_mutate() {
+        let mut modifier = OverwriteBool::new(4, false);
+        modifier.push(true);
+        modifier.push(false);
+        modifier.push(true);
+        modifier.push(false);
+        assert!(modifier.needs_update);
+        let mut was_applied = false;
+        modifier.apply_changes(|_, value| {
+            was_applied = true;
+            assert_eq!(value, Some(false));
+        });
+        assert!(was_applied);
+        assert!(!modifier.needs_update);
+        assert_eq!(modifier.len, 4);
+        assert_eq!(modifier.idx, 4);
+        modifier.rebuild(4);
+        assert_eq!(modifier.idx, 0);
+        assert_eq!(modifier.len, 4);
+        modifier.mutate(|first| *first = true);
+        assert!(!modifier.needs_update);
+        modifier.mutate(|second| *second = false);
+        assert!(!modifier.needs_update);
+        modifier.mutate(|third| *third = false);
+        assert!(!modifier.needs_update);
+        modifier.mutate(|fourth| *fourth = true);
+        assert!(modifier.needs_update);
+        let mut was_applied = false;
+        modifier.apply_changes(|_, value| {
+            was_applied = true;
+            assert_eq!(value, Some(true));
+        });
+        assert!(was_applied);
+        assert!(!modifier.needs_update);
+        assert_eq!(modifier.len, 4);
+        assert_eq!(modifier.idx, 4);
+    }
+
+    #[test]
+    fn overwrite_bool_skip() {
+        let mut modifier = OverwriteBool::new(3, false);
+        modifier.push(true);
+        modifier.push(false);
+        modifier.push(false);
+        let mut was_applied = false;
+        modifier.apply_changes(|_, value| {
+            was_applied = true;
+            assert_eq!(value, Some(false));
+        });
+        assert!(was_applied);
+        assert!(!modifier.needs_update);
+
+        assert_eq!(modifier.idx, 3);
+        modifier.rebuild(3);
+        assert_eq!(modifier.len, 3);
+        assert_eq!(modifier.idx, 0);
+        modifier.mutate(|first| *first = false); // is overwritten, so don't dirty-flag this.
+        assert_eq!(modifier.idx, 1);
+        assert!(!modifier.needs_update);
+        modifier.skip(2);
+        assert_eq!(modifier.len, 3);
+        assert_eq!(modifier.idx, 3);
+        assert!(!modifier.needs_update);
+        let mut was_applied = false;
+        modifier.apply_changes(|_, value| {
+            was_applied = true;
+            assert_eq!(value, Some(false));
+        });
+        // don't apply if nothing has changed...
+        assert!(!was_applied);
+    }
+
+    #[test]
+    fn overwrite_bool_update() {
+        let mut modifier = OverwriteBool::new(3, false);
+        modifier.push(true);
+        modifier.push(false);
+        modifier.push(false);
+        let mut was_applied = false;
+        modifier.apply_changes(|_, value| {
+            was_applied = true;
+            assert_eq!(value, Some(false));
+        });
+        assert!(was_applied);
+        assert!(!modifier.needs_update);
+
+        assert_eq!(modifier.idx, 3);
+        modifier.rebuild(3);
+        assert_eq!(modifier.len, 3);
+        assert_eq!(modifier.idx, 0);
+        assert_eq!(modifier.modifiers, 1);
+        // on rebuild
+        modifier.update(true, false);
+        assert_eq!(modifier.idx, 1);
+        assert_eq!(modifier.modifiers, 0);
+        assert!(!modifier.needs_update);
+        modifier.update(false, true);
+        assert_eq!(modifier.idx, 2);
+        assert_eq!(modifier.modifiers, 1 << 1);
+        assert!(!modifier.needs_update);
+        modifier.update(false, true);
+        assert_eq!(modifier.modifiers, 3 << 1);
+        assert_eq!(modifier.idx, 3);
+        assert!(modifier.needs_update);
+        let mut was_applied = false;
+        modifier.apply_changes(|_, value| {
+            was_applied = true;
+            assert_eq!(value, Some(true));
+        });
+        assert!(was_applied);
+
+        // test recreation
+        let mut modifier = OverwriteBool::new(3, false);
+        assert_eq!(modifier.len, 0);
+        assert_eq!(modifier.idx, 0);
+        modifier.update(false, true);
+        assert_eq!(modifier.idx, 1);
+        assert_eq!(modifier.modifiers, 1);
+        assert!(modifier.needs_update);
+        modifier.update(true, false);
+        modifier.update(true, false);
+        assert_eq!(modifier.len, 3);
+        assert_eq!(modifier.idx, 3);
+        assert_eq!(modifier.modifiers, 1);
+        let mut was_applied = false;
+        modifier.apply_changes(|_, value| {
+            was_applied = true;
+            assert_eq!(value, Some(false));
+        });
+        assert!(was_applied);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "This should never be called, when the underlying element was (re)created."
+    )]
+    fn panic_if_use_mutate_on_creation() {
+        let mut modifier = OverwriteBool::new(4, false);
+        assert!(modifier.was_created());
+        modifier.mutate(|m| *m = false);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "This should never be called, when the underlying element wasn't (re)created."
+    )]
+    fn panic_if_use_push_on_rebuild() {
+        let mut modifier = OverwriteBool::new(4, false);
+        assert!(modifier.was_created());
+        modifier.push(true);
+        let mut was_applied = false;
+        modifier.apply_changes(|_, value| {
+            was_applied = true;
+            assert_eq!(value, Some(true));
+        });
+        assert!(was_applied);
+        assert!(!modifier.was_created());
+        modifier.push(true);
+    }
+}

--- a/xilem_web/src/modifiers/overwrite.rs
+++ b/xilem_web/src/modifiers/overwrite.rs
@@ -3,6 +3,7 @@
 
 use super::Modifier;
 
+#[derive(Default)]
 /// A specialized optimized boolean overwrite modifier, with support of up to 32 boolean elements, to avoid allocations.
 ///
 /// It is intended for just overwriting a possibly previous set value.
@@ -33,17 +34,6 @@ macro_rules! assert_overflow {
 }
 
 impl OverwriteBool {
-    /// Creates a new [`OverwriteBool`] modifier, which is usually wrapped with a separate type for boolean (DOM) attributes.
-    pub(crate) fn new(size_hint: usize) -> Self {
-        assert_overflow!(size_hint);
-        Self {
-            modifiers: 0,
-            needs_update: false,
-            idx: 0,
-            len: 0,
-        }
-    }
-
     #[inline]
     pub fn rebuild(&mut self, prev_len: u8) {
         self.idx -= prev_len;
@@ -149,13 +139,10 @@ impl OverwriteBool {
 /// A macro to create a boolean overwrite modifier.
 macro_rules! overwrite_bool_modifier {
     ($modifier: ident) => {
+        #[derive(Default)]
         pub struct $modifier($crate::modifiers::OverwriteBool);
 
         impl $modifier {
-            pub(crate) fn new(size_hint: usize) -> Self {
-                $modifier($crate::modifiers::OverwriteBool::new(size_hint))
-            }
-
             fn as_overwrite_bool_modifier(
                 this: $crate::modifiers::Modifier<'_, Self>,
             ) -> $crate::modifiers::Modifier<'_, $crate::modifiers::OverwriteBool> {
@@ -262,7 +249,7 @@ mod tests {
 
     #[test]
     fn overwrite_bool_push() {
-        let mut modifier = OverwriteBool::new(2);
+        let mut modifier = OverwriteBool::default();
         let flags = &mut ElementFlags::new(false);
         let m = &mut Modifier::new(&mut modifier, flags);
         assert!(!m.flags.needs_update());
@@ -284,7 +271,7 @@ mod tests {
 
     #[test]
     fn overwrite_bool_mutate() {
-        let mut modifier = OverwriteBool::new(4);
+        let mut modifier = OverwriteBool::default();
         let flags = &mut ElementFlags::new(false);
         let m = &mut Modifier::new(&mut modifier, flags);
         OverwriteBool::push(m, true);
@@ -327,7 +314,7 @@ mod tests {
 
     #[test]
     fn overwrite_bool_skip() {
-        let mut modifier = OverwriteBool::new(3);
+        let mut modifier = OverwriteBool::default();
         let flags = &mut ElementFlags::new(false);
         let m = &mut Modifier::new(&mut modifier, flags);
         OverwriteBool::push(m, true);
@@ -365,7 +352,7 @@ mod tests {
 
     #[test]
     fn overwrite_bool_update() {
-        let mut modifier = OverwriteBool::new(3);
+        let mut modifier = OverwriteBool::default();
         let flags = &mut ElementFlags::new(false);
         let m = &mut Modifier::new(&mut modifier, flags);
         OverwriteBool::push(m, true);
@@ -407,7 +394,7 @@ mod tests {
         assert!(was_applied);
 
         // test recreation
-        let mut modifier = OverwriteBool::new(3);
+        let mut modifier = OverwriteBool::default();
         let flags = &mut ElementFlags::new(false);
         let modifier = &mut Modifier::new(&mut modifier, flags);
         assert_eq!(modifier.modifier.len, 0);
@@ -435,7 +422,7 @@ mod tests {
         expected = "This should never be called, when the underlying element was (re)created."
     )]
     fn panic_if_use_mutate_on_creation() {
-        let mut modifier = OverwriteBool::new(4);
+        let mut modifier = OverwriteBool::default();
         let flags = &mut ElementFlags::new(false);
         let m = &mut Modifier::new(&mut modifier, flags);
         assert!(m.flags.was_created());
@@ -447,7 +434,7 @@ mod tests {
         expected = "This should never be called, when the underlying element wasn't (re)created."
     )]
     fn panic_if_use_push_on_rebuild() {
-        let mut modifier = OverwriteBool::new(4);
+        let mut modifier = OverwriteBool::default();
         let flags = &mut ElementFlags::new(false);
         let m = &mut Modifier::new(&mut modifier, flags);
         assert!(m.flags.was_created());

--- a/xilem_web/src/modifiers/overwrite.rs
+++ b/xilem_web/src/modifiers/overwrite.rs
@@ -197,8 +197,7 @@ macro_rules! overwrite_bool_modifier_view {
 
             fn build(&self, ctx: &mut $crate::ViewCtx) -> (Self::Element, Self::ViewState) {
                 use $crate::modifiers::WithModifier;
-                let (mut el, state) =
-                    ctx.with_size_hint::<super::$modifier, _>(1, |ctx| self.inner.build(ctx));
+                let (mut el, state) = self.inner.build(ctx);
                 let modifier = &mut super::$modifier::as_overwrite_bool_modifier(el.modifier());
                 $crate::modifiers::OverwriteBool::push(modifier, self.value);
                 (el, state)

--- a/xilem_web/src/modifiers/style.rs
+++ b/xilem_web/src/modifiers/style.rs
@@ -6,7 +6,7 @@ use crate::{
     diff::{diff_iters, Diff},
     modifiers::With,
     vecmap::VecMap,
-    DomView, DynMessage, ElementProps, ViewCtx,
+    DomView, DynMessage, ViewCtx,
 };
 use peniko::kurbo::Vec2;
 use std::{
@@ -148,12 +148,6 @@ pub struct Styles {
     idx: u16,
     in_hydration: bool,
     was_created: bool,
-}
-
-impl With<Styles> for ElementProps {
-    fn modifier(&mut self) -> &mut Styles {
-        self.styles()
-    }
 }
 
 fn set_style(element: &web_sys::Element, name: &str, value: &str) {
@@ -424,7 +418,7 @@ impl Styles {
 
     #[inline]
     /// Updates the style property `name` by modifying its previous value with `create_modifier`.
-    pub fn update_style_mutator<T: PartialEq>(
+    pub fn update_with_modify_style<T: PartialEq>(
         &mut self,
         name: &'static str,
         prev: &T,
@@ -579,7 +573,7 @@ where
         Styles::rebuild(element, 1, |mut element| {
             self.el
                 .rebuild(&prev.el, view_state, ctx, element.reborrow_mut());
-            element.modifier().update_style_mutator(
+            element.modifier().update_with_modify_style(
                 "transform",
                 &prev.radians,
                 &self.radians,
@@ -700,7 +694,7 @@ where
         Styles::rebuild(element, 1, |mut element| {
             self.el
                 .rebuild(&prev.el, view_state, ctx, element.reborrow_mut());
-            element.modifier().update_style_mutator(
+            element.modifier().update_with_modify_style(
                 "transform",
                 &prev.scale,
                 &self.scale,

--- a/xilem_web/src/modifiers/style.rs
+++ b/xilem_web/src/modifiers/style.rs
@@ -4,7 +4,6 @@
 use crate::{
     core::{MessageResult, Mut, View, ViewElement, ViewId, ViewMarker},
     diff::{diff_iters, Diff},
-    modifiers::With,
     vecmap::VecMap,
     DomView, DynMessage, ViewCtx,
 };
@@ -16,6 +15,8 @@ use std::{
     marker::PhantomData,
 };
 use wasm_bindgen::{JsCast, UnwrapThrowExt};
+
+use super::{Modifier, With};
 
 type CowStr = std::borrow::Cow<'static, str>;
 
@@ -145,9 +146,7 @@ pub struct Styles {
     // while probably not helping much in the average case (of very few styles)...
     modifiers: Vec<StyleModifier>,
     updated: VecMap<CowStr, ()>,
-    idx: u16,
-    in_hydration: bool,
-    was_created: bool,
+    idx: usize,
 }
 
 fn set_style(element: &web_sys::Element, name: &str, value: &str) {
@@ -170,51 +169,49 @@ impl Styles {
     /// Creates a new `Styles` modifier.
     ///
     /// `size_hint` is used to avoid unnecessary allocations while traversing up the view-tree when adding modifiers in [`View::build`].
-    pub(crate) fn new(size_hint: usize, in_hydration: bool) -> Self {
+    pub(crate) fn new(size_hint: usize) -> Self {
         Self {
             modifiers: Vec::with_capacity(size_hint),
-            was_created: true,
-            in_hydration,
             ..Default::default()
         }
     }
 
     /// Applies potential changes of the inline styles of an element to the underlying DOM node.
-    pub fn apply_changes(&mut self, element: &web_sys::Element) {
-        if self.in_hydration {
-            self.in_hydration = false;
-            self.was_created = false;
-        } else if self.was_created {
-            self.was_created = false;
-            for modifier in &self.modifiers {
+    pub fn apply_changes(this: Modifier<'_, Self>, element: &web_sys::Element) {
+        if this.flags.in_hydration() {
+            return;
+        } else if this.flags.was_created() {
+            for modifier in &this.modifier.modifiers {
                 match modifier {
                     StyleModifier::Remove(name) => remove_style(element, name),
                     StyleModifier::Set(name, value) => set_style(element, name, value),
                 }
             }
-        } else if !self.updated.is_empty() {
-            for modifier in self.modifiers.iter().rev() {
+        } else if !this.modifier.updated.is_empty() {
+            for modifier in this.modifier.modifiers.iter().rev() {
                 match modifier {
-                    StyleModifier::Remove(name) if self.updated.remove(name).is_some() => {
+                    StyleModifier::Remove(name) if this.modifier.updated.remove(name).is_some() => {
                         remove_style(element, name);
                     }
-                    StyleModifier::Set(name, value) if self.updated.remove(name).is_some() => {
+                    StyleModifier::Set(name, value)
+                        if this.modifier.updated.remove(name).is_some() =>
+                    {
                         set_style(element, name, value);
                     }
                     _ => {}
                 }
             }
             // if there's any remaining key in updated, it means these are deleted keys
-            for (name, ()) in self.updated.drain() {
+            for (name, ()) in this.modifier.updated.drain() {
                 remove_style(element, &name);
             }
         }
-        debug_assert!(self.updated.is_empty());
+        debug_assert!(this.modifier.updated.is_empty());
     }
 
     /// Returns a previous [`StyleModifier`], when `predicate` returns true, this is similar to [`Iterator::find`].
     pub fn get(&self, mut predicate: impl FnMut(&StyleModifier) -> bool) -> Option<&StyleModifier> {
-        self.modifiers[..self.idx as usize]
+        self.modifiers[..self.idx]
             .iter()
             .rev()
             .find(|modifier| predicate(modifier))
@@ -236,14 +233,8 @@ impl Styles {
     /// Rebuilds the current element, while ensuring that the order of the modifiers stays correct.
     /// Any children should be rebuilt in inside `f`, *before* modifying any other properties of [`Styles`].
     pub fn rebuild<E: With<Self>>(mut element: E, prev_len: usize, f: impl FnOnce(E)) {
-        element.modifier().idx -= prev_len as u16;
+        element.modifier().modifier.idx -= prev_len;
         f(element);
-    }
-
-    #[inline]
-    /// Returns whether the underlying element has been built or rebuilt, this could e.g. happen, when `OneOf` changes a variant to a different element.
-    pub fn was_created(&self) -> bool {
-        self.was_created
     }
 
     #[inline]
@@ -255,142 +246,144 @@ impl Styles {
     #[inline]
     /// Pushes `modifier` at the end of the current modifiers
     ///
-    /// Must only be used when `self.was_created() == true`, use `Styles::insert` otherwise.
-    pub fn push(&mut self, modifier: StyleModifier) {
+    /// Must only be used when `this.flags.was_created() == true`, use `Styles::insert` otherwise.
+    pub fn push(this: &mut Modifier<'_, Self>, modifier: StyleModifier) {
         debug_assert!(
-            self.was_created(),
+            this.flags.was_created(),
             "This should never be called, when the underlying element wasn't (re)created. Use `Styles::insert` instead."
         );
-        if !self.was_created && !self.in_hydration {
-            self.updated.insert(modifier.name().clone(), ());
-        }
-        self.modifiers.push(modifier);
-        self.idx += 1;
+        this.flags.set_needs_update();
+        this.modifier.modifiers.push(modifier);
+        this.modifier.idx += 1;
     }
 
     #[inline]
     /// Inserts `modifier` at the current index
     ///
-    /// Must only be used when `self.was_created() == false`, use `Styles::push` otherwise.
-    pub fn insert(&mut self, modifier: StyleModifier) {
+    /// Must only be used when `this.flags.was_created() == false`, use `Styles::push` otherwise.
+    pub fn insert(this: &mut Modifier<'_, Self>, modifier: StyleModifier) {
         debug_assert!(
-            !self.was_created(),
+            !this.flags.was_created(),
             "This should never be called, when the underlying element was (re)created, use `Styles::push` instead."
         );
-        if !self.was_created && !self.in_hydration {
-            self.updated.insert(modifier.name().clone(), ());
-        }
+        this.modifier.updated.insert(modifier.name().clone(), ());
+        this.flags.set_needs_update();
         // TODO this could potentially be expensive, maybe think about `VecSplice` again.
         // Although in the average case, this is likely not relevant, as usually very few attributes are used, thus shifting is probably good enough
         // I.e. a `VecSplice` is probably less optimal (either more complicated code, and/or more memory usage)
-        self.modifiers.insert(self.idx as usize, modifier);
-        self.idx += 1;
+        this.modifier.modifiers.insert(this.modifier.idx, modifier);
+        this.modifier.idx += 1;
     }
 
     #[inline]
     /// Mutates the next modifier.
     ///
-    /// Must only be used when `self.was_created() == false`.
-    pub fn mutate<R>(&mut self, f: impl FnOnce(&mut StyleModifier) -> R) -> R {
+    /// Must only be used when `this.flags.was_created() == false`.
+    pub fn mutate<R>(this: &mut Modifier<'_, Self>, f: impl FnOnce(&mut StyleModifier) -> R) -> R {
         debug_assert!(
-            !self.was_created(),
+            !this.flags.was_created(),
             "This should never be called, when the underlying element was (re)created."
         );
-        let modifier = &mut self.modifiers[self.idx as usize];
+        let modifier = &mut this.modifier.modifiers[this.modifier.idx];
         let old = modifier.name().clone();
         let rv = f(modifier);
         let new = modifier.name();
         if *new != old {
-            self.updated.insert(new.clone(), ());
+            this.modifier.updated.insert(new.clone(), ());
         }
-        self.updated.insert(old, ());
-        self.idx += 1;
+        this.flags.set_needs_update();
+        this.modifier.updated.insert(old, ());
+        this.modifier.idx += 1;
         rv
     }
 
     #[inline]
     /// Skips the next `count` modifiers.
     ///
-    /// Must only be used when `self.was_created() == false`.
-    pub fn skip(&mut self, count: usize) {
+    /// Must only be used when `this.flags.was_created() == false`.
+    pub fn skip(this: &mut Modifier<'_, Self>, count: usize) {
         debug_assert!(
-            !self.was_created(),
+            !this.flags.was_created(),
             "This should never be called, when the underlying element was (re)created."
         );
-        self.idx += count as u16;
+        this.modifier.idx += count;
     }
 
     #[inline]
     /// Deletes the next `count` modifiers.
     ///
-    /// Must only be used when `self.was_created() == false`.
-    pub fn delete(&mut self, count: usize) {
+    /// Must only be used when `this.flags.was_created() == false`.
+    pub fn delete(this: &mut Modifier<'_, Self>, count: usize) {
         debug_assert!(
-            !self.was_created(),
+            !this.flags.was_created(),
             "This should never be called, when the underlying element was (re)created."
         );
-        let start = self.idx as usize;
-        for modifier in self.modifiers.drain(start..(start + count)) {
-            self.updated.insert(modifier.into_name(), ());
+        let start = this.modifier.idx;
+        this.flags.set_needs_update();
+        for modifier in this.modifier.modifiers.drain(start..(start + count)) {
+            this.modifier.updated.insert(modifier.into_name(), ());
         }
     }
 
     #[inline]
     /// Updates the next modifier, based on the diff of `prev` and `next`.
-    pub fn update(&mut self, prev: &StyleModifier, next: &StyleModifier) {
-        if self.was_created() {
-            self.push(next.clone());
+    pub fn update(this: &mut Modifier<'_, Self>, prev: &StyleModifier, next: &StyleModifier) {
+        if this.flags.was_created() {
+            Self::push(this, next.clone());
         } else if next != prev {
-            self.mutate(|modifier| *modifier = next.clone());
+            Self::mutate(this, |modifier| *modifier = next.clone());
         } else {
-            self.skip(1);
+            Self::skip(this, 1);
         }
     }
 
     #[inline]
     /// Extends the current modifiers with an iterator of modifiers. Returns the count of `modifiers`.
     ///
-    /// Must only be used when `self.was_created() == true`, use `Styles::apply_diff` otherwise.
-    pub fn extend(&mut self, modifiers: impl Iterator<Item = StyleModifier>) -> usize {
+    /// Must only be used when `this.flags.was_created() == true`, use `Styles::apply_diff` otherwise.
+    pub fn extend(
+        this: &mut Modifier<'_, Self>,
+        modifiers: impl Iterator<Item = StyleModifier>,
+    ) -> usize {
         debug_assert!(
-            self.was_created(),
+            this.flags.was_created(),
             "This should never be called, when the underlying element wasn't (re)created, use `Styles::apply_diff` instead."
         );
-        let prev_len = self.modifiers.len();
-        self.modifiers.extend(modifiers);
-        let iter_count = self.modifiers.len() - prev_len;
-        if !self.was_created && !self.in_hydration && iter_count > 0 {
-            for modifier in &self.modifiers[prev_len..] {
-                self.updated.insert(modifier.name().clone(), ());
-            }
-        }
-        self.idx += iter_count as u16;
+        let prev_len = this.modifier.modifiers.len();
+        this.modifier.modifiers.extend(modifiers);
+        let iter_count = this.modifier.modifiers.len() - prev_len;
+        this.flags.set_needs_update();
+        this.modifier.idx += iter_count;
         iter_count
     }
 
     #[inline]
     /// Diffs between two iterators, and updates the underlying modifiers if they have changed, returns the `next` iterator count.
     ///
-    /// Must only be used when `self.was_created() == false`, use [`Styles::extend`] otherwise.
-    pub fn apply_diff<T: Iterator<Item = StyleModifier>>(&mut self, prev: T, next: T) -> usize {
+    /// Must only be used when `this.flags.was_created() == false`, use [`Styles::extend`] otherwise.
+    pub fn apply_diff<T: Iterator<Item = StyleModifier>>(
+        this: &mut Modifier<'_, Self>,
+        prev: T,
+        next: T,
+    ) -> usize {
         debug_assert!(
-            !self.was_created(),
+            !this.flags.was_created(),
             "This should never be called, when the underlying element was (re)created, use `Styles::extend` instead."
         );
         let mut count = 0;
         for change in diff_iters(prev, next) {
             match change {
                 Diff::Add(modifier) => {
-                    self.insert(modifier);
+                    Self::insert(this, modifier);
                     count += 1;
                 }
-                Diff::Remove(count) => self.delete(count),
+                Diff::Remove(count) => Self::delete(this, count),
                 Diff::Change(new_modifier) => {
-                    self.mutate(|modifier| *modifier = new_modifier);
+                    Self::mutate(this, |modifier| *modifier = new_modifier);
                     count += 1;
                 }
                 Diff::Skip(c) => {
-                    self.skip(c);
+                    Self::skip(this, c);
                     count += c;
                 }
             }
@@ -401,17 +394,21 @@ impl Styles {
     #[inline]
     /// Updates styles defined by an iterator, returns the `next` iterator length.
     pub fn update_style_modifier_iter<T: StyleIter>(
-        &mut self,
+        this: &mut Modifier<'_, Self>,
         prev_len: usize,
         prev: &T,
         next: &T,
     ) -> usize {
-        if self.was_created() {
-            self.extend(next.style_modifiers_iter())
+        if this.flags.was_created() {
+            Self::extend(this, next.style_modifiers_iter())
         } else if next != prev {
-            self.apply_diff(prev.style_modifiers_iter(), next.style_modifiers_iter())
+            Self::apply_diff(
+                this,
+                prev.style_modifiers_iter(),
+                next.style_modifiers_iter(),
+            )
         } else {
-            self.skip(prev_len);
+            Self::skip(this, prev_len);
             prev_len
         }
     }
@@ -419,19 +416,19 @@ impl Styles {
     #[inline]
     /// Updates the style property `name` by modifying its previous value with `create_modifier`.
     pub fn update_with_modify_style<T: PartialEq>(
-        &mut self,
+        this: &mut Modifier<'_, Self>,
         name: &'static str,
         prev: &T,
         next: &T,
         create_modifier: impl FnOnce(Option<&CowStr>, &T) -> StyleModifier,
     ) {
-        if self.was_created() {
-            self.push(create_modifier(self.get_style(name), next));
-        } else if prev != next || self.was_updated(name) {
-            let new_modifier = create_modifier(self.get_style(name), next);
-            self.mutate(|modifier| *modifier = new_modifier);
+        if this.flags.was_created() {
+            Self::push(this, create_modifier(this.modifier.get_style(name), next));
+        } else if prev != next || this.modifier.was_updated(name) {
+            let new_modifier = create_modifier(this.modifier.get_style(name), next);
+            Self::mutate(this, |modifier| *modifier = new_modifier);
         } else {
-            self.skip(1);
+            Self::skip(this, 1);
         }
     }
 }
@@ -476,7 +473,7 @@ where
         let style_iter = self.styles.style_modifiers_iter();
         let (mut e, s) =
             ctx.with_size_hint::<Styles, _>(style_iter.size_hint().0, |ctx| self.el.build(ctx));
-        let len = e.modifier().extend(style_iter);
+        let len = Styles::extend(&mut e.modifier(), style_iter);
         (e, (len, s))
     }
 
@@ -490,8 +487,8 @@ where
         Styles::rebuild(element, *len, |mut elem| {
             self.el
                 .rebuild(&prev.el, view_state, ctx, elem.reborrow_mut());
-            let styles = elem.modifier();
-            *len = styles.update_style_modifier_iter(*len, &prev.styles, &self.styles);
+            let styles = &mut elem.modifier();
+            *len = Styles::update_style_modifier_iter(styles, *len, &prev.styles, &self.styles);
         });
     }
 
@@ -555,11 +552,11 @@ where
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let (mut element, state) = ctx.with_size_hint::<Styles, _>(1, |ctx| self.el.build(ctx));
-        let styles = element.modifier();
-        styles.push(rotate_transform_modifier(
-            styles.get_style("transform"),
-            &self.radians,
-        ));
+        let styles = &mut element.modifier();
+        Styles::push(
+            styles,
+            rotate_transform_modifier(styles.modifier.get_style("transform"), &self.radians),
+        );
         (element, state)
     }
 
@@ -573,7 +570,9 @@ where
         Styles::rebuild(element, 1, |mut element| {
             self.el
                 .rebuild(&prev.el, view_state, ctx, element.reborrow_mut());
-            element.modifier().update_with_modify_style(
+            let mut styles = element.modifier();
+            Styles::update_with_modify_style(
+                &mut styles,
                 "transform",
                 &prev.radians,
                 &self.radians,
@@ -676,11 +675,11 @@ where
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let (mut element, state) = ctx.with_size_hint::<Styles, _>(1, |ctx| self.el.build(ctx));
-        let styles = element.modifier();
-        styles.push(scale_transform_modifier(
-            styles.get_style("transform"),
-            &self.scale,
-        ));
+        let styles = &mut element.modifier();
+        Styles::push(
+            styles,
+            scale_transform_modifier(styles.modifier.get_style("transform"), &self.scale),
+        );
         (element, state)
     }
 
@@ -694,7 +693,9 @@ where
         Styles::rebuild(element, 1, |mut element| {
             self.el
                 .rebuild(&prev.el, view_state, ctx, element.reborrow_mut());
-            element.modifier().update_with_modify_style(
+            let styles = &mut element.modifier();
+            Styles::update_with_modify_style(
+                styles,
                 "transform",
                 &prev.scale,
                 &self.scale,

--- a/xilem_web/src/modifiers/style.rs
+++ b/xilem_web/src/modifiers/style.rs
@@ -16,7 +16,7 @@ use std::{
 };
 use wasm_bindgen::{JsCast, UnwrapThrowExt};
 
-use super::{Modifier, With};
+use super::{Modifier, WithModifier};
 
 type CowStr = std::borrow::Cow<'static, str>;
 
@@ -232,7 +232,7 @@ impl Styles {
     #[inline]
     /// Rebuilds the current element, while ensuring that the order of the modifiers stays correct.
     /// Any children should be rebuilt in inside `f`, *before* modifying any other properties of [`Styles`].
-    pub fn rebuild<E: With<Self>>(mut element: E, prev_len: usize, f: impl FnOnce(E)) {
+    pub fn rebuild<E: WithModifier<Self>>(mut element: E, prev_len: usize, f: impl FnOnce(E)) {
         element.modifier().modifier.idx -= prev_len;
         f(element);
     }
@@ -462,8 +462,8 @@ where
     State: 'static,
     Action: 'static,
     S: StyleIter,
-    V: DomView<State, Action, Element: With<Styles>>,
-    for<'a> <V::Element as ViewElement>::Mut<'a>: With<Styles>,
+    V: DomView<State, Action, Element: WithModifier<Styles>>,
+    for<'a> <V::Element as ViewElement>::Mut<'a>: WithModifier<Styles>,
 {
     type Element = V::Element;
 
@@ -543,8 +543,8 @@ impl<V, State, Action> View<State, Action, ViewCtx, DynMessage> for Rotate<V, St
 where
     State: 'static,
     Action: 'static,
-    V: DomView<State, Action, Element: With<Styles>>,
-    for<'a> <V::Element as ViewElement>::Mut<'a>: With<Styles>,
+    V: DomView<State, Action, Element: WithModifier<Styles>>,
+    for<'a> <V::Element as ViewElement>::Mut<'a>: WithModifier<Styles>,
 {
     type Element = V::Element;
 
@@ -666,8 +666,8 @@ impl<State, Action, V> View<State, Action, ViewCtx, DynMessage> for Scale<V, Sta
 where
     State: 'static,
     Action: 'static,
-    V: DomView<State, Action, Element: With<Styles>>,
-    for<'a> <V::Element as ViewElement>::Mut<'a>: With<Styles>,
+    V: DomView<State, Action, Element: WithModifier<Styles>>,
+    for<'a> <V::Element as ViewElement>::Mut<'a>: WithModifier<Styles>,
 {
     type Element = V::Element;
 

--- a/xilem_web/src/one_of.rs
+++ b/xilem_web/src/one_of.rs
@@ -6,7 +6,7 @@ use crate::{
         one_of::{OneOf, OneOfCtx, PhantomElementCtx},
         Mut,
     },
-    modifiers::With,
+    modifiers::{Modifier, With},
     DomNode, Pod, PodMut, ViewCtx,
 };
 use wasm_bindgen::UnwrapThrowExt;
@@ -230,7 +230,7 @@ where
     H: With<T>,
     I: With<T>,
 {
-    fn modifier(&mut self) -> &mut T {
+    fn modifier(&mut self) -> Modifier<'_, T> {
         match self {
             OneOf::A(e) => <A as With<T>>::modifier(e),
             OneOf::B(e) => <B as With<T>>::modifier(e),
@@ -261,7 +261,7 @@ impl<T> AsMut<T> for Noop {
 }
 
 impl<T> With<T> for Noop {
-    fn modifier(&mut self) -> &mut T {
+    fn modifier(&mut self) -> Modifier<'_, T> {
         match *self {}
     }
 }

--- a/xilem_web/src/one_of.rs
+++ b/xilem_web/src/one_of.rs
@@ -6,7 +6,7 @@ use crate::{
         one_of::{OneOf, OneOfCtx, PhantomElementCtx},
         Mut,
     },
-    modifiers::{Modifier, With},
+    modifiers::{Modifier, WithModifier},
     DomNode, Pod, PodMut, ViewCtx,
 };
 use wasm_bindgen::UnwrapThrowExt;
@@ -218,29 +218,29 @@ where
     }
 }
 
-impl<T, A, B, C, D, E, F, G, H, I> With<T> for OneOf<A, B, C, D, E, F, G, H, I>
+impl<T, A, B, C, D, E, F, G, H, I> WithModifier<T> for OneOf<A, B, C, D, E, F, G, H, I>
 where
-    A: With<T>,
-    B: With<T>,
-    C: With<T>,
-    D: With<T>,
-    E: With<T>,
-    F: With<T>,
-    G: With<T>,
-    H: With<T>,
-    I: With<T>,
+    A: WithModifier<T>,
+    B: WithModifier<T>,
+    C: WithModifier<T>,
+    D: WithModifier<T>,
+    E: WithModifier<T>,
+    F: WithModifier<T>,
+    G: WithModifier<T>,
+    H: WithModifier<T>,
+    I: WithModifier<T>,
 {
     fn modifier(&mut self) -> Modifier<'_, T> {
         match self {
-            OneOf::A(e) => <A as With<T>>::modifier(e),
-            OneOf::B(e) => <B as With<T>>::modifier(e),
-            OneOf::C(e) => <C as With<T>>::modifier(e),
-            OneOf::D(e) => <D as With<T>>::modifier(e),
-            OneOf::E(e) => <E as With<T>>::modifier(e),
-            OneOf::F(e) => <F as With<T>>::modifier(e),
-            OneOf::G(e) => <G as With<T>>::modifier(e),
-            OneOf::H(e) => <H as With<T>>::modifier(e),
-            OneOf::I(e) => <I as With<T>>::modifier(e),
+            OneOf::A(e) => <A as WithModifier<T>>::modifier(e),
+            OneOf::B(e) => <B as WithModifier<T>>::modifier(e),
+            OneOf::C(e) => <C as WithModifier<T>>::modifier(e),
+            OneOf::D(e) => <D as WithModifier<T>>::modifier(e),
+            OneOf::E(e) => <E as WithModifier<T>>::modifier(e),
+            OneOf::F(e) => <F as WithModifier<T>>::modifier(e),
+            OneOf::G(e) => <G as WithModifier<T>>::modifier(e),
+            OneOf::H(e) => <H as WithModifier<T>>::modifier(e),
+            OneOf::I(e) => <I as WithModifier<T>>::modifier(e),
         }
     }
 }
@@ -260,7 +260,7 @@ impl<T> AsMut<T> for Noop {
     }
 }
 
-impl<T> With<T> for Noop {
+impl<T> WithModifier<T> for Noop {
     fn modifier(&mut self) -> Modifier<'_, T> {
         match *self {}
     }

--- a/xilem_web/src/props/element.rs
+++ b/xilem_web/src/props/element.rs
@@ -12,7 +12,7 @@ use wasm_bindgen::UnwrapThrowExt;
 // Lazy access to attributes etc. to avoid allocating unnecessary memory when it isn't needed
 // Benchmarks have shown, that this can significantly increase performance and reduce memory usage...
 /// This holds all the state for a DOM [`Element`](`crate::interfaces::Element`), it is used for [`DomNode::Props`](`crate::DomNode::Props`)
-pub struct ElementProps {
+pub struct Element {
     pub(crate) in_hydration: bool,
     pub(crate) attributes: Option<Box<Attributes>>,
     pub(crate) classes: Option<Box<Classes>>,
@@ -20,13 +20,7 @@ pub struct ElementProps {
     pub(crate) children: Vec<AnyPod>,
 }
 
-impl With<Children> for ElementProps {
-    fn modifier(&mut self) -> &mut Children {
-        &mut self.children
-    }
-}
-
-impl ElementProps {
+impl Element {
     pub fn new(
         children: Vec<AnyPod>,
         attr_size_hint: usize,
@@ -103,7 +97,7 @@ impl Pod<web_sys::Element> {
 
         Self {
             node: element,
-            props: ElementProps::new(
+            props: Element::new(
                 children,
                 attr_size_hint,
                 style_size_hint,
@@ -122,7 +116,7 @@ impl Pod<web_sys::Element> {
 
         Self {
             node: element.unchecked_into(),
-            props: ElementProps::new(
+            props: Element::new(
                 children,
                 attr_size_hint,
                 style_size_hint,
@@ -130,5 +124,29 @@ impl Pod<web_sys::Element> {
                 true,
             ),
         }
+    }
+}
+
+impl With<Children> for Element {
+    fn modifier(&mut self) -> &mut Children {
+        &mut self.children
+    }
+}
+
+impl With<Attributes> for Element {
+    fn modifier(&mut self) -> &mut Attributes {
+        self.attributes()
+    }
+}
+
+impl With<Classes> for Element {
+    fn modifier(&mut self) -> &mut Classes {
+        self.classes()
+    }
+}
+
+impl With<Styles> for Element {
+    fn modifier(&mut self) -> &mut Styles {
+        self.styles()
     }
 }

--- a/xilem_web/src/props/element.rs
+++ b/xilem_web/src/props/element.rs
@@ -47,6 +47,7 @@ impl ElementFlags {
         self.0 |= Self::NEEDS_UPDATE;
     }
 }
+
 // Lazy access to attributes etc. to avoid allocating unnecessary memory when it isn't needed
 // Benchmarks have shown, that this can significantly increase performance and reduce memory usage...
 /// This holds all the state for a DOM [`Element`](`crate::interfaces::Element`), it is used for [`DomNode::Props`](`crate::DomNode::Props`)
@@ -175,3 +176,9 @@ impl With<Styles> for Element {
         Modifier::new(modifier, &mut self.flags)
     }
 }
+
+pub trait WithElementProps:
+    With<Attributes> + With<Children> + With<Classes> + With<Styles>
+{
+}
+impl<T: With<Attributes> + With<Children> + With<Classes> + With<Styles>> WithElementProps for T {}

--- a/xilem_web/src/props/html_input_element.rs
+++ b/xilem_web/src/props/html_input_element.rs
@@ -57,20 +57,15 @@ impl HtmlInputElement {
 }
 
 impl FromWithContext<Pod<web_sys::Element>> for Pod<web_sys::HtmlInputElement> {
-    fn from_with_ctx(value: Pod<web_sys::Element>, ctx: &mut ViewCtx) -> Self {
-        let checked_size_hint = ctx.take_modifier_size_hint::<Checked>();
-        let default_checked_size_hint = ctx.take_modifier_size_hint::<DefaultChecked>();
-        let disabled_size_hint = ctx.take_modifier_size_hint::<Disabled>();
-        let required_size_hint = ctx.take_modifier_size_hint::<Required>();
-        let multiple_size_hint = ctx.take_modifier_size_hint::<Multiple>();
+    fn from_with_ctx(value: Pod<web_sys::Element>, _ctx: &mut ViewCtx) -> Self {
         Pod {
             node: value.node.unchecked_into(),
             props: HtmlInputElement {
-                checked: Checked::new(checked_size_hint),
-                default_checked: DefaultChecked::new(default_checked_size_hint),
-                disabled: Disabled::new(disabled_size_hint),
-                required: Required::new(required_size_hint),
-                multiple: Multiple::new(multiple_size_hint),
+                checked: Checked::default(),
+                default_checked: DefaultChecked::default(),
+                disabled: Disabled::default(),
+                required: Required::default(),
+                multiple: Multiple::default(),
                 element_props: value.props,
             },
         }

--- a/xilem_web/src/props/html_input_element.rs
+++ b/xilem_web/src/props/html_input_element.rs
@@ -6,6 +6,8 @@ use crate::modifiers::{Modifier, With};
 use crate::{props, FromWithContext, Pod, ViewCtx};
 use wasm_bindgen::JsCast as _;
 
+use super::WithElementProps;
+
 /// Props specific to an input element.
 pub struct HtmlInputElement {
     element_props: props::Element,
@@ -112,4 +114,24 @@ impl With<Multiple> for HtmlInputElement {
     fn modifier(&mut self) -> Modifier<'_, Multiple> {
         Modifier::new(&mut self.multiple, &mut self.element_props.flags)
     }
+}
+
+pub trait WithHtmlInputElementProps:
+    WithElementProps
+    + With<Checked>
+    + With<DefaultChecked>
+    + With<Disabled>
+    + With<Required>
+    + With<Multiple>
+{
+}
+impl<
+        T: WithElementProps
+            + With<Checked>
+            + With<DefaultChecked>
+            + With<Disabled>
+            + With<Required>
+            + With<Multiple>,
+    > WithHtmlInputElementProps for T
+{
 }

--- a/xilem_web/src/props/html_input_element.rs
+++ b/xilem_web/src/props/html_input_element.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::modifiers::html_input_element::{Checked, DefaultChecked, Disabled, Multiple, Required};
 use crate::modifiers::{Modifier, With};
 use crate::{props, FromWithContext, Pod, ViewCtx};

--- a/xilem_web/src/props/html_input_element.rs
+++ b/xilem_web/src/props/html_input_element.rs
@@ -1,0 +1,108 @@
+use crate::modifiers::html_input_element::{Checked, DefaultChecked, Disabled, Multiple, Required};
+use crate::modifiers::With;
+use crate::{props, FromWithContext, Pod, ViewCtx};
+use wasm_bindgen::JsCast as _;
+
+/// Props specific to an input element.
+pub struct HtmlInputElement {
+    element_props: props::Element,
+    checked: Checked,
+    default_checked: DefaultChecked,
+    disabled: Disabled,
+    required: Required,
+    multiple: Multiple,
+}
+
+impl HtmlInputElement {
+    pub(crate) fn update_element(&mut self, element: &web_sys::HtmlInputElement) {
+        self.element_props.update_element(element);
+        // Set booleans to `false` as this is the default,
+        // if we wouldn't do that, possibly the previous value would persist, which is likely unwanted.
+        self.checked.apply_changes(|in_hydration, value| {
+            if !in_hydration {
+                element.set_checked(value.unwrap_or(false));
+            }
+        });
+        self.default_checked.apply_changes(|in_hydration, value| {
+            if !in_hydration {
+                element.set_default_checked(value.unwrap_or(false));
+            }
+        });
+        self.disabled.apply_changes(|in_hydration, value| {
+            if !in_hydration {
+                element.set_disabled(value.unwrap_or(false));
+            }
+        });
+        self.required.apply_changes(|in_hydration, value| {
+            if !in_hydration {
+                element.set_required(value.unwrap_or(false));
+            }
+        });
+        self.multiple.apply_changes(|in_hydration, value| {
+            if !in_hydration {
+                element.set_multiple(value.unwrap_or(false));
+            }
+        });
+    }
+}
+
+impl FromWithContext<Pod<web_sys::Element>> for Pod<web_sys::HtmlInputElement> {
+    fn from_with_ctx(value: Pod<web_sys::Element>, ctx: &mut ViewCtx) -> Self {
+        let checked_size_hint = ctx.take_modifier_size_hint::<Checked>();
+        let default_checked_size_hint = ctx.take_modifier_size_hint::<DefaultChecked>();
+        let disabled_size_hint = ctx.take_modifier_size_hint::<Disabled>();
+        let required_size_hint = ctx.take_modifier_size_hint::<Required>();
+        let multiple_size_hint = ctx.take_modifier_size_hint::<Multiple>();
+        let in_hydration = value.props.in_hydration;
+        Pod {
+            node: value.node.unchecked_into(),
+            props: HtmlInputElement {
+                checked: Checked::new(checked_size_hint, in_hydration),
+                default_checked: DefaultChecked::new(default_checked_size_hint, in_hydration),
+                disabled: Disabled::new(disabled_size_hint, in_hydration),
+                required: Required::new(required_size_hint, in_hydration),
+                multiple: Multiple::new(multiple_size_hint, in_hydration),
+                element_props: value.props,
+            },
+        }
+    }
+}
+
+impl<T> With<T> for HtmlInputElement
+where
+    props::Element: With<T>,
+{
+    fn modifier(&mut self) -> &mut T {
+        self.element_props.modifier()
+    }
+}
+
+impl With<Checked> for HtmlInputElement {
+    fn modifier(&mut self) -> &mut Checked {
+        &mut self.checked
+    }
+}
+
+impl With<DefaultChecked> for HtmlInputElement {
+    fn modifier(&mut self) -> &mut DefaultChecked {
+        &mut self.default_checked
+    }
+}
+
+impl With<Disabled> for HtmlInputElement {
+    fn modifier(&mut self) -> &mut Disabled {
+        &mut self.disabled
+    }
+}
+
+impl With<Required> for HtmlInputElement {
+    fn modifier(&mut self) -> &mut Required {
+        &mut self.required
+    }
+}
+
+impl With<Multiple> for HtmlInputElement {
+    fn modifier(&mut self) -> &mut Multiple {
+        &mut self.multiple
+    }
+}

--- a/xilem_web/src/props/html_input_element.rs
+++ b/xilem_web/src/props/html_input_element.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::modifiers::html_input_element::{Checked, DefaultChecked, Disabled, Multiple, Required};
-use crate::modifiers::{Modifier, With};
+use crate::modifiers::{Modifier, WithModifier};
 use crate::{props, FromWithContext, Pod, ViewCtx};
 use wasm_bindgen::JsCast as _;
 
@@ -77,61 +77,62 @@ impl FromWithContext<Pod<web_sys::Element>> for Pod<web_sys::HtmlInputElement> {
     }
 }
 
-impl<T> With<T> for HtmlInputElement
+impl<T> WithModifier<T> for HtmlInputElement
 where
-    props::Element: With<T>,
+    props::Element: WithModifier<T>,
 {
     fn modifier(&mut self) -> Modifier<'_, T> {
         self.element_props.modifier()
     }
 }
 
-impl With<Checked> for HtmlInputElement {
+impl WithModifier<Checked> for HtmlInputElement {
     fn modifier(&mut self) -> Modifier<'_, Checked> {
         Modifier::new(&mut self.checked, &mut self.element_props.flags)
     }
 }
 
-impl With<DefaultChecked> for HtmlInputElement {
+impl WithModifier<DefaultChecked> for HtmlInputElement {
     fn modifier(&mut self) -> Modifier<'_, DefaultChecked> {
         Modifier::new(&mut self.default_checked, &mut self.element_props.flags)
     }
 }
 
-impl With<Disabled> for HtmlInputElement {
+impl WithModifier<Disabled> for HtmlInputElement {
     fn modifier(&mut self) -> Modifier<'_, Disabled> {
         Modifier::new(&mut self.disabled, &mut self.element_props.flags)
     }
 }
 
-impl With<Required> for HtmlInputElement {
+impl WithModifier<Required> for HtmlInputElement {
     fn modifier(&mut self) -> Modifier<'_, Required> {
         Modifier::new(&mut self.required, &mut self.element_props.flags)
     }
 }
 
-impl With<Multiple> for HtmlInputElement {
+impl WithModifier<Multiple> for HtmlInputElement {
     fn modifier(&mut self) -> Modifier<'_, Multiple> {
         Modifier::new(&mut self.multiple, &mut self.element_props.flags)
     }
 }
 
+/// An alias trait to sum up all modifiers that a DOM `HTMLInputElement` can have. It's used to avoid a lot of boilerplate in public APIs.
 pub trait WithHtmlInputElementProps:
     WithElementProps
-    + With<Checked>
-    + With<DefaultChecked>
-    + With<Disabled>
-    + With<Required>
-    + With<Multiple>
+    + WithModifier<Checked>
+    + WithModifier<DefaultChecked>
+    + WithModifier<Disabled>
+    + WithModifier<Required>
+    + WithModifier<Multiple>
 {
 }
 impl<
         T: WithElementProps
-            + With<Checked>
-            + With<DefaultChecked>
-            + With<Disabled>
-            + With<Required>
-            + With<Multiple>,
+            + WithModifier<Checked>
+            + WithModifier<DefaultChecked>
+            + WithModifier<Disabled>
+            + WithModifier<Required>
+            + WithModifier<Multiple>,
     > WithHtmlInputElementProps for T
 {
 }

--- a/xilem_web/src/props/mod.rs
+++ b/xilem_web/src/props/mod.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
 mod element;
 pub use element::*;
 

--- a/xilem_web/src/props/mod.rs
+++ b/xilem_web/src/props/mod.rs
@@ -1,0 +1,5 @@
+mod element;
+pub use element::*;
+
+mod html_input_element;
+pub use html_input_element::*;

--- a/xilem_web/src/props/mod.rs
+++ b/xilem_web/src/props/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//! This module contains the state (called props in this crate) of the virtual DOM.
+
 mod element;
 pub use element::*;
 

--- a/xilem_web/src/svg/common_attrs.rs
+++ b/xilem_web/src/svg/common_attrs.rs
@@ -3,8 +3,7 @@
 
 use crate::{
     core::{MessageResult, Mut, View, ViewElement, ViewId, ViewMarker},
-    modifiers::With,
-    modifiers::{AttributeModifier, Attributes},
+    modifiers::{AttributeModifier, Attributes, Modifier, With},
     DomView, DynMessage, ViewCtx,
 };
 use peniko::{kurbo, Brush};
@@ -101,9 +100,12 @@ where
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let (mut element, state) =
             ctx.with_size_hint::<Attributes, _>(2, |ctx| self.child.build(ctx));
-        let attrs = element.modifier();
-        attrs.push(("fill", brush_to_string(&self.brush)));
-        attrs.push(opacity_attr_modifier("fill-opacity", &self.brush));
+        let mut attrs = element.modifier();
+        Attributes::push(&mut attrs, ("fill", brush_to_string(&self.brush)));
+        Attributes::push(
+            &mut attrs,
+            opacity_attr_modifier("fill-opacity", &self.brush),
+        );
         (element, state)
     }
 
@@ -117,15 +119,22 @@ where
         Attributes::rebuild(element, 2, |mut element| {
             self.child
                 .rebuild(&prev.child, view_state, ctx, element.reborrow_mut());
-            let attrs = element.modifier();
-            if attrs.was_created() {
-                attrs.push(("fill", brush_to_string(&self.brush)));
-                attrs.push(opacity_attr_modifier("fill-opacity", &self.brush));
+            let mut attrs = element.modifier();
+            if attrs.flags.was_created() {
+                Attributes::push(&mut attrs, ("fill", brush_to_string(&self.brush)));
+                Attributes::push(
+                    &mut attrs,
+                    opacity_attr_modifier("fill-opacity", &self.brush),
+                );
             } else if self.brush != prev.brush {
-                attrs.mutate(|m| *m = ("fill", brush_to_string(&self.brush)).into());
-                attrs.mutate(|m| *m = opacity_attr_modifier("fill-opacity", &self.brush));
+                Attributes::mutate(&mut attrs, |m| {
+                    *m = ("fill", brush_to_string(&self.brush)).into();
+                });
+                Attributes::mutate(&mut attrs, |m| {
+                    *m = opacity_attr_modifier("fill-opacity", &self.brush);
+                });
             } else {
-                attrs.skip(2);
+                Attributes::skip(&mut attrs, 2);
             }
         });
     }
@@ -150,50 +159,66 @@ where
     }
 }
 
-fn push_stroke_modifiers(attrs: &mut Attributes, stroke: &kurbo::Stroke, brush: &Brush) {
+fn push_stroke_modifiers(
+    mut attrs: Modifier<'_, Attributes>,
+    stroke: &kurbo::Stroke,
+    brush: &Brush,
+) {
     let dash_pattern =
         (!stroke.dash_pattern.is_empty()).then(|| join(&mut stroke.dash_pattern.iter(), " "));
-    attrs.push(("stroke-dasharray", dash_pattern));
+    Attributes::push(&mut attrs, ("stroke", brush_to_string(brush)));
+    Attributes::push(&mut attrs, opacity_attr_modifier("stroke-opacity", brush));
+    Attributes::push(&mut attrs, ("stroke-dasharray", dash_pattern));
 
     let dash_offset = (stroke.dash_offset != 0.0).then_some(stroke.dash_offset);
-    attrs.push(("stroke-dashoffset", dash_offset));
-    attrs.push(("stroke-width", stroke.width));
-    attrs.push(opacity_attr_modifier("stroke-opacity", brush));
+    Attributes::push(&mut attrs, ("stroke-dashoffset", dash_offset));
+    Attributes::push(&mut attrs, ("stroke-width", stroke.width));
 }
 
 // This function is not inlined to avoid unnecessary monomorphization, which may result in a bigger binary.
 fn update_stroke_modifiers(
-    attrs: &mut Attributes,
+    mut attrs: Modifier<'_, Attributes>,
     prev_stroke: &kurbo::Stroke,
     next_stroke: &kurbo::Stroke,
     prev_brush: &Brush,
     next_brush: &Brush,
 ) {
-    if attrs.was_created() {
+    if attrs.flags.was_created() {
         push_stroke_modifiers(attrs, next_stroke, next_brush);
     } else {
+        if next_brush != prev_brush {
+            Attributes::mutate(&mut attrs, |m| {
+                *m = ("stroke", brush_to_string(next_brush)).into();
+            });
+            Attributes::mutate(&mut attrs, |m| {
+                *m = opacity_attr_modifier("stroke-opacity", next_brush);
+            });
+        } else {
+            Attributes::skip(&mut attrs, 2);
+        }
         if next_stroke.dash_pattern != prev_stroke.dash_pattern {
             let dash_pattern = (!next_stroke.dash_pattern.is_empty())
                 .then(|| join(&mut next_stroke.dash_pattern.iter(), " "));
-            attrs.mutate(|m| *m = ("stroke-dasharray", dash_pattern).into());
+            Attributes::mutate(&mut attrs, |m| {
+                *m = ("stroke-dasharray", dash_pattern).into();
+            });
         } else {
-            attrs.skip(1);
+            Attributes::skip(&mut attrs, 1);
         }
         if next_stroke.dash_offset != prev_stroke.dash_offset {
             let dash_offset = (next_stroke.dash_offset != 0.0).then_some(next_stroke.dash_offset);
-            attrs.mutate(|m| *m = ("stroke-dashoffset", dash_offset).into());
+            Attributes::mutate(&mut attrs, |m| {
+                *m = ("stroke-dashoffset", dash_offset).into();
+            });
         } else {
-            attrs.skip(1);
+            Attributes::skip(&mut attrs, 1);
         }
         if next_stroke.width != prev_stroke.width {
-            attrs.mutate(|m| *m = ("stroke-width", next_stroke.width).into());
+            Attributes::mutate(&mut attrs, |m| {
+                *m = ("stroke-width", next_stroke.width).into();
+            });
         } else {
-            attrs.skip(1);
-        }
-        if next_brush != prev_brush {
-            attrs.mutate(|m| *m = opacity_attr_modifier("stroke-opacity", next_brush));
-        } else {
-            attrs.skip(1);
+            Attributes::skip(&mut attrs, 1);
         }
     }
 }
@@ -211,7 +236,7 @@ where
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let (mut element, state) =
-            ctx.with_size_hint::<Attributes, _>(4, |ctx| self.child.build(ctx));
+            ctx.with_size_hint::<Attributes, _>(5, |ctx| self.child.build(ctx));
         push_stroke_modifiers(element.modifier(), &self.style, &self.brush);
         (element, state)
     }
@@ -223,7 +248,7 @@ where
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
     ) {
-        Attributes::rebuild(element, 4, |mut element| {
+        Attributes::rebuild(element, 5, |mut element| {
             self.child
                 .rebuild(&prev.child, view_state, ctx, element.reborrow_mut());
             update_stroke_modifiers(

--- a/xilem_web/src/svg/common_attrs.rs
+++ b/xilem_web/src/svg/common_attrs.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     core::{MessageResult, Mut, View, ViewElement, ViewId, ViewMarker},
-    modifiers::{AttributeModifier, Attributes, Modifier, With},
+    modifiers::{AttributeModifier, Attributes, Modifier, WithModifier},
     DomView, DynMessage, ViewCtx,
 };
 use peniko::{kurbo, Brush};
@@ -91,8 +91,8 @@ impl<State, Action, V> View<State, Action, ViewCtx, DynMessage> for Fill<V, Stat
 where
     State: 'static,
     Action: 'static,
-    V: DomView<State, Action, Element: With<Attributes>>,
-    for<'a> <V::Element as ViewElement>::Mut<'a>: With<Attributes>,
+    V: DomView<State, Action, Element: WithModifier<Attributes>>,
+    for<'a> <V::Element as ViewElement>::Mut<'a>: WithModifier<Attributes>,
 {
     type ViewState = V::ViewState;
     type Element = V::Element;
@@ -228,8 +228,8 @@ impl<State, Action, V> View<State, Action, ViewCtx, DynMessage> for Stroke<V, St
 where
     State: 'static,
     Action: 'static,
-    V: DomView<State, Action, Element: With<Attributes>>,
-    for<'a> <V::Element as ViewElement>::Mut<'a>: With<Attributes>,
+    V: DomView<State, Action, Element: WithModifier<Attributes>>,
+    for<'a> <V::Element as ViewElement>::Mut<'a>: WithModifier<Attributes>,
 {
     type ViewState = V::ViewState;
     type Element = V::Element;

--- a/xilem_web/src/svg/kurbo_shape.rs
+++ b/xilem_web/src/svg/kurbo_shape.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     core::{MessageResult, Mut, OrphanView, ViewId},
-    modifiers::{Attributes, With},
+    modifiers::{Attributes, WithModifier},
     DynMessage, FromWithContext, Pod, ViewCtx, SVG_NS,
 };
 use peniko::kurbo::{BezPath, Circle, Line, Rect};

--- a/xilem_web/src/svg/kurbo_shape.rs
+++ b/xilem_web/src/svg/kurbo_shape.rs
@@ -36,11 +36,11 @@ impl<State: 'static, Action: 'static> OrphanView<Line, State, Action, DynMessage
     ) -> (Self::OrphanElement, Self::OrphanViewState) {
         create_element("line", ctx, 4, |element, ctx| {
             let mut element = Self::OrphanElement::from_with_ctx(element, ctx);
-            let attrs: &mut Attributes = element.modifier();
-            attrs.push(("x1", view.p0.x));
-            attrs.push(("y1", view.p0.y));
-            attrs.push(("x2", view.p1.x));
-            attrs.push(("y2", view.p1.y));
+            let attrs = &mut element.modifier();
+            Attributes::push(attrs, ("x1", view.p0.x));
+            Attributes::push(attrs, ("y1", view.p0.y));
+            Attributes::push(attrs, ("x2", view.p1.x));
+            Attributes::push(attrs, ("y2", view.p1.y));
             (element, ())
         })
     }
@@ -53,11 +53,11 @@ impl<State: 'static, Action: 'static> OrphanView<Line, State, Action, DynMessage
         element: Mut<Self::OrphanElement>,
     ) {
         Attributes::rebuild(element, 4, |mut element| {
-            let attrs: &mut Attributes = element.modifier();
-            attrs.update_with_same_key("x1", &prev.p0.x, &new.p0.x);
-            attrs.update_with_same_key("y1", &prev.p0.y, &new.p0.y);
-            attrs.update_with_same_key("x2", &prev.p1.x, &new.p1.x);
-            attrs.update_with_same_key("y2", &prev.p1.y, &new.p1.y);
+            let attrs = &mut element.modifier();
+            Attributes::update_with_same_key(attrs, "x1", &prev.p0.x, &new.p0.x);
+            Attributes::update_with_same_key(attrs, "y1", &prev.p0.y, &new.p0.y);
+            Attributes::update_with_same_key(attrs, "x2", &prev.p1.x, &new.p1.x);
+            Attributes::update_with_same_key(attrs, "y2", &prev.p1.y, &new.p1.y);
         });
     }
 
@@ -90,11 +90,11 @@ impl<State: 'static, Action: 'static> OrphanView<Rect, State, Action, DynMessage
     ) -> (Self::OrphanElement, Self::OrphanViewState) {
         create_element("rect", ctx, 4, |element, ctx| {
             let mut element = Self::OrphanElement::from_with_ctx(element, ctx);
-            let attrs: &mut Attributes = element.modifier();
-            attrs.push(("x", view.x0));
-            attrs.push(("y", view.y0));
-            attrs.push(("width", view.width()));
-            attrs.push(("height", view.height()));
+            let attrs = &mut element.modifier();
+            Attributes::push(attrs, ("x", view.x0));
+            Attributes::push(attrs, ("y", view.y0));
+            Attributes::push(attrs, ("width", view.width()));
+            Attributes::push(attrs, ("height", view.height()));
             (element, ())
         })
     }
@@ -107,11 +107,11 @@ impl<State: 'static, Action: 'static> OrphanView<Rect, State, Action, DynMessage
         element: Mut<Self::OrphanElement>,
     ) {
         Attributes::rebuild(element, 4, |mut element| {
-            let attrs: &mut Attributes = element.modifier();
-            attrs.update_with_same_key("x", &prev.x0, &new.x0);
-            attrs.update_with_same_key("y", &prev.y0, &new.y0);
-            attrs.update_with_same_key("width", &prev.width(), &new.width());
-            attrs.update_with_same_key("height", &prev.height(), &new.height());
+            let attrs = &mut element.modifier();
+            Attributes::update_with_same_key(attrs, "x", &prev.x0, &new.x0);
+            Attributes::update_with_same_key(attrs, "y", &prev.y0, &new.y0);
+            Attributes::update_with_same_key(attrs, "width", &prev.width(), &new.width());
+            Attributes::update_with_same_key(attrs, "height", &prev.height(), &new.height());
         });
     }
 
@@ -144,10 +144,10 @@ impl<State: 'static, Action: 'static> OrphanView<Circle, State, Action, DynMessa
     ) -> (Self::OrphanElement, Self::OrphanViewState) {
         create_element("circle", ctx, 3, |element, ctx| {
             let mut element = Self::OrphanElement::from_with_ctx(element, ctx);
-            let attrs: &mut Attributes = element.modifier();
-            attrs.push(("cx", view.center.x));
-            attrs.push(("cy", view.center.y));
-            attrs.push(("r", view.radius));
+            let attrs = &mut element.modifier();
+            Attributes::push(attrs, ("cx", view.center.x));
+            Attributes::push(attrs, ("cy", view.center.y));
+            Attributes::push(attrs, ("r", view.radius));
             (element, ())
         })
     }
@@ -160,10 +160,10 @@ impl<State: 'static, Action: 'static> OrphanView<Circle, State, Action, DynMessa
         element: Mut<Self::OrphanElement>,
     ) {
         Attributes::rebuild(element, 3, |mut element| {
-            let attrs: &mut Attributes = element.modifier();
-            attrs.update_with_same_key("cx", &prev.center.x, &new.center.x);
-            attrs.update_with_same_key("cy", &prev.center.y, &new.center.y);
-            attrs.update_with_same_key("height", &prev.radius, &new.radius);
+            let attrs = &mut element.modifier();
+            Attributes::update_with_same_key(attrs, "cx", &prev.center.x, &new.center.x);
+            Attributes::update_with_same_key(attrs, "cy", &prev.center.y, &new.center.y);
+            Attributes::update_with_same_key(attrs, "height", &prev.radius, &new.radius);
         });
     }
 
@@ -196,7 +196,8 @@ impl<State: 'static, Action: 'static> OrphanView<BezPath, State, Action, DynMess
     ) -> (Self::OrphanElement, Self::OrphanViewState) {
         create_element("path", ctx, 1, |element, ctx| {
             let mut element = Self::OrphanElement::from_with_ctx(element, ctx);
-            element.props.attributes().push(("d", view.to_svg()));
+            let attrs = &mut element.modifier();
+            Attributes::push(attrs, ("d", view.to_svg()));
             (element, ())
         })
     }
@@ -209,13 +210,13 @@ impl<State: 'static, Action: 'static> OrphanView<BezPath, State, Action, DynMess
         element: Mut<Self::OrphanElement>,
     ) {
         Attributes::rebuild(element, 1, |mut element| {
-            let attrs: &mut Attributes = element.modifier();
-            if attrs.was_created() {
-                attrs.push(("d", new.to_svg()));
+            let attrs = &mut element.modifier();
+            if attrs.flags.was_created() {
+                Attributes::push(attrs, ("d", new.to_svg()));
             } else if new != prev {
-                attrs.mutate(|m| *m = ("d", new.to_svg()).into());
+                Attributes::mutate(attrs, |m| *m = ("d", new.to_svg()).into());
             } else {
-                attrs.skip(1);
+                Attributes::skip(attrs, 1);
             }
         });
     }

--- a/xilem_web/web_examples/fetch/src/main.rs
+++ b/xilem_web/web_examples/fetch/src/main.rs
@@ -9,7 +9,7 @@ use xilem_web::{
     core::{fork, one_of::Either},
     document_body,
     elements::html::*,
-    interfaces::{Element, HtmlDivElement, HtmlImageElement, HtmlLabelElement},
+    interfaces::{Element, HtmlDivElement, HtmlImageElement, HtmlInputElement, HtmlLabelElement},
     App,
 };
 
@@ -188,7 +188,7 @@ fn cat_fetch_controls(state: &AppState) -> impl Element<AppState> {
                 td(input(())
                     .id("reset-debounce-update")
                     .attr("type", "checkbox")
-                    .attr("checked", state.reset_debounce_on_update)
+                    .checked(state.reset_debounce_on_update)
                     .on_input(|state: &mut AppState, event: web_sys::Event| {
                         state.reset_debounce_on_update = input_target(&event).checked();
                     })),

--- a/xilem_web/web_examples/todomvc/src/main.rs
+++ b/xilem_web/web_examples/todomvc/src/main.rs
@@ -30,7 +30,7 @@ fn todo_item(todo: &mut Todo, editing: bool) -> impl Element<Todo, TodoAction> {
     let checkbox = el::input(())
         .class("toggle")
         .attr("type", "checkbox")
-        .attr("checked", todo.completed)
+        .checked(todo.completed)
         .on_click(|state: &mut Todo, _| state.completed = !state.completed);
 
     el::li((
@@ -160,7 +160,7 @@ fn main_view(state: &mut AppState, should_display: bool) -> impl Element<AppStat
         .attr("id", "toggle-all")
         .class("toggle-all")
         .attr("type", "checkbox")
-        .attr("checked", state.are_all_complete());
+        .checked(state.are_all_complete());
 
     el::section((
         toggle_all.on_click(|state: &mut AppState, _| state.toggle_all_complete()),


### PR DESCRIPTION
This PR starts with supporting specialized elements (i.e. more than just the `Element` DOM interface), starting with boolean attributes in `HtmlInputElement`  (`checked`, `default_checked`, `disabled`, `required`, `multiple`).
With a general `OverwriteBool` modifier which is optimized by encoding boolean flags into a `u32`, thus not requiring allocations (compared to the other modifiers we currently have), but is limited to max 32 overwrites, which I don't think should be a real-world limitation (i.e. `input_el.checked().checked()...checked()` 32 times makes no sense), I also started adding tests for this, as it juggles around with bit-operations (and we should generally start writing more tests).
I have originally planned to feature-flag this (i.e. have a feature like `HtmlInputElement`).
But I'd like to see how far we can go without this, I haven't yet noticed significant (binary-size) regressions in the todomvc example (which uses `input` elements) that justifies the worse DX that additional features introduce.
Having features for this is also not optimal for another reason: It changes the API (e.g. `DomNode::Props` is `props::HtmlInputElement` instead of `props::Element`.

It also factors the element state flags (`was_created`, `in_hydration`) into a separate `ElementFlags` which is shared within a `Modifier<M>` struct (similar as `PodMut` or `WidgetMut` in masonry), so that we don't have to duplicate that state in every modifier. Additionally a new flag `needs_update` is introduced, which indicates that the element in general needs to update any modifier, and is entirely an optimization to avoid checking every modifier whether it has changed (not yet that important, but when we have a lot of modifiers per element, having to check every modifier is less efficient, it's also already *slightly* visible in the js-framework-benchmark).
For this, it unfortunately suffers similar as #705 from the free-form syntax by being a little bit more verbose (which may be reverted after `arbitrary_self_types` are stable).

It should also fix #716