### PR TITLE
Depend on `libegl-mesa0` instead of `libegl1-mesa`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
           sudo apt-get update -y -qq
           sudo add-apt-repository ppa:kisak/turtle -y
           sudo apt-get update
-          sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+          sudo apt install -y xvfb libegl-mesa0 libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
`libegl1-mesa` seems to have been an old name, which is no longer accurate, and is not published for Ubuntu 24.

I don't know where this was publicised, but hopefully this change fixes CI?