### PR TITLE
xilem_web: Add MemoizedStream view

### DIFF
--- a/xilem_web/src/concurrent/mod.rs
+++ b/xilem_web/src/concurrent/mod.rs
@@ -10,4 +10,4 @@ mod interval;
 pub use interval::{interval, Interval};
 
 mod memoized_await;
-pub use memoized_await::{memoized_await, MemoizedAwait};
+pub use memoized_await::{memoized_await, memoized_stream, MemoizedAwait, MemoizedStream};


### PR DESCRIPTION
The `MemoizedStream` view is is basically a `MemoizedAwait` view that accepts a stream and invokes the callback for each stream item received.
Since the implementation is almost the same, the two views are just wrappers for the private `MemoizedInner` struct.
If the approach is okay, I can also add an example.