### PR TITLE
Remove unused `SizedBox::width_and_height`

### DIFF
--- a/masonry/src/widget/sized_box.rs
+++ b/masonry/src/widget/sized_box.rs
@@ -457,11 +457,6 @@ impl SizedBox {
             Size::new(max_width, max_height),
         )
     }
-
-    #[allow(dead_code)]
-    pub(crate) fn width_and_height(&self) -> (Option<f64>, Option<f64>) {
-        (self.width, self.height)
-    }
 }
 
 // --- MARK: IMPL WIDGET ---


### PR DESCRIPTION
This isn't used, is marked as dead code, and is not public outside of the crate.