### PR TITLE
xilem_web: Update dependencies, and support `style` for `MathMlElement`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1821,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "fb15147158e79fd8b8afd0252522769c4f48725460b37338544d8379d94fc8f9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3889,9 +3889,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "21d3b25c3ea1126a2ad5f4f9068483c2af1e64168f847abe863a526b8dbfe00b"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3900,9 +3900,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "52857d4c32e496dc6537646b5b117081e71fd2ff06de792e3577a150627db283"
 dependencies = [
  "bumpalo",
  "log",
@@ -3915,21 +3915,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "951fe82312ed48443ac78b66fa43eded9999f738f6022e67aead7b708659e49a"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "920b0ffe069571ebbfc9ddc0b36ba305ef65577c94b06262ed793716a1afd981"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3937,9 +3938,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "bf59002391099644be3524e23b781fa43d2be0c5aa0719a18c0731b9d195cab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3950,9 +3951,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "e5047c5392700766601942795a436d7d2599af60dcc3cc1248c9120bfb0827b0"
 
 [[package]]
 name = "wayland-backend"
@@ -4065,9 +4066,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "476364ff87d0ae6bfb661053a9104ab312542658c3d8f963b7ace80b6f9b26b9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/xilem_web/Cargo.toml
+++ b/xilem_web/Cargo.toml
@@ -21,10 +21,10 @@ targets = []
 workspace = true
 
 [dependencies]
-futures = "0.3.30"
+futures = "0.3.31"
 peniko.workspace = true
-wasm-bindgen = "0.2.92"
-wasm-bindgen-futures = "0.4.42"
+wasm-bindgen = "0.2.96"
+wasm-bindgen-futures = "0.4.46"
 xilem_core = { workspace = true, features = ["kurbo"] }
 
 [dependencies.web-sys]
@@ -44,6 +44,7 @@ features = [
   "ResizeObserver",
   "ResizeObserverEntry",
   "DomRectReadOnly",
+  "MathMlElement",
   "SvgElement",
   "SvgaElement",
   "SvgAnimateElement",

--- a/xilem_web/src/modifiers/style.rs
+++ b/xilem_web/src/modifiers/style.rs
@@ -154,6 +154,8 @@ fn set_style(element: &web_sys::Element, name: &str, value: &str) {
         el.style().set_property(name, value).unwrap_throw();
     } else if let Some(el) = element.dyn_ref::<web_sys::SvgElement>() {
         el.style().set_property(name, value).unwrap_throw();
+    } else if let Some(el) = element.dyn_ref::<web_sys::MathMlElement>() {
+        el.style().set_property(name, value).unwrap_throw();
     }
 }
 
@@ -161,6 +163,8 @@ fn remove_style(element: &web_sys::Element, name: &str) {
     if let Some(el) = element.dyn_ref::<web_sys::HtmlElement>() {
         el.style().remove_property(name).unwrap_throw();
     } else if let Some(el) = element.dyn_ref::<web_sys::SvgElement>() {
+        el.style().remove_property(name).unwrap_throw();
+    } else if let Some(el) = element.dyn_ref::<web_sys::MathMlElement>() {
         el.style().remove_property(name).unwrap_throw();
     }
 }


### PR DESCRIPTION
As noted in https://github.com/linebender/xilem/pull/621#issuecomment-2405688142, https://github.com/rustwasm/wasm-bindgen/pull/4143 is now added in wasm_bindgen 0.2.96.

This PR updates all the dependencies of xilem_web and finally correctly supports `style`  for `MathMlElement`.