### PR TITLE
xilem_web: Extend `svgdraw` example to be an infinite zoomable canvas

### DIFF
--- a/xilem_web/src/interfaces.rs
+++ b/xilem_web/src/interfaces.rs
@@ -822,11 +822,41 @@ pub trait HtmlInputElement<State, Action = ()>:
     /// use xilem_web::{interfaces::{Element, HtmlInputElement}, elements::html::input};
     ///
     /// # fn component() -> impl HtmlInputElement<()> {
-    /// input(()).attr("type", "checkbox").checked(true) // results in <input type="checkbox" checked></input>
+    /// input(()).type_("checkbox").checked(true) // results in <input type="checkbox" checked></input>
     /// # }
     /// ```
     fn checked(self, checked: bool) -> html_input_element::view::Checked<Self, State, Action> {
         html_input_element::view::Checked::new(self, checked)
+    }
+
+    /// See <https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/type> for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xilem_web::{interfaces::{Element, HtmlInputElement}, elements::html::input};
+    ///
+    /// # fn component() -> impl HtmlInputElement<()> {
+    /// input(()).type_("radio") // results in <input type="radio"></input>
+    /// # }
+    /// ```
+    fn type_(self, value: impl Into<Cow<'static, str>>) -> Attr<Self, State, Action> {
+        Attr::new(self, "type".into(), value.into().into_attr_value())
+    }
+
+    /// See <https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/name> for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use xilem_web::{interfaces::{Element, HtmlInputElement}, elements::html::input};
+    ///
+    /// # fn component() -> impl HtmlInputElement<()> {
+    /// input(()).name("color") // results in <input name="color"></input>
+    /// # }
+    /// ```
+    fn name(self, value: impl Into<Cow<'static, str>>) -> Attr<Self, State, Action> {
+        Attr::new(self, "name".into(), value.into().into_attr_value())
     }
 
     /// See <https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/checked> for more details.
@@ -837,7 +867,7 @@ pub trait HtmlInputElement<State, Action = ()>:
     /// use xilem_web::{interfaces::{Element, HtmlInputElement}, elements::html::input};
     ///
     /// # fn component() -> impl HtmlInputElement<()> {
