### PR TITLE
Add padding attribute to `sized_box` view

### DIFF
--- a/masonry/src/widget/mod.rs
+++ b/masonry/src/widget/mod.rs
@@ -44,7 +44,7 @@ pub use progress_bar::ProgressBar;
 pub use prose::Prose;
 pub use root_widget::RootWidget;
 pub use scroll_bar::ScrollBar;
-pub use sized_box::SizedBox;
+pub use sized_box::{Padding, SizedBox};
 pub use spinner::Spinner;
 pub use split::Split;
 pub use textbox::Textbox;

--- a/masonry/src/widget/screenshots/masonry__widget__sized_box__tests__label_box_with_background_and_padding.png
+++ b/masonry/src/widget/screenshots/masonry__widget__sized_box__tests__label_box_with_background_and_padding.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c48f94e963359d2828503301a009a70ed979548a72ee4bd8ffd69bede970eee5
+size 4962

--- a/masonry/src/widget/screenshots/masonry__widget__sized_box__tests__label_box_with_outer_padding.png
+++ b/masonry/src/widget/screenshots/masonry__widget__sized_box__tests__label_box_with_outer_padding.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:065c6243f27710e0ccf57eb352fb1b835430cde82b143aa5108e9550e5905513
+size 5020

--- a/masonry/src/widget/screenshots/masonry__widget__sized_box__tests__label_box_with_padding.png
+++ b/masonry/src/widget/screenshots/masonry__widget__sized_box__tests__label_box_with_padding.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a455d1ba7eb1806b0d228d2b67aac89a657f77c02feca4f8b41c216e7718d447
+size 5422

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -25,6 +25,23 @@ struct BorderStyle {
     color: Color,
 }
 
+/// Padding specifies the spacing between the edges of the box and the child view.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Padding {
+    /// The amount of padding in logical pixels for the top edge.
+    pub top: f64,
+    /// The amount of padding in logical pixels for the trailing edge.
+    ///
+    /// For LTR contexts this is the right edge, for RTL it is the left edge.
+    pub trailing: f64,
+    /// The amount of padding in logical pixels for the bottom edge.
+    pub bottom: f64,
+    /// The amount of padding in logical pixels for the leading edge.
+    ///
+    /// For LTR contexts this is the left edge, for RTL it is the right edge.
+    pub leading: f64,
+}
+
 // TODO - Have Widget type as generic argument
 
 /// A widget with predefined size.
@@ -44,6 +61,83 @@ pub struct SizedBox {
     border: Option<BorderStyle>,
     corner_radius: RoundedRectRadii,
     padding: Padding,
+}
+
+// --- MARK: IMPL PADDING ---
+
+impl Padding {
+    /// Constructs a new `Padding` by specifying the amount of padding for each edge.
+    pub const fn new(top: f64, trailing: f64, bottom: f64, leading: f64) -> Self {
+        Self {
+            top,
+            trailing,
+            bottom,
+            leading,
+        }
+    }
+
+    /// A padding of zero for all edges.
+    pub const ZERO: Padding = Padding::all(0.);
+
+    /// Constructs a new `Padding` with equal amount of padding for all edges.
+    pub const fn all(padding: f64) -> Self {
+        Self::new(padding, padding, padding, padding)
+    }
+
+    /// Constructs a new `Padding` with the same amount of padding for the horizontal edges,
+    /// and zero padding for the vertical edges.
+    pub const fn horizontal(padding: f64) -> Self {
+        Self::new(0., padding, 0., padding)
+    }
+
+    /// Constructs a new `Padding` with the same amount of padding for the vertical edges,
+    /// and zero padding for the horizontal edges.
+    pub const fn vertical(padding: f64) -> Self {
+        Self::new(padding, 0., padding, 0.)
+    }
+
+    /// Constructs a new `Padding` with padding only at the top edge and zero padding for all other edges.
+    pub const fn top(padding: f64) -> Self {
+        Self::new(padding, 0., 0., 0.)
+    }
+
+    /// Constructs a new `Padding` with padding only at the trailing edge and zero padding for all other edges.
+    pub const fn trailing(padding: f64) -> Self {
+        Self::new(0., padding, 0., 0.)
+    }
+
+    /// Constructs a new `Padding` with padding only at the bottom edge and zero padding for all other edges.
+    pub const fn bottom(padding: f64) -> Self {
+        Self::new(0., 0., padding, 0.)
+    }
+
+    /// Constructs a new `Padding` with padding only at the leading edge and zero padding for all other edges.
+    pub const fn leading(padding: f64) -> Self {
+        Self::new(0., 0., 0., padding)
+    }
+}
+
+impl From<f64> for Padding {
+    /// Converts the value to a `Padding` object with that amount of padding on all edges.
+    fn from(value: f64) -> Self {
+        Self::all(value)
+    }
+}
+
+impl From<(f64, f64, f64, f64)> for Padding {
+    /// Converts the tuple to a `Padding` object,
+    /// following CSS padding order for 4 values (top, trailing, bottom, leading).
+    fn from(value: (f64, f64, f64, f64)) -> Self {
+        Self::new(value.0, value.1, value.2, value.3)
+    }
+}
+
+impl From<(f64, f64)> for Padding {
+    /// Converts the tuple to a `Padding` object,
+    /// following CSS padding order for 2 values (vertical, horizontal)
+    fn from(value: (f64, f64)) -> Self {
+        Self::new(value.0, value.1, value.0, value.1)
+    }
 }
 
 // --- MARK: BUILDERS ---
