### PR TITLE
xilem_web: Fix event views (when the underlying element was recreated) and factor flags and `Pod` into its own module

### DIFF
--- a/xilem_web/src/after_update.rs
+++ b/xilem_web/src/after_update.rs
@@ -121,7 +121,7 @@ where
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let (mut el, view_state) = self.element.build(ctx);
-        el.node.apply_props(&mut el.props);
+        el.node.apply_props(&mut el.props, &mut el.flags);
         (self.callback)(&el.node);
         (el, view_state)
     }
@@ -183,7 +183,7 @@ where
     ) {
         self.element
             .rebuild(&prev.element, view_state, ctx, element.reborrow_mut());
-        element.node.apply_props(element.props);
+        element.node.apply_props(element.props, element.flags);
         (self.callback)(element.node);
     }
 

--- a/xilem_web/src/elements.rs
+++ b/xilem_web/src/elements.rs
@@ -11,7 +11,7 @@ use wasm_bindgen::{JsCast, UnwrapThrowExt};
 use crate::{
     core::{AppendVec, ElementSplice, MessageResult, Mut, View, ViewId, ViewMarker},
     document,
-    modifiers::{Children, WithModifier},
+    modifiers::Children,
     vec_splice::VecSplice,
     AnyPod, DomFragment, DomNode, DynMessage, FromWithContext, Pod, ViewCtx, HTML_NS,
 };
