### PR TITLE
Add missing `request_render` call when setting text selection from AccessKit

### DIFF
--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -847,6 +847,12 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
                 self.editor
                     .driver(fctx, lctx)
                     .select_from_accesskit(selection);
+                let new_generation = self.editor.generation();
+                if new_generation != self.rendered_generation {
+                    ctx.request_render();
+                    ctx.set_ime_area(self.ime_area());
+                    self.rendered_generation = new_generation;
+                }
             }
         }
     }


### PR DESCRIPTION
Without this, the updated text selection is neither painted nor reflected in an updated accessibility tree until the user presses a key.