@@ -184,7 +278,7 @@ impl SizedBox {
         self
     }
 
-    /// Builder style method for specifying the padding between the box and the child widget.
+    /// Builder style method for specifying the padding added by the box.
     pub fn padding(mut self, padding: impl Into<Padding>) -> Self {
         self.padding = padding.into();
         self
@@ -587,98 +681,4 @@ mod tests {
     }
 
     // TODO - add screenshot tests for different brush types
-}
-
-// --- MARK: PADDING STRUCT ---
-
-/// Padding specifies the spacing between the edges of the box and the child view.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Padding {
-    /// The amount of padding for the top edge.
-    pub top: f64,
-    /// The amount of padding for the trailing edge.
-    ///
-    /// For LTR contexts this is the right edge, for RTL it is the left edge.
-    pub trailing: f64,
-    /// The amount of padding for the bottom edge.
-    pub bottom: f64,
-    /// The amount of padding for the leading edge.
-    ///
-    /// For LTR contexts this is the left edge, for RTL it is the right edge.
-    pub leading: f64,
-}
-
-impl Padding {
-    /// Creates a new [Padding] object by specifying the amount of padding for each edge.
-    pub const fn new(top: f64, trailing: f64, bottom: f64, leading: f64) -> Self {
-        Self {
-            top,
-            trailing,
-            bottom,
-            leading,
-        }
-    }
-
-    /// A padding of zero for all edges.
-    pub const ZERO: Padding = Padding::all(0.);
-
-    /// Creates a new [Padding] object with equal amount of padding for all edges.
-    pub const fn all(padding: f64) -> Self {
-        Self::new(padding, padding, padding, padding)
-    }
-
-    /// Creates a new [Padding] object with the same amount of padding for the horizontal edges,
-    /// and zero padding for the vertical edges.
-    pub const fn horizontal(padding: f64) -> Self {
-        Self::new(0., padding, 0., padding)
-    }
-
-    /// Creates a new [Padding] object with the same amount of padding for the vertical edges,
-    /// and zero padding for the horizontal edges.
-    pub const fn vertical(padding: f64) -> Self {
-        Self::new(padding, 0., padding, 0.)
-    }
-
-    /// Creates a new [Padding] object with padding only at the top edge and zero padding for all other edges.
-    pub const fn top(padding: f64) -> Self {
-        Self::new(padding, 0., 0., 0.)
-    }
-
-    /// Creates a new [Padding] object with padding only at the trailing edge and zero padding for all other edges.
-    pub const fn trailing(padding: f64) -> Self {
-        Self::new(0., padding, 0., 0.)
-    }
-
-    /// Creates a new [Padding] object with padding only at the bottom edge and zero padding for all other edges.
-    pub const fn bottom(padding: f64) -> Self {
-        Self::new(0., 0., padding, 0.)
-    }
-
-    /// Creates a new [Padding] object with padding only at the leading edge and zero padding for all other edges.
-    pub const fn leading(padding: f64) -> Self {
-        Self::new(0., 0., 0., padding)
-    }
-}
-
-impl From<f64> for Padding {
-    /// Converts the value to a [Padding] object with that amount of padding on all edges.
-    fn from(value: f64) -> Self {
-        Self::all(value)
-    }
-}
-
-impl From<(f64, f64, f64, f64)> for Padding {
-    /// Converts the tuple to a [Padding] object,
-    /// following CSS padding order for 4 values (top, trailing, bottom, leading).
-    fn from(value: (f64, f64, f64, f64)) -> Self {
-        Self::new(value.0, value.1, value.2, value.3)
-    }
-}
-
-impl From<(f64, f64)> for Padding {
-    /// Converts the tuple to a [Padding] object,
-    /// following CSS padding order for 2 values (vertical, horizontal)
-    fn from(value: (f64, f64)) -> Self {
-        Self::new(value.0, value.1, value.0, value.1)
-    }
 }

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -26,6 +26,9 @@ struct BorderStyle {
 }
 
 /// Padding specifies the spacing between the edges of the box and the child view.