@@ -262,11 +262,11 @@ pub(crate) fn rebuild_element<State, Action, Element>(
     State: 'static,
     Action: 'static,
     Element: 'static,
-    Element: DomNode<Props: WithModifier<Children>>,
+    Element: DomNode<Props: AsMut<Children>>,
 {
     let mut dom_children_splice = DomChildrenSplice::new(
         &mut state.append_scratch,
-        WithModifier::<Children>::modifier(element.props).modifier,
+        element.props.as_mut(),
         &mut state.vec_splice_scratch,
         element.node.as_ref(),
         ctx.fragment.clone(),
@@ -290,11 +290,11 @@ pub(crate) fn teardown_element<State, Action, Element>(
     State: 'static,
     Action: 'static,
     Element: 'static,
-    Element: DomNode<Props: WithModifier<Children>>,
+    Element: DomNode<Props: AsMut<Children>>,
 {
     let mut dom_children_splice = DomChildrenSplice::new(
         &mut state.append_scratch,
-        WithModifier::<Children>::modifier(element.props).modifier,
+        element.props.as_mut(),
         &mut state.vec_splice_scratch,
         element.node.as_ref(),
         ctx.fragment.clone(),

--- a/xilem_web/src/events.rs
+++ b/xilem_web/src/events.rs
@@ -173,14 +173,15 @@ fn rebuild_event_listener<State, Action, V, Event>(
             element.reborrow_mut(),
         );
         let was_created = element.flags.was_created();
-        if prev_capture != capture || prev_passive != passive || was_created {
-            if !was_created {
-                remove_event_listener(element.as_ref(), event, &state.callback, prev_capture);
-            }
-
-            state.callback =
-                create_event_listener::<Event>(element.as_ref(), event, capture, passive, ctx);
+        let needs_update = prev_capture != capture || prev_passive != passive || was_created;
+        if !needs_update {
+            return;
         }
+        if !was_created {
+            remove_event_listener(element.as_ref(), event, &state.callback, prev_capture);
+        }
+        state.callback =
+            create_event_listener::<Event>(element.as_ref(), event, capture, passive, ctx);
     });
 }
 
@@ -278,29 +279,29 @@ where
             );
 
             let was_created = element.flags.was_created();
-
-            if prev.capture != self.capture
+            let needs_update = prev.capture != self.capture
                 || prev.passive != self.passive
                 || prev.event != self.event
-                || was_created
-            {
-                if !was_created {
-                    remove_event_listener(
-                        element.as_ref(),
-                        &prev.event,
-                        &view_state.callback,
-                        prev.capture,
-                    );
-                }
-
-                view_state.callback = create_event_listener::<Event>(
+                || was_created;
+            if !needs_update {
+                return;
+            }
+            if !was_created {
+                remove_event_listener(
                     element.as_ref(),
-                    &self.event,
-                    self.capture,
-                    self.passive,
-                    ctx,
+                    &prev.event,
+                    &view_state.callback,
+                    prev.capture,
                 );
             }
+
+            view_state.callback = create_event_listener::<Event>(
+                element.as_ref(),
+                &self.event,
+                self.capture,
+                self.passive,
+                ctx,
+            );
         });
     }
 

--- a/xilem_web/src/interfaces.rs
+++ b/xilem_web/src/interfaces.rs
@@ -313,7 +313,7 @@ pub trait Element<State, Action = ()>:
         Self::Element: AsRef<web_sys::Element>,
     {
         events::OnResize {
-            element: self,
+            dom_view: self,
             handler,
             phantom_event_ty: std::marker::PhantomData,
         }

--- a/xilem_web/src/lib.rs
+++ b/xilem_web/src/lib.rs
@@ -65,9 +65,7 @@ pub use templated::{templated, Templated};
 
 pub use xilem_core as core;
 
-use core::{
-    Adapt, AdaptThunk, AnyView, MapAction, MapState, MessageResult, View, ViewElement, ViewSequence,
-};
+use core::{Adapt, AdaptThunk, AnyView, MapAction, MapState, MessageResult, View, ViewSequence};
 
 /// A trait used for type erasure of [`DomNode`]s
 /// It is e.g. used in [`AnyPod`]
@@ -225,16 +223,6 @@ impl<V, State, Action> DomFragment<State, Action> for V where
 {
 }
 
-/// Syntax sugar for adding a type bound on the `ViewElement` of a view, such that both, [`ViewElement`] and [`ViewElement::Mut`] have the same [`AsRef`] type
-pub trait ElementAsRef<E>: for<'a> ViewElement<Mut<'a>: AsRef<E>> + AsRef<E> {}
-
-impl<E, T> ElementAsRef<E> for T
-where
-    T: ViewElement + AsRef<E>,
-    for<'a> T::Mut<'a>: AsRef<E>,
-{
-}
-
 impl DomNode for Box<dyn AnyNode> {
     type Props = Box<dyn Any>;
 
@@ -254,29 +242,21 @@ impl DomNode for web_sys::Element {
     type Props = props::Element;
 
     fn apply_props(&self, props: &mut props::Element, flags: &mut PodFlags) {
-        if flags.needs_update() {
-            props.update_element(self, flags);
-        }
-        flags.clear();
+        props.update_element(self, flags);
     }
 }
 
 impl DomNode for web_sys::Text {
     type Props = ();
 
-    fn apply_props(&self, (): &mut (), flags: &mut PodFlags) {
-        flags.clear();
-    }
+    fn apply_props(&self, (): &mut (), _flags: &mut PodFlags) {}
 }
 
 impl DomNode for web_sys::HtmlInputElement {
     type Props = props::HtmlInputElement;
 
     fn apply_props(&self, props: &mut props::HtmlInputElement, flags: &mut PodFlags) {
-        if flags.needs_update() {
-            props.update_element(self, flags);
-        }
-        flags.clear();
+        props.update_element(self, flags);
     }
 }
 
@@ -297,10 +277,7 @@ macro_rules! impl_dom_node_for_elements {
             type Props = props::Element;
 
             fn apply_props(&self, props: &mut props::Element, flags: &mut PodFlags) {
-                if flags.needs_update() {
-                    props.update_element(self, flags);
-                }
-                flags.clear();
+                props.update_element(self, flags);
             }
         }
 

--- a/xilem_web/src/lib.rs
+++ b/xilem_web/src/lib.rs
@@ -12,12 +12,8 @@
 //! </style>
 #![doc = include_str!("../README.md")]
 
-use std::{
-    any::Any,
-    ops::{Deref as _, DerefMut as _},
-};
+use std::{any::Any, ops::Deref as _};
 
-use wasm_bindgen::UnwrapThrowExt;
 use web_sys::wasm_bindgen::JsCast;
 
 /// The HTML namespace
@@ -35,6 +31,7 @@ mod dom_helpers;
 mod message;
 mod one_of;
 mod optional_action;
+mod pod;
 mod pointer;
 mod templated;
 mod text;
@@ -60,6 +57,7 @@ pub use self::{
     dom_helpers::{document, document_body, get_element_by_id, input_event_target_value},
     message::{DynMessage, Message},
     optional_action::{Action, OptionalAction},
+    pod::{AnyPod, Pod, PodFlags, PodMut},
     pointer::{Pointer, PointerDetails, PointerMsg},
 };
 
@@ -67,9 +65,8 @@ pub use templated::{templated, Templated};
 
 pub use xilem_core as core;
 
-use xilem_core::{
-    Adapt, AdaptThunk, AnyElement, AnyView, MapAction, MapState, MessageResult, SuperElement, View,
-    ViewElement, ViewSequence,
+use core::{
+    Adapt, AdaptThunk, AnyView, MapAction, MapState, MessageResult, View, ViewElement, ViewSequence,
 };
 
 /// A trait used for type erasure of [`DomNode`]s
@@ -89,17 +86,7 @@ pub trait DomNode: AnyNode {
     type Props: 'static;
     /// When this is called any accumulated (virtual) `props` changes are applied to the underlying DOM node.
     /// Where `props` stands for all kinds of modifiable properties, like attributes, styles, classes or more specific properties related to an element.
-    fn apply_props(&self, props: &mut Self::Props);
-}
-
-/// Syntax sugar for adding a type bound on the `ViewElement` of a view, such that both, [`ViewElement`] and [`ViewElement::Mut`] have the same [`AsRef`] type
-pub trait ElementAsRef<E>: for<'a> ViewElement<Mut<'a>: AsRef<E>> + AsRef<E> {}
-
-impl<E, T> ElementAsRef<E> for T
-where
-    T: ViewElement + AsRef<E>,
-    for<'a> T::Mut<'a>: AsRef<E>,
-{
+    fn apply_props(&self, props: &mut Self::Props, flags: &mut PodFlags);
 }
 
 /// A view which can have any [`DomView`] type, see [`AnyView`] for more details.
@@ -238,31 +225,20 @@ impl<V, State, Action> DomFragment<State, Action> for V where
 {
 }
 
-/// A container, which holds the actual DOM node, and associated props, such as attributes or classes.
-///
-/// These attributes are not directly set on the DOM node to avoid mutating or reading from the DOM tree unnecessarily, and to have more control over the whole update flow.
-pub struct Pod<N: DomNode> {
-    pub node: N,
-    pub props: N::Props,
-}
+/// Syntax sugar for adding a type bound on the `ViewElement` of a view, such that both, [`ViewElement`] and [`ViewElement::Mut`] have the same [`AsRef`] type
+pub trait ElementAsRef<E>: for<'a> ViewElement<Mut<'a>: AsRef<E>> + AsRef<E> {}
 
-/// Type-erased [`Pod`], it's used for example as intermediate representation for children of a DOM node
-pub type AnyPod = Pod<Box<dyn AnyNode>>;
-
-impl<N: DomNode> Pod<N> {
-    pub fn into_any_pod(mut pod: Pod<N>) -> AnyPod {
-        pod.node.apply_props(&mut pod.props);
-        Pod {
-            node: Box::new(pod.node),
-            props: Box::new(pod.props),
-        }
-    }
+impl<E, T> ElementAsRef<E> for T
+where
+    T: ViewElement + AsRef<E>,
+    for<'a> T::Mut<'a>: AsRef<E>,
+{
 }
 
 impl DomNode for Box<dyn AnyNode> {
     type Props = Box<dyn Any>;
 
-    fn apply_props(&self, _props: &mut Self::Props) {
+    fn apply_props(&self, _props: &mut Self::Props, _: &mut PodFlags) {
         // TODO this is probably not optimal, as misleading, this is only implemented for concrete (non-type-erased) elements
         // I do *think* it's necessary as method on the trait because of the Drop impl (and not having specialization there)
     }
@@ -274,138 +250,33 @@ impl AsRef<web_sys::Node> for Box<dyn AnyNode> {
     }
 }
 
-impl<N: DomNode> ViewElement for Pod<N> {
-    type Mut<'a> = PodMut<'a, N>;
-}
-
-impl<N: DomNode> SuperElement<Pod<N>, ViewCtx> for AnyPod {
-    fn upcast(_ctx: &mut ViewCtx, child: Pod<N>) -> Self {
-        Pod::into_any_pod(child)
-    }
-
-    fn with_downcast_val<R>(
-        mut this: Self::Mut<'_>,
-        f: impl FnOnce(PodMut<N>) -> R,
-    ) -> (Self::Mut<'_>, R) {
-        let downcast = this.downcast();
-        let ret = f(downcast);
-        (this, ret)
-    }
-}
-
-impl<N: DomNode> AnyElement<Pod<N>, ViewCtx> for AnyPod {
-    fn replace_inner(this: Self::Mut<'_>, mut child: Pod<N>) -> Self::Mut<'_> {
-        child.node.apply_props(&mut child.props);
-        if let Some(parent) = this.parent {
-            parent
-                .replace_child(child.node.as_ref(), this.node.as_ref())
-                .unwrap_throw();
-        }
-        *this.node = Box::new(child.node);
-        *this.props = Box::new(child.props);
-        this
-    }
-}
-
-impl AnyPod {
-    fn as_mut<'a>(
-        &'a mut self,
-        parent: impl Into<Option<&'a web_sys::Node>>,
-        was_removed: bool,
-    ) -> PodMut<'a, Box<dyn AnyNode>> {
-        PodMut::new(&mut self.node, &mut self.props, parent.into(), was_removed)
-    }
-}
-
-/// The mutable representation of [`Pod`].
-///
-/// This is a container which contains info of what has changed and provides mutable access to the underlying element and its props
-/// When it's dropped all changes are applied to the underlying DOM node
-pub struct PodMut<'a, N: DomNode> {
-    node: &'a mut N,
-    props: &'a mut N::Props,
-    parent: Option<&'a web_sys::Node>,
-    was_removed: bool,
-    is_reborrow: bool,
-}
-
-impl<'a, N: DomNode> PodMut<'a, N> {
-    fn new(
-        node: &'a mut N,
-        props: &'a mut N::Props,
-        parent: Option<&'a web_sys::Node>,
-        was_removed: bool,
-    ) -> PodMut<'a, N> {
-        PodMut {
-            node,
-            props,
-            parent,
-            was_removed,
-            is_reborrow: false,
-        }
-    }
-
-    fn reborrow_mut(&mut self) -> PodMut<N> {
-        PodMut {
-            node: self.node,
-            props: self.props,
-            parent: self.parent,
-            was_removed: self.was_removed,
-            is_reborrow: true,
-        }
-    }
-}
-
-impl PodMut<'_, Box<dyn AnyNode>> {
-    fn downcast<N: DomNode>(&mut self) -> PodMut<N> {
-        PodMut::new(
-            self.node.deref_mut().as_any_mut().downcast_mut().unwrap(),
-            self.props.downcast_mut().unwrap(),
-            self.parent,
-            false,
-        )
-    }
-}
-
-impl<N: DomNode> Drop for PodMut<'_, N> {
-    fn drop(&mut self) {
-        if !self.is_reborrow && !self.was_removed {
-            self.node.apply_props(self.props);
-        }
-    }
-}
-
-impl<T, N: AsRef<T> + DomNode> AsRef<T> for Pod<N> {
-    fn as_ref(&self) -> &T {
-        <N as AsRef<T>>::as_ref(&self.node)
-    }
-}
-
-impl<T, N: AsRef<T> + DomNode> AsRef<T> for PodMut<'_, N> {
-    fn as_ref(&self) -> &T {
-        <N as AsRef<T>>::as_ref(self.node)
-    }
-}
-
 impl DomNode for web_sys::Element {
     type Props = props::Element;
 
-    fn apply_props(&self, props: &mut props::Element) {
-        props.update_element(self);
+    fn apply_props(&self, props: &mut props::Element, flags: &mut PodFlags) {
+        if flags.needs_update() {
+            props.update_element(self, flags);
+        }
+        flags.clear();
     }
 }
 
 impl DomNode for web_sys::Text {
     type Props = ();
 
-    fn apply_props(&self, (): &mut ()) {}
+    fn apply_props(&self, (): &mut (), flags: &mut PodFlags) {
+        flags.clear();
+    }
 }
 
 impl DomNode for web_sys::HtmlInputElement {
     type Props = props::HtmlInputElement;
 
-    fn apply_props(&self, props: &mut props::HtmlInputElement) {
-        props.update_element(self);
+    fn apply_props(&self, props: &mut props::HtmlInputElement, flags: &mut PodFlags) {
+        if flags.needs_update() {
+            props.update_element(self, flags);
+        }
+        flags.clear();
     }
 }
 
@@ -425,8 +296,11 @@ macro_rules! impl_dom_node_for_elements {
         impl DomNode for web_sys::$ty {
             type Props = props::Element;
 
-            fn apply_props(&self, props: &mut props::Element) {
-                props.update_element(self);
+            fn apply_props(&self, props: &mut props::Element, flags: &mut PodFlags) {
+                if flags.needs_update() {
+                    props.update_element(self, flags);
+                }
+                flags.clear();
             }
         }
 
@@ -435,6 +309,7 @@ macro_rules! impl_dom_node_for_elements {
                 Self {
                     node: value.node.unchecked_into(),
                     props: value.props,
+                    flags: value.flags,
                 }
             }
         }

--- a/xilem_web/src/modifiers/overwrite.rs
+++ b/xilem_web/src/modifiers/overwrite.rs
@@ -242,14 +242,14 @@ macro_rules! overwrite_bool_modifier_view {
 
 #[cfg(test)]
 mod tests {
-    use crate::props::ElementFlags;
+    use crate::PodFlags;
 
     use super::*;
 
     #[test]
     fn overwrite_bool_push() {
         let mut modifier = OverwriteBool::default();
-        let flags = &mut ElementFlags::new(false);
+        let flags = &mut PodFlags::new(false);
         let m = &mut Modifier::new(&mut modifier, flags);
         assert!(!m.flags.needs_update());
         OverwriteBool::push(m, true);
@@ -271,7 +271,7 @@ mod tests {
     #[test]
     fn overwrite_bool_mutate() {
         let mut modifier = OverwriteBool::default();
-        let flags = &mut ElementFlags::new(false);
+        let flags = &mut PodFlags::new(false);
         let m = &mut Modifier::new(&mut modifier, flags);
         OverwriteBool::push(m, true);
         OverwriteBool::push(m, false);
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn overwrite_bool_skip() {
         let mut modifier = OverwriteBool::default();
-        let flags = &mut ElementFlags::new(false);
+        let flags = &mut PodFlags::new(false);
         let m = &mut Modifier::new(&mut modifier, flags);
         OverwriteBool::push(m, true);
         OverwriteBool::push(m, false);
@@ -352,7 +352,7 @@ mod tests {
     #[test]
     fn overwrite_bool_update() {
         let mut modifier = OverwriteBool::default();
-        let flags = &mut ElementFlags::new(false);
+        let flags = &mut PodFlags::new(false);
         let m = &mut Modifier::new(&mut modifier, flags);
         OverwriteBool::push(m, true);
         OverwriteBool::push(m, false);
@@ -394,7 +394,7 @@ mod tests {
 
         // test recreation
         let mut modifier = OverwriteBool::default();
-        let flags = &mut ElementFlags::new(false);
+        let flags = &mut PodFlags::new(false);
         let modifier = &mut Modifier::new(&mut modifier, flags);
         assert_eq!(modifier.modifier.len, 0);
         assert_eq!(modifier.modifier.idx, 0);
@@ -422,7 +422,7 @@ mod tests {
     )]
     fn panic_if_use_mutate_on_creation() {
         let mut modifier = OverwriteBool::default();
-        let flags = &mut ElementFlags::new(false);
+        let flags = &mut PodFlags::new(false);
         let m = &mut Modifier::new(&mut modifier, flags);
         assert!(m.flags.was_created());
         OverwriteBool::mutate(m, |m| *m = false);
@@ -434,7 +434,7 @@ mod tests {
     )]
     fn panic_if_use_push_on_rebuild() {
         let mut modifier = OverwriteBool::default();
-        let flags = &mut ElementFlags::new(false);
+        let flags = &mut PodFlags::new(false);
         let m = &mut Modifier::new(&mut modifier, flags);
         assert!(m.flags.was_created());
         OverwriteBool::push(m, true);

--- a/xilem_web/src/one_of.rs
+++ b/xilem_web/src/one_of.rs
@@ -6,7 +6,6 @@ use crate::{
         one_of::{OneOf, OneOfCtx, PhantomElementCtx},
         Mut,
     },
-    modifiers::{Modifier, WithModifier},
     DomNode, Pod, PodFlags, PodMut, ViewCtx,
 };
 use wasm_bindgen::UnwrapThrowExt;
@@ -202,12 +201,6 @@ impl<T> AsRef<T> for Noop {
 
 impl<T> AsMut<T> for Noop {
     fn as_mut(&mut self) -> &mut T {
-        match *self {}
-    }
-}
-
-impl<T> WithModifier<T> for Noop {
-    fn modifier(&mut self) -> Modifier<'_, T> {
         match *self {}
     }
 }

--- a/xilem_web/src/one_of.rs
+++ b/xilem_web/src/one_of.rs
@@ -7,7 +7,7 @@ use crate::{
         Mut,
     },
     modifiers::{Modifier, WithModifier},
-    DomNode, Pod, PodMut, ViewCtx,
+    DomNode, Pod, PodFlags, PodMut, ViewCtx,
 };
 use wasm_bindgen::UnwrapThrowExt;
 
@@ -42,42 +42,15 @@ where
         >,
     ) -> Self::OneOfElement {
         match elem {
-            OneOf::A(e) => Pod {
-                node: OneOf::A(e.node),
-                props: OneOf::A(e.props),
-            },
-            OneOf::B(e) => Pod {
-                node: OneOf::B(e.node),
-                props: OneOf::B(e.props),
-            },
-            OneOf::C(e) => Pod {
-                node: OneOf::C(e.node),
-                props: OneOf::C(e.props),
-            },
-            OneOf::D(e) => Pod {
-                node: OneOf::D(e.node),
-                props: OneOf::D(e.props),
-            },
-            OneOf::E(e) => Pod {
-                node: OneOf::E(e.node),
-                props: OneOf::E(e.props),
-            },
-            OneOf::F(e) => Pod {
-                node: OneOf::F(e.node),
-                props: OneOf::F(e.props),
-            },
-            OneOf::G(e) => Pod {
-                node: OneOf::G(e.node),
-                props: OneOf::G(e.props),
-            },
-            OneOf::H(e) => Pod {
-                node: OneOf::H(e.node),
-                props: OneOf::H(e.props),
-            },
-            OneOf::I(e) => Pod {
-                node: OneOf::I(e.node),
-                props: OneOf::I(e.props),
-            },
+            OneOf::A(e) => Pod::new(OneOf::A(e.node), OneOf::A(e.props), e.flags),
+            OneOf::B(e) => Pod::new(OneOf::B(e.node), OneOf::B(e.props), e.flags),
+            OneOf::C(e) => Pod::new(OneOf::C(e.node), OneOf::C(e.props), e.flags),
+            OneOf::D(e) => Pod::new(OneOf::D(e.node), OneOf::D(e.props), e.flags),
+            OneOf::E(e) => Pod::new(OneOf::E(e.node), OneOf::E(e.props), e.flags),
+            OneOf::F(e) => Pod::new(OneOf::F(e.node), OneOf::F(e.props), e.flags),
+            OneOf::G(e) => Pod::new(OneOf::G(e.node), OneOf::G(e.props), e.flags),
+            OneOf::H(e) => Pod::new(OneOf::H(e.node), OneOf::H(e.props), e.flags),
+            OneOf::I(e) => Pod::new(OneOf::I(e.node), OneOf::I(e.props), e.flags),
         }
     }
 
@@ -102,80 +75,80 @@ where
                 parent.replace_child(new_node, old_node).unwrap_throw();
             }
         }
-        (*elem_mut.node, *elem_mut.props) = match new_elem {
-            OneOf::A(e) => (OneOf::A(e.node), OneOf::A(e.props)),
-            OneOf::B(e) => (OneOf::B(e.node), OneOf::B(e.props)),
-            OneOf::C(e) => (OneOf::C(e.node), OneOf::C(e.props)),
-            OneOf::D(e) => (OneOf::D(e.node), OneOf::D(e.props)),
-            OneOf::E(e) => (OneOf::E(e.node), OneOf::E(e.props)),
-            OneOf::F(e) => (OneOf::F(e.node), OneOf::F(e.props)),
-            OneOf::G(e) => (OneOf::G(e.node), OneOf::G(e.props)),
-            OneOf::H(e) => (OneOf::H(e.node), OneOf::H(e.props)),
-            OneOf::I(e) => (OneOf::I(e.node), OneOf::I(e.props)),
+        (*elem_mut.node, *elem_mut.props, *elem_mut.flags) = match new_elem {
+            OneOf::A(e) => (OneOf::A(e.node), OneOf::A(e.props), e.flags),
+            OneOf::B(e) => (OneOf::B(e.node), OneOf::B(e.props), e.flags),
+            OneOf::C(e) => (OneOf::C(e.node), OneOf::C(e.props), e.flags),
+            OneOf::D(e) => (OneOf::D(e.node), OneOf::D(e.props), e.flags),
+            OneOf::E(e) => (OneOf::E(e.node), OneOf::E(e.props), e.flags),
+            OneOf::F(e) => (OneOf::F(e.node), OneOf::F(e.props), e.flags),
+            OneOf::G(e) => (OneOf::G(e.node), OneOf::G(e.props), e.flags),
+            OneOf::H(e) => (OneOf::H(e.node), OneOf::H(e.props), e.flags),
+            OneOf::I(e) => (OneOf::I(e.node), OneOf::I(e.props), e.flags),
         };
     }
 
-    fn with_downcast_a(elem: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N1>>)) {
-        let (OneOf::A(node), OneOf::A(props)) = (&mut elem.node, &mut elem.props) else {
+    fn with_downcast_a(e: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N1>>)) {
+        let (OneOf::A(node), OneOf::A(props)) = (&mut e.node, &mut e.props) else {
             unreachable!()
         };
-        f(PodMut::new(node, props, elem.parent, elem.was_removed));
+        f(PodMut::new(node, props, e.flags, e.parent, e.was_removed));
     }
 
-    fn with_downcast_b(elem: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N2>>)) {
-        let (OneOf::B(node), OneOf::B(props)) = (&mut elem.node, &mut elem.props) else {
+    fn with_downcast_b(e: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N2>>)) {
+        let (OneOf::B(node), OneOf::B(props)) = (&mut e.node, &mut e.props) else {
             unreachable!()
         };
-        f(PodMut::new(node, props, elem.parent, elem.was_removed));
+        f(PodMut::new(node, props, e.flags, e.parent, e.was_removed));
     }
 
-    fn with_downcast_c(elem: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N3>>)) {
-        let (OneOf::C(node), OneOf::C(props)) = (&mut elem.node, &mut elem.props) else {
+    fn with_downcast_c(e: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N3>>)) {
+        let (OneOf::C(node), OneOf::C(props)) = (&mut e.node, &mut e.props) else {
             unreachable!()
         };
-        f(PodMut::new(node, props, elem.parent, elem.was_removed));
+        f(PodMut::new(node, props, e.flags, e.parent, e.was_removed));
     }
 
-    fn with_downcast_d(elem: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N4>>)) {
-        let (OneOf::D(node), OneOf::D(props)) = (&mut elem.node, &mut elem.props) else {
+    fn with_downcast_d(e: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N4>>)) {
+        let (OneOf::D(node), OneOf::D(props)) = (&mut e.node, &mut e.props) else {
             unreachable!()
         };
-        f(PodMut::new(node, props, elem.parent, elem.was_removed));
+        f(PodMut::new(node, props, e.flags, e.parent, e.was_removed));
     }
 
-    fn with_downcast_e(elem: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N5>>)) {
-        let (OneOf::E(node), OneOf::E(props)) = (&mut elem.node, &mut elem.props) else {
+    fn with_downcast_e(e: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N5>>)) {
+        let (OneOf::E(node), OneOf::E(props)) = (&mut e.node, &mut e.props) else {
             unreachable!()
         };
-        f(PodMut::new(node, props, elem.parent, elem.was_removed));
+        f(PodMut::new(node, props, e.flags, e.parent, e.was_removed));
     }
 
-    fn with_downcast_f(elem: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N6>>)) {
-        let (OneOf::F(node), OneOf::F(props)) = (&mut elem.node, &mut elem.props) else {
+    fn with_downcast_f(e: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N6>>)) {
+        let (OneOf::F(node), OneOf::F(props)) = (&mut e.node, &mut e.props) else {
             unreachable!()
         };
-        f(PodMut::new(node, props, elem.parent, elem.was_removed));
+        f(PodMut::new(node, props, e.flags, e.parent, e.was_removed));
     }
 
-    fn with_downcast_g(elem: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N7>>)) {
-        let (OneOf::G(node), OneOf::G(props)) = (&mut elem.node, &mut elem.props) else {
+    fn with_downcast_g(e: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N7>>)) {
+        let (OneOf::G(node), OneOf::G(props)) = (&mut e.node, &mut e.props) else {
             unreachable!()
         };
-        f(PodMut::new(node, props, elem.parent, elem.was_removed));
+        f(PodMut::new(node, props, e.flags, e.parent, e.was_removed));
     }
 
-    fn with_downcast_h(elem: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N8>>)) {
-        let (OneOf::H(node), OneOf::H(props)) = (&mut elem.node, &mut elem.props) else {
+    fn with_downcast_h(e: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N8>>)) {
+        let (OneOf::H(node), OneOf::H(props)) = (&mut e.node, &mut e.props) else {
             unreachable!()
         };
-        f(PodMut::new(node, props, elem.parent, elem.was_removed));
+        f(PodMut::new(node, props, e.flags, e.parent, e.was_removed));
     }
 
-    fn with_downcast_i(elem: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N9>>)) {
-        let (OneOf::I(node), OneOf::I(props)) = (&mut elem.node, &mut elem.props) else {
+    fn with_downcast_i(e: &mut Mut<Self::OneOfElement>, f: impl FnOnce(Mut<Pod<N9>>)) {
+        let (OneOf::I(node), OneOf::I(props)) = (&mut e.node, &mut e.props) else {
             unreachable!()
         };
-        f(PodMut::new(node, props, elem.parent, elem.was_removed));
+        f(PodMut::new(node, props, e.flags, e.parent, e.was_removed));
     }
 }
 
@@ -202,45 +175,18 @@ where
         N8::Props,
         N9::Props,
     >;
-    fn apply_props(&self, props: &mut Self::Props) {
+    fn apply_props(&self, props: &mut Self::Props, flags: &mut PodFlags) {
         match (self, props) {
-            (OneOf::A(el), OneOf::A(props)) => el.apply_props(props),
-            (OneOf::B(el), OneOf::B(props)) => el.apply_props(props),
-            (OneOf::C(el), OneOf::C(props)) => el.apply_props(props),
-            (OneOf::D(el), OneOf::D(props)) => el.apply_props(props),
-            (OneOf::E(el), OneOf::E(props)) => el.apply_props(props),
-            (OneOf::F(el), OneOf::F(props)) => el.apply_props(props),
-            (OneOf::G(el), OneOf::G(props)) => el.apply_props(props),
-            (OneOf::H(el), OneOf::H(props)) => el.apply_props(props),
-            (OneOf::I(el), OneOf::I(props)) => el.apply_props(props),
+            (OneOf::A(el), OneOf::A(props)) => el.apply_props(props, flags),
+            (OneOf::B(el), OneOf::B(props)) => el.apply_props(props, flags),
+            (OneOf::C(el), OneOf::C(props)) => el.apply_props(props, flags),
+            (OneOf::D(el), OneOf::D(props)) => el.apply_props(props, flags),
+            (OneOf::E(el), OneOf::E(props)) => el.apply_props(props, flags),
+            (OneOf::F(el), OneOf::F(props)) => el.apply_props(props, flags),
+            (OneOf::G(el), OneOf::G(props)) => el.apply_props(props, flags),
+            (OneOf::H(el), OneOf::H(props)) => el.apply_props(props, flags),
+            (OneOf::I(el), OneOf::I(props)) => el.apply_props(props, flags),
             _ => unreachable!(),
-        }
-    }
-}
-
-impl<T, A, B, C, D, E, F, G, H, I> WithModifier<T> for OneOf<A, B, C, D, E, F, G, H, I>
-where
-    A: WithModifier<T>,
-    B: WithModifier<T>,
-    C: WithModifier<T>,
-    D: WithModifier<T>,
-    E: WithModifier<T>,
-    F: WithModifier<T>,
-    G: WithModifier<T>,
-    H: WithModifier<T>,
-    I: WithModifier<T>,
-{
-    fn modifier(&mut self) -> Modifier<'_, T> {
-        match self {
-            OneOf::A(e) => <A as WithModifier<T>>::modifier(e),
-            OneOf::B(e) => <B as WithModifier<T>>::modifier(e),
-            OneOf::C(e) => <C as WithModifier<T>>::modifier(e),
-            OneOf::D(e) => <D as WithModifier<T>>::modifier(e),
-            OneOf::E(e) => <E as WithModifier<T>>::modifier(e),
-            OneOf::F(e) => <F as WithModifier<T>>::modifier(e),
-            OneOf::G(e) => <G as WithModifier<T>>::modifier(e),
-            OneOf::H(e) => <H as WithModifier<T>>::modifier(e),
-            OneOf::I(e) => <I as WithModifier<T>>::modifier(e),
         }
     }
 }
@@ -271,7 +217,7 @@ impl PhantomElementCtx for ViewCtx {
 }
 
 impl DomNode for Noop {
-    fn apply_props(&self, _props: &mut Self::Props) {
+    fn apply_props(&self, _props: &mut Self::Props, _: &mut PodFlags) {
         match *self {}
     }
 

--- a/xilem_web/src/pod.rs
+++ b/xilem_web/src/pod.rs
@@ -107,7 +107,7 @@ pub struct PodMut<'a, N: DomNode> {
 }
 
 impl<'a, N: DomNode> PodMut<'a, N> {
-    pub const fn new(
+    pub fn new(
         node: &'a mut N,
         props: &'a mut N::Props,
         flags: &'a mut PodFlags,

--- a/xilem_web/src/pod.rs
+++ b/xilem_web/src/pod.rs
@@ -1,0 +1,200 @@
+use std::ops::DerefMut as _;
+
+use crate::core::{AnyElement, SuperElement, ViewElement};
+use crate::{AnyNode, DomNode, ViewCtx};
+use wasm_bindgen::UnwrapThrowExt;
+
+/// A container, which holds the actual DOM node, and associated props, such as attributes or classes.
+///
+/// These attributes are not directly set on the DOM node to avoid mutating or reading from the DOM tree unnecessarily, and to have more control over the whole update flow.
+pub struct Pod<N: DomNode> {
+    pub node: N,
+    pub flags: PodFlags,
+    pub props: N::Props,
+}
+
+/// Type-erased [`Pod`], it's used for example as intermediate representation for children of a DOM node
+pub type AnyPod = Pod<Box<dyn AnyNode>>;
+
+impl<N: DomNode> Pod<N> {
+    pub fn new(node: N, props: N::Props, flags: PodFlags) -> Self {
+        Pod { node, props, flags }
+    }
+
+    pub fn into_any_pod(mut pod: Pod<N>) -> AnyPod {
+        pod.node.apply_props(&mut pod.props, &mut pod.flags);
+        Pod {
+            node: Box::new(pod.node),
+            props: Box::new(pod.props),
+            flags: pod.flags,
+        }
+    }
+}
+
+impl AnyPod {
+    pub(crate) fn as_mut<'a>(
+        &'a mut self,
+        parent: impl Into<Option<&'a web_sys::Node>>,
+        was_removed: bool,
+    ) -> PodMut<'a, Box<dyn AnyNode>> {
+        PodMut::new(
+            &mut self.node,
+            &mut self.props,
+            &mut self.flags,
+            parent.into(),
+            was_removed,
+        )
+    }
+}
+
+impl<N: DomNode> ViewElement for Pod<N> {
+    type Mut<'a> = PodMut<'a, N>;
+}
+
+impl<N: DomNode> SuperElement<Pod<N>, ViewCtx> for AnyPod {
+    fn upcast(_ctx: &mut ViewCtx, child: Pod<N>) -> Self {
+        Pod::into_any_pod(child)
+    }
+
+    fn with_downcast_val<R>(
+        mut this: Self::Mut<'_>,
+        f: impl FnOnce(PodMut<N>) -> R,
+    ) -> (Self::Mut<'_>, R) {
+        let downcast = this.downcast();
+        let ret = f(downcast);
+        (this, ret)
+    }
+}
+
+impl<N: DomNode> AnyElement<Pod<N>, ViewCtx> for AnyPod {
+    fn replace_inner(this: Self::Mut<'_>, mut child: Pod<N>) -> Self::Mut<'_> {
+        child.node.apply_props(&mut child.props, &mut child.flags);
+        if let Some(parent) = this.parent {
+            parent
+                .replace_child(child.node.as_ref(), this.node.as_ref())
+                .unwrap_throw();
+        }
+        *this.node = Box::new(child.node);
+        *this.props = Box::new(child.props);
+        *this.flags = child.flags;
+        this
+    }
+}
+
+/// The mutable representation of [`Pod`].
+///
+/// This is a container which contains info of what has changed and provides mutable access to the underlying element and its props
+/// When it's dropped all changes are applied to the underlying DOM node
+pub struct PodMut<'a, N: DomNode> {
+    pub node: &'a mut N,
+    pub props: &'a mut N::Props,
+    pub flags: &'a mut PodFlags,
+    pub parent: Option<&'a web_sys::Node>,
+    pub was_removed: bool,
+    pub is_reborrow: bool,
+}
+
+impl<'a, N: DomNode> PodMut<'a, N> {
+    pub fn new(
+        node: &'a mut N,
+        props: &'a mut N::Props,
+        flags: &'a mut PodFlags,
+        parent: Option<&'a web_sys::Node>,
+        was_removed: bool,
+    ) -> PodMut<'a, N> {
+        PodMut {
+            node,
+            props,
+            flags,
+            parent,
+            was_removed,
+            is_reborrow: false,
+        }
+    }
+
+    pub fn reborrow_mut(&mut self) -> PodMut<N> {
+        PodMut {
+            node: self.node,
+            props: self.props,
+            flags: self.flags,
+            parent: self.parent,
+            was_removed: self.was_removed,
+            is_reborrow: true,
+        }
+    }
+}
+
+impl PodMut<'_, Box<dyn AnyNode>> {
+    fn downcast<N: DomNode>(&mut self) -> PodMut<N> {
+        PodMut::new(
+            self.node.deref_mut().as_any_mut().downcast_mut().unwrap(),
+            self.props.downcast_mut().unwrap(),
+            self.flags,
+            self.parent,
+            false,
+        )
+    }
+}
+
+impl<N: DomNode> Drop for PodMut<'_, N> {
+    fn drop(&mut self) {
+        if !self.is_reborrow && !self.was_removed {
+            self.node.apply_props(self.props, self.flags);
+        }
+    }
+}
+
+impl<T, N: AsRef<T> + DomNode> AsRef<T> for Pod<N> {
+    fn as_ref(&self) -> &T {
+        <N as AsRef<T>>::as_ref(&self.node)
+    }
+}
+
+impl<T, N: AsRef<T> + DomNode> AsRef<T> for PodMut<'_, N> {
+    fn as_ref(&self) -> &T {
+        <N as AsRef<T>>::as_ref(self.node)
+    }
+}
+
+// TODO maybe use bitflags for this, but not sure if it's worth it to pull the dependency in just for this.
+/// General flags describing the current state of the element (in hydration, was created, needs update (in general for optimization))
+pub struct PodFlags(u8);
+
+impl PodFlags {
+    const IN_HYDRATION: u8 = 1 << 0;
+    const WAS_CREATED: u8 = 1 << 1;
+    const NEEDS_UPDATE: u8 = 1 << 2;
+
+    pub(crate) fn new(in_hydration: bool) -> Self {
+        if in_hydration {
+            PodFlags(Self::WAS_CREATED | Self::IN_HYDRATION)
+        } else {
+            PodFlags(Self::WAS_CREATED)
+        }
+    }
+
+    /// This should only be used in tests, other than within the [`Element`] props
+    pub(crate) fn clear(&mut self) {
+        self.0 = 0;
+    }
+
+    /// Whether the current element was just created, this is usually `true` within `View::build`, but can also happen, e.g. within a `OneOf` variant change.
+    pub fn was_created(&self) -> bool {
+        self.0 & Self::WAS_CREATED != 0
+    }
+
+    /// Whether the current element is within a hydration context, that could e.g. happen when inside a [`Templated`](crate::Templated) view.
+    pub fn in_hydration(&self) -> bool {
+        self.0 & Self::IN_HYDRATION != 0
+    }
+
+    /// Whether the current element generally needs to be updated, this serves as cheap preliminary check whether anything changed at all.
+    pub fn needs_update(&self) -> bool {
+        self.0 & Self::NEEDS_UPDATE != 0
+    }
+
+    /// This should be called as soon as anything has changed for the current element (except children, as they're handled within the element views).
+    pub fn set_needs_update(&mut self) {
+        self.0 |= Self::NEEDS_UPDATE;
+    }
+}

--- a/xilem_web/src/pod.rs
+++ b/xilem_web/src/pod.rs
@@ -20,7 +20,7 @@ pub struct Pod<N: DomNode> {
 pub type AnyPod = Pod<Box<dyn AnyNode>>;
 
 impl<N: DomNode> Pod<N> {
-    pub fn new(node: N, props: N::Props, flags: PodFlags) -> Self {
+    pub const fn new(node: N, props: N::Props, flags: PodFlags) -> Self {
         Pod { node, props, flags }
     }
 
@@ -107,7 +107,7 @@ pub struct PodMut<'a, N: DomNode> {
 }
 
 impl<'a, N: DomNode> PodMut<'a, N> {
-    pub fn new(
+    pub const fn new(
         node: &'a mut N,
         props: &'a mut N::Props,
         flags: &'a mut PodFlags,
@@ -157,9 +157,10 @@ impl PodMut<'_, Box<dyn AnyNode>> {
 
 impl<N: DomNode> Drop for PodMut<'_, N> {
     fn drop(&mut self) {
-        if !self.is_reborrow && !self.was_removed {
-            self.apply_changes();
+        if self.is_reborrow || self.was_removed {
+            return;
         }
+        self.apply_changes();
     }
 }
 

--- a/xilem_web/src/pointer.rs
+++ b/xilem_web/src/pointer.rs
@@ -180,7 +180,7 @@ where
         let Some((first, remainder)) = id_path.split_first() else {
             throw_str("Parent view of `Pointer` sent outdated and/or incorrect empty view path");
         };
-        if first.routing_id() != 0 {
+        if *first != POINTER_VIEW_ID {
             throw_str("Parent view of `Pointer` sent outdated and/or incorrect empty view path");
         }
         if remainder.is_empty() {

--- a/xilem_web/src/pointer.rs
+++ b/xilem_web/src/pointer.rs
@@ -6,7 +6,7 @@
 use crate::{
     core::{MessageResult, Mut, View, ViewId, ViewMarker, ViewPathTracker},
     interfaces::Element,
-    DynMessage, ElementAsRef, ViewCtx,
+    DomView, DynMessage, ViewCtx,
 };
 use std::marker::PhantomData;
 use wasm_bindgen::{prelude::Closure, throw_str, JsCast, UnwrapThrowExt};
@@ -77,8 +77,7 @@ where
     State: 'static,
     Action: 'static,
     Callback: Fn(&mut State, PointerMsg) -> Action + 'static,
-    V: View<State, Action, ViewCtx, DynMessage>,
-    V::Element: ElementAsRef<web_sys::Element>,
+    V: DomView<State, Action>,
 {
     type ViewState = PointerState<V::ViewState>;
     type Element = V::Element;

--- a/xilem_web/src/props/element.rs
+++ b/xilem_web/src/props/element.rs
@@ -3,7 +3,6 @@
 
 use crate::{
     document,
-    events::Events,
     modifiers::{Attributes, Children, Classes, Modifier, Styles},
     AnyPod, Pod, PodFlags, ViewCtx,
 };
@@ -18,7 +17,6 @@ pub struct Element {
     pub(crate) classes: Option<Box<Classes>>,
     pub(crate) styles: Option<Box<Styles>>,
     pub(crate) children: Vec<AnyPod>,
-    pub(crate) events: Events,
 }
 
 impl Element {
@@ -33,7 +31,6 @@ impl Element {
             classes: (class_size_hint > 0).then(|| Classes::new(class_size_hint).into()),
             styles: (style_size_hint > 0).then(|| Styles::new(style_size_hint).into()),
             children,
-            events: Events,
         }
     }
 
@@ -112,12 +109,6 @@ impl AsMut<Classes> for Element {
 impl AsMut<Styles> for Element {
     fn as_mut(&mut self) -> &mut Styles {
         self.styles.get_or_insert_with(|| Styles::new(0).into())
-    }
-}
-
-impl AsMut<Events> for Element {
-    fn as_mut(&mut self) -> &mut Events {
-        &mut self.events
     }
 }
 

--- a/xilem_web/src/props/element.rs
+++ b/xilem_web/src/props/element.rs
@@ -4,60 +4,16 @@
 use crate::{
     document,
     events::Events,
-    modifiers::{Attributes, Children, Classes, Modifier, Styles, WithModifier},
-    AnyPod, Pod, ViewCtx,
+    modifiers::{Attributes, Children, Classes, Modifier, Styles},
+    AnyPod, Pod, PodFlags, ViewCtx,
 };
 use wasm_bindgen::JsCast;
 use wasm_bindgen::UnwrapThrowExt;
-
-// TODO maybe use bitflags for this, but not sure if it's worth it to pull the dependency in just for this.
-/// General flags describing the current state of the element (in hydration, was created, needs update (in general for optimization))
-pub struct ElementFlags(u8);
-
-impl ElementFlags {
-    const IN_HYDRATION: u8 = 1 << 0;
-    const WAS_CREATED: u8 = 1 << 1;
-    const NEEDS_UPDATE: u8 = 1 << 2;
-
-    pub(crate) fn new(in_hydration: bool) -> Self {
-        if in_hydration {
-            ElementFlags(Self::WAS_CREATED | Self::IN_HYDRATION)
-        } else {
-            ElementFlags(Self::WAS_CREATED)
-        }
-    }
-
-    /// This should only be used in tests, other than within the [`Element`] props
-    pub(crate) fn clear(&mut self) {
-        self.0 = 0;
-    }
-
-    /// Whether the current element was just created, this is usually `true` within `View::build`, but can also happen, e.g. within a `OneOf` variant change.
-    pub fn was_created(&self) -> bool {
-        self.0 & Self::WAS_CREATED != 0
-    }
-
-    /// Whether the current element is within a hydration context, that could e.g. happen when inside a [`Templated`](crate::Templated) view.
-    pub fn in_hydration(&self) -> bool {
-        self.0 & Self::IN_HYDRATION != 0
-    }
-
-    /// Whether the current element generally needs to be updated, this serves as cheap preliminary check whether anything changed at all.
-    pub fn needs_update(&self) -> bool {
-        self.0 & Self::NEEDS_UPDATE != 0
-    }
-
-    /// This should be called as soon as anything has changed for the current element (except children, as they're handled within the element views).
-    pub fn set_needs_update(&mut self) {
-        self.0 |= Self::NEEDS_UPDATE;
-    }
-}
 
 // Lazy access to attributes etc. to avoid allocating unnecessary memory when it isn't needed
 // Benchmarks have shown, that this can significantly increase performance and reduce memory usage...
 /// This holds all the state for a DOM [`Element`](`crate::interfaces::Element`), it is used for [`DomNode::Props`](`crate::DomNode::Props`)
 pub struct Element {
-    pub(crate) flags: ElementFlags,
     pub(crate) attributes: Option<Box<Attributes>>,
     pub(crate) classes: Option<Box<Classes>>,
     pub(crate) styles: Option<Box<Styles>>,
@@ -71,33 +27,28 @@ impl Element {
         attr_size_hint: usize,
         style_size_hint: usize,
         class_size_hint: usize,
-        in_hydration: bool,
     ) -> Self {
         Self {
             attributes: (attr_size_hint > 0).then(|| Attributes::new(attr_size_hint).into()),
             classes: (class_size_hint > 0).then(|| Classes::new(class_size_hint).into()),
             styles: (style_size_hint > 0).then(|| Styles::new(style_size_hint).into()),
             children,
-            flags: ElementFlags::new(in_hydration),
             events: Events,
         }
     }
 
     // All of this is slightly more complicated than it should be,
     // because we want to minimize DOM traffic as much as possible (that's basically the bottleneck)
-    pub fn update_element(&mut self, element: &web_sys::Element) {
-        if self.flags.needs_update() {
-            if let Some(attributes) = &mut self.attributes {
-                Attributes::apply_changes(Modifier::new(attributes, &mut self.flags), element);
-            }
-            if let Some(classes) = &mut self.classes {
-                Classes::apply_changes(Modifier::new(classes, &mut self.flags), element);
-            }
-            if let Some(styles) = &mut self.styles {
-                Styles::apply_changes(Modifier::new(styles, &mut self.flags), element);
-            }
+    pub fn update_element(&mut self, element: &web_sys::Element, flags: &mut PodFlags) {
+        if let Some(attributes) = &mut self.attributes {
+            Attributes::apply_changes(Modifier::new(attributes, flags), element);
         }
-        self.flags.clear();
+        if let Some(classes) = &mut self.classes {
+            Classes::apply_changes(Modifier::new(classes, flags), element);
+        }
+        if let Some(styles) = &mut self.styles {
+            Styles::apply_changes(Modifier::new(styles, flags), element);
+        }
     }
 }
 
@@ -123,16 +74,8 @@ impl Pod<web_sys::Element> {
             let _ = element.append_child(child.node.as_ref());
         }
 
-        Self {
-            node: element,
-            props: Element::new(
-                children,
-                attr_size_hint,
-                style_size_hint,
-                class_size_hint,
-                false,
-            ),
-        }
+        let props = Element::new(children, attr_size_hint, style_size_hint, class_size_hint);
+        Pod::new(element.unchecked_into(), props, PodFlags::new(false))
     }
 
     /// Creates a new Pod that hydrates an existing node (within the `ViewCtx`) as [`web_sys::Element`] and [`Element`] as its [`DomNode::Props`](`crate::DomNode::Props`).
@@ -142,64 +85,48 @@ impl Pod<web_sys::Element> {
         let style_size_hint = ctx.take_modifier_size_hint::<Styles>();
         let element = ctx.hydrate_node().unwrap_throw();
 
-        Self {
-            node: element.unchecked_into(),
-            props: Element::new(
-                children,
-                attr_size_hint,
-                style_size_hint,
-                class_size_hint,
-                true,
-            ),
-        }
+        let props = Element::new(children, attr_size_hint, style_size_hint, class_size_hint);
+        Pod::new(element.unchecked_into(), props, PodFlags::new(true))
     }
 }
 
-impl WithModifier<Attributes> for Element {
-    fn modifier(&mut self) -> Modifier<'_, Attributes> {
-        let modifier = self
-            .attributes
-            .get_or_insert_with(|| Attributes::new(0).into());
-        Modifier::new(modifier, &mut self.flags)
+impl AsMut<Children> for Element {
+    fn as_mut(&mut self) -> &mut Children {
+        &mut self.children
     }
 }
 
-impl WithModifier<Children> for Element {
-    fn modifier(&mut self) -> Modifier<'_, Children> {
-        Modifier::new(&mut self.children, &mut self.flags)
+impl AsMut<Attributes> for Element {
+    fn as_mut(&mut self) -> &mut Attributes {
+        self.attributes
+            .get_or_insert_with(|| Attributes::new(0).into())
     }
 }
 
-impl WithModifier<Classes> for Element {
-    fn modifier(&mut self) -> Modifier<'_, Classes> {
-        let modifier = self.classes.get_or_insert_with(|| Classes::new(0).into());
-        Modifier::new(modifier, &mut self.flags)
+impl AsMut<Classes> for Element {
+    fn as_mut(&mut self) -> &mut Classes {
+        self.classes.get_or_insert_with(|| Classes::new(0).into())
     }
 }
 
-impl WithModifier<Events> for Element {
-    fn modifier(&mut self) -> Modifier<'_, Events> {
-        Modifier::new(&mut self.events, &mut self.flags)
+impl AsMut<Styles> for Element {
+    fn as_mut(&mut self) -> &mut Styles {
+        self.styles.get_or_insert_with(|| Styles::new(0).into())
     }
 }
 
-impl WithModifier<Styles> for Element {
-    fn modifier(&mut self) -> Modifier<'_, Styles> {
-        let modifier = self.styles.get_or_insert_with(|| Styles::new(0).into());
-        Modifier::new(modifier, &mut self.flags)
+impl AsMut<Events> for Element {
+    fn as_mut(&mut self) -> &mut Events {
+        &mut self.events
     }
 }
 
 /// An alias trait to sum up all modifiers that a DOM `Element` can have. It's used to avoid a lot of boilerplate in public APIs.
 pub trait WithElementProps:
-    WithModifier<Attributes> + WithModifier<Children> + WithModifier<Classes> + WithModifier<Styles>
+    AsMut<Attributes> + AsMut<Children> + AsMut<Classes> + AsMut<Styles>
 {
 }
-impl<
-        T: WithModifier<Attributes>
-            + WithModifier<Children>
-            + WithModifier<Classes>
-            + WithModifier<Styles>,
-    > WithElementProps for T
+impl<T: AsMut<Attributes> + AsMut<Children> + AsMut<Classes> + AsMut<Styles>> WithElementProps
+    for T
 {
 }

--- a/xilem_web/src/props/element.rs
+++ b/xilem_web/src/props/element.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     document,
+    events::Events,
     modifiers::{Attributes, Children, Classes, Modifier, Styles, WithModifier},
     AnyPod, Pod, ViewCtx,
 };
@@ -61,6 +62,7 @@ pub struct Element {
     pub(crate) classes: Option<Box<Classes>>,
     pub(crate) styles: Option<Box<Styles>>,
     pub(crate) children: Vec<AnyPod>,
+    pub(crate) events: Events,
 }
 
 impl Element {
@@ -77,6 +79,7 @@ impl Element {
             styles: (style_size_hint > 0).then(|| Styles::new(style_size_hint).into()),
             children,
             flags: ElementFlags::new(in_hydration),
+            events: Events,
         }
     }
 
@@ -171,6 +174,12 @@ impl WithModifier<Classes> for Element {
     fn modifier(&mut self) -> Modifier<'_, Classes> {
         let modifier = self.classes.get_or_insert_with(|| Classes::new(0).into());
         Modifier::new(modifier, &mut self.flags)
+    }
+}
+
+impl WithModifier<Events> for Element {
+    fn modifier(&mut self) -> Modifier<'_, Events> {
+        Modifier::new(&mut self.events, &mut self.flags)
     }
 }
 

--- a/xilem_web/src/props/html_input_element.rs
+++ b/xilem_web/src/props/html_input_element.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::modifiers::html_input_element::{Checked, DefaultChecked, Disabled, Multiple, Required};
-use crate::modifiers::{Modifier, WithModifier};
-use crate::{props, FromWithContext, Pod, ViewCtx};
+use crate::{props, FromWithContext, Pod, PodFlags, ViewCtx};
 use wasm_bindgen::JsCast as _;
 
 use super::WithElementProps;
@@ -19,40 +18,41 @@ pub struct HtmlInputElement {
 }
 
 impl HtmlInputElement {
-    pub(crate) fn update_element(&mut self, element: &web_sys::HtmlInputElement) {
-        if self.element_props.flags.needs_update() {
-            let in_hydration = self.element_props.flags.in_hydration();
+    pub(crate) fn update_element(
+        &mut self,
+        element: &web_sys::HtmlInputElement,
+        flags: &mut PodFlags,
+    ) {
+        let in_hydration = flags.in_hydration();
 
-            // Set booleans to `false` as this is the default,
-            // if we wouldn't do that, possibly the previous value would persist, which is likely unwanted.
-            self.checked.apply_changes(|value| {
-                if !in_hydration {
-                    element.set_checked(value.unwrap_or(false));
-                }
-            });
-            self.default_checked.apply_changes(|value| {
-                if !in_hydration {
-                    element.set_default_checked(value.unwrap_or(false));
-                }
-            });
-            self.disabled.apply_changes(|value| {
-                if !in_hydration {
-                    element.set_disabled(value.unwrap_or(false));
-                }
-            });
-            self.required.apply_changes(|value| {
-                if !in_hydration {
-                    element.set_required(value.unwrap_or(false));
-                }
-            });
-            self.multiple.apply_changes(|value| {
-                if !in_hydration {
-                    element.set_multiple(value.unwrap_or(false));
-                }
-            });
-        }
-        // flags are cleared in the following call
-        self.element_props.update_element(element);
+        // Set booleans to `false` as this is the default,
+        // if we wouldn't do that, possibly the previous value would persist, which is likely unwanted.
+        self.checked.apply_changes(|value| {
+            if !in_hydration {
+                element.set_checked(value.unwrap_or(false));
+            }
+        });
+        self.default_checked.apply_changes(|value| {
+            if !in_hydration {
+                element.set_default_checked(value.unwrap_or(false));
+            }
+        });
+        self.disabled.apply_changes(|value| {
+            if !in_hydration {
+                element.set_disabled(value.unwrap_or(false));
+            }
+        });
+        self.required.apply_changes(|value| {
+            if !in_hydration {
+                element.set_required(value.unwrap_or(false));
+            }
+        });
+        self.multiple.apply_changes(|value| {
+            if !in_hydration {
+                element.set_multiple(value.unwrap_or(false));
+            }
+        });
+        self.element_props.update_element(element, flags);
     }
 }
 
@@ -60,6 +60,7 @@ impl FromWithContext<Pod<web_sys::Element>> for Pod<web_sys::HtmlInputElement> {
     fn from_with_ctx(value: Pod<web_sys::Element>, _ctx: &mut ViewCtx) -> Self {
         Pod {
             node: value.node.unchecked_into(),
+            flags: value.flags,
             props: HtmlInputElement {
                 checked: Checked::default(),
                 default_checked: DefaultChecked::default(),
@@ -72,62 +73,62 @@ impl FromWithContext<Pod<web_sys::Element>> for Pod<web_sys::HtmlInputElement> {
     }
 }
 
-impl<T> WithModifier<T> for HtmlInputElement
+impl<T> AsMut<T> for HtmlInputElement
 where
-    props::Element: WithModifier<T>,
+    props::Element: AsMut<T>,
 {
-    fn modifier(&mut self) -> Modifier<'_, T> {
-        self.element_props.modifier()
+    fn as_mut(&mut self) -> &mut T {
+        self.element_props.as_mut()
     }
 }
 
-impl WithModifier<Checked> for HtmlInputElement {
-    fn modifier(&mut self) -> Modifier<'_, Checked> {
-        Modifier::new(&mut self.checked, &mut self.element_props.flags)
+impl AsMut<Checked> for HtmlInputElement {
+    fn as_mut(&mut self) -> &mut Checked {
+        &mut self.checked
     }
 }
 
-impl WithModifier<DefaultChecked> for HtmlInputElement {
-    fn modifier(&mut self) -> Modifier<'_, DefaultChecked> {
-        Modifier::new(&mut self.default_checked, &mut self.element_props.flags)
+impl AsMut<DefaultChecked> for HtmlInputElement {
+    fn as_mut(&mut self) -> &mut DefaultChecked {
+        &mut self.default_checked
     }
 }
 
-impl WithModifier<Disabled> for HtmlInputElement {
-    fn modifier(&mut self) -> Modifier<'_, Disabled> {
-        Modifier::new(&mut self.disabled, &mut self.element_props.flags)
+impl AsMut<Disabled> for HtmlInputElement {
+    fn as_mut(&mut self) -> &mut Disabled {
+        &mut self.disabled
     }
 }
 
-impl WithModifier<Required> for HtmlInputElement {
-    fn modifier(&mut self) -> Modifier<'_, Required> {
-        Modifier::new(&mut self.required, &mut self.element_props.flags)
+impl AsMut<Required> for HtmlInputElement {
+    fn as_mut(&mut self) -> &mut Required {
+        &mut self.required
     }
 }
 
-impl WithModifier<Multiple> for HtmlInputElement {
-    fn modifier(&mut self) -> Modifier<'_, Multiple> {
-        Modifier::new(&mut self.multiple, &mut self.element_props.flags)
+impl AsMut<Multiple> for HtmlInputElement {
+    fn as_mut(&mut self) -> &mut Multiple {
+        &mut self.multiple
     }
 }
 
 /// An alias trait to sum up all modifiers that a DOM `HTMLInputElement` can have. It's used to avoid a lot of boilerplate in public APIs.
 pub trait WithHtmlInputElementProps:
     WithElementProps
-    + WithModifier<Checked>
-    + WithModifier<DefaultChecked>
-    + WithModifier<Disabled>
-    + WithModifier<Required>
-    + WithModifier<Multiple>
+    + AsMut<Checked>
+    + AsMut<DefaultChecked>
+    + AsMut<Disabled>
+    + AsMut<Required>
+    + AsMut<Multiple>
 {
 }
 impl<
         T: WithElementProps
-            + WithModifier<Checked>
-            + WithModifier<DefaultChecked>
-            + WithModifier<Disabled>
-            + WithModifier<Required>
-            + WithModifier<Multiple>,
+            + AsMut<Checked>
+            + AsMut<DefaultChecked>
+            + AsMut<Disabled>
+            + AsMut<Required>
+            + AsMut<Multiple>,
     > WithHtmlInputElementProps for T
 {
 }

--- a/xilem_web/src/templated.rs
+++ b/xilem_web/src/templated.rs
@@ -36,8 +36,8 @@ where
             let prev = prev.downcast_ref::<E>().unwrap_throw();
             let node = template_node.clone_node_with_deep(true).unwrap_throw();
             let (mut el, mut state) = ctx.with_hydration_node(node, |ctx| prev.build(ctx));
-            el.node.apply_props(&mut el.props);
-            let pod_mut = PodMut::new(&mut el.node, &mut el.props, None, false);
+            el.node.apply_props(&mut el.props, &mut el.flags);
+            let pod_mut = PodMut::new(&mut el.node, &mut el.props, &mut el.flags, None, false);
             self.0.rebuild(prev, &mut state, ctx, pod_mut);
 
             (el, state)

--- a/xilem_web/src/templated.rs
+++ b/xilem_web/src/templated.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     core::{MessageResult, Mut, View, ViewId, ViewMarker},
-    DomNode, DomView, DynMessage, PodMut, ViewCtx,
+    DomView, DynMessage, PodMut, ViewCtx,
 };
 use std::{any::TypeId, ops::Deref as _, rc::Rc};
 use wasm_bindgen::UnwrapThrowExt;
@@ -36,7 +36,7 @@ where
             let prev = prev.downcast_ref::<E>().unwrap_throw();
             let node = template_node.clone_node_with_deep(true).unwrap_throw();
             let (mut el, mut state) = ctx.with_hydration_node(node, |ctx| prev.build(ctx));
-            el.node.apply_props(&mut el.props, &mut el.flags);
+            el.apply_changes();
             let pod_mut = PodMut::new(&mut el.node, &mut el.props, &mut el.flags, None, false);
             self.0.rebuild(prev, &mut state, ctx, pod_mut);
 

--- a/xilem_web/src/text.rs
+++ b/xilem_web/src/text.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     core::{MessageResult, Mut, OrphanView, ViewId},
-    DynMessage, Pod, ViewCtx,
+    DynMessage, Pod, PodFlags, ViewCtx,
 };
 use wasm_bindgen::JsCast;
 
@@ -24,7 +24,7 @@ macro_rules! impl_string_view {
                 } else {
                     web_sys::Text::new_with_data(view).unwrap()
                 };
-                (Pod { node, props: () }, ())
+                (Pod::new(node, (), PodFlags::new(ctx.is_hydrating())), ())
             }
 
             fn orphan_rebuild(
@@ -80,7 +80,7 @@ macro_rules! impl_to_string_view {
                 } else {
                     web_sys::Text::new_with_data(&view.to_string()).unwrap()
                 };
-                (Pod { node, props: () }, ())
+                (Pod::new(node, (), PodFlags::new(ctx.is_hydrating())), ())
             }
 
             fn orphan_rebuild(


### PR DESCRIPTION
This renames the `ElementFlags` into `PodFlags` as these are general enough to keep them directly in the `Pod(Mut)`.
This reduces duplicated code (and thus a potential of making errors) in the props (that logic is now in `PodMut::drop`, `SuperElement::upcast` and `AnyElement::replace_inner`).

The `WithModifier` trait is adjusted and only implemented on the `View::Element` with a blanket impl of `AsMut<T>` instead (which should also reduce boilerplate), this was mostly a necessity to avoid `impl WithModifier` for either variants `Pod` and `PodMut` on every props (i.e. more boilerplate).

Further all kinds of event views were fixed, as they would break currently when the underlying element changes (e.g. via a variant change of `OneOf`). This was actually the original planned change, but I guess that escalated a little bit...