### PR TITLE
masonry: Export `WindowSizePolicy`

### DIFF
--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -156,7 +156,7 @@ pub use event::{
     AccessEvent, PointerButton, PointerEvent, PointerState, TextEvent, Update, WindowEvent,
     WindowTheme,
 };
-pub use render_root::{RenderRoot, RenderRootOptions, RenderRootSignal};
+pub use render_root::{RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy};
 pub use util::{AsAny, Handled};
 pub use widget::widget::{AllowRawMut, Widget, WidgetId};
 pub use widget::WidgetPod;


### PR DESCRIPTION
This is a pub enum within `render_root` and is required for creating a `RenderRootOptions` which is already exported. This is needed for people embedding masonry in a non-Xilem way.