+///
+/// A Padding can also be constructed using [`from(value: f64)`][Self::from]
+/// as well as from a `(f64, f64)` tuple, or `(f64, f64, f64, f64)` tuple, following the CSS padding conventions.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Padding {
     /// The amount of padding in logical pixels for the top edge.

--- a/masonry/src/widget/snapshots/masonry__widget__sized_box__tests__label_box_with_padding.snap
+++ b/masonry/src/widget/snapshots/masonry__widget__sized_box__tests__label_box_with_padding.snap
@@ -1,0 +1,7 @@
+---
+source: masonry/src/widget/sized_box.rs
+expression: harness.root_widget()
+---
+SizedBox(
+    Label<hello>,
+)

--- a/masonry/src/widget/snapshots/masonry__widget__sized_box__tests__label_box_with_padding_and_background.snap
+++ b/masonry/src/widget/snapshots/masonry__widget__sized_box__tests__label_box_with_padding_and_background.snap
@@ -1,0 +1,7 @@
+---
+source: masonry/src/widget/sized_box.rs
+expression: harness.root_widget()
+---
+SizedBox(
+    Label<hello>,
+)

--- a/masonry/src/widget/snapshots/masonry__widget__sized_box__tests__label_box_with_padding_outside.snap
+++ b/masonry/src/widget/snapshots/masonry__widget__sized_box__tests__label_box_with_padding_outside.snap
@@ -1,0 +1,9 @@
+---
+source: masonry/src/widget/sized_box.rs
+expression: harness.root_widget()
+---
+SizedBox(
+    SizedBox(
+        Label<hello>,
+    ),
+)

--- a/xilem/examples/http_cats.rs
+++ b/xilem/examples/http_cats.rs
@@ -10,6 +10,7 @@
 
 use std::sync::Arc;
 
+use masonry::widget::Padding;
 use vello::peniko::{Blob, Image};
 use winit::dpi::LogicalSize;
 use winit::error::EventLoopError;
@@ -18,7 +19,7 @@ use xilem::core::fork;
 use xilem::core::one_of::OneOf3;
 use xilem::view::{
     button, flex, image, inline_prose, portal, prose, sized_box, spinner, worker, Axis, FlexExt,
-    FlexSpacer, Padding,
+    FlexSpacer,
 };
 use xilem::{Color, EventLoop, EventLoopBuilder, TextAlignment, WidgetView, Xilem};
 
@@ -54,7 +55,7 @@ impl HttpCats {
                 .map(Status::list_view)
                 .collect::<Vec<_>>(),
         ))))
-        .padding(Padding::leading(20.));
+        .padding(Padding::leading(5.));
 
         let (info_area, worker_value) = if let Some(selected_code) = self.selected_code {
             if let Some(selected_status) =
@@ -199,8 +200,9 @@ impl Status {
             FlexSpacer::Fixed(10.),
             image,
             // TODO: Overlay on top of the image?
+            // HACK: Trailing padding workaround scrollbar covering content
             sized_box(prose("Copyright ©️ https://http.cat").alignment(TextAlignment::End))
-                .padding(Padding::trailing(20.)),
+                .padding(Padding::trailing(15.)),
         ))
         .main_axis_alignment(xilem::view::MainAxisAlignment::Start)
     }

--- a/xilem/examples/http_cats.rs
+++ b/xilem/examples/http_cats.rs
@@ -18,7 +18,7 @@ use xilem::core::fork;
 use xilem::core::one_of::OneOf3;
 use xilem::view::{
     button, flex, image, inline_prose, portal, prose, sized_box, spinner, worker, Axis, FlexExt,
-    FlexSpacer,
+    FlexSpacer, Padding,
 };
 use xilem::{Color, EventLoop, EventLoopBuilder, TextAlignment, WidgetView, Xilem};
 
