### PR TITLE
Improve IME area reporting and set IME area in `TextArea`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,8 +1083,9 @@ dependencies = [
 [[package]]
 name = "fontique"
 version = "0.2.0"
-source = "git+https://github.com/linebender/parley?rev=211878fae20ba8b4bf4dcc39e6bf790eece8aa03#211878fae20ba8b4bf4dcc39e6bf790eece8aa03"
+source = "git+https://github.com/linebender/parley?rev=1a8740d8d86ebf751201e45e89bb71019340137d#1a8740d8d86ebf751201e45e89bb71019340137d"
 dependencies = [
+ "bytemuck",
  "core-foundation",
  "core-text",
  "fontconfig-cache-parser",
@@ -2506,7 +2507,7 @@ dependencies = [
 [[package]]
 name = "parley"
 version = "0.2.0"
-source = "git+https://github.com/linebender/parley?rev=211878fae20ba8b4bf4dcc39e6bf790eece8aa03#211878fae20ba8b4bf4dcc39e6bf790eece8aa03"
+source = "git+https://github.com/linebender/parley?rev=1a8740d8d86ebf751201e45e89bb71019340137d#1a8740d8d86ebf751201e45e89bb71019340137d"
 dependencies = [
  "accesskit",
  "fontique",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ tree_arena = { version = "0.1.0", path = "tree_arena" }
 vello = "0.3"
 wgpu = "22.1.0"
 kurbo = "0.11.1"
-parley = { git = "https://github.com/linebender/parley", rev = "211878fae20ba8b4bf4dcc39e6bf790eece8aa03", features = [
+parley = { git = "https://github.com/linebender/parley", rev = "1a8740d8d86ebf751201e45e89bb71019340137d", features = [
     "accesskit",
 ] }
 peniko = "0.2.0"

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -195,6 +195,21 @@ impl_context_method!(
                 .expect("get_child_state_mut: child not found");
             child_state_mut.item
         }
+
+        /// Set the IME cursor area.
+        ///
+        /// The reported IME area can be used by the platform to, for example, place a candidate
+        /// box near that area, while ensuring the area is not obscured.
+        pub fn set_ime_area(&mut self, ime_area: Rect) {
+            self.widget_state.ime_area = Some(ime_area);
+        }
+
+        /// Remove the IME cursor area.
+        ///
+        /// See [`LayoutCtx::set_ime_area`](LayoutCtx::set_ime_area) for more details.
+        pub fn clear_ime_area(&mut self) {
+            self.widget_state.ime_area = None;
+        }
     }
 );
 

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -198,8 +198,12 @@ impl_context_method!(
 
         /// Set the IME cursor area.
         ///
-        /// The reported IME area can be used by the platform to, for example, place a candidate
-        /// box near that area, while ensuring the area is not obscured.
+        /// When this widget is [focused] and [accepts text input], the reported IME area is sent
+        /// to the platform. The area can be used by the platform to, for example, place a
+        /// candidate box near that area, while ensuring the area is not obscured.
+        ///
+        /// [focused]: EventCtx::request_focus
+        /// [accepts text input]: Widget::accepts_text_input
         pub fn set_ime_area(&mut self, ime_area: Rect) {
             self.widget_state.ime_area = Some(ime_area);
         }

--- a/masonry/src/passes/compose.rs
+++ b/masonry/src/passes/compose.rs
@@ -6,7 +6,7 @@ use tree_arena::ArenaMut;
 use vello::kurbo::Vec2;
 
 use crate::passes::{enter_span_if, recurse_on_children};
-use crate::render_root::{RenderRoot, RenderRootSignal, RenderRootState};
+use crate::render_root::{RenderRoot, RenderRootState};
 use crate::{ComposeCtx, Widget, WidgetState};
 
 // --- MARK: RECURSE ---
@@ -40,12 +40,6 @@ fn compose_widget(
     };
     if ctx.widget_state.request_compose {
         widget.item.compose(&mut ctx);
-    }
-
-    // TODO - Add unit tests for this.
-    if moved && state.item.accepts_text_input && global_state.is_focused(state.item.id) {
-        let ime_area = state.item.get_ime_area();
-        global_state.emit_signal(RenderRootSignal::new_ime_moved_signal(ime_area));
     }
 
     // We need to update the accessibility node's coordinates and repaint it at the new position.

--- a/masonry/src/passes/update.rs
+++ b/masonry/src/passes/update.rs
@@ -523,11 +523,6 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
             if widget_state.accepts_text_input {
                 root.global_state.emit_signal(RenderRootSignal::StartIme);
             }
-
-            root.global_state
-                .emit_signal(RenderRootSignal::new_ime_moved_signal(
-                    widget_state.get_ime_area(),
-                ));
         } else {
             root.global_state.is_ime_active = false;
         }


### PR DESCRIPTION
This adds the required context methods for (re)setting the IME area. These are added to the mutable context types, which I believe is the right place.

`TextArea` now uses `PlainEditor::ime_cursor_area` to report its IME area.

Note Masonry currently reports new IME cursor areas only when the widget itself moves or the focus changes to a new widget, but Parley's `PlainEditor` determines the IME cursor area based on the selection and preedit state of the editor, meaning the area can change based on events as well. Other widgets may choose to have different behavior still.

(It appears Masonry currently doesn't account for the IME area potentially changing based on relayout, which may be a bug.)

This replaces the old IME area reporting with a check at the end of the rewrite pass to see if IME is active, and if it is, whether the IME area has moved. If it has, the new area is reported to the platform.