### PR TITLE
Eliminate needless lifetimes

### DIFF
--- a/masonry/src/app_driver.rs
+++ b/masonry/src/app_driver.rs
@@ -26,7 +26,7 @@ pub trait AppDriver {
     fn on_start(&mut self, state: &mut MasonryState) {}
 }
 
-impl<'a> DriverCtx<'a> {
+impl DriverCtx<'_> {
     // TODO - Add method to create timer
 
     /// Return a [`WidgetMut`] to the root widget.

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -409,7 +409,7 @@ impl_context_method!(MutateCtx<'_>, EventCtx<'_>, UpdateCtx<'_>, {
 
 // --- MARK: WIDGET_MUT ---
 // Methods to get a child WidgetMut from a parent.
-impl<'a> MutateCtx<'a> {
+impl MutateCtx<'_> {
     /// Return a [`WidgetMut`] to a child widget.
     pub fn get_mut<'c, Child: Widget>(
         &'c mut self,
@@ -1303,7 +1303,7 @@ impl<Ctx: IsContext, W> RawWrapperMut<'_, Ctx, W> {
     }
 }
 
-impl<'a, Ctx: IsContext, W> Drop for RawWrapperMut<'a, Ctx, W> {
+impl<Ctx: IsContext, W> Drop for RawWrapperMut<'_, Ctx, W> {
     fn drop(&mut self) {
         self.parent_widget_state
             .merge_up(self.ctx.get_widget_state());

--- a/masonry/src/tree_arena.rs
+++ b/masonry/src/tree_arena.rs
@@ -93,21 +93,21 @@ pub struct ArenaMapMut<'a> {
 
 // -- MARK: IMPLS ---
 
-impl<'a, Item> Clone for ArenaRef<'a, Item> {
+impl<Item> Clone for ArenaRef<'_, Item> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, Item> Copy for ArenaRef<'a, Item> {}
+impl<Item> Copy for ArenaRef<'_, Item> {}
 
-impl<'a, Item> Clone for ArenaRefChildren<'a, Item> {
+impl<Item> Clone for ArenaRefChildren<'_, Item> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, Item> Copy for ArenaRefChildren<'a, Item> {}
+impl<Item> Copy for ArenaRefChildren<'_, Item> {}
 
 impl<Item> TreeArena<Item> {
     /// Create an empty tree.
@@ -213,7 +213,7 @@ impl<Item> TreeNode<Item> {
     }
 }
 
-impl<'a, Item> ArenaRef<'a, Item> {
+impl<Item> ArenaRef<'_, Item> {
     /// Id of the item this handle is associated with.
     pub fn id(&self) -> u64 {
         // ArenaRefChildren always has an id when it's a member of ArenaRef
@@ -221,7 +221,7 @@ impl<'a, Item> ArenaRef<'a, Item> {
     }
 }
 
-impl<'a, Item> ArenaMut<'a, Item> {
+impl<Item> ArenaMut<'_, Item> {
     /// Id of the item this handle is associated with.
     pub fn id(&self) -> u64 {
         // ArenaMutChildren always has an id when it's a member of ArenaMut
@@ -486,7 +486,7 @@ impl<'a, Item> ArenaMutChildren<'a, Item> {
     }
 }
 
-impl<'a> ArenaMapRef<'a> {
+impl ArenaMapRef<'_> {
     /// Construct the path of items from the given item to the root of the tree.
     ///
     /// The path is in order from the bottom to the top, starting at the given item and ending at
@@ -519,7 +519,7 @@ impl<'a> ArenaMapRef<'a> {
         path
     }
 }
-impl<'a> ArenaMapMut<'a> {
+impl ArenaMapMut<'_> {
     /// Returns a shared handle equivalent to this one.
     pub fn reborrow(&self) -> ArenaMapRef<'_> {
         ArenaMapRef {

--- a/masonry/src/widget/widget_mut.rs
+++ b/masonry/src/widget/widget_mut.rs
@@ -38,7 +38,7 @@ impl<W: Widget> Drop for WidgetMut<'_, W> {
     }
 }
 
-impl<'w, W: Widget> WidgetMut<'w, W> {
+impl<W: Widget> WidgetMut<'_, W> {
     /// Get a `WidgetMut` for the same underlying widget with a shorter lifetime.
     pub fn reborrow_mut(&mut self) -> WidgetMut<'_, W> {
         let widget = &mut self.widget;
@@ -49,7 +49,7 @@ impl<'w, W: Widget> WidgetMut<'w, W> {
     }
 }
 
-impl<'a> WidgetMut<'a, Box<dyn Widget>> {
+impl WidgetMut<'_, Box<dyn Widget>> {
     /// Attempt to downcast to `WidgetMut` of concrete Widget type.
     pub fn try_downcast<W2: Widget>(&mut self) -> Option<WidgetMut<'_, W2>> {
         Some(WidgetMut {

--- a/masonry/src/widget/widget_ref.rs
+++ b/masonry/src/widget/widget_ref.rs
@@ -28,7 +28,7 @@ pub struct WidgetRef<'w, W: Widget + ?Sized> {
 // --- TRAIT IMPLS ---
 
 #[allow(clippy::non_canonical_clone_impl)]
-impl<'w, W: Widget + ?Sized> Clone for WidgetRef<'w, W> {
+impl<W: Widget + ?Sized> Clone for WidgetRef<'_, W> {
     fn clone(&self) -> Self {
         Self {
             ctx: self.ctx,
@@ -37,9 +37,9 @@ impl<'w, W: Widget + ?Sized> Clone for WidgetRef<'w, W> {
     }
 }
 
-impl<'w, W: Widget + ?Sized> Copy for WidgetRef<'w, W> {}
+impl<W: Widget + ?Sized> Copy for WidgetRef<'_, W> {}
 
-impl<'w, W: Widget + ?Sized> std::fmt::Debug for WidgetRef<'w, W> {
+impl<W: Widget + ?Sized> std::fmt::Debug for WidgetRef<'_, W> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let widget_name = self.widget.short_type_name();
         let display_name = if let Some(debug_text) = self.widget.get_debug_text() {
@@ -62,7 +62,7 @@ impl<'w, W: Widget + ?Sized> std::fmt::Debug for WidgetRef<'w, W> {
     }
 }
 
-impl<'w, W: Widget + ?Sized> Deref for WidgetRef<'w, W> {
+impl<W: Widget + ?Sized> Deref for WidgetRef<'_, W> {
     type Target = W;
 
     fn deref(&self) -> &Self::Target {

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -24,7 +24,6 @@
 #![cfg_attr(not(test), no_std)]
 #![forbid(unsafe_code)]
 // TODO: Remove any items listed as "Deferred"
-#![expect(single_use_lifetimes, reason = "Deferred: Noisy")]
 #![expect(clippy::exhaustive_enums, reason = "Deferred: Noisy")]
 #![expect(
     clippy::shadow_unrelated,

--- a/xilem_core/src/views/adapt.rs
+++ b/xilem_core/src/views/adapt.rs
@@ -132,8 +132,8 @@ where
     }
 }
 
-impl<'a, ChildState, ChildAction, Context, ChildView, Message>
-    AdaptThunk<'a, ChildState, ChildAction, Context, ChildView, Message>
+impl<ChildState, ChildAction, Context, ChildView, Message>
+    AdaptThunk<'_, ChildState, ChildAction, Context, ChildView, Message>
 where
     Context: ViewPathTracker,
     ChildView: View<ChildState, ChildAction, Context, Message>,

--- a/xilem_core/tests/common/mod.rs
+++ b/xilem_core/tests/common/mod.rs
@@ -269,7 +269,7 @@ pub(super) fn assert_action(result: MessageResult<Action>, id: u32) {
     assert_eq!(inner.id, id);
 }
 
-impl<'a> ElementSplice<TestElement> for SeqTracker<'a> {
+impl ElementSplice<TestElement> for SeqTracker<'_> {
     fn with_scratch<R>(&mut self, f: impl FnOnce(&mut AppendVec<TestElement>) -> R) -> R {
         let ret = f(self.scratch);
         for element in self.scratch.drain() {

--- a/xilem_core/tests/common/mod.rs
+++ b/xilem_core/tests/common/mod.rs
@@ -9,7 +9,6 @@
 #![expect(clippy::allow_attributes, reason = "Deferred: Noisy")]
 #![expect(clippy::allow_attributes_without_reason, reason = "Deferred: Noisy")]
 #![expect(clippy::missing_assert_message, reason = "Deferred: Noisy")]
-#![expect(single_use_lifetimes, reason = "Deferred: Noisy")]
 
 use xilem_core::*;
 

--- a/xilem_web/src/elements.rs
+++ b/xilem_web/src/elements.rs
@@ -147,7 +147,7 @@ impl<'a, 'b, 'c, 'd> DomChildrenSplice<'a, 'b, 'c, 'd> {
     }
 }
 
-impl<'a, 'b, 'c, 'd> ElementSplice<AnyPod> for DomChildrenSplice<'a, 'b, 'c, 'd> {
+impl ElementSplice<AnyPod> for DomChildrenSplice<'_, '_, '_, '_> {
     fn with_scratch<R>(&mut self, f: impl FnOnce(&mut AppendVec<AnyPod>) -> R) -> R {
         let ret = f(self.scratch);
         if !self.scratch.is_empty() {

--- a/xilem_web/src/lib.rs
+++ b/xilem_web/src/lib.rs
@@ -24,7 +24,6 @@
 #![expect(let_underscore_drop, reason = "Deferred: Noisy")]
 #![expect(missing_debug_implementations, reason = "Deferred: Noisy")]
 #![expect(unused_qualifications, reason = "Deferred: Noisy")]
-#![expect(single_use_lifetimes, reason = "Deferred: Noisy")]
 #![expect(clippy::exhaustive_enums, reason = "Deferred: Noisy")]
 #![expect(clippy::match_same_arms, reason = "Deferred: Noisy")]
 #![expect(clippy::cast_possible_truncation, reason = "Deferred: Noisy")]


### PR DESCRIPTION
Result from `__CARGO_FIX_YOLO=1 cargo clippy --fix`.
As newest nightly clippy bleats about all of this. 