### PR TITLE
heading level and doc for masonry readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: cargo rdme masonry
         run: |
-          cargo rdme --check --workspace-project=masonry
+          cargo rdme --check --heading-base-level=0 --workspace-project=masonry
 
       - name: cargo rdme tree_arena
         run: |

--- a/masonry/README.md
+++ b/masonry/README.md
@@ -16,6 +16,11 @@
 
 [tracing_tracy]: https://crates.io/crates/tracing-tracy
 
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=color --heading-base-level=0
+Full documentation at https://github.com/orium/cargo-rdme -->
+
 <!-- cargo-rdme start -->
 
 Masonry gives you a platform to create windows (using [winit] as a backend) each with a tree of widgets. It also gives you tools to inspect that widget tree at runtime, write unit tests on it, and generally have an easier time debugging and maintaining your app.

--- a/masonry/README.md
+++ b/masonry/README.md
@@ -14,12 +14,14 @@
 
 </div>
 
-[tracing_tracy]: https://crates.io/crates/tracing-tracy
-
 <!-- We use cargo-rdme to update the README with the contents of lib.rs.
 To edit the following section, update it in lib.rs, then run:
 cargo rdme --workspace-project=color --heading-base-level=0
 Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs should be evaluated here.
+See https://linebender.org/blog/doc-include/ for related discussion. -->
+[tracing_tracy]: https://crates.io/crates/tracing-tracy
 
 <!-- cargo-rdme start -->
 

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -12,7 +12,7 @@
 //! Masonry can currently be considered to be in an alpha state.
 //! Lots of things need improvements, e.g. text input is janky and snapshot testing is not consistent across platforms.
 //!
-//! # Example
+//! ## Example
 //!
 //! The to-do-list example looks like this:
 //!
@@ -77,7 +77,7 @@
 //!
 //! For more information, see [the documentation module](crate::doc).
 //!
-//! ## Crate feature flags
+//! ### Crate feature flags
 //!
 //! The following feature flags are available:
 //!


### PR DESCRIPTION
Update the Masonry readme with documentation on how it is generated and change the heading level to be consistent with Color
