### PR TITLE
Include widget ids in tracing spans

### DIFF
--- a/masonry/examples/calc_masonry.rs
+++ b/masonry/examples/calc_masonry.rs
@@ -12,8 +12,8 @@ use masonry::dpi::LogicalSize;
 use masonry::widget::{Align, CrossAxisAlignment, Flex, Label, RootWidget, SizedBox};
 use masonry::{
     AccessCtx, AccessEvent, Action, AppDriver, BoxConstraints, Color, DriverCtx, EventCtx,
-    LayoutCtx, PaintCtx, Point, PointerEvent, RegisterCtx, Size, TextEvent, Update, UpdateCtx,
-    Widget, WidgetId, WidgetPod,
+    LayoutCtx, PaintCtx, Point, PointerEvent, QueryCtx, RegisterCtx, Size, TextEvent, Update,
+    UpdateCtx, Widget, WidgetId, WidgetPod,
 };
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, Span};
@@ -239,8 +239,8 @@ impl Widget for CalcButton {
         smallvec![self.inner.id()]
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("CalcButton")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("CalcButton", id = ctx.widget_id().trace())
     }
 }
 

--- a/masonry/examples/custom_widget.rs
+++ b/masonry/examples/custom_widget.rs
@@ -12,7 +12,8 @@ use masonry::kurbo::{BezPath, Stroke};
 use masonry::widget::{ObjectFit, RootWidget};
 use masonry::{
     AccessCtx, AccessEvent, Action, Affine, AppDriver, BoxConstraints, Color, DriverCtx, EventCtx,
-    LayoutCtx, PaintCtx, Point, PointerEvent, Rect, RegisterCtx, Size, TextEvent, Widget, WidgetId,
+    LayoutCtx, PaintCtx, Point, PointerEvent, QueryCtx, Rect, RegisterCtx, Size, TextEvent, Widget,
+    WidgetId,
 };
 use parley::layout::Alignment;
 use parley::style::{FontFamily, FontStack, StyleProperty};
@@ -136,8 +137,8 @@ impl Widget for CustomWidget {
         SmallVec::new()
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("CustomWidget")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("CustomWidget", id = ctx.widget_id().trace())
     }
 }
 

--- a/masonry/src/passes/accessibility.rs
+++ b/masonry/src/passes/accessibility.rs
@@ -10,6 +10,8 @@ use crate::render_root::{RenderRoot, RenderRootState};
 use crate::tree_arena::ArenaMut;
 use crate::{AccessCtx, Widget, WidgetState};
 
