### PR TITLE
Delay CI cache restore until the toolchain has been installed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
-
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -122,6 +117,11 @@ jobs:
       - name: install native dependencies
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: cargo clippy
         run: cargo hack clippy --workspace --locked --optional-deps --each-feature -- -D warnings
@@ -140,11 +140,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
-
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -156,6 +151,11 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: cargo clippy
         run: cargo hack clippy --workspace ${{ env.NO_WASM_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature -- -D warnings
@@ -210,11 +210,6 @@ jobs:
       - uses: actions/checkout@v4
         # We intentionally do not use lfs: true here, instead using the caching method to save LFS bandwidth.
 
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
-
       - name: Restore lfs cache
         id: lfs-cache
         uses: actions/cache/restore@v4
@@ -252,6 +247,11 @@ jobs:
         with:
           tool: cargo-nextest
 
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
       - name: cargo test
         run: cargo nextest run --workspace --locked --all-features
         env:
@@ -275,16 +275,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
-
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_STABLE_VER }}
           targets: wasm32-unknown-unknown
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
 
       # TODO: Find a way to make tests work. Until then the tests are merely compiled.
       - name: cargo test compile
@@ -296,16 +296,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
-
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_STABLE_VER }}
           targets: aarch64-linux-android
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: install cargo apk
         run: cargo install cargo-apk
@@ -325,11 +325,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
-
       - name: install msrv toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -344,6 +339,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
 
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
       - name: cargo check
         run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature
 
@@ -352,11 +352,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: restore cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: install msrv toolchain
         uses: dtolnay/rust-toolchain@master
@@ -369,6 +364,11 @@ jobs:
         with:
           tool: cargo-hack
 
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
       - name: cargo check
         run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} ${{ env.NO_WASM_PKGS }} --locked --target wasm32-unknown-unknown --optional-deps --each-feature
 
@@ -380,13 +380,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
       - name: restore cache
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
-
-      - name: install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
 
       # We test documentation using nightly to match docs.rs. This prevents potential breakages
       - name: cargo doc


### PR DESCRIPTION
The [cache action's docs](https://github.com/Swatinem/rust-cache/blob/68b3cb7503c78e67dae8373749990a220eb65352/README.md) state:
> selecting a toolchain either by action or manual `rustup` calls should happen before the plugin, as the cache uses the current rustc version as its cache key

In practice we weren't affected too much, because it turns out the cache key is also derived using all environment variables that have the prefix `RUST`, which includes e.g. our `RUST_STABLE_VER`. So even if the key was derived using the CI runner's pre-installed old Rust toolchain, our env variable prevented most conflicts.

The cache docs also state that it does not cache, by cleaning the following:
> Any files in ~/.cargo/bin that were present before the action ran (for example rustc).

As we were installing the toolchain after the cache action, the potential for caching the toolchain seems there. However the cache size hasn't changed after this ordering change. Perhaps it does a simple path check only and the pre-installed toolchain was in the same path.

In any case, better to invoke the cache action after the toolchain has been installed, as the docs suggest.