### PR TITLE
Move cursor to end of text area when text is changed

### DIFF
--- a/masonry/src/widget/text_area.rs
+++ b/masonry/src/widget/text_area.rs
@@ -829,13 +829,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
 
     fn update(&mut self, ctx: &mut UpdateCtx, event: &Update) {
         match event {
-            Update::FocusChanged(focus) => {
-                // If we lose focus, set the selection up so that next time
-                // we get focus, selection will be at the end of the text.
-                if !*focus {
-                    let (fctx, lctx) = ctx.text_contexts();
-                    self.editor.driver(fctx, lctx).move_to_text_end();
-                }
+            Update::FocusChanged(_) => {
                 ctx.request_render();
             }
             Update::DisabledChanged(_) => {

--- a/masonry/src/widget/text_area.rs
+++ b/masonry/src/widget/text_area.rs
@@ -391,6 +391,9 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
         }
         this.widget.editor.set_text(new_text);
 
+        let (fctx, lctx) = this.ctx.text_contexts();
+        this.widget.editor.driver(fctx, lctx).move_to_text_end();
+
         this.ctx.request_layout();
     }
 

--- a/masonry/src/widget/text_area.rs
+++ b/masonry/src/widget/text_area.rs
@@ -829,7 +829,13 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
 
     fn update(&mut self, ctx: &mut UpdateCtx, event: &Update) {
         match event {
-            Update::FocusChanged(_) => {
+            Update::FocusChanged(focus) => {
+                // If we lose focus, set the selection up so that next time
+                // we get focus, selection will be at the end of the text.
+                if !*focus {
+                    let (fctx, lctx) = ctx.text_contexts();
+                    self.editor.driver(fctx, lctx).move_to_text_end();
+                }
                 ctx.request_render();
             }
             Update::DisabledChanged(_) => {


### PR DESCRIPTION
This matches the behavior of other frameworks in similar situations.