+use super::enter_span_if;
+
 // --- MARK: BUILD TREE ---
 fn build_accessibility_tree(
     global_state: &mut RenderRootState,
@@ -19,10 +21,12 @@ fn build_accessibility_tree(
     rebuild_all: bool,
     scale_factor: f64,
 ) {
-    let _span = global_state
-        .trace
-        .access
-        .then(|| widget.item.make_trace_span().entered());
+    let _span = enter_span_if(
+        global_state.trace.access,
+        global_state,
+        widget.reborrow(),
+        state.reborrow(),
+    );
     let id = state.item.id;
 
     if !rebuild_all && !state.item.needs_accessibility {

--- a/masonry/src/passes/anim.rs
+++ b/masonry/src/passes/anim.rs
@@ -3,7 +3,7 @@
 
 use tracing::info_span;
 
-use crate::passes::recurse_on_children;
+use crate::passes::{enter_span_if, recurse_on_children};
 use crate::render_root::{RenderRoot, RenderRootState};
 use crate::tree_arena::ArenaMut;
 use crate::{UpdateCtx, Widget, WidgetState};
@@ -15,11 +15,12 @@ fn update_anim_for_widget(
     mut state: ArenaMut<'_, WidgetState>,
     elapsed_ns: u64,
 ) {
-    let _span = global_state
-        .trace
-        .anim
-        .then(|| widget.item.make_trace_span().entered());
-
+    let _span = enter_span_if(
+        global_state.trace.anim,
+        global_state,
+        widget.reborrow(),
+        state.reborrow(),
+    );
     if !state.item.needs_anim {
         return;
     }

--- a/masonry/src/passes/compose.rs
+++ b/masonry/src/passes/compose.rs
@@ -4,7 +4,7 @@
 use tracing::info_span;
 use vello::kurbo::Vec2;
 
-use crate::passes::recurse_on_children;
+use crate::passes::{enter_span_if, recurse_on_children};
 use crate::render_root::{RenderRoot, RenderRootSignal, RenderRootState};
 use crate::tree_arena::ArenaMut;
 use crate::{ComposeCtx, Widget, WidgetState};
@@ -17,10 +17,12 @@ fn compose_widget(
     parent_moved: bool,
     parent_translation: Vec2,
 ) {
-    let _span = global_state
-        .trace
-        .compose
-        .then(|| widget.item.make_trace_span().entered());
+    let _span = enter_span_if(
+        global_state.trace.compose,
+        global_state,
+        widget.reborrow(),
+        state.reborrow(),
+    );
 
     let moved = parent_moved || state.item.translation_changed;
     let translation = parent_translation + state.item.translation + state.item.origin.to_vec2();

--- a/masonry/src/passes/layout.rs
+++ b/masonry/src/passes/layout.rs
@@ -10,7 +10,7 @@ use smallvec::SmallVec;
 use tracing::{info_span, trace};
 use vello::kurbo::{Point, Rect, Size};
 
-use crate::passes::recurse_on_children;
+use crate::passes::{enter_span_if, recurse_on_children};
 use crate::render_root::{RenderRoot, RenderRootSignal, WindowSizePolicy};
 use crate::widget::WidgetState;
 use crate::{BoxConstraints, LayoutCtx, Widget, WidgetPod};
@@ -28,7 +28,12 @@ pub(crate) fn run_layout_on<W: Widget>(
     let mut state = parent_ctx.widget_state_children.get_child_mut(id).unwrap();
 
     let trace = parent_ctx.global_state.trace.layout;
-    let _span = trace.then(|| widget.item.make_trace_span().entered());
+    let _span = enter_span_if(
+        trace,
+        parent_ctx.global_state,
+        widget.reborrow(),
+        state.reborrow(),
+    );
 
     let mut children_ids = SmallVec::new();
     if cfg!(debug_assertions) {

--- a/masonry/src/passes/mod.rs
+++ b/masonry/src/passes/mod.rs
@@ -1,9 +1,12 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::tree_arena::{ArenaMut, ArenaMutChildren};
+use tracing::span::EnteredSpan;
+
+use crate::render_root::RenderRootState;
+use crate::tree_arena::{ArenaMut, ArenaMutChildren, ArenaRef};
 use crate::widget::WidgetArena;
-use crate::{Widget, WidgetId, WidgetState};
+use crate::{QueryCtx, Widget, WidgetId, WidgetState};
 
 pub(crate) mod accessibility;
 pub(crate) mod anim;
@@ -13,6 +16,35 @@ pub(crate) mod layout;
 pub(crate) mod mutate;
 pub(crate) mod paint;
 pub(crate) mod update;
+
+#[must_use = "Span will be immediately closed if dropped"]
+pub(crate) fn enter_span_if(
+    enabled: bool,
+    global_state: &RenderRootState,
+    widget: ArenaRef<'_, Box<dyn Widget>>,
+    state: ArenaRef<'_, WidgetState>,
+) -> Option<EnteredSpan> {
+    if enabled {
+        Some(enter_span(global_state, widget, state))
+    } else {
+        None
+    }
+}
+
+#[must_use = "Span will be immediately closed if dropped"]
+pub(crate) fn enter_span(
+    global_state: &RenderRootState,
+    widget: ArenaRef<'_, Box<dyn Widget>>,
+    state: ArenaRef<'_, WidgetState>,
+) -> EnteredSpan {
+    let ctx = QueryCtx {
+        global_state,
+        widget_state: state.item,
+        widget_state_children: state.children,
+        widget_children: widget.children,
+    };
+    widget.item.make_trace_span(&ctx).entered()
+}
 
 pub(crate) fn recurse_on_children(
     id: WidgetId,

--- a/masonry/src/passes/mod.rs
+++ b/masonry/src/passes/mod.rs
@@ -100,6 +100,12 @@ pub(crate) fn merge_state_up(arena: &mut WidgetArena, widget_id: WidgetId) {
 /// `MASONRY_TRACE_PASSES` environment variable.
 ///
 /// Note that passes which are bounded by depth (rather than absolute size) are never filtered out here.
+///
+/// Ideally, we'd cache the spans, which would make a lot (but not all) of this unnecessary.
+/// However, each pass uses a different parent span (with the individual pass's name), so it's
+/// (at best) non-trivial to make that work.
+///
+/// We could *maybe* use a global parent span called "Pass", with a name field, but that's extremely ugly.
 pub(crate) struct PassTracing {
     pub(crate) update_tree: bool,
     pub(crate) anim: bool,

--- a/masonry/src/passes/paint.rs
+++ b/masonry/src/passes/paint.rs
@@ -8,7 +8,7 @@ use vello::kurbo::{Affine, Stroke};
 use vello::peniko::Mix;
 use vello::Scene;
 
-use crate::passes::recurse_on_children;
+use crate::passes::{enter_span_if, recurse_on_children};
 use crate::render_root::{RenderRoot, RenderRootState};
 use crate::theme::get_debug_color;
 use crate::tree_arena::ArenaMut;
@@ -24,7 +24,8 @@ fn paint_widget(
     debug_paint: bool,
 ) {
     let trace = global_state.trace.paint;
-    let _span = trace.then(|| widget.item.make_trace_span().entered());
+    let _span = enter_span_if(trace, global_state, widget.reborrow(), state.reborrow());
+
     let id = state.item.id;
 
     // TODO - Handle invalidation regions

--- a/masonry/src/testing/helper_widgets.rs
+++ b/masonry/src/testing/helper_widgets.rs
@@ -378,8 +378,8 @@ impl<S: 'static> Widget for ModularWidget<S> {
         self.accepts_text_input
     }
 
-    fn make_trace_span(&self) -> tracing::Span {
-        trace_span!("ModularWidget")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> tracing::Span {
+        trace_span!("ModularWidget", id = ctx.widget_id().trace())
     }
 
     fn get_debug_text(&self) -> Option<String> {
@@ -578,8 +578,8 @@ impl<W: Widget> Widget for Recorder<W> {
         self.child.accepts_text_input()
     }
 
-    fn make_trace_span(&self) -> tracing::Span {
-        self.child.make_trace_span()
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> tracing::Span {
+        self.child.make_trace_span(ctx)
     }
 
     fn get_debug_text(&self) -> Option<String> {

--- a/masonry/src/widget/align.rs
+++ b/masonry/src/widget/align.rs
@@ -17,8 +17,8 @@ use crate::contexts::AccessCtx;
 use crate::paint_scene_helpers::UnitPoint;
 use crate::widget::WidgetPod;
 use crate::{
-    AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent, Rect, RegisterCtx,
-    Size, TextEvent, Widget, WidgetId,
+    AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent, QueryCtx, Rect,
+    RegisterCtx, Size, TextEvent, Widget, WidgetId,
 };
 
 // TODO - Have child widget type as generic argument
@@ -148,8 +148,8 @@ impl Widget for Align {
         smallvec![self.child.id()]
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("Align")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("Align", id = ctx.widget_id().trace())
     }
 }
 

--- a/masonry/src/widget/button.rs
+++ b/masonry/src/widget/button.rs
@@ -15,7 +15,7 @@ use crate::text::ArcStr;
 use crate::widget::{Label, WidgetMut, WidgetPod};
 use crate::{
     theme, AccessCtx, AccessEvent, BoxConstraints, EventCtx, Insets, LayoutCtx, PaintCtx,
-    PointerEvent, Size, TextEvent, Update, UpdateCtx, Widget, WidgetId,
+    PointerEvent, QueryCtx, Size, TextEvent, Update, UpdateCtx, Widget, WidgetId,
 };
 
 // the minimum padding added to a button.
@@ -204,8 +204,8 @@ impl Widget for Button {
         smallvec![self.label.id()]
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("Button")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("Button", id = ctx.widget_id().trace())
     }
 
     // FIXME

--- a/masonry/src/widget/checkbox.rs
+++ b/masonry/src/widget/checkbox.rs
@@ -15,7 +15,7 @@ use crate::text::ArcStr;
 use crate::widget::{Label, WidgetMut};
 use crate::{
     theme, AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
-    RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetPod,
+    QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetPod,
 };
 
 /// A checkbox that can be toggled.
@@ -213,8 +213,8 @@ impl Widget for Checkbox {
         smallvec![self.label.id()]
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("Checkbox")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("Checkbox", id = ctx.widget_id().trace())
     }
 
     fn get_debug_text(&self) -> Option<String> {

--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -14,7 +14,7 @@ use crate::theme::get_debug_color;
 use crate::widget::WidgetMut;
 use crate::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, Point, PointerEvent,
-    Rect, Size, TextEvent, Widget, WidgetId, WidgetPod,
+    QueryCtx, Rect, Size, TextEvent, Widget, WidgetId, WidgetPod,
 };
 
 /// A container with either horizontal or vertical layout.
@@ -1202,8 +1202,8 @@ impl Widget for Flex {
             .collect()
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("Flex")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("Flex", id = ctx.widget_id().trace())
     }
 }
 

--- a/masonry/src/widget/grid.rs
+++ b/masonry/src/widget/grid.rs
@@ -11,7 +11,7 @@ use crate::theme::get_debug_color;
 use crate::widget::WidgetMut;
 use crate::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, Point, PointerEvent,
-    Size, TextEvent, Widget, WidgetId, WidgetPod,
+    QueryCtx, Size, TextEvent, Widget, WidgetId, WidgetPod,
 };
 
 pub struct Grid {
@@ -311,8 +311,8 @@ impl Widget for Grid {
             .collect()
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("Grid")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("Grid", id = ctx.widget_id().trace())
     }
 }
 

--- a/masonry/src/widget/image.rs
+++ b/masonry/src/widget/image.rs
@@ -164,7 +164,9 @@ mod tests {
     #[test]
     fn tall_paint() {
         let image_data = ImageBuf::new(
-            // This could have a more concise chain, but
+            // This could have a more concise chain, but previously used versions either
+            // had unreadable formatting or used `rustfmt::skip`, which broke formatting
+            // across large parts of the file.
             [
                 [255, 255, 255, 255],
                 [000, 000, 000, 255],

--- a/masonry/src/widget/image.rs
+++ b/masonry/src/widget/image.rs
@@ -13,7 +13,7 @@ use vello::Scene;
 
 use crate::widget::{ObjectFit, WidgetMut};
 use crate::{
-    AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
+    AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent, QueryCtx,
     RegisterCtx, Size, TextEvent, Update, UpdateCtx, Widget, WidgetId,
 };
 
@@ -134,8 +134,8 @@ impl Widget for Image {
         SmallVec::new()
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("Image")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("Image", id = ctx.widget_id().trace())
     }
 }
 
@@ -163,14 +163,18 @@ mod tests {
 
     #[test]
     fn tall_paint() {
-        #[rustfmt::skip]
         let image_data = ImageBuf::new(
-            vec![
-                255, 255, 255, 255, 
-                0, 0, 0, 255,
-                0, 0, 0, 255,
-                255, 255, 255, 255,
-            ].into(),
+            // This could have a more concise chain, but
+            [
+                [255, 255, 255, 255],
+                [000, 000, 000, 255],
+                [000, 000, 000, 255],
+                [255, 255, 255, 255],
+            ]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+            .into(),
             Format::Rgba8,
             2,
             2,

--- a/masonry/src/widget/label.rs
+++ b/masonry/src/widget/label.rs
@@ -16,7 +16,7 @@ use vello::Scene;
 use crate::text::{ArcStr, TextBrush, TextLayout};
 use crate::widget::WidgetMut;
 use crate::{
-    AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
+    AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent, QueryCtx,
     RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
 };
 
@@ -249,8 +249,8 @@ impl Widget for Label {
         false
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("Label")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("Label", id = ctx.widget_id().trace())
     }
 
     fn get_debug_text(&self) -> Option<String> {

--- a/masonry/src/widget/portal.rs
+++ b/masonry/src/widget/portal.rs
@@ -14,7 +14,7 @@ use vello::Scene;
 use crate::widget::{Axis, ScrollBar, WidgetMut};
 use crate::{
     AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
-    PointerEvent, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetPod,
+    PointerEvent, QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetPod,
 };
 
 // TODO - refactor - see https://github.com/linebender/xilem/issues/366
@@ -467,8 +467,8 @@ impl<W: Widget> Widget for Portal<W> {
         ]
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("Portal")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("Portal", id = ctx.widget_id().trace())
     }
 }
 

--- a/masonry/src/widget/progress_bar.rs
+++ b/masonry/src/widget/progress_bar.rs
@@ -14,7 +14,7 @@ use crate::text::{ArcStr, TextLayout};
 use crate::widget::WidgetMut;
 use crate::{
     theme, AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, Point,
-    PointerEvent, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
+    PointerEvent, QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
 };
 
 /// A progress bar
@@ -191,8 +191,8 @@ impl Widget for ProgressBar {
         smallvec![]
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("ProgressBar")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("ProgressBar", id = ctx.widget_id().trace())
     }
 
     fn get_debug_text(&self) -> Option<String> {

--- a/masonry/src/widget/prose.rs
+++ b/masonry/src/widget/prose.rs
@@ -283,8 +283,8 @@ impl Widget for Prose {
         SmallVec::new()
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("Prose")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("Prose", id = ctx.widget_id().trace())
     }
 
     fn get_debug_text(&self) -> Option<String> {

--- a/masonry/src/widget/root_widget.rs
+++ b/masonry/src/widget/root_widget.rs
@@ -9,7 +9,7 @@ use vello::Scene;
 
 use crate::widget::{WidgetMut, WidgetPod};
 use crate::{
-    AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
+    AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent, QueryCtx,
     RegisterCtx, Size, TextEvent, Widget, WidgetId,
 };
 
@@ -65,7 +65,7 @@ impl<W: Widget> Widget for RootWidget<W> {
         smallvec![self.pod.id()]
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("RootWidget")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("RootWidget", id = ctx.widget_id().trace())
     }
 }

--- a/masonry/src/widget/scroll_bar.rs
+++ b/masonry/src/widget/scroll_bar.rs
@@ -13,7 +13,8 @@ use crate::paint_scene_helpers::{fill_color, stroke};
 use crate::widget::{Axis, WidgetMut};
 use crate::{
     theme, AccessCtx, AccessEvent, AllowRawMut, BoxConstraints, EventCtx, LayoutCtx, PaintCtx,
-    Point, PointerEvent, RegisterCtx, Size, TextEvent, Update, UpdateCtx, Widget, WidgetId,
+    Point, PointerEvent, QueryCtx, RegisterCtx, Size, TextEvent, Update, UpdateCtx, Widget,
+    WidgetId,
 };
 
 // RULES
@@ -223,8 +224,8 @@ impl Widget for ScrollBar {
         SmallVec::new()
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("ScrollBar")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("ScrollBar", id = ctx.widget_id().trace())
     }
 }
 

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -14,7 +14,7 @@ use crate::paint_scene_helpers::stroke;
 use crate::widget::{WidgetMut, WidgetPod};
 use crate::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, Point, PointerEvent,
-    RegisterCtx, Size, TextEvent, Widget, WidgetId,
+    QueryCtx, RegisterCtx, Size, TextEvent, Widget, WidgetId,
 };
 
 // FIXME - Improve all doc in this module ASAP.
@@ -401,8 +401,8 @@ impl Widget for SizedBox {
         }
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("SizedBox")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("SizedBox", id = ctx.widget_id().trace())
     }
 }
 

--- a/masonry/src/widget/spinner.rs
+++ b/masonry/src/widget/spinner.rs
@@ -14,7 +14,8 @@ use vello::Scene;
 use crate::widget::WidgetMut;
 use crate::{
     theme, AccessCtx, AccessEvent, BoxConstraints, Color, EventCtx, LayoutCtx, PaintCtx, Point,
-    PointerEvent, RegisterCtx, Size, TextEvent, Update, UpdateCtx, Vec2, Widget, WidgetId,
+    PointerEvent, QueryCtx, RegisterCtx, Size, TextEvent, Update, UpdateCtx, Vec2, Widget,
+    WidgetId,
 };
 
 /// An animated spinner widget for showing a loading state.
@@ -148,8 +149,8 @@ impl Widget for Spinner {
         SmallVec::new()
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("Spinner")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("Spinner", id = ctx.widget_id().trace())
     }
 }
 

--- a/masonry/src/widget/split.rs
+++ b/masonry/src/widget/split.rs
@@ -540,8 +540,8 @@ impl Widget for Split {
         smallvec![self.child1.id(), self.child2.id()]
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("Split")
+    fn make_trace_span(&self, ctx: &QueryCtx) -> Span {
+        trace_span!("Split", id = ctx.widget_id().trace())
     }
 }
 

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -332,8 +332,8 @@ impl Widget for Textbox {
         true
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("Textbox")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("Textbox", id = ctx.widget_id().trace())
     }
 
     fn get_debug_text(&self) -> Option<String> {

--- a/masonry/src/widget/variable_label.rs
+++ b/masonry/src/widget/variable_label.rs
@@ -18,7 +18,7 @@ use vello::Scene;
 use crate::text::{ArcStr, Hinting, TextBrush, TextLayout};
 use crate::widget::{LineBreaking, WidgetMut};
 use crate::{
-    AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
+    AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent, QueryCtx,
     RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
 };
 
@@ -411,8 +411,8 @@ impl Widget for VariableLabel {
         SmallVec::new()
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("VariableLabel")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("VariableLabel", id = ctx.widget_id().trace())
     }
 
     fn get_debug_text(&self) -> Option<String> {

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -3,6 +3,7 @@
 
 #![cfg(not(tarpaulin_include))]
 
+use tracing::Span;
 use vello::kurbo::{Insets, Point, Rect, Size, Vec2};
 
 use crate::WidgetId;
@@ -145,6 +146,11 @@ pub(crate) struct WidgetState {
     pub(crate) has_focus: bool,
 
     // --- DEBUG INFO ---
+    /// The tracing span of this widget
+    pub(crate) span: tracing::Span,
+    /// Whether this element's span is out of date.
+    pub(crate) request_span: bool,
+
     // TODO - document
     #[cfg(debug_assertions)]
     pub(crate) widget_name: &'static str,
@@ -190,6 +196,8 @@ impl WidgetState {
             focus_chain: Vec::new(),
             children_changed: true,
             update_focus_chain: true,
+            request_span: true,
+            span: Span::none(),
             #[cfg(debug_assertions)]
             widget_name,
         }

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -3,7 +3,6 @@
 
 #![cfg(not(tarpaulin_include))]
 
-use tracing::Span;
 use vello::kurbo::{Insets, Point, Rect, Size, Vec2};
 
 use crate::WidgetId;
@@ -146,11 +145,6 @@ pub(crate) struct WidgetState {
     pub(crate) has_focus: bool,
 
     // --- DEBUG INFO ---
-    /// The tracing span of this widget
-    pub(crate) span: tracing::Span,
-    /// Whether this element's span is out of date.
-    pub(crate) request_span: bool,
-
     // TODO - document
     #[cfg(debug_assertions)]
     pub(crate) widget_name: &'static str,
@@ -196,8 +190,6 @@ impl WidgetState {
             focus_chain: Vec::new(),
             children_changed: true,
             update_focus_chain: true,
-            request_span: true,
-            span: Span::none(),
             #[cfg(debug_assertions)]
             widget_name,
         }

--- a/xilem/src/any_view.rs
+++ b/xilem/src/any_view.rs
@@ -5,7 +5,7 @@ use accesskit::{NodeBuilder, Role};
 use masonry::widget::WidgetMut;
 use masonry::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, Point, PointerEvent,
-    RegisterCtx, Size, TextEvent, Widget, WidgetId, WidgetPod,
+    QueryCtx, RegisterCtx, Size, TextEvent, Widget, WidgetId, WidgetPod,
 };
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace_span, Span};
@@ -100,7 +100,7 @@ impl Widget for DynWidget {
         smallvec![self.inner.id()]
     }
 
-    fn make_trace_span(&self) -> Span {
-        trace_span!("DynWidget")
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("DynWidget", id = ctx.widget_id().trace())
     }
 }


### PR DESCRIPTION
New tracy image:

![image](https://github.com/user-attachments/assets/94e54c89-8159-4dd4-a521-4a7122f64375)

New log tracing file:
<details><summary>An overview of the new logs</summary>
<p>

```
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}: masonry::passes::update: RootWidget received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}: masonry::passes::update: Flex received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#8}: masonry::passes::update: Flex received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#8}:SizedBox{id=#7}: masonry::passes::update: SizedBox received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#8}:SizedBox{id=#7}:Flex{id=#6}: masonry::passes::update: Flex received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#8}:SizedBox{id=#7}:Flex{id=#6}:Flex{id=#3}: masonry::passes::update: Flex received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#8}:SizedBox{id=#7}:Flex{id=#6}:Flex{id=#3}:Prose{id=#1}: masonry::passes::update: Prose received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#8}:SizedBox{id=#7}:Flex{id=#6}:Flex{id=#3}:Label{id=#2}: masonry::passes::update: Label received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#8}:SizedBox{id=#7}:Flex{id=#6}:Flex{id=#5}: masonry::passes::update: Flex received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#8}:SizedBox{id=#7}:Flex{id=#6}:Flex{id=#5}:VariableLabel{id=#4}: masonry::passes::update: VariableLabel received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#17}: masonry::passes::update: Flex received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#17}:Button{id=#10}: masonry::passes::update: Button received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#17}:Button{id=#10}:Label{id=#9}: masonry::passes::update: Label received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#17}:Button{id=#12}: masonry::passes::update: Button received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#17}:Button{id=#12}:Label{id=#11}: masonry::passes::update: Label received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#17}:Button{id=#14}: masonry::passes::update: Button received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#17}:Button{id=#14}:Label{id=#13}: masonry::passes::update: Label received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#17}:Button{id=#16}: masonry::passes::update: Button received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Flex{id=#17}:Button{id=#16}:Label{id=#15}: masonry::passes::update: Label received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Portal{id=#163}: masonry::passes::update: Portal received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Portal{id=#163}:Flex{id=#160}: masonry::passes::update: Flex received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Portal{id=#163}:Flex{id=#160}:SizedBox{id=#24}: masonry::passes::update: SizedBox received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Portal{id=#163}:Flex{id=#160}:SizedBox{id=#24}:Flex{id=#23}: masonry::passes::update: Flex received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Portal{id=#163}:Flex{id=#160}:SizedBox{id=#24}:Flex{id=#23}:Flex{id=#20}: masonry::passes::update: Flex received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Portal{id=#163}:Flex{id=#160}:SizedBox{id=#24}:Flex{id=#23}:Flex{id=#20}:Prose{id=#18}: masonry::passes::update: Prose received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Portal{id=#163}:Flex{id=#160}:SizedBox{id=#24}:Flex{id=#23}:Flex{id=#20}:Label{id=#19}: masonry::passes::update: Label received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Portal{id=#163}:Flex{id=#160}:SizedBox{id=#24}:Flex{id=#23}:Flex{id=#22}: masonry::passes::update: Flex received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Portal{id=#163}:Flex{id=#160}:SizedBox{id=#24}:Flex{id=#23}:Flex{id=#22}:VariableLabel{id=#21}: masonry::passes::update: VariableLabel received Update::WidgetAdded
14:37:40.365Z TRACE update_new_widgets:RootWidget{id=#165}:Flex{id=#164}:Portal{id=#163}:Flex{id=#160}:SizedBox{id=#31}: masonry::passes::update: SizedBox received Update::WidgetAdded
```

</p>
</details> 

This was originally an experiment into caching spans, but I determined that was non-viable due to the pass names.