-    /// input(()).attr("type", "radio").default_checked(true) // results in <input type="radio" checked></input>
+    /// input(()).type_("radio").default_checked(true) // results in <input type="radio" checked></input>
     /// # }
     /// ```
     fn default_checked(

--- a/xilem_web/web_examples/fetch/src/main.rs
+++ b/xilem_web/web_examples/fetch/src/main.rs
@@ -175,7 +175,7 @@ fn cat_fetch_controls(state: &AppState) -> impl Element<AppState> {
                 td(label("How many cats would you like?").for_("cat-count")),
                 td(input(())
                     .id("cat-count")
-                    .attr("type", "number")
+                    .type_("number")
                     .attr("min", 0)
                     .attr("value", state.cats_to_fetch)
                     .on_input(|state: &mut AppState, ev: web_sys::Event| {
@@ -193,7 +193,7 @@ fn cat_fetch_controls(state: &AppState) -> impl Element<AppState> {
                 ),
                 td(input(())
                     .id("reset-debounce-update")
-                    .attr("type", "checkbox")
+                    .type_("checkbox")
                     .checked(state.reset_debounce_on_update)
                     .on_input(|state: &mut AppState, event: web_sys::Event| {
                         state.reset_debounce_on_update = input_target(&event).checked();
@@ -203,7 +203,7 @@ fn cat_fetch_controls(state: &AppState) -> impl Element<AppState> {
                 td(label("Debounce timeout in ms:").for_("debounce-timeout-duration")),
                 td(input(())
                     .id("debounce-timeout-duration")
-                    .attr("type", "number")
+                    .type_("number")
                     .attr("min", 0)
                     .attr("value", state.debounce_in_ms)
                     .on_input(|state: &mut AppState, ev: web_sys::Event| {

--- a/xilem_web/web_examples/mathml_svg/src/main.rs
+++ b/xilem_web/web_examples/mathml_svg/src/main.rs
@@ -48,7 +48,7 @@ fn slider(
     cb: fn(&mut Triangle, web_sys::Event),
 ) -> impl HtmlInputElement<Triangle> {
     html::input(())
-        .attr("type", "range")
+        .type_("range")
         .attr("min", 1)
         .attr("max", max)
         .attr("value", value)

--- a/xilem_web/web_examples/svgdraw/index.html
+++ b/xilem_web/web_examples/svgdraw/index.html
@@ -23,10 +23,12 @@
       height: 1.5rem;
       padding-top: 0.25rem;
       padding-bottom: 0.25rem;
+      font-family: monospace, monospace;
     }
 
     .controls>span {
       vertical-align: top;
+      font-family: monospace, monospace;
     }
 
     .value-range {
@@ -53,7 +55,7 @@
     .value-range::before {
       text-align: left;
       /* hardcoded values aren't optimal here, but this example is not about styling/layouting */
-      content: "1";
+      content: "0.1";
     }
 
     .value-range::after {

--- a/xilem_web/web_examples/svgdraw/index.html
+++ b/xilem_web/web_examples/svgdraw/index.html
@@ -14,29 +14,48 @@
       touch-action: none;
     }
 
-    .controls {
-      display: block;
-      left: 0;
-      right: 0;
-      margin-inline: auto;
-      width: fit-content;
-      height: 1.5rem;
-      padding-top: 0.25rem;
-      padding-bottom: 0.25rem;
-      font-family: monospace, monospace;
+    input[type=radio] {
+      display: none;
     }
 
-    .controls>span {
-      vertical-align: top;
-      font-family: monospace, monospace;
+    .color>input[type=radio]:checked+div {
+      transform: scale(1.25);
+    }
+
+    .color>input[type=radio]+div {
+      transition: transform 0.3s ease-in-out;
+      border-radius: 50%;
+      border-color: black;
+      border-width: 1px;
+      border-style: solid;
+      width: 23px;
+      height: 23px;
+      margin: 2.2px;
+      background-color: red;
+      display: block;
+    }
+
+    .color {
+      display: inline-block
+    }
+
+    .controls {
+      position: absolute;
+      left: 0;
+      width: fit-content;
+      height: 1.5rem;
+      padding: 1.0rem;
+      font-family: Arial, Helvetica, sans-serif, monospace;
+    }
+
+    .controls>div {
+      margin-bottom: 10px;
     }
 
     .value-range {
-      display: inline-block;
-      position: relative;
+      position: absolute;
       height: 1.5rem;
       width: 20rem;
-
     }
 
     .value-range::before,
@@ -60,7 +79,7 @@
 
     .value-range::after {
       text-align: right;
-      content: "30";
+      content: "1000";
     }
 
     input[type=range] {
@@ -97,7 +116,6 @@
 
     label {
       line-height: 1.5rem;
-      position: absolute;
     }
   </style>
 </head>

--- a/xilem_web/web_examples/svgdraw/src/main.rs
+++ b/xilem_web/web_examples/svgdraw/src/main.rs
@@ -3,6 +3,7 @@
 
 //! An example showing how SVG paths can be used for a vector-drawing application
 
+use std::rc::Rc;
 use wasm_bindgen::UnwrapThrowExt;
 use xilem_web::{
     document_body,
@@ -17,7 +18,7 @@ use xilem_web::{
         kurbo::{BezPath, Point, QuadSpline, Shape, Stroke},
         peniko::Color,
     },
-    App, DomFragment, PointerMsg,
+    AnyDomView, App, DomFragment, PointerMsg,
 };
 
 const RAINBOW_COLORS: &[Color] = &[
@@ -70,37 +71,111 @@ impl SplineLine {
 
 #[derive(Default)]
 struct Draw {
-    lines: Vec<SplineLine>,
+    cur_line: Option<SplineLine>,
+    cursor_position: Point,
+    canvas_position: Point,
+    draw_position: Point,
+    lines_cached: Vec<Rc<AnyDomView<Draw>>>,
     new_line_width: f64,
     is_drawing: bool,
+    is_moving: bool,
+    zoom: f64,
 }
 
 impl Draw {
+    fn update_cursor(&mut self, cursor: Point) {
+        let last_cursor_position = self.cursor_position;
+        self.cursor_position = cursor;
+        let cursor_delta = self.cursor_position - last_cursor_position;
+        let zoom_corrected_delta = cursor_delta / self.zoom;
+        self.draw_position += zoom_corrected_delta;
+        if self.is_moving {
+            self.canvas_position -= zoom_corrected_delta;
+            self.draw_position -= zoom_corrected_delta;
+        }
+    }
+
+    // TODO support pinch as well
+    fn zoom_with_wheel_event(&mut self, event: web_sys::WheelEvent) {
+        let delta_mode_factor = match event.delta_mode() {
+            2 => 100.0, // Pages
+            1 => 16.0,  // Lines
+            _ => 1.0,   // Pixels and Default
+        };
+        let mut delta = event.delta_y() * delta_mode_factor;
+
+        let delta_sign = delta.signum();
+        let factor = 1.0 + 0.001 * delta.abs();
+        delta = if delta_sign < 0.0 {
+            factor
+        } else {
+            1.0 / factor
+        };
+
+        self.zoom *= delta;
+        self.canvas_position -= (self.cursor_position.to_vec2() * (1.0 - delta)) / self.zoom;
+    }
+
+    fn start_new_line(&mut self) {
+        let line = SplineLine::new(self.draw_position, random_color(), self.new_line_width);
+        self.lines_cached
+            .push(Rc::new(line.view()) as Rc<AnyDomView<Self>>);
+        self.cur_line = Some(line);
+        self.is_drawing = true;
+    }
+
+    fn extend_current_line(&mut self) {
+        if self.is_drawing {
+            let cur_line = self.cur_line.as_mut().unwrap();
+            cur_line.points.push(self.draw_position);
+            *self.lines_cached.last_mut().unwrap() =
+                Rc::new(cur_line.view()) as Rc<AnyDomView<Self>>;
+        }
+    }
+
+    fn finish_current_line(&mut self) {
+        self.is_drawing = false;
+    }
+
     fn view(&mut self) -> impl DomFragment<Self> {
-        let lines = self.lines.iter().map(SplineLine::view).collect::<Vec<_>>();
-        let canvas = svg(g(lines).fill(Color::TRANSPARENT))
-            .pointer(|state: &mut Self, e| {
-                match e {
-                    PointerMsg::Down(p) => {
-                        let l = SplineLine::new(p.position, random_color(), state.new_line_width);
-                        state.lines.push(l);
-                        state.is_drawing = true;
-                    }
-                    PointerMsg::Move(p) => {
-                        if state.is_drawing {
-                            state.lines.last_mut().unwrap().points.push(p.position);
-                        }
-                    }
-                    PointerMsg::Up(_) => state.is_drawing = false,
-                };
-            })
-            .style([s("width", "100vw"), s("height", "100vh")]);
+        let x = -self.canvas_position.x;
+        let y = -self.canvas_position.y;
+        let zoom = self.zoom;
+        let canvas = svg(g(self.lines_cached.clone())
+            .fill(Color::TRANSPARENT)
+            .style(s(
+                "transform",
+                format!("scale({zoom}) translate({x}px, {y}px)"),
+            )))
+        .pointer(|state: &mut Self, e| {
+            state.update_cursor(e.position());
+            match e {
+                PointerMsg::Down(e) => match e.button {
+                    0 => state.start_new_line(),
+                    1 | 2 => state.is_moving = true,
+                    _ => (),
+                },
+                PointerMsg::Move(_) => state.extend_current_line(),
+                PointerMsg::Up(e) => match e.button {
+                    0 => state.finish_current_line(),
+                    1 | 2 => state.is_moving = false,
+                    _ => (),
+                },
+            };
+        })
+        .style([s("width", "100vw"), s("height", "100vh")])
+        .on_wheel(|state, event| state.zoom_with_wheel_event(event))
+        .on_click(|_, event| event.prevent_default())
+        .passive(false)
+        .on_contextmenu(|_, event| event.prevent_default())
+        .passive(false);
 
         let controls = label((
-            span("Stroke width:"),
+            // a space width would be more ideal, but for some reason spaces are truncated...
+            span(format!("Stroke width {:>05.2}: ", self.new_line_width)),
             div(input(())
                 .attr("type", "range")
-                .attr("min", 1)
+                .attr("min", 0.1)
                 .attr("max", 30)
                 .attr("step", 0.01)
                 .attr("value", self.new_line_width)
@@ -123,6 +198,7 @@ fn main() {
         document_body(),
         Draw {
             new_line_width: 5.0,
+            zoom: 1.0,
             ..Draw::default()
         },
         Draw::view,

--- a/xilem_web/web_examples/svgdraw/src/main.rs
+++ b/xilem_web/web_examples/svgdraw/src/main.rs
@@ -18,7 +18,7 @@ use xilem_web::{
         kurbo::{BezPath, Point, QuadSpline, Shape, Stroke},
         peniko::Color,
     },
-    AnyDomView, App, DomFragment, PointerMsg,
+    AnyDomView, App, DomFragment,
 };
 
 const RAINBOW_COLORS: &[Color] = &[

--- a/xilem_web/web_examples/todomvc/src/main.rs
+++ b/xilem_web/web_examples/todomvc/src/main.rs
@@ -36,7 +36,7 @@ impl Action for TodoAction {}
 fn todo_item(todo: &mut Todo, editing: bool) -> impl Element<Todo, TodoAction> {
     let checkbox = el::input(())
         .class("toggle")
-        .attr("type", "checkbox")
+        .type_("checkbox")
         .checked(todo.completed)
         .on_click(|state: &mut Todo, _| state.completed = !state.completed);
 
@@ -166,7 +166,7 @@ fn main_view(state: &mut AppState, should_display: bool) -> impl Element<AppStat
     let toggle_all = el::input(())
         .attr("id", "toggle-all")
         .class("toggle-all")
-        .attr("type", "checkbox")
+        .type_("checkbox")
         .checked(state.are_all_complete());
 
     el::section((


### PR DESCRIPTION
This allows zooming with the mousewheel and panning with the mid/right mouse button.
I think it would be nice to add touch support with a pinch gesture handler as well.

It also replaces the random color with a color selector. And makes the stroke width range logarithmic.
And adds `type_` and `name` attributes to `HtmlInputElement`.

It was also optimized by using an `Rc<AnyDomView>` to memoize all previously drawn lines. This way I think the bottleneck now certainly is the browser.