### PR TITLE
Set a transform on the root AccessKit node

### DIFF
--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -132,7 +132,6 @@ pub struct AccessCtx<'a> {
     pub(crate) widget_children: ArenaMutChildren<'a, Box<dyn Widget>>,
     pub(crate) tree_update: &'a mut TreeUpdate,
     pub(crate) rebuild_all: bool,
-    pub(crate) scale_factor: f64,
 }
 
 // --- MARK: GETTERS ---
@@ -1265,7 +1264,6 @@ impl<'s> AccessCtx<'s> {
             global_state: self.global_state,
             tree_update: self.tree_update,
             rebuild_all: self.rebuild_all,
-            scale_factor: self.scale_factor,
         };
         RawWrapper {
             ctx: child_ctx,

--- a/masonry/src/passes/accessibility.rs
+++ b/masonry/src/passes/accessibility.rs
@@ -19,7 +19,7 @@ fn build_accessibility_tree(
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
     rebuild_all: bool,
-    scale_factor: f64,
+    scale_factor: Option<f64>,
 ) {
     let _span = enter_span_if(
         global_state.trace.access,
@@ -49,10 +49,12 @@ fn build_accessibility_tree(
             widget_children: widget.children.reborrow_mut(),
             tree_update,
             rebuild_all,
-            scale_factor,
         };
         let mut node = build_access_node(widget.item, &mut ctx);
         widget.item.accessibility(&mut ctx, &mut node);
+        if let Some(scale_factor) = scale_factor {
+            node.set_transform(accesskit::Affine::scale(scale_factor));
+        }
 
         let id: NodeId = ctx.widget_state.id.into();
         if ctx.global_state.trace.access {
@@ -79,7 +81,7 @@ fn build_accessibility_tree(
                 widget,
                 state.reborrow_mut(),
                 rebuild_all,
-                scale_factor,
+                None,
             );
             parent_state.merge_up(state.item);
         },
@@ -168,7 +170,7 @@ pub(crate) fn run_accessibility_pass(root: &mut RenderRoot, scale_factor: f64) -
         root_widget,
         root_state,
         root.rebuild_access_tree,
-        scale_factor,
+        Some(scale_factor),
     );
     root.rebuild_access_tree = false;
 

--- a/masonry/src/passes/accessibility.rs
+++ b/masonry/src/passes/accessibility.rs
@@ -89,10 +89,7 @@ fn build_accessibility_tree(
 // --- MARK: BUILD NODE ---
 fn build_access_node(widget: &mut dyn Widget, ctx: &mut AccessCtx) -> Node {
     let mut node = Node::new(widget.accessibility_role());
-    node.set_bounds(to_accesskit_rect(
-        ctx.widget_state.window_layout_rect(),
-        ctx.scale_factor,
-    ));
+    node.set_bounds(to_accesskit_rect(ctx.widget_state.window_layout_rect()));
 
     node.set_children(
         widget
@@ -124,9 +121,8 @@ fn build_access_node(widget: &mut dyn Widget, ctx: &mut AccessCtx) -> Node {
     node
 }
 
-fn to_accesskit_rect(r: Rect, scale_factor: f64) -> accesskit::Rect {
-    let sr = r.scale_from_origin(scale_factor);
-    accesskit::Rect::new(sr.x0, sr.y0, sr.x1, sr.y1)
+fn to_accesskit_rect(r: Rect) -> accesskit::Rect {
+    accesskit::Rect::new(r.x0, r.y0, r.x1, r.y1)
 }
 
 // --- MARK: ROOT ---

--- a/masonry/src/widget/root_widget.rs
+++ b/masonry/src/widget/root_widget.rs
@@ -59,9 +59,7 @@ impl<W: Widget> Widget for RootWidget<W> {
         Role::Window
     }
 
-    fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut Node) {
-        node.set_transform(accesskit::Affine::scale(ctx.scale_factor));
-    }
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut Node) {}
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         smallvec![self.pod.id()]

--- a/masonry/src/widget/root_widget.rs
+++ b/masonry/src/widget/root_widget.rs
@@ -59,7 +59,9 @@ impl<W: Widget> Widget for RootWidget<W> {
         Role::Window
     }
 
-    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut Node) {}
+    fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut Node) {
+        node.set_transform(accesskit::Affine::scale(ctx.scale_factor));
+    }
 
     fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
         smallvec![self.pod.id()]


### PR DESCRIPTION
This is better than having to apply the scale factor to the bounding rectangles of all nodes, especially when we take externally generated AccessKit nodes, such as those generated by Parley, into account.