### PR TITLE
Consistently use `FontWeight` as the name

### DIFF
--- a/masonry/examples/hello_masonry.rs
+++ b/masonry/examples/hello_masonry.rs
@@ -10,8 +10,7 @@
 use masonry::dpi::LogicalSize;
 use masonry::text::StyleProperty;
 use masonry::widget::{Button, Flex, Label, RootWidget};
-use masonry::{Action, AppDriver, DriverCtx, WidgetId};
-use parley::fontique::Weight;
+use masonry::{Action, AppDriver, DriverCtx, FontWeight, WidgetId};
 use winit::window::Window;
 
 const VERTICAL_WIDGET_SPACING: f64 = 20.0;
@@ -35,7 +34,7 @@ fn main() {
     let label = Label::new("Hello")
         .with_style(StyleProperty::FontSize(32.0))
         // Ideally there's be an Into in Parley for this
-        .with_style(StyleProperty::FontWeight(Weight::BOLD));
+        .with_style(StyleProperty::FontWeight(FontWeight::BOLD));
     let button = Button::new("Say hello");
 
     // Arrange the two widgets vertically, with some padding

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -177,8 +177,8 @@ pub use vello::kurbo;
 
 pub use cursor_icon::{CursorIcon, ParseError as CursorIconParseError};
 pub use kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
-pub use parley::fontique::Weight as TextWeight;
 pub use parley::layout::Alignment as TextAlignment;
+pub use parley::style::FontWeight;
 pub use vello::peniko::{Color, Gradient};
 
 pub use action::Action;

--- a/masonry/src/widget/variable_label.rs
+++ b/masonry/src/widget/variable_label.rs
@@ -6,7 +6,6 @@
 use std::cmp::Ordering;
 
 use accesskit::{Node, Role};
-use parley::fontique::Weight;
 use smallvec::{smallvec, SmallVec};
 use tracing::{trace_span, Span};
 use vello::kurbo::{Point, Size};
@@ -15,8 +14,8 @@ use vello::Scene;
 use crate::text::{ArcStr, StyleProperty};
 use crate::widget::WidgetMut;
 use crate::{
-    AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent, QueryCtx,
-    RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
+    AccessCtx, AccessEvent, BoxConstraints, EventCtx, FontWeight, LayoutCtx, PaintCtx,
+    PointerEvent, QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
 };
 
 use super::{Label, WidgetPod};
@@ -142,7 +141,7 @@ impl VariableLabel {
     pub fn from_label_pod(label: WidgetPod<Label>) -> Self {
         Self {
             label,
-            weight: AnimatedF32::stable(Weight::NORMAL.value()),
+            weight: AnimatedF32::stable(FontWeight::NORMAL.value()),
         }
     }
 
@@ -206,7 +205,7 @@ impl Widget for VariableLabel {
             }
             Label::insert_style(
                 &mut label,
-                StyleProperty::FontWeight(Weight::new(new_weight)),
+                StyleProperty::FontWeight(FontWeight::new(new_weight)),
             );
         });
         if !result.is_completed() {

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -16,7 +16,7 @@ use xilem::view::{
     button, button_any_pointer, checkbox, flex, label, prose, task, textbox, Axis, FlexExt as _,
     FlexSpacer,
 };
-use xilem::{Color, EventLoop, EventLoopBuilder, TextAlignment, TextWeight, WidgetView, Xilem};
+use xilem::{Color, EventLoop, EventLoopBuilder, FontWeight, TextAlignment, WidgetView, Xilem};
 const LOREM: &str = r"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi cursus mi sed euismod euismod. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam placerat efficitur tellus at semper. Morbi ac risus magna. Donec ut cursus ex. Etiam quis posuere tellus. Mauris posuere dui et turpis mollis, vitae luctus tellus consectetur. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eu facilisis nisl.
 
 Phasellus in viverra dolor, vitae facilisis est. Maecenas malesuada massa vel ultricies feugiat. Vivamus venenatis et nibh nec pharetra. Phasellus vestibulum elit enim, nec scelerisque orci faucibus id. Vivamus consequat purus sit amet orci egestas, non iaculis massa porttitor. Vestibulum ut eros leo. In fermentum convallis magna in finibus. Donec justo leo, maximus ac laoreet id, volutpat ut elit. Mauris sed leo non neque laoreet faucibus. Aliquam orci arcu, faucibus in molestie eget, ornare non dui. Donec volutpat nulla in fringilla elementum. Aliquam vitae ante egestas ligula tempus vestibulum sit amet sed ante. ";
@@ -66,7 +66,7 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> {
         flex((
             flex((
                 label("Label").brush(Color::REBECCA_PURPLE),
-                label("Bold Label").weight(TextWeight::BOLD),
+                label("Bold Label").weight(FontWeight::BOLD),
                 // TODO masonry doesn't allow setting disabled manually anymore?
                 // label("Disabled label").disabled(),
             ))

--- a/xilem/examples/variable_clock.rs
+++ b/xilem/examples/variable_clock.rs
@@ -6,7 +6,6 @@
 
 use std::time::Duration;
 
-use masonry::parley::fontique::Weight;
 use time::error::IndeterminateOffset;
 use time::macros::format_description;
 use time::{OffsetDateTime, UtcOffset};
@@ -16,11 +15,11 @@ use xilem::view::{
     button, flex, inline_prose, label, portal, prose, sized_box, task, variable_label, Axis,
     FlexExt, FlexSpacer,
 };
-use xilem::{Color, EventLoop, EventLoopBuilder, WidgetView, Xilem};
+use xilem::{Color, EventLoop, EventLoopBuilder, FontWeight, WidgetView, Xilem};
 
 /// The state of the application, owned by Xilem and updated by the callbacks below.
 struct Clocks {
-    /// The font [weight](Weight) used for the values.
+    /// The font [weight](FontWeight) used for the values.
     weight: f32,
     /// The current UTC offset on this machine.
     local_offset: Result<UtcOffset, IndeterminateOffset>,
@@ -182,7 +181,7 @@ const ROBOTO_FLEX: &[u8] = include_bytes!(concat!(
 
 fn run(event_loop: EventLoopBuilder) -> Result<(), EventLoopError> {
     let data = Clocks {
-        weight: Weight::BLACK.value(),
+        weight: FontWeight::BLACK.value(),
         // TODO: We can't get this on Android, because
         local_offset: UtcOffset::current_local_offset(),
         now_utc: OffsetDateTime::now_utc(),

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -54,7 +54,7 @@ use crate::core::{
     ViewPathTracker, ViewSequence,
 };
 pub use masonry::event_loop_runner::{EventLoop, EventLoopBuilder};
-pub use masonry::{dpi, Color, TextAlignment, TextWeight};
+pub use masonry::{dpi, Color, FontWeight, TextAlignment};
 pub use xilem_core as core;
 
 /// Tokio is the async runner used with Xilem.

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -1,13 +1,13 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::parley::FontStack;
+use masonry::parley::style::{FontStack, FontWeight};
 use masonry::text::{ArcStr, StyleProperty};
 use masonry::widget;
 use vello::peniko::Brush;
 
 use crate::core::{DynMessage, Mut, ViewMarker};
-use crate::{Color, MessageResult, Pod, TextAlignment, TextWeight, View, ViewCtx, ViewId};
+use crate::{Color, MessageResult, Pod, TextAlignment, View, ViewCtx, ViewId};
 
 pub fn label(label: impl Into<ArcStr>) -> Label {
     Label {
@@ -15,7 +15,7 @@ pub fn label(label: impl Into<ArcStr>) -> Label {
         text_brush: Color::WHITE.into(),
         alignment: TextAlignment::default(),
         text_size: masonry::theme::TEXT_SIZE_NORMAL,
-        weight: TextWeight::NORMAL,
+        weight: FontWeight::NORMAL,
         font: FontStack::List(std::borrow::Cow::Borrowed(&[])),
     }
 }
@@ -28,7 +28,7 @@ pub struct Label {
     pub(in crate::view) text_brush: Brush,
     pub(in crate::view) alignment: TextAlignment,
     pub(in crate::view) text_size: f32,
-    pub(in crate::view) weight: TextWeight,
+    pub(in crate::view) weight: FontWeight,
     pub(in crate::view) font: FontStack<'static>, // TODO: add more attributes of `masonry::widget::Label`
 }
 
@@ -50,7 +50,7 @@ impl Label {
         self
     }
 
-    pub fn weight(mut self, weight: TextWeight) -> Self {
+    pub fn weight(mut self, weight: FontWeight) -> Self {
         self.weight = weight;
         self
     }

--- a/xilem/src/view/variable_label.rs
+++ b/xilem/src/view/variable_label.rs
@@ -1,15 +1,14 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::parley::fontique::Weight;
-use masonry::parley::style::FontStack;
+use masonry::parley::style::{FontStack, FontWeight};
 use masonry::text::ArcStr;
 use masonry::{widget, TextAlignment};
 use vello::peniko::Brush;
 use xilem_core::ViewPathTracker;
 
 use crate::core::{DynMessage, Mut, ViewMarker};
-use crate::{MessageResult, Pod, TextWeight, View, ViewCtx, ViewId};
+use crate::{MessageResult, Pod, View, ViewCtx, ViewId};
 
 use super::{label, Label};
 
@@ -17,7 +16,7 @@ use super::{label, Label};
 pub fn variable_label(text: impl Into<ArcStr>) -> VariableLabel {
     VariableLabel {
         label: label(text),
-        target_weight: Weight::NORMAL,
+        target_weight: FontWeight::NORMAL,
         over_millis: 0.,
     }
 }
@@ -25,7 +24,7 @@ pub fn variable_label(text: impl Into<ArcStr>) -> VariableLabel {
 #[must_use = "View values do nothing unless provided to Xilem."]
 pub struct VariableLabel {
     label: Label,
-    target_weight: Weight,
+    target_weight: FontWeight,
     over_millis: f32,
 }
 
@@ -45,7 +44,7 @@ impl VariableLabel {
     /// If `weight` is non-finite.
     pub fn target_weight(mut self, weight: f32, over_millis: f32) -> Self {
         assert!(weight.is_finite(), "Invalid target weight {weight}.");
-        self.target_weight = Weight::new(weight);
+        self.target_weight = FontWeight::new(weight);
         self.over_millis = over_millis;
         self
     }
@@ -79,7 +78,7 @@ impl VariableLabel {
         self
     }
 
-    pub fn weight(mut self, weight: TextWeight) -> Self {
+    pub fn weight(mut self, weight: FontWeight) -> Self {
         self.label.weight = weight;
         self
     }


### PR DESCRIPTION
Right now, there are uses of `Weight` from Fontique, `TextWeight` from Masonry, and `FontWeight` from Parley.

We should just use a single name.