@@ -47,13 +47,15 @@ enum ImageState {
 
 impl HttpCats {
     fn view(&mut self) -> impl WidgetView<HttpCats> {
-        let left_column = portal(flex((
+        let left_column = sized_box(portal(flex((
             prose("Status"),
             self.statuses
                 .iter_mut()
                 .map(Status::list_view)
                 .collect::<Vec<_>>(),
-        )));
+        ))))
+        .padding(Padding::leading(20.));
+
         let (info_area, worker_value) = if let Some(selected_code) = self.selected_code {
             if let Some(selected_status) =
                 self.statuses.iter_mut().find(|it| it.code == selected_code)
@@ -197,8 +199,8 @@ impl Status {
             FlexSpacer::Fixed(10.),
             image,
             // TODO: Overlay on top of the image?
-            // HACK: Trailing spaces workaround scrollbar covering content
-            prose("Copyright ©️ https://http.cat      ").alignment(TextAlignment::End),
+            sized_box(prose("Copyright ©️ https://http.cat").alignment(TextAlignment::End))
+                .padding(Padding::trailing(20.)),
         ))
         .main_axis_alignment(xilem::view::MainAxisAlignment::Start)
     }

--- a/xilem/examples/http_cats.rs
+++ b/xilem/examples/http_cats.rs
@@ -10,7 +10,6 @@
 
 use std::sync::Arc;
 
-use masonry::widget::Padding;
 use vello::peniko::{Blob, Image};
 use winit::dpi::LogicalSize;
 use winit::error::EventLoopError;
@@ -19,7 +18,7 @@ use xilem::core::fork;
 use xilem::core::one_of::OneOf3;
 use xilem::view::{
     button, flex, image, inline_prose, portal, prose, sized_box, spinner, worker, Axis, FlexExt,
-    FlexSpacer,
+    FlexSpacer, Padding,
 };
 use xilem::{Color, EventLoop, EventLoopBuilder, TextAlignment, WidgetView, Xilem};
 

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -297,8 +297,8 @@ impl From<Insets> for Padding {
     }
 }
 
-impl Into<Insets> for Padding {
-    fn into(self) -> Insets {
-        Insets::new(self.leading, self.top, self.trailing, self.bottom)
+impl From<Padding> for Insets {
+    fn from(value: Padding) -> Self {
+        Insets::new(value.leading, value.top, value.trailing, value.bottom)
     }
 }

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -3,7 +3,8 @@
 
 use std::marker::PhantomData;
 
-use masonry::widget::{self, Padding};
+use masonry::widget;
+pub use masonry::widget::Padding;
 use vello::kurbo::RoundedRectRadii;
 use vello::peniko::{Brush, Color};
 

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -277,10 +277,17 @@ impl From<f64> for Padding {
     }
 }
 
-// Follows CSS padding order of values
+// Follows CSS padding order for 4 values (top, trailing, bottom, leading)
 impl From<(f64, f64, f64, f64)> for Padding {
     fn from(value: (f64, f64, f64, f64)) -> Self {
         Self::new(value.0, value.1, value.2, value.3)
+    }
+}
+
+// Follows CSS padding order for 2 values (vertical, horizontal)
+impl From<(f64, f64)> for Padding {
+    fn from(value: (f64, f64)) -> Self {
+        Self::new(value.0, value.1, value.0, value.1)
     }
 }
 

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -3,7 +3,7 @@
 
 use std::marker::PhantomData;
 
-use masonry::{widget, Insets};
+use masonry::widget::{self, Padding};
 use vello::kurbo::RoundedRectRadii;
 use vello::peniko::{Brush, Color};
 
@@ -220,85 +220,4 @@ where
 struct BorderStyle {
     width: f64,
     color: Color,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Padding {
-    top: f64,
-    trailing: f64,
-    bottom: f64,
-    leading: f64,
-}
-
-impl Padding {
-    pub const fn new(top: f64, trailing: f64, bottom: f64, leading: f64) -> Self {
-        Self {
-            top,
-            trailing,
-            bottom,
-            leading,
-        }
-    }
-
-    pub const ZERO: Padding = Padding::all(0.);
-
-    pub const fn all(padding: f64) -> Self {
-        Self::new(padding, padding, padding, padding)
-    }
-
-    pub const fn horizontal(padding: f64) -> Self {
-        Self::new(0., padding, 0., padding)
-    }
-
-    pub const fn vertical(padding: f64) -> Self {
-        Self::new(padding, 0., padding, 0.)
-    }
-
-    pub const fn top(padding: f64) -> Self {
-        Self::new(padding, 0., 0., 0.)
-    }
-
-    pub const fn trailing(padding: f64) -> Self {
-        Self::new(0., padding, 0., 0.)
-    }
-
-    pub const fn bottom(padding: f64) -> Self {
-        Self::new(0., 0., padding, 0.)
-    }
-
-    pub const fn leading(padding: f64) -> Self {
-        Self::new(0., 0., 0., padding)
-    }
-}
-
-impl From<f64> for Padding {
-    fn from(value: f64) -> Self {
-        Self::all(value)
-    }
-}
-
-// Follows CSS padding order for 4 values (top, trailing, bottom, leading)
-impl From<(f64, f64, f64, f64)> for Padding {
-    fn from(value: (f64, f64, f64, f64)) -> Self {
-        Self::new(value.0, value.1, value.2, value.3)
-    }
-}
-
-// Follows CSS padding order for 2 values (vertical, horizontal)
-impl From<(f64, f64)> for Padding {
-    fn from(value: (f64, f64)) -> Self {
-        Self::new(value.0, value.1, value.0, value.1)
-    }
-}
-
-impl From<Insets> for Padding {
-    fn from(value: Insets) -> Self {
-        Self::new(value.y0, value.x1, value.y1, value.x0)
-    }
-}
-
-impl From<Padding> for Insets {
-    fn from(value: Padding) -> Self {
-        Insets::new(value.leading, value.top, value.trailing, value.bottom)
-    }
 }


### PR DESCRIPTION
## Changes

### Masonry
- Added new padding attribute to sized_box Masonry widget.
- 3 unit tests demonstrating how padding is used.

### Xilem
- Added `Padding` struct with convenience methods for working with paddings.
- Updated `http_cats` example to use padding when more convenient and fixed hack.

## Examples

```rs
sized_box(label("hello world")).padding(10.) // Equal padding on all edges
sized_box(label("hello world")).padding(Padding::top(10.)) // Padding only on top edge
sized_box(label("hello world")).padding((10., 20., 30., 40.)) // Different padding for each edge
```

## HTTP Cats

Added padding on the left in the `http_cats` example, to make it more balanced with the right side.
<img width="912" alt="Screenshot 2024-11-10 at 16 22 52" src="https://github.com/user-attachments/assets/ce5fd4e6-412b-46c1-9387-6886ef97e653">

## Discussion

### Rename `sized_box` to `frame`?

In swiftUI the view modifier [`.frame()`](https://developer.apple.com/documentation/swiftui/view/frame(width:height:alignment:)) is used to change the size of a view. I think the name `frame` better describes the purpose of `sized_box`, since it also does backgrounds, borders (and now padding). So I wanted to suggest that `sized_box` be renamed to `frame`.

### Add `SizedBoxExt` for better ergonomics?

Similar to [`FlexExt`](https://github.com/linebender/xilem/blob/62588565692584e16197fb6d19cd3b41c104b675/xilem/src/view/flex.rs#L340C11-L340C18) and [`GridExt`](https://github.com/linebender/xilem/blob/62588565692584e16197fb6d19cd3b41c104b675/xilem/src/view/grid.rs#L248), I was thinking that a new `SizedBoxExt` could be introduced to easily wrap any view in a `sized_box`, something like the following.

```rust
pub trait SizedBoxExt<State, Action>: WidgetView<State, Action> {
  fn sized_box(self) -> SizedBox<Self, State, Action> {
    sized_box(self)
  }
}
```

This would allow for chaining modifiers like this:

```rust
label("Hello world")
  .text_size(20.)
  .sized_box() // After this padding, background, width, height can be added
  .padding(20.)
```

Or even somthing more advanced like this:

```rust
label("Hello world")
  .sized_box()
  .padding(20.)
  .background(Color::Teal)
  .border(Color::Blue, 4.)
  .sized_box() // By wrapping in another sized box we add another border rather than overwriting the previous one
  .border(Color::Magenta, 4.)
```
