### PR TITLE
Add special case when window is resized to zero

### DIFF
--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -479,6 +479,12 @@ impl MasonryState<'_> {
                 event_loop.exit();
             }
             WinitWindowEvent::Resized(size) => {
+                if size.width == 0 || size.height == 0 {
+                    self.handle_suspended(event_loop);
+                    return;
+                } else if let WindowState::Suspended { .. } = &mut self.window {
+                    self.handle_resumed(event_loop);
+                }
                 self.render_root
                     .handle_window_event(WindowEvent::Resize(size));
             }


### PR DESCRIPTION
There have been reported crashes with Xilem when minimizing an app with Windows 11 (see also https://github.com/linebender/vello/issues/371).

This fix is based on the solution proposed in:

https://xi.zulipchat.com/#narrow/channel/197075-gpu/topic/Windows.2011.20minimizing

I've tested it on Linux just enough to confirm it doesn't crash. Haven't tested in on Windows yet, so I'm not sure it actually fixes the crash on minimize.