### PR TITLE
Re-add IME support

### DIFF
--- a/masonry/src/passes/update.rs
+++ b/masonry/src/passes/update.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use cursor_icon::CursorIcon;
 use tracing::{info_span, trace};
 
-use crate::passes::event::run_on_pointer_event_pass;
+use crate::passes::event::{run_on_pointer_event_pass, run_on_text_event_pass};
 use crate::passes::{enter_span, enter_span_if, merge_state_up, recurse_on_children};
 use crate::render_root::{RenderRoot, RenderRootSignal, RenderRootState};
 use crate::tree_arena::ArenaMut;
@@ -14,8 +14,6 @@ use crate::{
     PointerEvent, QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
     WidgetState,
 };
-
-use super::event::run_on_text_event_pass;
 
 // --- MARK: HELPERS ---
 fn get_id_path(root: &RenderRoot, widget_id: Option<WidgetId>) -> Vec<WidgetId> {

--- a/masonry/src/passes/update.rs
+++ b/masonry/src/passes/update.rs
@@ -394,13 +394,6 @@ pub(crate) fn run_update_focus_chain_pass(root: &mut RenderRoot) {
 // --- MARK: UPDATE FOCUS ---
 pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
     let _span = info_span!("update_focus").entered();
-    // If the focused widget is disabled, stashed or removed, we set
-    // the focused id to None
-    if let Some(id) = root.global_state.next_focused_widget {
-        if !root.is_still_interactive(id) {
-            root.global_state.next_focused_widget = None;
-        }
-    }
 
     let prev_focused = root.global_state.focused_widget;
     let was_ime_active = root.global_state.is_ime_active;
@@ -433,8 +426,13 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
         }
     }
 
-    // Note: handling of the Ime::Disabled event sent above may have changed the next focused
-    // widget.
+    // If the focused widget is disabled, stashed or removed, we set
+    // the focused id to None
+    if let Some(id) = root.global_state.next_focused_widget {
+        if !root.is_still_interactive(id) {
+            root.global_state.next_focused_widget = None;
+        }
+    }
     let next_focused = root.global_state.next_focused_widget;
 
     // "Focused path" means the focused widget, and all its parents.

