### PR TITLE
xilem_core: implement `View` for `Rc<impl View>`

### DIFF
--- a/xilem_core/src/message.rs
+++ b/xilem_core/src/message.rs
@@ -17,9 +17,10 @@ pub enum MessageResult<Action, Message = DynMessage> {
     ///
     /// This allows for sub-sections of your app to use an elm-like architecture
     Action(Action),
-    // TODO: What does this mean?
-    /// This message's handler needs a rebuild to happen.
-    /// The exact semantics of this method haven't been determined.
+    /// A view has requested a full rebuild, even if it wasn't changed by the user directly.
+    ///
+    /// This can happen for example by some kind of async action.
+    /// An example would be an async virtualized list, which fetches new entries, and requires a rebuild for the new entries.
     RequestRebuild,
     #[default]
     /// This event had no impact on the app state, or the impact it did have

--- a/xilem_core/src/message.rs
+++ b/xilem_core/src/message.rs
@@ -17,7 +17,7 @@ pub enum MessageResult<Action, Message = DynMessage> {
     ///
     /// This allows for sub-sections of your app to use an elm-like architecture
     Action(Action),
-    /// A view has requested a full rebuild, even if it wasn't changed by the user directly.
+    /// A view has requested a rebuild, even though its value hasn't changed.
     ///
     /// This can happen for example by some kind of async action.
     /// An example would be an async virtualized list, which fetches new entries, and requires a rebuild for the new entries.

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -210,7 +210,7 @@ pub struct RcState<ViewState> {
     view_state: ViewState,
     /// This is a flag that is set, when an inner view signifies that it requires a rebuild (via [`MessageResult::RequestRebuild`]).
     /// This can happen, e.g. when an inner view wasn't changed by the app-developer directly (i.e. it points to the same view),
-    /// but e.g. some kind of async action.
+    /// but e.g. through some kind of async action.
     /// An example would be an async virtualized list, which fetches new entries, and requires a rebuild for the new entries.
     dirty: bool,
 }

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -208,6 +208,9 @@ where
 #[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
 pub struct RcState<ViewState> {
     view_state: ViewState,
+    /// This is a flag that is set, when an inner view signifies that it requires a rebuild (via [`MessageResult::RequestRebuild`]).
+    /// This can happen, e.g. when an inner view wasn't changed by the user directly, but e.g. some kind of async action.
+    /// An example would be an async virtualized list, which fetches new entries, and requires a rebuild for the new entries.
     dirty: bool,
 }
 
@@ -239,7 +242,6 @@ where
         ctx: &mut Context,
         element: Mut<Self::Element>,
     ) {
-        // If this is the same value, or no rebuild was forced, there's no need to rebuild
         if core::mem::take(&mut view_state.dirty) || !Arc::ptr_eq(self, prev) {
             self.deref()
                 .rebuild(prev, &mut view_state.view_state, ctx, element);
@@ -301,7 +303,6 @@ where
         ctx: &mut Context,
         element: Mut<Self::Element>,
     ) {
-        // If this is the same value, or no rebuild was forced, there's no need to rebuild
         if core::mem::take(&mut view_state.dirty) || !Rc::ptr_eq(self, prev) {
             self.deref()
                 .rebuild(prev, &mut view_state.view_state, ctx, element);

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -206,7 +206,7 @@ where
 }
 
 #[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
-pub struct ArcState<ViewState> {
+pub struct RcState<ViewState> {
     view_state: ViewState,
     dirty: bool,
 }
@@ -219,13 +219,13 @@ where
     V: View<State, Action, Context, Message> + ?Sized,
 {
     type Element = V::Element;
-    type ViewState = ArcState<V::ViewState>;
+    type ViewState = RcState<V::ViewState>;
 
     fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
         let (element, view_state) = self.deref().build(ctx);
         (
             element,
-            ArcState {
+            RcState {
                 view_state,
                 dirty: false,
             },
@@ -281,13 +281,13 @@ where
     V: View<State, Action, Context, Message> + ?Sized,
 {
     type Element = V::Element;
-    type ViewState = ArcState<V::ViewState>;
+    type ViewState = RcState<V::ViewState>;
 
     fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
         let (element, view_state) = self.deref().build(ctx);
         (
             element,
-            ArcState {
+            RcState {
                 view_state,
                 dirty: false,
             },

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -209,7 +209,8 @@ where
 pub struct RcState<ViewState> {
     view_state: ViewState,
     /// This is a flag that is set, when an inner view signifies that it requires a rebuild (via [`MessageResult::RequestRebuild`]).
-    /// This can happen, e.g. when an inner view wasn't changed by the user directly, but e.g. some kind of async action.
+    /// This can happen, e.g. when an inner view wasn't changed by the app-developer directly (i.e. it points to the same view),
+    /// but e.g. some kind of async action.
     /// An example would be an async virtualized list, which fetches new entries, and requires a rebuild for the new entries.
     dirty: bool,
 }

--- a/xilem_web/src/templated.rs
+++ b/xilem_web/src/templated.rs
@@ -9,31 +9,25 @@ use std::{any::TypeId, rc::Rc};
 use wasm_bindgen::UnwrapThrowExt;
 
 /// This view creates an internally cached deep-clone of the underlying DOM node. When the inner view is created again, this will be done more efficiently.
-pub struct Templated<E>(Rc<E>);
+pub struct Templated<V>(Rc<V>);
 
-#[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
-pub struct TemplatedState<ViewState> {
-    view_state: ViewState,
-    dirty: bool,
-}
-
-impl<E> ViewMarker for Templated<E> {}
-impl<State, Action, E> View<State, Action, ViewCtx, DynMessage> for Templated<E>
+impl<V> ViewMarker for Templated<V> {}
+impl<State, Action, V> View<State, Action, ViewCtx, DynMessage> for Templated<V>
 where
     State: 'static,
     Action: 'static,
-    E: DomView<State, Action>,
+    V: DomView<State, Action>,
 {
-    type Element = E::Element;
+    type Element = V::Element;
 
-    type ViewState = TemplatedState<<Rc<E> as View<State, Action, ViewCtx, DynMessage>>::ViewState>;
+    type ViewState = <Rc<V> as View<State, Action, ViewCtx, DynMessage>>::ViewState;
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let type_id = TypeId::of::<Self>();
         let (element, view_state) = if let Some((template_node, view)) = ctx.templates.get(&type_id)
         {
             let prev = view.clone();
-            let prev = prev.downcast_ref::<Rc<E>>().unwrap_throw();
+            let prev = prev.downcast_ref::<Rc<V>>().unwrap_throw();
             let node = template_node.clone_node_with_deep(true).unwrap_throw();
             let (mut el, mut state) = ctx.with_hydration_node(node, |ctx| prev.build(ctx));
             el.apply_changes();
@@ -54,11 +48,7 @@ where
                 .insert(type_id, (template, Rc::new(self.0.clone())));
             (element, state)
         };
-        let state = TemplatedState {
-            view_state,
-            dirty: false,
-        };
-        (element, state)
+        (element, view_state)
     }
 
     fn rebuild(
@@ -68,11 +58,7 @@ where
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
     ) {
-        // If this is the same value, or no rebuild was forced, there's no need to rebuild
-        if core::mem::take(&mut view_state.dirty) || !Rc::ptr_eq(&self.0, &prev.0) {
-            self.0
-                .rebuild(&prev.0, &mut view_state.view_state, ctx, element);
-        }
+        self.0.rebuild(&prev.0, view_state, ctx, element);
     }
 
     fn teardown(
@@ -81,7 +67,7 @@ where
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
     ) {
-        self.0.teardown(&mut view_state.view_state, ctx, element);
+        self.0.teardown(view_state, ctx, element);
     }
 
     fn message(
@@ -91,13 +77,7 @@ where
         message: DynMessage,
         app_state: &mut State,
     ) -> MessageResult<Action, DynMessage> {
-        let message_result =
-            self.0
-                .message(&mut view_state.view_state, id_path, message, app_state);
-        if matches!(message_result, MessageResult::RequestRebuild) {
-            view_state.dirty = true;
-        }
-        message_result
+        self.0.message(view_state, id_path, message, app_state)
     }
 }
 


### PR DESCRIPTION
I needed this in xilem_web, I could've used `Arc` as well, but I think it's fine to add this for consistency when an `Arc` is not needed.

It's basically copy-pasta of the `Arc`. (I don't think a macro is worth it here?). Had to fix some resulting issues in the `Templated` view (due to ambiguity?).