### PR TITLE
Fix `clippy::use_self` in Xilem Core

### DIFF
--- a/masonry/src/text/backspace.rs
+++ b/masonry/src/text/backspace.rs
@@ -6,7 +6,7 @@
 // TODO: `expect` doesn't work here
 #[allow(
     clippy::wildcard_imports,
-    reason = "Mostly a wrapper around xi_unicode."
+    reason = "Mostly a wrapper around xi_unicode"
 )]
 use xi_unicode::*;
 

--- a/xilem_core/examples/filesystem.rs
+++ b/xilem_core/examples/filesystem.rs
@@ -3,7 +3,6 @@
 
 //! An example using Xilem Core to manipulate a filesystem.
 
-#![expect(clippy::use_self, reason = "Deferred: Noisy")]
 #![expect(let_underscore_drop, reason = "Deferred: Noisy")]
 
 use std::io::stdin;
@@ -104,22 +103,22 @@ impl<V, State, Action> FileView<State, Action> for V where
 
 type DynFileView<State, Action = ()> = Box<dyn AnyView<State, Action, ViewCtx, FsPath>>;
 
-impl SuperElement<FsPath, ViewCtx> for FsPath {
-    fn upcast(_ctx: &mut ViewCtx, child: FsPath) -> Self {
+impl SuperElement<Self, ViewCtx> for FsPath {
+    fn upcast(_ctx: &mut ViewCtx, child: Self) -> Self {
         child
     }
 
     fn with_downcast_val<R>(
         this: Self::Mut<'_>,
-        f: impl FnOnce(Mut<'_, FsPath>) -> R,
+        f: impl FnOnce(Mut<'_, Self>) -> R,
     ) -> (Self::Mut<'_>, R) {
         let ret = f(this);
         (this, ret)
     }
 }
 
-impl AnyElement<FsPath, ViewCtx> for FsPath {
-    fn replace_inner(this: Self::Mut<'_>, child: FsPath) -> Self::Mut<'_> {
+impl AnyElement<Self, ViewCtx> for FsPath {
+    fn replace_inner(this: Self::Mut<'_>, child: Self) -> Self::Mut<'_> {
         *this = child.0;
         this
     }

--- a/xilem_core/src/deferred.rs
+++ b/xilem_core/src/deferred.rs
@@ -126,11 +126,11 @@ pub enum ProxyError {
 impl Display for ProxyError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match &self {
-            ProxyError::DriverFinished(_) => f.write_fmt(format_args!("the driver finished")),
-            ProxyError::ViewExpired(_, _) => {
+            Self::DriverFinished(_) => f.write_fmt(format_args!("the driver finished")),
+            Self::ViewExpired(_, _) => {
                 f.write_fmt(format_args!("the corresponding view is no longer present"))
             }
-            ProxyError::Other(inner) => Display::fmt(inner, f),
+            Self::Other(inner) => Display::fmt(inner, f),
         }
     }
 }
@@ -138,7 +138,7 @@ impl Display for ProxyError {
 impl core::error::Error for ProxyError {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
-            ProxyError::Other(inner) => inner.source(),
+            Self::Other(inner) => inner.source(),
             _ => None,
         }
     }

--- a/xilem_core/src/element.rs
+++ b/xilem_core/src/element.rs
@@ -96,14 +96,14 @@ impl ViewElement for NoElement {
     type Mut<'a> = ();
 }
 
-impl<Context> SuperElement<NoElement, Context> for NoElement {
-    fn upcast(_ctx: &mut Context, child: NoElement) -> Self {
+impl<Context> SuperElement<Self, Context> for NoElement {
+    fn upcast(_ctx: &mut Context, child: Self) -> Self {
         child
     }
 
     fn with_downcast_val<R>(
         this: Mut<'_, Self>,
-        f: impl FnOnce(Mut<'_, NoElement>) -> R,
+        f: impl FnOnce(Mut<'_, Self>) -> R,
     ) -> (Self::Mut<'_>, R) {
         ((), f(this))
     }

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -27,7 +27,6 @@
 #![expect(single_use_lifetimes, reason = "Deferred: Noisy")]
 #![expect(clippy::exhaustive_enums, reason = "Deferred: Noisy")]
 #![expect(clippy::missing_assert_message, reason = "Deferred: Noisy")]
-#![expect(clippy::use_self, reason = "Deferred: Noisy")]
 #![expect(clippy::missing_errors_doc, reason = "Can be quite noisy?")]
 #![expect(
     clippy::shadow_unrelated,

--- a/xilem_core/src/message.rs
+++ b/xilem_core/src/message.rs
@@ -34,10 +34,10 @@ impl<A, Message> MessageResult<A, Message> {
     /// Maps the action type `A` to `B`, i.e. [`MessageResult<A>`] to [`MessageResult<B>`]
     pub fn map<B>(self, f: impl FnOnce(A) -> B) -> MessageResult<B, Message> {
         match self {
-            MessageResult::Action(a) => MessageResult::Action(f(a)),
-            MessageResult::RequestRebuild => MessageResult::RequestRebuild,
-            MessageResult::Stale(message) => MessageResult::Stale(message),
-            MessageResult::Nop => MessageResult::Nop,
+            Self::Action(a) => MessageResult::Action(f(a)),
+            Self::RequestRebuild => MessageResult::RequestRebuild,
+            Self::Stale(message) => MessageResult::Stale(message),
+            Self::Nop => MessageResult::Nop,
         }
     }
 }

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -244,7 +244,8 @@ where
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
     ) {
-        if core::mem::take(&mut view_state.dirty) || !Self::ptr_eq(self, prev) {
+        #![expect(clippy::use_self, reason = "`Arc::ptr_eq` is the canonical form")]
+        if core::mem::take(&mut view_state.dirty) || !Arc::ptr_eq(self, prev) {
             self.deref()
                 .rebuild(prev, &mut view_state.view_state, ctx, element);
         }
@@ -305,7 +306,8 @@ where
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
     ) {
-        if core::mem::take(&mut view_state.dirty) || !Self::ptr_eq(self, prev) {
+        #![expect(clippy::use_self, reason = "`Rc::ptr_eq` is the canonical form")]
+        if core::mem::take(&mut view_state.dirty) || !Rc::ptr_eq(self, prev) {
             self.deref()
                 .rebuild(prev, &mut view_state.view_state, ctx, element);
         }

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -244,7 +244,7 @@ where
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
     ) {
-        if core::mem::take(&mut view_state.dirty) || !Arc::ptr_eq(self, prev) {
+        if core::mem::take(&mut view_state.dirty) || !Self::ptr_eq(self, prev) {
             self.deref()
                 .rebuild(prev, &mut view_state.view_state, ctx, element);
         }
@@ -305,7 +305,7 @@ where
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
     ) {
-        if core::mem::take(&mut view_state.dirty) || !Rc::ptr_eq(self, prev) {
+        if core::mem::take(&mut view_state.dirty) || !Self::ptr_eq(self, prev) {
             self.deref()
                 .rebuild(prev, &mut view_state.view_state, ctx, element);
         }

--- a/xilem_core/src/views/one_of.rs
+++ b/xilem_core/src/views/one_of.rs
@@ -73,15 +73,15 @@ where
 {
     fn as_ref(&self) -> &T {
         match self {
-            OneOf::A(e) => <A as AsRef<T>>::as_ref(e),
-            OneOf::B(e) => <B as AsRef<T>>::as_ref(e),
-            OneOf::C(e) => <C as AsRef<T>>::as_ref(e),
-            OneOf::D(e) => <D as AsRef<T>>::as_ref(e),
-            OneOf::E(e) => <E as AsRef<T>>::as_ref(e),
-            OneOf::F(e) => <F as AsRef<T>>::as_ref(e),
-            OneOf::G(e) => <G as AsRef<T>>::as_ref(e),
-            OneOf::H(e) => <H as AsRef<T>>::as_ref(e),
-            OneOf::I(e) => <I as AsRef<T>>::as_ref(e),
+            Self::A(e) => <A as AsRef<T>>::as_ref(e),
+            Self::B(e) => <B as AsRef<T>>::as_ref(e),
+            Self::C(e) => <C as AsRef<T>>::as_ref(e),
+            Self::D(e) => <D as AsRef<T>>::as_ref(e),
+            Self::E(e) => <E as AsRef<T>>::as_ref(e),
+            Self::F(e) => <F as AsRef<T>>::as_ref(e),
+            Self::G(e) => <G as AsRef<T>>::as_ref(e),
+            Self::H(e) => <H as AsRef<T>>::as_ref(e),
+            Self::I(e) => <I as AsRef<T>>::as_ref(e),
         }
     }
 }
@@ -100,15 +100,15 @@ where
 {
     fn as_mut(&mut self) -> &mut T {
         match self {
-            OneOf::A(e) => <A as AsMut<T>>::as_mut(e),
-            OneOf::B(e) => <B as AsMut<T>>::as_mut(e),
-            OneOf::C(e) => <C as AsMut<T>>::as_mut(e),
-            OneOf::D(e) => <D as AsMut<T>>::as_mut(e),
-            OneOf::E(e) => <E as AsMut<T>>::as_mut(e),
-            OneOf::F(e) => <F as AsMut<T>>::as_mut(e),
-            OneOf::G(e) => <G as AsMut<T>>::as_mut(e),
-            OneOf::H(e) => <H as AsMut<T>>::as_mut(e),
-            OneOf::I(e) => <I as AsMut<T>>::as_mut(e),
+            Self::A(e) => <A as AsMut<T>>::as_mut(e),
+            Self::B(e) => <B as AsMut<T>>::as_mut(e),
+            Self::C(e) => <C as AsMut<T>>::as_mut(e),
+            Self::D(e) => <D as AsMut<T>>::as_mut(e),
+            Self::E(e) => <E as AsMut<T>>::as_mut(e),
+            Self::F(e) => <F as AsMut<T>>::as_mut(e),
+            Self::G(e) => <G as AsMut<T>>::as_mut(e),
+            Self::H(e) => <H as AsMut<T>>::as_mut(e),
+            Self::I(e) => <I as AsMut<T>>::as_mut(e),
         }
     }
 }
@@ -229,39 +229,39 @@ where
     fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
         let generation = 0;
         let (element, state) = ctx.with_id(ViewId::new(generation), |ctx| match self {
-            OneOf::A(v) => {
+            Self::A(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::A(new_element), OneOf::A(state))
             }
-            OneOf::B(v) => {
+            Self::B(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::B(new_element), OneOf::B(state))
             }
-            OneOf::C(v) => {
+            Self::C(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::C(new_element), OneOf::C(state))
             }
-            OneOf::D(v) => {
+            Self::D(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::D(new_element), OneOf::D(state))
             }
-            OneOf::E(v) => {
+            Self::E(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::E(new_element), OneOf::E(state))
             }
-            OneOf::F(v) => {
+            Self::F(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::F(new_element), OneOf::F(state))
             }
-            OneOf::G(v) => {
+            Self::G(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::G(new_element), OneOf::G(state))
             }
-            OneOf::H(v) => {
+            Self::H(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::H(new_element), OneOf::H(state))
             }
-            OneOf::I(v) => {
+            Self::I(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::I(new_element), OneOf::I(state))
             }
@@ -286,7 +286,7 @@ where
         let id = ViewId::new(view_state.generation);
         // If both elements are of the same type, do a simple rebuild
         match (self, prev, &mut view_state.inner_state) {
-            (OneOf::A(this), OneOf::A(prev), OneOf::A(ref mut state)) => {
+            (Self::A(this), Self::A(prev), OneOf::A(ref mut state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_a(&mut element, |element| {
                         this.rebuild(prev, state, ctx, element);
@@ -294,7 +294,7 @@ where
                 });
                 return;
             }
-            (OneOf::B(this), OneOf::B(prev), OneOf::B(ref mut state)) => {
+            (Self::B(this), Self::B(prev), OneOf::B(ref mut state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_b(&mut element, |element| {
                         this.rebuild(prev, state, ctx, element);
@@ -302,7 +302,7 @@ where
                 });
                 return;
             }
-            (OneOf::C(this), OneOf::C(prev), OneOf::C(ref mut state)) => {
+            (Self::C(this), Self::C(prev), OneOf::C(ref mut state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_c(&mut element, |element| {
                         this.rebuild(prev, state, ctx, element);
@@ -310,7 +310,7 @@ where
                 });
                 return;
             }
-            (OneOf::D(this), OneOf::D(prev), OneOf::D(ref mut state)) => {
+            (Self::D(this), Self::D(prev), OneOf::D(ref mut state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_d(&mut element, |element| {
                         this.rebuild(prev, state, ctx, element);
@@ -318,7 +318,7 @@ where
                 });
                 return;
             }
-            (OneOf::E(this), OneOf::E(prev), OneOf::E(ref mut state)) => {
+            (Self::E(this), Self::E(prev), OneOf::E(ref mut state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_e(&mut element, |element| {
                         this.rebuild(prev, state, ctx, element);
@@ -326,7 +326,7 @@ where
                 });
                 return;
             }
-            (OneOf::F(this), OneOf::F(prev), OneOf::F(ref mut state)) => {
+            (Self::F(this), Self::F(prev), OneOf::F(ref mut state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_f(&mut element, |element| {
                         this.rebuild(prev, state, ctx, element);
@@ -334,7 +334,7 @@ where
                 });
                 return;
             }
-            (OneOf::G(this), OneOf::G(prev), OneOf::G(ref mut state)) => {
+            (Self::G(this), Self::G(prev), OneOf::G(ref mut state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_g(&mut element, |element| {
                         this.rebuild(prev, state, ctx, element);
@@ -342,7 +342,7 @@ where
                 });
                 return;
             }
-            (OneOf::H(this), OneOf::H(prev), OneOf::H(ref mut state)) => {
+            (Self::H(this), Self::H(prev), OneOf::H(ref mut state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_h(&mut element, |element| {
                         this.rebuild(prev, state, ctx, element);
@@ -350,7 +350,7 @@ where
                 });
                 return;
             }
-            (OneOf::I(this), OneOf::I(prev), OneOf::I(ref mut state)) => {
+            (Self::I(this), Self::I(prev), OneOf::I(ref mut state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_i(&mut element, |element| {
                         this.rebuild(prev, state, ctx, element);
@@ -363,47 +363,47 @@ where
 
         // We're changing the type of the view. Teardown the old version
         ctx.with_id(id, |ctx| match (prev, &mut view_state.inner_state) {
-            (OneOf::A(prev), OneOf::A(ref mut state)) => {
+            (Self::A(prev), OneOf::A(ref mut state)) => {
                 Context::with_downcast_a(&mut element, |element| {
                     prev.teardown(state, ctx, element);
                 });
             }
-            (OneOf::B(prev), OneOf::B(ref mut state)) => {
+            (Self::B(prev), OneOf::B(ref mut state)) => {
                 Context::with_downcast_b(&mut element, |element| {
                     prev.teardown(state, ctx, element);
                 });
             }
-            (OneOf::C(prev), OneOf::C(ref mut state)) => {
+            (Self::C(prev), OneOf::C(ref mut state)) => {
                 Context::with_downcast_c(&mut element, |element| {
                     prev.teardown(state, ctx, element);
                 });
             }
-            (OneOf::D(prev), OneOf::D(ref mut state)) => {
+            (Self::D(prev), OneOf::D(ref mut state)) => {
                 Context::with_downcast_d(&mut element, |element| {
                     prev.teardown(state, ctx, element);
                 });
             }
-            (OneOf::E(prev), OneOf::E(ref mut state)) => {
+            (Self::E(prev), OneOf::E(ref mut state)) => {
                 Context::with_downcast_e(&mut element, |element| {
                     prev.teardown(state, ctx, element);
                 });
             }
-            (OneOf::F(prev), OneOf::F(ref mut state)) => {
+            (Self::F(prev), OneOf::F(ref mut state)) => {
                 Context::with_downcast_f(&mut element, |element| {
                     prev.teardown(state, ctx, element);
                 });
             }
-            (OneOf::G(prev), OneOf::G(ref mut state)) => {
+            (Self::G(prev), OneOf::G(ref mut state)) => {
                 Context::with_downcast_g(&mut element, |element| {
                     prev.teardown(state, ctx, element);
                 });
             }
-            (OneOf::H(prev), OneOf::H(ref mut state)) => {
+            (Self::H(prev), OneOf::H(ref mut state)) => {
                 Context::with_downcast_h(&mut element, |element| {
                     prev.teardown(state, ctx, element);
                 });
             }
-            (OneOf::I(prev), OneOf::I(ref mut state)) => {
+            (Self::I(prev), OneOf::I(ref mut state)) => {
                 Context::with_downcast_i(&mut element, |element| {
                     prev.teardown(state, ctx, element);
                 });
@@ -418,39 +418,39 @@ where
         #[expect(clippy::shadow_unrelated, reason = "The old value is no longer valid.")]
         let id = ViewId::new(view_state.generation);
         let (new_element, state) = ctx.with_id(id, |ctx| match self {
-            OneOf::A(v) => {
+            Self::A(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::A(new_element), OneOf::A(state))
             }
-            OneOf::B(v) => {
+            Self::B(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::B(new_element), OneOf::B(state))
             }
-            OneOf::C(v) => {
+            Self::C(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::C(new_element), OneOf::C(state))
             }
-            OneOf::D(v) => {
+            Self::D(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::D(new_element), OneOf::D(state))
             }
-            OneOf::E(v) => {
+            Self::E(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::E(new_element), OneOf::E(state))
             }
-            OneOf::F(v) => {
+            Self::F(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::F(new_element), OneOf::F(state))
             }
-            OneOf::G(v) => {
+            Self::G(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::G(new_element), OneOf::G(state))
             }
-            OneOf::H(v) => {
+            Self::H(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::H(new_element), OneOf::H(state))
             }
-            OneOf::I(v) => {
+            Self::I(v) => {
                 let (new_element, state) = v.build(ctx);
                 (OneOf::I(new_element), OneOf::I(state))
             }
@@ -468,47 +468,47 @@ where
     ) {
         ctx.with_id(ViewId::new(view_state.generation), |ctx| {
             match (self, &mut view_state.inner_state) {
-                (OneOf::A(v), OneOf::A(ref mut state)) => {
+                (Self::A(v), OneOf::A(ref mut state)) => {
                     Context::with_downcast_a(&mut element, |element| {
                         v.teardown(state, ctx, element);
                     });
                 }
-                (OneOf::B(v), OneOf::B(ref mut state)) => {
+                (Self::B(v), OneOf::B(ref mut state)) => {
                     Context::with_downcast_b(&mut element, |element| {
                         v.teardown(state, ctx, element);
                     });
                 }
-                (OneOf::C(v), OneOf::C(ref mut state)) => {
+                (Self::C(v), OneOf::C(ref mut state)) => {
                     Context::with_downcast_c(&mut element, |element| {
                         v.teardown(state, ctx, element);
                     });
                 }
-                (OneOf::D(v), OneOf::D(ref mut state)) => {
+                (Self::D(v), OneOf::D(ref mut state)) => {
                     Context::with_downcast_d(&mut element, |element| {
                         v.teardown(state, ctx, element);
                     });
                 }
-                (OneOf::E(v), OneOf::E(ref mut state)) => {
+                (Self::E(v), OneOf::E(ref mut state)) => {
                     Context::with_downcast_e(&mut element, |element| {
                         v.teardown(state, ctx, element);
                     });
                 }
-                (OneOf::F(v), OneOf::F(ref mut state)) => {
+                (Self::F(v), OneOf::F(ref mut state)) => {
                     Context::with_downcast_f(&mut element, |element| {
                         v.teardown(state, ctx, element);
                     });
                 }
-                (OneOf::G(v), OneOf::G(ref mut state)) => {
+                (Self::G(v), OneOf::G(ref mut state)) => {
                     Context::with_downcast_g(&mut element, |element| {
                         v.teardown(state, ctx, element);
                     });
                 }
-                (OneOf::H(v), OneOf::H(ref mut state)) => {
+                (Self::H(v), OneOf::H(ref mut state)) => {
                     Context::with_downcast_h(&mut element, |element| {
                         v.teardown(state, ctx, element);
                     });
                 }
-                (OneOf::I(v), OneOf::I(ref mut state)) => {
+                (Self::I(v), OneOf::I(ref mut state)) => {
                     Context::with_downcast_i(&mut element, |element| {
                         v.teardown(state, ctx, element);
                     });
@@ -533,15 +533,15 @@ where
             return MessageResult::Stale(message);
         }
         match (self, &mut view_state.inner_state) {
-            (OneOf::A(v), OneOf::A(ref mut state)) => v.message(state, rest, message, app_state),
-            (OneOf::B(v), OneOf::B(ref mut state)) => v.message(state, rest, message, app_state),
-            (OneOf::C(v), OneOf::C(ref mut state)) => v.message(state, rest, message, app_state),
-            (OneOf::D(v), OneOf::D(ref mut state)) => v.message(state, rest, message, app_state),
-            (OneOf::E(v), OneOf::E(ref mut state)) => v.message(state, rest, message, app_state),
-            (OneOf::F(v), OneOf::F(ref mut state)) => v.message(state, rest, message, app_state),
-            (OneOf::G(v), OneOf::G(ref mut state)) => v.message(state, rest, message, app_state),
-            (OneOf::H(v), OneOf::H(ref mut state)) => v.message(state, rest, message, app_state),
-            (OneOf::I(v), OneOf::I(ref mut state)) => v.message(state, rest, message, app_state),
+            (Self::A(v), OneOf::A(ref mut state)) => v.message(state, rest, message, app_state),
+            (Self::B(v), OneOf::B(ref mut state)) => v.message(state, rest, message, app_state),
+            (Self::C(v), OneOf::C(ref mut state)) => v.message(state, rest, message, app_state),
+            (Self::D(v), OneOf::D(ref mut state)) => v.message(state, rest, message, app_state),
+            (Self::E(v), OneOf::E(ref mut state)) => v.message(state, rest, message, app_state),
+            (Self::F(v), OneOf::F(ref mut state)) => v.message(state, rest, message, app_state),
+            (Self::G(v), OneOf::G(ref mut state)) => v.message(state, rest, message, app_state),
+            (Self::H(v), OneOf::H(ref mut state)) => v.message(state, rest, message, app_state),
+            (Self::I(v), OneOf::I(ref mut state)) => v.message(state, rest, message, app_state),
             _ => unreachable!(),
         }
     }
@@ -564,7 +564,7 @@ mod hidden {
     {
         type Element = Context::PhantomElement;
 
-        type ViewState = Never;
+        type ViewState = Self;
 
         fn build(&self, _: &mut Context) -> (Self::Element, Self::ViewState) {
             match *self {}

--- a/xilem_core/src/views/one_of.rs
+++ b/xilem_core/src/views/one_of.rs
@@ -415,7 +415,7 @@ where
         view_state.generation = view_state.generation.wrapping_add(1);
 
         // And rebuild the new one
-        #[expect(clippy::shadow_unrelated, reason = "The old value is no longer valid.")]
+        #[expect(clippy::shadow_unrelated, reason = "The old value is no longer valid")]
         let id = ViewId::new(view_state.generation);
         let (new_element, state) = ctx.with_id(id, |ctx| match self {
             Self::A(v) => {

--- a/xilem_core/src/views/orphan.rs
+++ b/xilem_core/src/views/orphan.rs
@@ -3,7 +3,7 @@
 
 #![allow(
     unused_qualifications,
-    reason = "We have `std` enabled when testing, which means that some items are conditionally in the prelude."
+    reason = "We have `std` enabled when testing, which means that some items are conditionally in the prelude"
 )]
 
 use crate::{

--- a/xilem_core/tests/common/mod.rs
+++ b/xilem_core/tests/common/mod.rs
@@ -9,7 +9,6 @@
 #![expect(clippy::allow_attributes, reason = "Deferred: Noisy")]
 #![expect(clippy::allow_attributes_without_reason, reason = "Deferred: Noisy")]
 #![expect(clippy::missing_assert_message, reason = "Deferred: Noisy")]
-#![expect(clippy::use_self, reason = "Deferred: Noisy")]
 #![expect(single_use_lifetimes, reason = "Deferred: Noisy")]
 
 use xilem_core::*;
@@ -216,22 +215,22 @@ impl<const N: u32> View<(), Action, TestCtx> for OperationView<N> {
     }
 }
 
-impl SuperElement<TestElement, TestCtx> for TestElement {
-    fn upcast(_ctx: &mut TestCtx, child: TestElement) -> Self {
+impl SuperElement<Self, TestCtx> for TestElement {
+    fn upcast(_ctx: &mut TestCtx, child: Self) -> Self {
         child
     }
 
     fn with_downcast_val<R>(
         this: Self::Mut<'_>,
-        f: impl FnOnce(Mut<'_, TestElement>) -> R,
+        f: impl FnOnce(Mut<'_, Self>) -> R,
     ) -> (Self::Mut<'_>, R) {
         let ret = f(this);
         (this, ret)
     }
 }
 
-impl AnyElement<TestElement, TestCtx> for TestElement {
-    fn replace_inner(this: Self::Mut<'_>, child: TestElement) -> Self::Mut<'_> {
+impl AnyElement<Self, TestCtx> for TestElement {
+    fn replace_inner(this: Self::Mut<'_>, child: Self) -> Self::Mut<'_> {
         assert_eq!(child.operations.len(), 1);
         let Operation::Build(child_id) = child.operations.first().unwrap() else {
             panic!()


### PR DESCRIPTION
All fixes except for removing the `expect`s are results from `cargo fix`.