### PR TITLE
xilem_web: Fix todomvc example (items left in footer)

### DIFF
--- a/xilem_web/web_examples/todomvc/src/main.rs
+++ b/xilem_web/web_examples/todomvc/src/main.rs
@@ -82,12 +82,6 @@ fn todo_item(todo: &mut Todo, editing: bool) -> impl Element<Todo, TodoAction> {
 }
 
 fn footer_view(state: &mut AppState, should_display: bool) -> impl Element<AppState> {
-    let item_str = if state.todos.len() == 1 {
-        "item"
-    } else {
-        "items"
-    };
-
     let clear_button = (state.todos.iter().filter(|todo| todo.completed).count() > 0).then(|| {
         el::button("Clear completed")
             .class("clear-completed")
@@ -98,12 +92,11 @@ fn footer_view(state: &mut AppState, should_display: bool) -> impl Element<AppSt
 
     let filter_class = |filter| (state.filter == filter).then_some("selected");
 
+    let items_left = state.todos.iter().filter(|todo| !todo.completed).count();
+    let item_noun = if items_left == 1 { "item" } else { "items" };
+
     el::footer((
-        el::span((
-            el::strong(state.todos.len().to_string()),
-            format!(" {} left", item_str),
-        ))
-        .class("todo-count"),
+        el::span(format!("{items_left} {item_noun} left")).class("todo-count"),
         el::ul((
             el::li(Element::on_click(
                 el::a("All")


### PR DESCRIPTION
Previously the complete count of todo items were shown, but only active (i.e. non-completed) todos should be considered in the count.
In the original todomvc implementation (e.g. [react](https://todomvc.com/examples/react/dist/)), I haven't found the `<strong>` node as well, so that is just combined as a single text node.