### PR TITLE
Disable debug info compilation in CI to boost performance.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
           save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: Run cargo nextest
-        run: cargo nextest run --workspace --locked --all-features --no-fail-fast
+        run: cargo nextest run --workspace --locked --cargo-profile ci --all-features --no-fail-fast
         env:
           # We do not run the masonry render tests on platforms without a working GPU,
           # because those require Vello rendering to be working
@@ -294,7 +294,7 @@ jobs:
           path: masonry/src/widget/screenshots
 
       - name: Run cargo test --doc
-        run: cargo test --doc --workspace --locked --all-features --no-fail-fast
+        run: cargo test --doc --workspace --locked --profile ci --all-features --no-fail-fast
 
   test-stable-wasm:
     name: cargo test (wasm32)
@@ -316,7 +316,7 @@ jobs:
 
       # TODO: Find a way to make tests work. Until then the tests are merely compiled.
       - name: Run cargo test --no-run
-        run: cargo test --workspace ${{ env.NO_WASM_PKGS }} --locked --target wasm32-unknown-unknown --all-features --no-run
+        run: cargo test --workspace ${{ env.NO_WASM_PKGS }} --locked --profile ci --target wasm32-unknown-unknown --all-features --no-run
 
   check-stable-android:
     name: cargo check (aarch64-android)
@@ -434,7 +434,7 @@ jobs:
 
       # We test documentation using nightly to match docs.rs.
       - name: Run cargo doc
-        run: cargo doc --workspace --locked --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
+        run: cargo doc --workspace --locked --profile ci --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
         env:
           RUSTDOCFLAGS: '--cfg docsrs -D warnings'
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,6 @@ time = "0.3.36"
 [profile.ci]
 inherits = "dev"
 debug = 0 # Don't compile debug info to reduce compilation artifact size for cache benefits.
-strip = "debuginfo" # Implied with debug = 0 since Rust 1.77, still useful for older.
+strip = "debuginfo" # Implied by debug = 0 since Rust 1.77, but still needed for an older MSRV.
 [profile.ci.package."*"]
 debug-assertions = true # Keep always on for dependencies for cache reuse.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,5 +128,7 @@ time = "0.3.36"
 
 [profile.ci]
 inherits = "dev"
+debug = 0 # Don't compile debug info to reduce compilation artifact size for cache benefits.
+strip = "debuginfo" # Implied with debug = 0 since Rust 1.77, still useful for older.
 [profile.ci.package."*"]
 debug-assertions = true # Keep always on for dependencies for cache reuse.


### PR DESCRIPTION
Turning off debug info in CI gives us tiny speedups, with potential for more [in some scenarios](https://davidlattimore.github.io/posts/2024/02/04/speeding-up-the-rust-edit-build-run-cycle.html#avoid-linking-debug-info). Most notably there is 30% space savings on artifact size in Linux, really helping with cache pressure and compression/decompression time.

We don't really need the benefits of debug info in the CI environment. We're not attaching debuggers there and in case of panics we can still get a backtrace. Thus it's just wasted effort to generate the debug info and then to link it in and cache it.

## Benchmarks

I did some minor benchmarking on three different OS setups with Rust 1.83. Every step was repeated four times (1 warmup, then 3 for measuring), but stuff like CPU boost frequency etc was not controlled for. Even so, the numbers are useful for ballparking.

I set `CARGO_INCREMENTAL` to `0` to match the CI and measured `cargo clippy -p xilem --locked --profile ci --all-features`.

| Windows 11 23H2 | Old         | New         | Diff |
|-----------------|-------------|-------------|------|
| Cold duration   | 17.40s      | 17.21s      | -1%  |
| Warm duration   | 0.74s       | 0.73s       | -1%  |
| Cache size      | 490 801 867 | 485 287 057 | -1%  |

| macOS 10.15.4 | Old         | New         | Diff |
|---------------|-------------|-------------|------|
| Cold duration | 30.58s      | 30.34s      | -1%  |
| Warm duration | 1.27s       | 1.21s       | -5%  |
| Cache size    | 207 200 857 | 200 717 130 | -3%  |

| Ubuntu 23.10  | Old         | New         | Diff |
|---------------|-------------|-------------|------|
| Cold duration | 24.50s      | 23.50s      | -4%  |
| Warm duration | 0.84s       | 0.87s       | +4%  |
| Cache size    | 597 456 507 | 411 918 698 | -31% 🚀 |

