### PR TITLE
Fix `unused_qualifications` in Xilem Core

### DIFF
--- a/xilem_core/src/any_view.rs
+++ b/xilem_core/src/any_view.rs
@@ -182,7 +182,7 @@ impl<State, Action, Context, Element, Message> View<State, Action, Context, Mess
 where
     // Element must be `static` so it can be downcasted
     Element: ViewElement + 'static,
-    Context: crate::ViewPathTracker + 'static,
+    Context: ViewPathTracker + 'static,
     State: 'static,
     Action: 'static,
     Message: 'static,
@@ -217,10 +217,10 @@ where
     fn message(
         &self,
         view_state: &mut Self::ViewState,
-        id_path: &[crate::ViewId],
+        id_path: &[ViewId],
         message: Message,
         app_state: &mut State,
-    ) -> crate::MessageResult<Action, Message> {
+    ) -> MessageResult<Action, Message> {
         self.dyn_message(view_state, id_path, message, app_state)
     }
 }
@@ -236,7 +236,7 @@ impl<State, Action, Context, Element, Message> View<State, Action, Context, Mess
 where
     // Element must be `static` so it can be downcasted
     Element: ViewElement + 'static,
-    Context: crate::ViewPathTracker + 'static,
+    Context: ViewPathTracker + 'static,
     State: 'static,
     Action: 'static,
     Message: 'static,
@@ -271,10 +271,10 @@ where
     fn message(
         &self,
         view_state: &mut Self::ViewState,
-        id_path: &[crate::ViewId],
+        id_path: &[ViewId],
         message: Message,
         app_state: &mut State,
-    ) -> crate::MessageResult<Action, Message> {
+    ) -> MessageResult<Action, Message> {
         self.dyn_message(view_state, id_path, message, app_state)
     }
 }
@@ -288,7 +288,7 @@ impl<State, Action, Context, Element, Message> View<State, Action, Context, Mess
 where
     // Element must be `static` so it can be downcasted
     Element: ViewElement + 'static,
-    Context: crate::ViewPathTracker + 'static,
+    Context: ViewPathTracker + 'static,
     State: 'static,
     Action: 'static,
     Message: 'static,
@@ -323,10 +323,10 @@ where
     fn message(
         &self,
         view_state: &mut Self::ViewState,
-        id_path: &[crate::ViewId],
+        id_path: &[ViewId],
         message: Message,
         app_state: &mut State,
-    ) -> crate::MessageResult<Action, Message> {
+    ) -> MessageResult<Action, Message> {
         self.dyn_message(view_state, id_path, message, app_state)
     }
 }
@@ -340,7 +340,7 @@ impl<State, Action, Context, Element, Message> View<State, Action, Context, Mess
 where
     // Element must be `static` so it can be downcasted
     Element: ViewElement + 'static,
-    Context: crate::ViewPathTracker + 'static,
+    Context: ViewPathTracker + 'static,
     State: 'static,
     Action: 'static,
     Message: 'static,
@@ -375,10 +375,10 @@ where
     fn message(
         &self,
         view_state: &mut Self::ViewState,
-        id_path: &[crate::ViewId],
+        id_path: &[ViewId],
         message: Message,
         app_state: &mut State,
-    ) -> crate::MessageResult<Action, Message> {
+    ) -> MessageResult<Action, Message> {
         self.dyn_message(view_state, id_path, message, app_state)
     }
 }

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -24,7 +24,6 @@
 #![warn(clippy::print_stdout, clippy::print_stderr)]
 // TODO: Remove any items listed as "Deferred"
 #![deny(clippy::trivially_copy_pass_by_ref)]
-#![expect(unused_qualifications, reason = "Deferred: Noisy")]
 #![expect(single_use_lifetimes, reason = "Deferred: Noisy")]
 #![expect(clippy::exhaustive_enums, reason = "Deferred: Noisy")]
 #![expect(clippy::missing_assert_message, reason = "Deferred: Noisy")]

--- a/xilem_core/src/views/fork.rs
+++ b/xilem_core/src/views/fork.rs
@@ -88,7 +88,7 @@ where
     fn message(
         &self,
         (active_state, alongside_state): &mut Self::ViewState,
-        id_path: &[crate::ViewId],
+        id_path: &[ViewId],
         message: Message,
         app_state: &mut State,
     ) -> crate::MessageResult<Action, Message> {

--- a/xilem_core/src/views/memoize.rs
+++ b/xilem_core/src/views/memoize.rs
@@ -250,10 +250,10 @@ where
     fn message(
         &self,
         view_state: &mut Self::ViewState,
-        id_path: &[crate::ViewId],
+        id_path: &[ViewId],
         message: Message,
         app_state: &mut State,
-    ) -> crate::MessageResult<Action, Message> {
+    ) -> MessageResult<Action, Message> {
         let message_result =
             view_state
                 .view

--- a/xilem_core/src/views/one_of.rs
+++ b/xilem_core/src/views/one_of.rs
@@ -213,7 +213,7 @@ where
     type Element = Context::OneOfElement;
 
     #[doc(hidden)]
-    type ViewState = hidden::OneOfState<
+    type ViewState = OneOfState<
         A::ViewState,
         B::ViewState,
         C::ViewState,

--- a/xilem_core/src/views/orphan.rs
+++ b/xilem_core/src/views/orphan.rs
@@ -1,6 +1,11 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(
+    unused_qualifications,
+    reason = "We have `std` enabled when testing, which means that some items are conditionally in the prelude."
+)]
+
 use crate::{
     DynMessage, MessageResult, Mut, View, ViewElement, ViewId, ViewMarker, ViewPathTracker,
 };

--- a/xilem_core/src/views/run_once.rs
+++ b/xilem_core/src/views/run_once.rs
@@ -49,7 +49,7 @@ where
 {
     const {
         assert!(
-            core::mem::size_of::<F>() == 0,
+            size_of::<F>() == 0,
             "`run_once` will not be ran again when its captured variables are updated.\n\
             To ignore this warning, use `run_once_raw`."
         );


### PR DESCRIPTION
Most of the change is remove the `expect` and run `cargo fix`.

For the orphan view, I've added a blanket exception. At the moment, this only applies to String, but the

I did try using `#![no_implicit_prelude]` in that module, but there are a lot of useful things in the implicit prelude, it was worse than the exception.