### PR TITLE
Fix `missing_debug_implementations` in Xilem Core

### DIFF
--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -52,8 +52,12 @@ impl RawProxy for MasonryProxy {
             }
         }
     }
+    fn dyn_debug(&self) -> &dyn std::fmt::Debug {
+        self
+    }
 }
 
+#[derive(Debug)]
 pub struct MasonryProxy(pub(crate) EventLoopProxy);
 
 impl MasonryProxy {

--- a/xilem_core/src/any_view.rs
+++ b/xilem_core/src/any_view.rs
@@ -166,6 +166,7 @@ where
 /// The state used by [`AnyView`].
 #[doc(hidden)]
 #[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
+#[derive(Debug)]
 pub struct AnyViewState {
     inner_state: Box<dyn Any>,
     /// The generation is the value which is shown

--- a/xilem_core/src/docs.rs
+++ b/xilem_core/src/docs.rs
@@ -38,6 +38,7 @@
 use crate::{run_once, View, ViewPathTracker};
 
 /// A type used for documentation
+#[derive(Debug)]
 pub enum Fake {}
 
 impl ViewPathTracker for Fake {
@@ -63,6 +64,7 @@ pub trait DocsView<State, Action = ()>: View<State, Action, Fake> {}
 impl<V, State, Action> DocsView<State, Action> for V where V: View<State, Action, Fake> {}
 
 /// A state type usable in a component
+#[derive(Debug)]
 pub struct State;
 
 /// A minimal component.

--- a/xilem_core/src/element.rs
+++ b/xilem_core/src/element.rs
@@ -87,6 +87,7 @@ where
 /// correct `State` and `Action` types), as they do not need to actually add an element to the sequence.
 ///
 /// These views can also as the `alongside_view` in [`fork`](crate::fork).
+#[derive(Debug)]
 pub struct NoElement;
 
 impl ViewElement for NoElement {

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -24,7 +24,6 @@
 #![warn(clippy::print_stdout, clippy::print_stderr)]
 // TODO: Remove any items listed as "Deferred"
 #![deny(clippy::trivially_copy_pass_by_ref)]
-#![expect(missing_debug_implementations, reason = "Deferred: Noisy")]
 #![expect(unused_qualifications, reason = "Deferred: Noisy")]
 #![expect(single_use_lifetimes, reason = "Deferred: Noisy")]
 #![expect(clippy::exhaustive_enums, reason = "Deferred: Noisy")]

--- a/xilem_core/src/message.rs
+++ b/xilem_core/src/message.rs
@@ -11,7 +11,7 @@ use core::ops::Deref;
 /// The possible outcomes from a [`View::message`]
 ///
 /// [`View::message`]: crate::View::message
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub enum MessageResult<Action, Message = DynMessage> {
     /// An action for a parent message handler to use
     ///

--- a/xilem_core/src/sequence.rs
+++ b/xilem_core/src/sequence.rs
@@ -197,6 +197,7 @@ where
 
 /// The state used to implement `ViewSequence` for `Option<impl ViewSequence>`
 #[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
+#[derive(Debug)]
 pub struct OptionSeqState<InnerState> {
     /// The current state.
     ///
@@ -341,6 +342,7 @@ where
 // This is managed in [`create_generational_view_id`] and [`view_id_to_index_generation`]
 #[doc(hidden)]
 #[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
+#[derive(Debug)]
 pub struct VecViewState<InnerState> {
     inner_states: Vec<InnerState>,
 

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -206,6 +206,7 @@ where
 }
 
 #[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
+#[derive(Debug)]
 pub struct RcState<ViewState> {
     view_state: ViewState,
     /// This is a flag that is set, when an inner view signifies that it requires a rebuild (via [`MessageResult::RequestRebuild`]).

--- a/xilem_core/src/views/adapt.rs
+++ b/xilem_core/src/views/adapt.rs
@@ -6,6 +6,7 @@ use core::marker::PhantomData;
 use crate::{MessageResult, Mut, View, ViewId, ViewMarker, ViewPathTracker};
 
 /// A view that wraps a child view and modifies the state that callbacks have access to.
+#[derive(Debug)]
 pub struct Adapt<
     ParentState,
     ParentAction,
@@ -37,6 +38,7 @@ pub struct Adapt<
 ///
 /// The closure passed to [`Adapt`] should call this thunk with the child's
 /// app state.
+#[derive(Debug)]
 pub struct AdaptThunk<'a, ChildState, ChildAction, Context, ChildView, Message>
 where
     Context: ViewPathTracker,

--- a/xilem_core/src/views/fork.rs
+++ b/xilem_core/src/views/fork.rs
@@ -20,6 +20,7 @@ pub fn fork<Active, Alongside>(
 }
 
 /// The view for [`fork`].
+#[derive(Debug)]
 pub struct Fork<Active, Alongside> {
     active_view: Active,
     alongside_view: Alongside,

--- a/xilem_core/src/views/map_state.rs
+++ b/xilem_core/src/views/map_state.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use core::marker::PhantomData;
+use core::{fmt::Debug, marker::PhantomData};
 
 use crate::{MessageResult, Mut, View, ViewId, ViewMarker, ViewPathTracker};
 
@@ -12,6 +12,18 @@ pub struct MapState<V, F, ParentState, ChildState, Action, Context, Message> {
     map_state: F,
     child: V,
     phantom: PhantomData<fn(ParentState) -> (ChildState, Action, Context, Message)>,
+}
+
+impl<V, F, ParentState, ChildState, Action, Context, Message> Debug
+    for MapState<V, F, ParentState, ChildState, Action, Context, Message>
+where
+    V: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MapAction")
+            .field("child", &self.child)
+            .finish_non_exhaustive()
+    }
 }
 
 /// A view that "extracts" state from a [`View<ParentState,_,_>`] to [`View<ChildState,_,_>`].

--- a/xilem_core/src/views/one_of.rs
+++ b/xilem_core/src/views/one_of.rs
@@ -22,6 +22,7 @@ pub trait PhantomElementCtx: ViewPathTracker {
 
 /// A [`View`] which can be one of nine inner view types.
 #[allow(missing_docs)] // On variants
+#[derive(Debug)]
 pub enum OneOf<A = (), B = (), C = (), D = (), E = (), F = (), G = (), H = (), I = ()> {
     A(A),
     B(B),
@@ -552,6 +553,7 @@ mod hidden {
     use crate::{View, ViewMarker};
 
     #[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
+    #[derive(Debug)]
     pub enum Never {}
 
     impl ViewMarker for Never {}
@@ -592,6 +594,7 @@ mod hidden {
     }
     /// The state used to implement `View` for `OneOfN`
     #[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
+    #[derive(Debug)]
     pub struct OneOfState<A, B, C, D, E, F, G, H, I> {
         /// The current state of the inner view or view sequence.
         pub(super) inner_state: super::OneOf<A, B, C, D, E, F, G, H, I>,

--- a/xilem_core/src/views/run_once.rs
+++ b/xilem_core/src/views/run_once.rs
@@ -75,6 +75,12 @@ pub struct RunOnce<F> {
     once: F,
 }
 
+impl<F> Debug for RunOnce<F> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RunOnce").finish_non_exhaustive()
+    }
+}
+
 impl<F> ViewMarker for RunOnce<F> {}
 impl<F, State, Action, Context, Message> View<State, Action, Context, Message> for RunOnce<F>
 where

--- a/xilem_web/src/lib.rs
+++ b/xilem_web/src/lib.rs
@@ -218,7 +218,10 @@ pub trait DomView<State, Action = ()>:
     }
 
     /// See [`map_action`](`core::map_action`)
-    fn map_action<ParentAction, F>(self, f: F) -> MapAction<State, ParentAction, Action, Self, F>
+    fn map_action<ParentAction, F>(
+        self,
+        f: F,
+    ) -> MapAction<Self, State, ParentAction, Action, ViewCtx, DynMessage, F>
     where
         State: 'static,
         ParentAction: 'static,


### PR DESCRIPTION
This also updates to use `core::error::Error` now that it is stable.