### PR TITLE
Stop IME just before shutting down

### DIFF
--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -472,7 +472,9 @@ impl MasonryState<'_> {
                 accesskit_adapter.update_if_active(|| tree_update);
             }
             WinitWindowEvent::CloseRequested => {
-                //
+                // HACK: When we exit, on some systems (known to happen with Wayland on KDE),
+                // the IME state gets preserved until the app next opens. We work around this by force-deleting
+                // the IME state just before exiting.
                 window.set_ime_allowed(false);
                 event_loop.exit();
             }

--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -471,7 +471,11 @@ impl MasonryState<'_> {
                 };
                 accesskit_adapter.update_if_active(|| tree_update);
             }
-            WinitWindowEvent::CloseRequested => event_loop.exit(),
+            WinitWindowEvent::CloseRequested => {
+                //
+                window.set_ime_allowed(false);
+                event_loop.exit();
+            }
             WinitWindowEvent::Resized(size) => {
                 self.render_root
                     .handle_window_event(WindowEvent::Resize(size));


### PR DESCRIPTION
This works around a janky behaviour where IME content is transferred to new instances of the same app.

This might not be needed on other systems, but I don't think that this change can cause any harm either.