--- a/masonry/src/text/editor.rs
+++ b/masonry/src/text/editor.rs
@@ -804,11 +804,6 @@ where
             builder.push_default(prop.to_owned());
         }
         if let Some(ref preedit_range) = self.compose {
-            // TODO: underline currently doesn't show up, maybe the brush is invisible?
-            builder.push(
-                parley::style::StyleProperty::UnderlineBrush(Some(T::default())),
-                preedit_range.clone(),
-            );
             builder.push(
                 parley::style::StyleProperty::Underline(true),
                 preedit_range.clone(),

--- a/masonry/src/text/editor.rs
+++ b/masonry/src/text/editor.rs
@@ -110,17 +110,23 @@ where
     // --- MARK: Forced relayout ---
     /// Insert at cursor, or replace selection.
     pub fn insert_or_replace_selection(&mut self, s: &str) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .replace_selection(self.font_cx, self.layout_cx, s);
     }
 
     /// Delete the selection.
     pub fn delete_selection(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.insert_or_replace_selection("");
     }
 
     /// Delete the selection or the next cluster (typical ‘delete’ behavior).
     pub fn delete(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         if self.editor.selection.is_collapsed() {
             // Upstream cluster range
             if let Some(range) = self
@@ -142,6 +148,8 @@ where
 
     /// Delete the selection or up to the next word boundary (typical ‘ctrl + delete’ behavior).
     pub fn delete_word(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         if self.editor.selection.is_collapsed() {
             let focus = self.editor.selection.focus();
             let start = focus.index();
@@ -161,6 +169,8 @@ where
 
     /// Delete the selection or the previous cluster (typical ‘backspace’ behavior).
     pub fn backdelete(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         if self.editor.selection.is_collapsed() {
             // Upstream cluster
             if let Some(cluster) = self
@@ -201,6 +211,8 @@ where
 
     /// Delete the selection or back to the previous word boundary (typical ‘ctrl + backspace’ behavior).
     pub fn backdelete_word(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         if self.editor.selection.is_collapsed() {
             let focus = self.editor.selection.focus();
             let end = focus.index();
@@ -285,6 +297,8 @@ where
     // --- MARK: Cursor Movement ---
     /// Move the cursor to the cluster boundary nearest this point in the layout.
     pub fn move_to_point(&mut self, x: f32, y: f32) {
+        debug_assert!(!self.editor.is_composing());
+
         self.refresh_layout();
         self.editor
             .set_selection(Selection::from_point(&self.editor.layout, x, y));
@@ -294,6 +308,8 @@ where
     ///
     /// No-op if index is not a char boundary.
     pub fn move_to_byte(&mut self, index: usize) {
+        debug_assert!(!self.editor.is_composing());
+
         if self.editor.buffer.is_char_boundary(index) {
             self.refresh_layout();
             self.editor
@@ -303,6 +319,8 @@ where
 
     /// Move the cursor to the start of the buffer.
     pub fn move_to_text_start(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
             isize::MIN,
@@ -312,12 +330,16 @@ where
 
     /// Move the cursor to the start of the physical line.
     pub fn move_to_line_start(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .set_selection(self.editor.selection.line_start(&self.editor.layout, false));
     }
 
     /// Move the cursor to the end of the buffer.
     pub fn move_to_text_end(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
             isize::MAX,
@@ -327,12 +349,16 @@ where
 
     /// Move the cursor to the end of the physical line.
     pub fn move_to_line_end(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .set_selection(self.editor.selection.line_end(&self.editor.layout, false));
     }
 
     /// Move up to the closest physical cluster boundary on the previous line, preserving the horizontal position for repeated movements.
     pub fn move_up(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -342,12 +368,16 @@ where
 
     /// Move down to the closest physical cluster boundary on the next line, preserving the horizontal position for repeated movements.
     pub fn move_down(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .set_selection(self.editor.selection.next_line(&self.editor.layout, false));
     }
 
     /// Move to the next cluster left in visual order.
     pub fn move_left(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -357,6 +387,8 @@ where
 
     /// Move to the next cluster right in visual order.
     pub fn move_right(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -366,6 +398,8 @@ where
 
     /// Move to the next word boundary left.
     pub fn move_word_left(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -375,6 +409,8 @@ where
 
     /// Move to the next word boundary right.
     pub fn move_word_right(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -384,6 +420,8 @@ where
 
     /// Select the whole buffer.
     pub fn select_all(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             Selection::from_byte_index(&self.editor.layout, 0_usize, Affinity::default())
                 .move_lines(&self.editor.layout, isize::MAX, true),
@@ -392,11 +430,15 @@ where
 
     /// Collapse selection into caret.
     pub fn collapse_selection(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(self.editor.selection.collapse());
     }
 
     /// Move the selection focus point to the start of the buffer.
     pub fn select_to_text_start(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
             isize::MIN,
@@ -406,12 +448,16 @@ where
 
     /// Move the selection focus point to the start of the physical line.
     pub fn select_to_line_start(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .set_selection(self.editor.selection.line_start(&self.editor.layout, true));
     }
 
     /// Move the selection focus point to the end of the buffer.
     pub fn select_to_text_end(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(self.editor.selection.move_lines(
             &self.editor.layout,
             isize::MAX,
@@ -421,12 +467,16 @@ where
 
     /// Move the selection focus point to the end of the physical line.
     pub fn select_to_line_end(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .set_selection(self.editor.selection.line_end(&self.editor.layout, true));
     }
 
     /// Move the selection focus point up to the nearest cluster boundary on the previous line, preserving the horizontal position for repeated movements.
     pub fn select_up(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -436,12 +486,16 @@ where
 
     /// Move the selection focus point down to the nearest cluster boundary on the next line, preserving the horizontal position for repeated movements.
     pub fn select_down(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .set_selection(self.editor.selection.next_line(&self.editor.layout, true));
     }
 
     /// Move the selection focus point to the next cluster left in visual order.
     pub fn select_left(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -451,12 +505,16 @@ where
 
     /// Move the selection focus point to the next cluster right in visual order.
     pub fn select_right(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor
             .set_selection(self.editor.selection.next_visual(&self.editor.layout, true));
     }
 
     /// Move the selection focus point to the next word boundary left.
     pub fn select_word_left(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -466,6 +524,8 @@ where
 
     /// Move the selection focus point to the next word boundary right.
     pub fn select_word_right(&mut self) {
+        debug_assert!(!self.editor.is_composing());
+
         self.editor.set_selection(
             self.editor
                 .selection
@@ -475,6 +535,8 @@ where
 
     /// Select the word at the point.
     pub fn select_word_at_point(&mut self, x: f32, y: f32) {
+        debug_assert!(!self.editor.is_composing());
+
         self.refresh_layout();
         self.editor
             .set_selection(Selection::word_from_point(&self.editor.layout, x, y));
@@ -482,6 +544,8 @@ where
 
     /// Select the physical line at the point.
     pub fn select_line_at_point(&mut self, x: f32, y: f32) {
+        debug_assert!(!self.editor.is_composing());
+
         self.refresh_layout();
         let line = Selection::line_from_point(&self.editor.layout, x, y);
         self.editor.set_selection(line);
@@ -489,6 +553,8 @@ where
 
     /// Move the selection focus point to the cluster boundary closest to point.
     pub fn extend_selection_to_point(&mut self, x: f32, y: f32) {
+        debug_assert!(!self.editor.is_composing());
+
         self.refresh_layout();
         // FIXME: This is usually the wrong way to handle selection extension for mouse moves, but not a regression.
         self.editor.set_selection(
@@ -502,6 +568,8 @@ where
     ///
     /// No-op if index is not a char boundary.
     pub fn extend_selection_to_byte(&mut self, index: usize) {
+        debug_assert!(!self.editor.is_composing());
+
         if self.editor.buffer.is_char_boundary(index) {
             self.refresh_layout();
             self.editor
@@ -513,6 +581,8 @@ where
     ///
     /// No-op if either index is not a char boundary.
     pub fn select_byte_range(&mut self, start: usize, end: usize) {
+        debug_assert!(!self.editor.is_composing());
+
         if self.editor.buffer.is_char_boundary(start) && self.editor.buffer.is_char_boundary(end) {
             self.refresh_layout();
             self.editor.set_selection(Selection::new(
@@ -523,6 +593,8 @@ where
     }
 
     pub fn select_from_accesskit(&mut self, selection: &accesskit::TextSelection) {
+        debug_assert!(!self.editor.is_composing());
+
         self.refresh_layout();
         if let Some(selection) = Selection::from_access_selection(
             selection,

--- a/masonry/src/text/editor.rs
+++ b/masonry/src/text/editor.rs
@@ -653,7 +653,7 @@ where
     fn cursor_at(&self, index: usize) -> Cursor {
         // TODO: Do we need to be non-dirty?
         // FIXME: `Selection` should make this easier
-        if index > self.buffer.len() {
+        if index >= self.buffer.len() {
             Cursor::from_byte_index(&self.layout, self.buffer.len(), Affinity::Upstream)
         } else {
             Cursor::from_byte_index(&self.layout, index, Affinity::Downstream)

--- a/masonry/src/widget/text_area.rs
+++ b/masonry/src/widget/text_area.rs
@@ -745,7 +745,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
                             .transact(fctx, lctx, |txn| txn.insert_or_replace_selection(text));
                         submit_text = Some(self.text().to_string());
                     }
-                    _ => {}
+                    winit::event::Ime::Enabled => {}
                 }
 
                 ctx.set_handled();

--- a/masonry/src/widget/text_area.rs
+++ b/masonry/src/widget/text_area.rs
@@ -750,7 +750,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
 
                 ctx.set_handled();
                 if let Some(text) = submit_text {
-                    ctx.submit_action(dbg!(crate::Action::TextChanged(text)));
+                    ctx.submit_action(crate::Action::TextChanged(text));
                 }
                 let new_generation = self.editor.generation();
                 if new_generation != self.rendered_generation {

--- a/masonry/src/widget/text_area.rs
+++ b/masonry/src/widget/text_area.rs
@@ -788,17 +788,8 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
 
     fn update(&mut self, ctx: &mut UpdateCtx, event: &Update) {
         match event {
-            Update::FocusChanged(focused) => {
-                // HACK: currently, when moving focus away from a text area, the Ime::Disabled
-                // event is routed to the newly focused widget. Do IME clean up here.
-                if !focused && self.editor.is_composing() {
-                    let (fctx, lctx) = ctx.text_contexts();
-                    self.editor.transact(fctx, lctx, |txn| txn.clear_compose());
-                    self.rendered_generation = self.editor.generation();
-                    ctx.request_layout();
-                } else {
-                    ctx.request_render();
-                }
+            Update::FocusChanged(_) => {
+                ctx.request_render();
             }
             Update::DisabledChanged(_) => {
                 // We might need to use the disabled brush, and stop displaying the selection.


### PR DESCRIPTION
This adds IME support back into Masonry. This sticks close to https://github.com/linebender/parley/pull/111, except that during IME compose, this version doesn't allow changing the selection anchor, making the code simpler. For reference, there's also https://github.com/linebender/parley/pull/136.

This tweaks the focus update pass: when a widget with IME is unfocused, Masonry sends the platform's IME disable event to the newly focused widget. As a workaround, we synthesize an IME disable event in the focus pass and send it to the widget that is about to be unfocused. A complication is that the handling of that event can request focus to a different widget, and in particular, can request itself to be focused again. This handles that case, too.

Remaining work is setting the IME candidate region to be near the current selection and to make a decision on cursor/selection hiding when the platform sends a `None` cursor.