### PR TITLE
Tweak documentation for readability

### DIFF
--- a/masonry/src/action.rs
+++ b/masonry/src/action.rs
@@ -5,7 +5,8 @@ use std::any::Any;
 
 use crate::event::PointerButton;
 
-// TODO - Refactor - See issue https://github.com/linebender/xilem/issues/335
+// TODO - Replace actions with an associated type on the Widget trait
+// See https://github.com/linebender/xilem/issues/664
 
 // TODO - TextCursor changed, ImeChanged, EnterKey, MouseEnter
 #[non_exhaustive]

--- a/masonry/src/box_constraints.rs
+++ b/masonry/src/box_constraints.rs
@@ -187,7 +187,8 @@ impl BoxConstraints {
     ///
     /// ## Panics
     ///
-    /// Panics if `aspect_ratio` or `width` are not finite or are negative.
+    /// Panics if `aspect_ratio` or `width` are NaN, infinite or negative.
+    #[track_caller]
     pub fn constrain_aspect_ratio(&self, aspect_ratio: f64, width: f64) -> Size {
         assert!(aspect_ratio.is_finite());
         assert!(width.is_finite());

--- a/masonry/src/box_constraints.rs
+++ b/masonry/src/box_constraints.rs
@@ -184,7 +184,16 @@ impl BoxConstraints {
     ///
     /// Use this function when maintaining an aspect ratio is more important than minimizing the
     /// distance between input and output size width and height.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if `aspect_ratio` or `width` are not finite or are negative.
     pub fn constrain_aspect_ratio(&self, aspect_ratio: f64, width: f64) -> Size {
+        assert!(aspect_ratio.is_finite());
+        assert!(width.is_finite());
+        assert!(aspect_ratio >= 0.0);
+        assert!(width >= 0.0);
+
         // Minimizing/maximizing based on aspect ratio seems complicated, but in reality everything
         // is linear, so the amount of work to do is low.
         let ideal_size = Size {
@@ -201,8 +210,6 @@ impl BoxConstraints {
             return ideal_size;
         }
 
-        // Then we check if any `Size`s with our desired aspect ratio are inside the constraints.
-        // TODO this currently outputs garbage when things are < 0 - See https://github.com/linebender/xilem/issues/377
         let min_w_min_h = self.min.height / self.min.width;
         let max_w_min_h = self.min.height / self.max.width;
         let min_w_max_h = self.max.height / self.min.width;

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -574,7 +574,7 @@ impl_context_method!(MutateCtx<'_>, EventCtx<'_>, UpdateCtx<'_>, {
     pub fn children_changed(&mut self) {
         trace!("children_changed");
         self.widget_state.children_changed = true;
-        self.widget_state.update_focus_chain = true;
+        self.widget_state.needs_update_focus_chain = true;
         self.request_layout();
     }
 

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -3,8 +3,6 @@
 
 //! The context types that are passed into various widget methods.
 
-use std::time::Duration;
-
 use accesskit::TreeUpdate;
 use dpi::LogicalPosition;
 use parley::{FontContext, LayoutContext};
@@ -710,14 +708,6 @@ impl_context_method!(
                 .push_back(RenderRootSignal::ShowWindowMenu(position));
         }
 
-        /// Request a timer event.
-        ///
-        /// The return value is a token, which can be used to associate the
-        /// request with the event.
-        pub fn request_timer(&mut self, _deadline: Duration) -> TimerToken {
-            todo!("request_timer");
-        }
-
         /// Mark child widget as stashed.
         ///
         /// If `stashed` is true, the child will not be painted or listed in the accessibility tree.
@@ -737,9 +727,6 @@ impl_context_method!(
         }
     }
 );
-
-// FIXME - Remove
-pub struct TimerToken;
 
 impl EventCtx<'_> {
     // TODO - clearly document all semantics of pointer capture when they've been decided on

--- a/masonry/src/debug_logger.rs
+++ b/masonry/src/debug_logger.rs
@@ -204,7 +204,7 @@ impl DebugLogger {
             StateTree::new("has_focus", w_state.has_focus),
             StateTree::new("request_anim", w_state.request_anim),
             StateTree::new("children_changed", w_state.children_changed),
-            StateTree::new("update_focus_chain", w_state.update_focus_chain),
+            StateTree::new("update_focus_chain", w_state.needs_update_focus_chain),
         ]
         .into();
         state

--- a/masonry/src/doc/01_creating_app.md
+++ b/masonry/src/doc/01_creating_app.md
@@ -118,8 +118,8 @@ When handling `ButtonPressed`:
 - `ctx.render_root()` returns a reference to the `RenderRoot`, which owns the widget tree and all the associated visual state.
 - `RenderRoot::edit_root_widget()` takes a closure; that closure takes a `WidgetMut<Box<dyn Widget>>` which we call `root`. Once the closure returns, `RenderRoot` runs some passes to update the app's internal states.
 - `root.downcast::<...>()` returns a `WidgetMut<RootWidget<...>>`.
-- `RootWidget::child_mut()` returns a `WidgetMut<Portal<...>>` for the `Portal`.
-- `Portal::child_mut()` returns a `WidgetMut<Flex>` for the `Flex`.
+- `RootWidget::child_mut()` returns a `WidgetMut<Portal<...>>`.
+- `Portal::child_mut()` returns a `WidgetMut<Flex>`.
 
 A [`WidgetMut`] is a smart reference type which lets us modify the widget tree.
 It's set up to automatically propagate update flags and update internal state when dropped.

--- a/masonry/src/doc/03_implementing_container_widget.md
+++ b/masonry/src/doc/03_implementing_container_widget.md
@@ -254,11 +254,11 @@ Doesn't `VerticalStack::paint` need to call `paint` on its children, for instanc
 
 It doesn't.
 
-In Masonry, most passes are automatically propagated to children, without container widgets having to implement code iterating over their children.
+In Masonry, most passes are automatically propagated to children, and so container widgets do not need to *and cannot* call the pass methods on their children.
 
 So for instance, if `VerticalStack::children_ids()` returns a list of three children, the paint pass will automatically call `paint` on all three children after `VerticalStack::paint()`.
 
-So various methods in container widgets should only implement the logic that is specific to the container itself.
+Pass methods in container widgets should only implement the logic that is specific to the container itself.
 For instance, a container widget with a background color should implement `paint` to draw the background.
 
 [`Widget`]: crate::Widget

--- a/masonry/src/doc/05_pass_system.md
+++ b/masonry/src/doc/05_pass_system.md
@@ -106,6 +106,13 @@ It is called when new widgets are added to the tree, or existing widgets are rem
 
 It will call the `register_children()` widget method on container widgets whose children changed, then the `update()` method with the `WidgetAdded` event on new widgets.
 
+<!-- TODO - document UPDATE DISABLED --- -->
+<!-- TODO - document UPDATE STASHED --- -->
+<!-- TODO - document UPDATE FOCUS CHAIN --- -->
+<!-- TODO - document UPDATE FOCUS --- (document iteration order) -->
+<!-- TODO - document UPDATE SCROLL --- -->
+<!-- TODO - document UPDATE POINTER --- (document iteration order) -->
+
 ### Layout pass
 
 The layout pass runs bidirectionally, passing constraints from the top down and getting back sizes and other layout info from the bottom up.

--- a/masonry/src/doc/05_pass_system.md
+++ b/masonry/src/doc/05_pass_system.md
@@ -106,12 +106,12 @@ It is called when new widgets are added to the tree, or existing widgets are rem
 
 It will call the `register_children()` widget method on container widgets whose children changed, then the `update()` method with the `WidgetAdded` event on new widgets.
 
-<!-- TODO - document UPDATE DISABLED --- -->
-<!-- TODO - document UPDATE STASHED --- -->
-<!-- TODO - document UPDATE FOCUS CHAIN --- -->
-<!-- TODO - document UPDATE FOCUS --- (document iteration order) -->
-<!-- TODO - document UPDATE SCROLL --- -->
-<!-- TODO - document UPDATE POINTER --- (document iteration order) -->
+<!-- TODO - document update disabled --- -->
+<!-- TODO - document update stashed --- -->
+<!-- TODO - document update focus chain --- -->
+<!-- TODO - document update focus --- (document iteration order) -->
+<!-- TODO - document update scroll --- -->
+<!-- TODO - document update pointer --- (document iteration order) -->
 
 ### Layout pass
 

--- a/masonry/src/event.rs
+++ b/masonry/src/event.rs
@@ -181,7 +181,6 @@ impl From<PointerButton> for PointerButtons {
 // TODO - How can RenderRoot express "I started a drag-and-drop op"?
 // TODO - Touchpad, Touch, AxisMotion
 // TODO - How to handle CursorEntered?
-// Note to self: Events like "pointerenter", "pointerleave" are handled differently at the Widget level. But that's weird because WidgetPod can distribute them. Need to think about this again.
 #[derive(Debug, Clone)]
 pub enum PointerEvent {
     PointerDown(PointerButton, PointerState),
@@ -313,6 +312,7 @@ pub enum Update {
 }
 
 impl PointerEvent {
+    /// Create a [`PointerEvent::PointerLeave`] event with dummy values.
     pub fn new_pointer_leave() -> Self {
         // TODO - The fact we're creating so many dummy values might be
         // a sign we should refactor that struct
@@ -328,6 +328,7 @@ impl PointerEvent {
         Self::PointerLeave(pointer_state)
     }
 
+    /// Returns the [`PointerState`] of the event.
     pub fn pointer_state(&self) -> &PointerState {
         match self {
             Self::PointerDown(_, state)
@@ -343,6 +344,7 @@ impl PointerEvent {
         }
     }
 
+    /// Returns the position of the pointer event, except for [`PointerEvent::PointerLeave`] and [`PointerEvent::HoverFileCancel`].
     pub fn position(&self) -> Option<LogicalPosition<f64>> {
         match self {
             Self::PointerLeave(_) | Self::HoverFileCancel(_) => None,
@@ -350,6 +352,9 @@ impl PointerEvent {
         }
     }
 
+    /// Short name, for debug logging.
+    ///
+    /// Returns the enum variant name.
     pub fn short_name(&self) -> &'static str {
         match self {
             Self::PointerDown(_, _) => "PointerDown",
@@ -365,6 +370,10 @@ impl PointerEvent {
         }
     }
 
+    /// Returns true if the event is likely to occur every frame.
+    ///
+    /// Developers should avoid logging during high-density events to avoid
+    /// cluttering the console.
     pub fn is_high_density(&self) -> bool {
         match self {
             Self::PointerDown(_, _) => false,
@@ -382,20 +391,25 @@ impl PointerEvent {
 }
 
 impl TextEvent {
+    /// Short name, for debug logging.
     pub fn short_name(&self) -> &'static str {
         match self {
-            Self::KeyboardKey(KeyEvent { repeat: true, .. }, _) => "KeyboardKey (repeat)",
+            Self::KeyboardKey(KeyEvent { repeat: true, .. }, _) => "KeyboardKey(repeat)",
             Self::KeyboardKey(_, _) => "KeyboardKey",
             Self::Ime(Ime::Disabled) => "Ime::Disabled",
             Self::Ime(Ime::Enabled) => "Ime::Enabled",
             Self::Ime(Ime::Commit(_)) => "Ime::Commit",
             Self::Ime(Ime::Preedit(s, _)) if s.is_empty() => "Ime::Preedit(\"\")",
-            Self::Ime(Ime::Preedit(_, _)) => "Ime::Preedit",
+            Self::Ime(Ime::Preedit(_, _)) => "Ime::Preedit(\"...\")",
             Self::ModifierChange(_) => "ModifierChange",
             Self::FocusChange(_) => "FocusChange",
         }
     }
 
+    /// Returns true if the event is likely to occur every frame.
+    ///
+    /// Developers should avoid logging during high-density events to avoid
+    /// cluttering the console.
     pub fn is_high_density(&self) -> bool {
         match self {
             Self::KeyboardKey(_, _) => false,
@@ -408,6 +422,9 @@ impl TextEvent {
 }
 
 impl AccessEvent {
+    /// Short name, for debug logging.
+    ///
+    /// Returns the enum variant name.
     pub fn short_name(&self) -> &'static str {
         match self.action {
             accesskit::Action::Click => "Click",
@@ -442,15 +459,6 @@ impl AccessEvent {
 
 impl PointerState {
     pub fn empty() -> Self {
-        #[cfg(FALSE)]
-        #[allow(unsafe_code)]
-        // SAFETY: Uuuuh, unclear. Winit says the dummy id should only be used in
-        // tests and should never be passed to winit. In principle, we're never
-        // passing this id to winit, but it's still visible to custom widgets which
-        // might do so if they tried really hard.
-        // It would be a lot better if winit could just make this constructor safe.
-        let device_id = unsafe { DeviceId::dummy() };
-
         Self {
             physical_position: PhysicalPosition::new(0.0, 0.0),
             position: LogicalPosition::new(0.0, 0.0),
@@ -466,7 +474,7 @@ impl PointerState {
 impl Update {
     /// Short name, for debug logging.
     ///
-    /// Essentially returns the enum variant name.
+    /// Returns the enum variant name.
     pub fn short_name(&self) -> &str {
         match self {
             Self::WidgetAdded => "WidgetAdded",

--- a/masonry/src/event.rs
+++ b/masonry/src/event.rs
@@ -312,22 +312,6 @@ pub enum Update {
 }
 
 impl PointerEvent {
-    /// Create a [`PointerEvent::PointerLeave`] event with dummy values.
-    pub fn new_pointer_leave() -> Self {
-        // TODO - The fact we're creating so many dummy values might be
-        // a sign we should refactor that struct
-        let pointer_state = PointerState {
-            physical_position: Default::default(),
-            position: Default::default(),
-            buttons: Default::default(),
-            mods: Default::default(),
-            count: 0,
-            focus: false,
-            force: None,
-        };
-        Self::PointerLeave(pointer_state)
-    }
-
     /// Returns the [`PointerState`] of the event.
     pub fn pointer_state(&self) -> &PointerState {
         match self {
@@ -387,6 +371,25 @@ impl PointerEvent {
             Self::HoverFileCancel(_) => false,
             Self::Pinch(_, _) => true,
         }
+    }
+
+    /// Create a [`PointerEvent::PointerLeave`] event with dummy values.
+    ///
+    /// This is used internally to create synthetic `PointerLeave` events when pointer
+    /// capture is lost.
+    pub fn new_pointer_leave() -> Self {
+        // TODO - The fact we're creating so many dummy values might be
+        // a sign we should refactor that struct
+        let pointer_state = PointerState {
+            physical_position: Default::default(),
+            position: Default::default(),
+            buttons: Default::default(),
+            mods: Default::default(),
+            count: 0,
+            focus: false,
+            force: None,
+        };
+        Self::PointerLeave(pointer_state)
     }
 }
 

--- a/masonry/src/passes/accessibility.rs
+++ b/masonry/src/passes/accessibility.rs
@@ -102,7 +102,7 @@ fn build_access_node(widget: &mut dyn Widget, ctx: &mut AccessCtx) -> Node {
             .collect::<Vec<NodeId>>(),
     );
 
-    // Note - These WidgetState flags can be modified by other passes.
+    // Note - The values returned by these methods can be modified by other passes.
     // When that happens, the other pass should set flags to request an accessibility pass.
     if ctx.is_disabled() {
         node.set_disabled();

--- a/masonry/src/passes/compose.rs
+++ b/masonry/src/passes/compose.rs
@@ -74,7 +74,7 @@ fn compose_widget(
 pub(crate) fn run_compose_pass(root: &mut RenderRoot) {
     let _span = info_span!("compose").entered();
 
-    // If widgets are moved, pointer-related info may be stale.
+    // If widgets have moved, pointer-related info may be stale.
     // For instance, the "hovered" widget may have moved and no longer be under the pointer.
     if root.root_state().needs_compose {
         root.global_state.needs_pointer_pass = true;

--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -11,7 +11,7 @@ use crate::render_root::RenderRoot;
 use crate::{AccessEvent, EventCtx, Handled, PointerEvent, TextEvent, Widget, WidgetId};
 
 // --- MARK: HELPERS ---
-fn get_target_widget(
+fn get_pointer_target(
     root: &RenderRoot,
     pointer_pos: Option<LogicalPosition<f64>>,
 ) -> Option<WidgetId> {
@@ -89,8 +89,8 @@ pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEv
 
     if event.is_high_density() {
         // We still want to record that this pass occurred in the debug file log.
-        // However, we choose not record any other tracing for this event,
-        // as that would have a lot of noise.
+        // However, we choose not to record any other tracing for this event,
+        // as that would create a lot of noise.
         trace!("Running ON_POINTER_EVENT pass with {}", event.short_name());
     } else {
         debug!("Running ON_POINTER_EVENT pass with {}", event.short_name());
@@ -101,7 +101,7 @@ pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEv
         root.last_mouse_pos = event.position();
     }
 
-    let target_widget_id = get_target_widget(root, event.position());
+    let target_widget_id = get_pointer_target(root, event.position());
 
     let handled = run_event_pass(
         root,
@@ -134,11 +134,6 @@ pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEv
 
     handled
 }
-
-// TODO https://github.com/linebender/xilem/issues/376 - Some implicit invariants:
-// - If a Widget gets a keyboard event or an ImeStateChange, then
-// focus is on it, its child or its parent.
-// - If a Widget has focus, then none of its parents is hidden
 
 // --- MARK: TEXT EVENT ---
 pub(crate) fn run_on_text_event_pass(root: &mut RenderRoot, event: &TextEvent) -> Handled {

--- a/masonry/src/passes/layout.rs
+++ b/masonry/src/passes/layout.rs
@@ -161,22 +161,6 @@ pub(crate) fn run_layout_on<W: Widget>(
                     child_state.id,
                 );
             }
-
-            // TODO - This check might be redundant with the code updating local_paint_rect
-            let child_rect = child_state.paint_rect();
-            if !state.item.local_paint_rect.contains_rect(child_rect)
-                && state.item.clip_path.is_none()
-            {
-                debug_panic!(
-                    "Error in '{}' {}: paint_rect {:?} doesn't contain paint_rect {:?} of child widget '{}' {}",
-                    name,
-                    pod.id(),
-                    state.item.local_paint_rect,
-                    child_rect,
-                    child_state.widget_name,
-                    child_state.id,
-                );
-            }
         }
 
         let new_children_ids = widget.item.children_ids();
@@ -197,16 +181,6 @@ pub(crate) fn run_layout_on<W: Widget>(
             );
         }
     }
-
-    // TODO - Figure out how to deal with the overflow problem, eg:
-    // What happens if a widget returns a size larger than the allowed constraints?
-    // Some possibilities are:
-    // - Always clip: might be expensive
-    // - Display it anyway: might lead to graphical bugs
-    // - Panic: too harsh?
-    // Also, we need to avoid spurious crashes when we initialize the app and the
-    // size is (0,0)
-    // See https://github.com/linebender/xilem/issues/377
 
     let state_mut = parent_ctx.widget_state_children.get_child_mut(id).unwrap();
     parent_ctx.widget_state.merge_up(state_mut.item);

--- a/masonry/src/passes/mutate.rs
+++ b/masonry/src/passes/mutate.rs
@@ -16,8 +16,8 @@ pub(crate) fn mutate_widget<R>(
     let (widget_mut, state_mut) = root.widget_arena.get_pair_mut(id);
 
     let _span = info_span!("mutate_widget", name = widget_mut.item.short_type_name()).entered();
-    // NOTE - parent_widget_state can be None here, because the loop below will merge the
-    // state up to the root.
+    // NOTE - we can set parent_widget_state to None here, because the loop below will merge the
+    // states up to the root.
     let root_widget = WidgetMut {
         ctx: MutateCtx {
             global_state: &mut root.global_state,

--- a/masonry/src/passes/paint.rs
+++ b/masonry/src/passes/paint.rs
@@ -28,7 +28,8 @@ fn paint_widget(
 
     let id = state.item.id;
 
-    // TODO - Handle invalidation regions
+    // TODO - Handle damage regions
+    // https://github.com/linebender/xilem/issues/789
     let mut ctx = PaintCtx {
         global_state,
         widget_state: state.item,
@@ -71,7 +72,7 @@ fn paint_widget(
         state.children,
         |widget, mut state| {
             // TODO - We skip painting stashed items.
-            // This may have knock-on effects we'd need to document.
+            // This may lead to zombie flags in rare cases, we need to fix this.
             if state.item.is_stashed {
                 return;
             }

--- a/masonry/src/testing/helper_widgets.rs
+++ b/masonry/src/testing/helper_widgets.rs
@@ -16,15 +16,14 @@ use accesskit::{Node, Role};
 use smallvec::SmallVec;
 use tracing::trace_span;
 use vello::Scene;
-use widget::widget::get_child_at_pos;
-use widget::WidgetRef;
 
 use crate::event::{PointerEvent, TextEvent};
-use crate::widget::SizedBox;
-
-// TODO: Expect doesn't work here
-#[allow(clippy::wildcard_imports, reason = "Deferred: Noisy")]
-use crate::*;
+use crate::widget::widget::get_child_at_pos;
+use crate::widget::{SizedBox, WidgetRef};
+use crate::{
+    AccessCtx, AccessEvent, AsAny, BoxConstraints, ComposeCtx, CursorIcon, EventCtx, LayoutCtx,
+    PaintCtx, Point, QueryCtx, RegisterCtx, Size, Update, UpdateCtx, Widget, WidgetId, WidgetPod,
+};
 
 pub type PointerEventFn<S> = dyn FnMut(&mut S, &mut EventCtx, &PointerEvent);
 pub type TextEventFn<S> = dyn FnMut(&mut S, &mut EventCtx, &TextEvent);
@@ -284,13 +283,13 @@ impl<S> ModularWidget<S> {
 
 #[warn(clippy::missing_trait_methods)]
 impl<S: 'static> Widget for ModularWidget<S> {
-    fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &event::PointerEvent) {
+    fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         if let Some(f) = self.on_pointer_event.as_mut() {
             f(&mut self.state, ctx, event);
         }
     }
 
-    fn on_text_event(&mut self, ctx: &mut EventCtx, event: &event::TextEvent) {
+    fn on_text_event(&mut self, ctx: &mut EventCtx, event: &TextEvent) {
         if let Some(f) = self.on_text_event.as_mut() {
             f(&mut self.state, ctx, event);
         }
@@ -441,9 +440,9 @@ impl Widget for ReplaceChild {
         self.child.on_event(ctx, event)
     }
 
-    fn on_pointer_event(&mut self, _ctx: &mut EventCtx, _event: &event::PointerEvent) {}
+    fn on_pointer_event(&mut self, _ctx: &mut EventCtx, _event: &PointerEvent) {}
 
-    fn on_text_event(&mut self, _ctx: &mut EventCtx, _event: &event::TextEvent) {}
+    fn on_text_event(&mut self, _ctx: &mut EventCtx, _event: &TextEvent) {}
 
     fn on_access_event(&mut self, _ctx: &mut EventCtx, _event: &AccessEvent) {}
 
@@ -507,12 +506,12 @@ impl Recording {
 
 #[warn(clippy::missing_trait_methods)]
 impl<W: Widget> Widget for Recorder<W> {
-    fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &event::PointerEvent) {
+    fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
         self.recording.push(Record::PE(event.clone()));
         self.child.on_pointer_event(ctx, event);
     }
 
-    fn on_text_event(&mut self, ctx: &mut EventCtx, event: &event::TextEvent) {
+    fn on_text_event(&mut self, ctx: &mut EventCtx, event: &TextEvent) {
         self.recording.push(Record::TE(event.clone()));
         self.child.on_text_event(ctx, event);
     }

--- a/masonry/src/text/mod.rs
+++ b/masonry/src/text/mod.rs
@@ -4,7 +4,7 @@
 //! Support for text display and rendering
 //!
 //! There are three kinds of text commonly needed:
-//!  1) Entirely display text (e.g. a button)
+//!  1) Non interactive text (e.g. a button's label)
 //!  2) Selectable text (e.g. a paragraph of content)
 //!  3) Editable text (e.g. a search bar)
 //!

--- a/masonry/src/widget/align.rs
+++ b/masonry/src/widget/align.rs
@@ -164,7 +164,6 @@ fn log_size_warnings(size: Size) {
 }
 
 // --- MARK: TESTS ---
-// --- MARK: TESTS ---
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widget/button.rs
+++ b/masonry/src/widget/button.rs
@@ -18,7 +18,7 @@ use crate::{
     PointerEvent, QueryCtx, Size, TextEvent, Update, UpdateCtx, Widget, WidgetId,
 };
 
-// the minimum padding added to a button.
+// The minimum padding added to a button.
 // NOTE: these values are chosen to match the existing look of TextBox; these
 // should be reevaluated at some point.
 const LABEL_INSETS: Insets = Insets::uniform_xy(8., 2.);
@@ -206,12 +206,6 @@ impl Widget for Button {
 
     fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
         trace_span!("Button", id = ctx.widget_id().trace())
-    }
-
-    // FIXME
-    #[cfg(FALSE)]
-    fn get_debug_text(&self) -> Option<String> {
-        Some(self.label.as_ref().text().as_ref().to_string())
     }
 }
 

--- a/masonry/src/widget/flex.rs
+++ b/masonry/src/widget/flex.rs
@@ -32,10 +32,9 @@ pub struct Flex {
 /// Optional parameters for an item in a [`Flex`] container (row or column).
 ///
 /// Generally, when you would like to add a flexible child to a container,
-/// you can simply call [`with_flex_child`](Flex::with_flex_child), passing the
-/// child and the desired flex factor as a `f64`, which has an impl of
+/// you can simply call [`with_flex_child`](Flex::with_flex_child) or [`add_flex_child`](Flex::add_flex_child),
+/// passing the child and the desired flex factor as a `f64`, which has an impl of
 /// `Into<FlexParams>`.
-// FIXME - "with_flex_child or [`add_flex_child`](FlexMut::add_flex_child)"
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
 pub struct FlexParams {
     flex: Option<f64>,
@@ -540,7 +539,6 @@ impl Flex {
         this.ctx.request_layout();
     }
 
-    // FIXME - Remove Box
     pub fn child_mut<'t>(
         this: &'t mut WidgetMut<'_, Self>,
         idx: usize,

--- a/masonry/src/widget/scroll_bar.rs
+++ b/masonry/src/widget/scroll_bar.rs
@@ -17,18 +17,13 @@ use crate::{
     WidgetId,
 };
 
-// RULES
-// -
+// TODO
+// - Fade scrollbars? Find out how Linux/MacOS/Windows do it
+// - Rename cursor to oval/rect/bar/grabber/grabbybar
+// - Rename progress to something more descriptive
+// - Document names
+// - Document invariants
 
-// TODO - Document names:
-// - grabbybar
-// - empty_space
-// - _z
-// - _length
-
-// TODO - Fade scrollbars? Find out how Linux/MacOS/Windows do it
-// TODO - Rename cursor to oval/rect/bar/grabber/grabbybar
-// TODO - Rename progress to ???
 pub struct ScrollBar {
     axis: Axis,
     pub(crate) cursor_progress: f64,
@@ -287,41 +282,7 @@ mod tests {
         assert_render_snapshot!(harness, "scrollbar_horizontal_middle");
     }
 
-    // TODO - portal larger than content
+    // TODO - Add "portal larger than content" test
 
-    #[cfg(FALSE)]
-    #[test]
-    fn edit_button() {
-        let image_1 = {
-            let button = Button::from_label(
-                Label::new("The quick brown fox jumps over the lazy dog")
-                    .with_text_color(PRIMARY_LIGHT)
-                    .with_text_size(20.0),
-            );
-
-            let mut harness = TestHarness::create_with_size(button, Size::new(50.0, 50.0));
-
-            harness.render()
-        };
-
-        let image_2 = {
-            let button = Button::new("Hello world");
-
-            let mut harness = TestHarness::create_with_size(button, Size::new(50.0, 50.0));
-
-            harness.edit_root_widget(|mut button, _| {
-                let mut button = button.downcast::<Button>().unwrap();
-                button.set_text("The quick brown fox jumps over the lazy dog");
-
-                let mut label = button.label_mut();
-                label.set_text_color(PRIMARY_LIGHT);
-                label.set_text_size(20.0);
-            });
-
-            harness.render()
-        };
-
-        // We don't use assert_eq because we don't want rich assert
-        assert!(image_1 == image_2);
-    }
+    // TODO - Add WidgetMut tests
 }

--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -324,8 +324,6 @@ impl SizedBox {
         self.padding = padding.into();
         self
     }
-
-    // TODO - child()
 }
 
 // --- MARK: WIDGETMUT ---

--- a/masonry/src/widget/textbox.rs
+++ b/masonry/src/widget/textbox.rs
@@ -46,14 +46,14 @@ pub struct Textbox {
 }
 
 impl Textbox {
-    /// Create a new `Prose` with the given text.
+    /// Create a new `Textbox` with the given text.
     ///
     /// To use non-default text properties, use [`from_text_area`](Self::from_text_area) instead.
     pub fn new(text: &str) -> Self {
         Self::from_text_area(TextArea::new_editable(text))
     }
 
-    /// Create a new `Prose` from a styled text area.
+    /// Create a new `Textbox` from a styled text area.
     pub fn from_text_area(text: TextArea<true>) -> Self {
         let text = text.with_padding_if_default(TEXTBOX_PADDING);
         Self {
@@ -62,9 +62,9 @@ impl Textbox {
         }
     }
 
-    /// Create a new `Prose` from a styled text area in a [`WidgetPod`].
+    /// Create a new `Textbox` from a styled text area in a [`WidgetPod`].
     ///
-    /// Note that the default padding used for prose will not apply.
+    /// Note that the default padding used for textbox will not apply.
     pub fn from_text_area_pod(text: WidgetPod<TextArea<true>>) -> Self {
         Self { text, clip: false }
     }
@@ -185,8 +185,6 @@ mod tests {
     };
 
     #[test]
-    /// A wrapping prose's alignment should be respected, regardless of
-    /// its parent's alignment.
     fn textbox_outline() {
         let textbox = Textbox::from_text_area(
             TextArea::new_editable("Textbox contents").with_style(StyleProperty::FontSize(10.0)),

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -125,7 +125,7 @@ pub trait Widget: AsAny {
     /// changes in the widget graph or in the state of your specific widget.
     fn update(&mut self, ctx: &mut UpdateCtx, event: &Update) {}
 
-    /// Compute layout.
+    /// Compute layout and return the widget's size.
     ///
     /// A leaf widget should determine its size (subject to the provided
     /// constraints) and return it.
@@ -147,7 +147,9 @@ pub trait Widget: AsAny {
     /// **Container widgets should not add or remove children during layout.**
     /// Doing so is a logic error and may trigger a debug assertion.
     ///
-    /// The layout strategy is strongly inspired by Flutter.
+    /// While each widget should try to return a size that fits the input constraints,
+    /// **any widget may return a size that doesn't fit its constraints**, and container
+    /// widgets should handle those cases gracefully.
     fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size;
 
     fn compose(&mut self, ctx: &mut ComposeCtx) {}

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -216,7 +216,6 @@ pub trait Widget: AsAny {
     /// As methods recurse through the widget tree, trace spans are added for each child
     /// widget visited, and popped when control flow goes back to the parent. This method
     /// returns a static span (that you can use to filter traces and logs).
-    // TODO: Make include the widget's id?
     fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
         trace_span!(
             "Widget",

--- a/masonry/src/widget/widget_pod.rs
+++ b/masonry/src/widget/widget_pod.rs
@@ -3,23 +3,19 @@
 
 use crate::{Widget, WidgetId};
 
-// TODO - rewrite links in doc
-
 /// A container for one widget in the hierarchy.
 ///
 /// Generally, container widgets don't contain other widgets directly,
 /// but rather contain a `WidgetPod`, which has additional state needed
 /// for layout and for the widget to participate in event flow.
-///
-/// `WidgetPod` will translate internal Masonry events to regular events,
-/// synthesize additional events of interest, and stop propagation when it makes sense.
+// TODO - Add reference to container tutorial
 pub struct WidgetPod<W> {
     id: WidgetId,
     inner: WidgetPodInner<W>,
 }
 
 // TODO - This is a simple state machine that lets users create WidgetPods
-// without immediate access to the widget arena. It's *extremely* inefficient
+// without immediate access to the widget arena. It's very inefficient
 // and leads to ugly code. The alternative is to force users to create WidgetPods
 // through context methods where they already have access to the arena.
 // Implementing that requires solving non-trivial design questions.

--- a/masonry/src/widget/widget_ref.rs
+++ b/masonry/src/widget/widget_ref.rs
@@ -10,9 +10,9 @@ use crate::{QueryCtx, Widget, WidgetId};
 
 /// A rich reference to a [`Widget`].
 ///
-/// Widgets in Masonry are bundled with additional metadata called [`WidgetState`].
+/// Widgets in Masonry are bundled with additional metadata.
 ///
-/// A `WidgetRef` to a widget carries both a reference to the widget and to its `WidgetState`. It can [`Deref`] to the referenced widget.
+/// A `WidgetRef` to a widget carries both a reference to the widget and to its metadata. It can [`Deref`] to the referenced widget.
 ///
 /// This type is mostly used for debugging, to query a certain widget in the widget
 /// graph, get their layout, etc. It also implements [`std::fmt::Debug`] for convenience;

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -27,10 +27,19 @@ use crate::WidgetId;
 /// ## Naming scheme
 ///
 /// Some fields follow a naming scheme:
-/// - `request_xxx`: this specific widget has requested the xxx pass to run on it
-/// - `needs_xxx`: this widget or a descendant has requested the xxx pass to run on it
-/// - `is_xxx`: this widget has the xxx property
-/// - `has_xxx`: this widget or an ancestor has the xxx property
+/// - `request_xxx`: this specific widget has requested the xxx pass to run on it.
+/// - `needs_xxx`: this widget or a descendant has requested the xxx pass to run on it.
+/// - `is_xxx`: this widget has the xxx property.
+/// - `has_xxx`: this widget or a descendant has the xxx property.
+///
+/// ## Resetting flags
+///
+/// Generally, the `needs_foobar` and `request_foobar` flags will be reset to
+/// false during the "foobar" pass after calling the "foobar" method.
+///
+/// In principle this shouldn't be a problem because most passes shouldn't be
+/// able to request themselves. The exception is the anim pass: an anim frame can
+/// (and usually will) request a new anim frame.
 ///
 /// [`WidgetMut`]: crate::widget::WidgetMut
 #[derive(Clone, Debug)]

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -1,8 +1,6 @@
 // Copyright 2018 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(not(tarpaulin_include))]
-
 use vello::kurbo::{Insets, Point, Rect, Size, Vec2};
 
 use crate::WidgetId;


### PR DESCRIPTION
Apply many small tweaks I found while going over the documentation.
Rename some variables.
Add asserts to `BoxConstraints::constrain_aspect_ratio`.
Flesh out the WidgetState documentation.
Introduce the concept of "zombie flags".