### PR TITLE
Move the `transform` related boilerplate in Xilem to a single View

### DIFF
--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -163,6 +163,11 @@ impl_context_method!(
                 .expect("get_child_state: child not found");
             child_state_ref.item
         }
+
+        /// The current (local) transform of this widget.
+        pub fn transform(&self) -> Affine {
+            self.widget_state.transform
+        }
     }
 );
 

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -236,6 +236,15 @@ impl MutateCtx<'_> {
             widget_children: self.widget_children.reborrow_mut(),
         }
     }
+
+    /// Whether the (local) transform of this widget has been modified since
+    /// the last time this widget's transformation was resolved.
+    ///
+    /// This is exposed for Xilem, and is more likely to change or be removed
+    /// in major releases of Masonry.
+    pub fn transform_has_changed(&self) -> bool {
+        self.widget_state.transform_changed
+    }
 }
 
 // --- MARK: WIDGET_REF ---

--- a/xilem/examples/transforms.rs
+++ b/xilem/examples/transforms.rs
@@ -6,8 +6,8 @@
 use std::f64::consts::{PI, TAU};
 
 use winit::error::EventLoopError;
-use xilem::view::{button, grid, label, sized_box, GridExt as _};
-use xilem::{Color, EventLoop, Vec2, WidgetView, Xilem};
+use xilem::view::{button, grid, label, sized_box, transformed, GridExt as _};
+use xilem::{Affine, Color, EventLoop, Vec2, WidgetView, Xilem};
 
 struct TransformsGame {
     rotation: f64,
@@ -41,20 +41,18 @@ impl TransformsGame {
             [1.0, 0.0, 0.0, 0.2]
         };
 
+        let status = sized_box(status).background(Color::new(bg_color));
         // Every view can be transformed similar as with CSS transforms in the web.
         // Currently only 2D transforms are supported.
         // Note that the order of the transformations is relevant.
-        let transformed_status = sized_box(status)
-            .background(Color::new(bg_color))
-            .transformed()
-            .translate(self.translation)
-            // In an actual app, you wouldn't use `.transformed` here.
+        let transformed_status = transformed(
+            // In an actual app, you wouldn't use both `transformed` and `.transform`.
             // This is here to validate that Xilem's support for nested `Transformed`
             // values works as expected.
-            .transformed()
-            .rotate(self.rotation)
-            .transformed()
-            .scale(self.scale);
+            status.transform(Affine::translate(self.translation)),
+        )
+        .rotate(self.rotation)
+        .scale(self.scale);
 
         let controls = (
             button("↶", |this: &mut Self| {

--- a/xilem/examples/transforms.rs
+++ b/xilem/examples/transforms.rs
@@ -6,7 +6,7 @@
 use std::f64::consts::{PI, TAU};
 
 use winit::error::EventLoopError;
-use xilem::view::{button, grid, label, sized_box, GridExt as _, Transformable as _};
+use xilem::view::{button, grid, label, sized_box, GridExt as _};
 use xilem::{Color, EventLoop, Vec2, WidgetView, Xilem};
 
 struct TransformsGame {
@@ -46,6 +46,7 @@ impl TransformsGame {
         // Note that the order of the transformations is relevant.
         let transformed_status = sized_box(status)
             .background(Color::new(bg_color))
+            .transformed()
             .translate(self.translation)
             .rotate(self.rotation)
             .scale(self.scale);

--- a/xilem/examples/transforms.rs
+++ b/xilem/examples/transforms.rs
@@ -48,7 +48,12 @@ impl TransformsGame {
             .background(Color::new(bg_color))
             .transformed()
             .translate(self.translation)
+            // In an actual app, you wouldn't use `.transformed` here.
+            // This is here to validate that Xilem's support for nested `Transformed`
+            // values works as expected.
+            .transformed()
             .rotate(self.rotation)
+            .transformed()
             .scale(self.scale);
 
         let controls = (

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -191,7 +191,8 @@ pub struct Pod<W: Widget> {
     pub id: WidgetId,
     /// The transform the widget will be created with.
     ///
-    /// If changing transforms of widgets, prefer to use [`WidgetView::transformed`].
+    /// If changing transforms of widgets, prefer to use [`transformed`]
+    /// (or [`WidgetView::transform`]).
     /// This has a protocol to ensure that multiple views changing the
     /// transform interoperate successfully.
     pub transform: Affine,

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -342,11 +342,6 @@ impl ViewCtx {
     pub fn new_pod<W: Widget>(&mut self, widget: W) -> Pod<W> {
         Pod::new(widget)
     }
-    pub fn new_pod_with_transform<W: Widget>(&mut self, widget: W, transform: Affine) -> Pod<W> {
-        let mut pod = Pod::new(widget);
-        pod.transform = Some(transform);
-        pod
-    }
 
     pub fn with_leaf_action_widget<E: Widget>(
         &mut self,

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -189,7 +189,12 @@ where
 pub struct Pod<W: Widget> {
     pub widget: W,
     pub id: WidgetId,
-    pub transform: Option<Affine>,
+    /// The transform the widget will be created with.
+    ///
+    /// If changing transforms of widgets, prefer to use [`WidgetView::transformed`].
+    /// This has a protocol to ensure that multiple views changing the
+    /// transform interoperate successfully.
+    pub transform: Affine,
 }
 
 impl<W: Widget> Pod<W> {
@@ -201,18 +206,10 @@ impl<W: Widget> Pod<W> {
         }
     }
     fn into_widget_pod(self) -> WidgetPod<W> {
-        WidgetPod::new_with_id_and_transform(
-            self.widget,
-            self.id,
-            self.transform.unwrap_or_default(),
-        )
+        WidgetPod::new_with_id_and_transform(self.widget, self.id, self.transform)
     }
     fn boxed_widget_pod(self) -> WidgetPod<Box<dyn Widget>> {
-        WidgetPod::new_with_id_and_transform(
-            Box::new(self.widget),
-            self.id,
-            self.transform.unwrap_or_default(),
-        )
+        WidgetPod::new_with_id_and_transform(Box::new(self.widget), self.id, self.transform)
     }
     fn boxed(self) -> Pod<Box<dyn Widget>> {
         Pod {

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -266,14 +266,14 @@ pub trait WidgetView<State, Action = ()>:
 
     /// This widget with a 2d transform applied.
     ///
-    /// The returned view has methods to control individual components of
-    /// the transform, as well as apply an arbitrary transform.
-    /// See [`transformed`] for more details.
-    fn transformed(self) -> Transformed<Self, State, Action>
+    /// See [`transformed`] for similar functionality with a builder-API using this.
+    /// The return type is the same as for `transformed`, and so also has these
+    /// builder methods.
+    fn transform(self, by: Affine) -> Transformed<Self, State, Action>
     where
         Self: Sized,
     {
-        transformed(self)
+        transformed(self).transform(by)
     }
 }
 

--- a/xilem/src/one_of.rs
+++ b/xilem/src/one_of.rs
@@ -13,8 +13,7 @@ use vello::Scene;
 
 use crate::core::one_of::OneOf;
 use crate::core::Mut;
-use crate::view::Transformable;
-use crate::{Affine, Pod, ViewCtx};
+use crate::{Pod, ViewCtx};
 
 impl<
         A: Widget,
@@ -140,33 +139,6 @@ impl<
             OneOfWidget::I(w) => elem_mut.ctx.remove_child(w),
         }
         elem_mut.ctx.children_changed();
-    }
-}
-
-impl<A, B, C, D, E, F, G, H, I> Transformable for OneOf<A, B, C, D, E, F, G, H, I>
-where
-    A: Transformable,
-    B: Transformable,
-    C: Transformable,
-    D: Transformable,
-    E: Transformable,
-    F: Transformable,
-    G: Transformable,
-    H: Transformable,
-    I: Transformable,
-{
-    fn transform_mut(&mut self) -> &mut Affine {
-        match self {
-            Self::A(w) => w.transform_mut(),
-            Self::B(w) => w.transform_mut(),
-            Self::C(w) => w.transform_mut(),
-            Self::D(w) => w.transform_mut(),
-            Self::E(w) => w.transform_mut(),
-            Self::F(w) => w.transform_mut(),
-            Self::G(w) => w.transform_mut(),
-            Self::H(w) => w.transform_mut(),
-            Self::I(w) => w.transform_mut(),
-        }
     }
 }
 

--- a/xilem/src/view/checkbox.rs
+++ b/xilem/src/view/checkbox.rs
@@ -5,9 +5,7 @@ use masonry::text::ArcStr;
 use masonry::widget;
 
 use crate::core::{DynMessage, Mut, ViewMarker};
-use crate::{Affine, MessageResult, Pod, View, ViewCtx, ViewId};
-
-use super::Transformable;
+use crate::{MessageResult, Pod, View, ViewCtx, ViewId};
 
 pub fn checkbox<F, State, Action>(
     label: impl Into<ArcStr>,
@@ -21,7 +19,6 @@ where
         label: label.into(),
         callback,
         checked,
-        transform: Affine::IDENTITY,
     }
 }
 
@@ -30,13 +27,6 @@ pub struct Checkbox<F> {
     label: ArcStr,
     checked: bool,
     callback: F,
-    transform: Affine,
-}
-
-impl<F> Transformable for Checkbox<F> {
-    fn transform_mut(&mut self) -> &mut Affine {
-        &mut self.transform
-    }
 }
 
 impl<F> ViewMarker for Checkbox<F> {}
@@ -49,10 +39,7 @@ where
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         ctx.with_leaf_action_widget(|ctx| {
-            ctx.new_pod_with_transform(
-                widget::Checkbox::new(self.checked, self.label.clone()),
-                self.transform,
-            )
+            ctx.new_pod(widget::Checkbox::new(self.checked, self.label.clone()))
         })
     }
 
@@ -63,9 +50,6 @@ where
         _ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        if prev.transform != self.transform {
-            element.set_transform(self.transform);
-        }
         if prev.label != self.label {
             widget::Checkbox::set_text(&mut element, self.label.clone());
         }

--- a/xilem/src/view/flex.rs
+++ b/xilem/src/view/flex.rs
@@ -11,7 +11,7 @@ use crate::core::{
     AppendVec, DynMessage, ElementSplice, MessageResult, Mut, SuperElement, View, ViewElement,
     ViewId, ViewMarker, ViewPathTracker, ViewSequence,
 };
-use crate::{Affine, AnyWidgetView, Pod, ViewCtx, WidgetView};
+use crate::{AnyWidgetView, Pod, ViewCtx, WidgetView};
 
 pub fn flex<State, Action, Seq: FlexSequence<State, Action>>(
     sequence: Seq,
@@ -19,7 +19,6 @@ pub fn flex<State, Action, Seq: FlexSequence<State, Action>>(
     Flex {
         sequence,
         axis: Axis::Vertical,
-        transform: Affine::IDENTITY,
         cross_axis_alignment: CrossAxisAlignment::Center,
         main_axis_alignment: MainAxisAlignment::Start,
         fill_major_axis: false,
@@ -32,7 +31,6 @@ pub fn flex<State, Action, Seq: FlexSequence<State, Action>>(
 pub struct Flex<Seq, State, Action = ()> {
     sequence: Seq,
     axis: Axis,
-    transform: Affine,
     cross_axis_alignment: CrossAxisAlignment,
     main_axis_alignment: MainAxisAlignment,
     fill_major_axis: bool,
@@ -87,12 +85,6 @@ impl<Seq, State, Action> Flex<Seq, State, Action> {
     }
 }
 
-impl<Seq, State, Action> Transformable for Flex<Seq, State, Action> {
-    fn transform_mut(&mut self) -> &mut Affine {
-        &mut self.transform
-    }
-}
-
 impl<Seq, State, Action> ViewMarker for Flex<Seq, State, Action> {}
 impl<State, Action, Seq> View<State, Action, ViewCtx> for Flex<Seq, State, Action>
 where
@@ -121,7 +113,7 @@ where
                 FlexElement::FlexSpacer(flex) => widget.with_flex_spacer(flex),
             }
         }
-        let pod = ctx.new_pod_with_transform(widget, self.transform);
+        let pod = ctx.new_pod(widget);
         (pod, seq_state)
     }
 
@@ -132,9 +124,6 @@ where
         ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        if prev.transform != self.transform {
-            element.set_transform(self.transform);
-        }
         if prev.axis != self.axis {
             widget::Flex::set_direction(&mut element, self.axis);
         }
@@ -645,8 +634,6 @@ mod hidden {
     }
 }
 use hidden::AnyFlexChildState;
-
-use super::Transformable;
 
 impl<State, Action> ViewMarker for AnyFlexChild<State, Action> {}
 impl<State, Action> View<State, Action, ViewCtx> for AnyFlexChild<State, Action>

--- a/xilem/src/view/grid.rs
+++ b/xilem/src/view/grid.rs
@@ -10,9 +10,7 @@ use crate::core::{
     AppendVec, DynMessage, ElementSplice, MessageResult, Mut, SuperElement, View, ViewElement,
     ViewId, ViewMarker, ViewSequence,
 };
-use crate::{Affine, Pod, ViewCtx, WidgetView};
-
-use super::Transformable;
+use crate::{Pod, ViewCtx, WidgetView};
 
 pub fn grid<State, Action, Seq: GridSequence<State, Action>>(
     sequence: Seq,
@@ -25,7 +23,6 @@ pub fn grid<State, Action, Seq: GridSequence<State, Action>>(
         phantom: PhantomData,
         height,
         width,
-        transform: Affine::IDENTITY,
     }
 }
 
@@ -35,7 +32,6 @@ pub struct Grid<Seq, State, Action = ()> {
     spacing: f64,
     width: i32,
     height: i32,
-    transform: Affine,
     /// Used to associate the State and Action in the call to `.grid()` with the State and Action
     /// used in the View implementation, to allow inference to flow backwards, allowing State and
     /// Action to be inferred properly
@@ -51,12 +47,6 @@ impl<Seq, State, Action> Grid<Seq, State, Action> {
             panic!("Invalid `spacing` {spacing}; expected a non-negative finite value.")
         }
         self
-    }
-}
-
-impl<Seq, State, Action> Transformable for Grid<Seq, State, Action> {
-    fn transform_mut(&mut self) -> &mut Affine {
-        &mut self.transform
     }
 }
 
@@ -84,7 +74,7 @@ where
                 }
             }
         }
-        let pod = ctx.new_pod_with_transform(widget, self.transform);
+        let pod = ctx.new_pod(widget);
         (pod, seq_state)
     }
 
@@ -95,9 +85,6 @@ where
         ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        if prev.transform != self.transform {
-            element.set_transform(self.transform);
-        }
         if prev.height != self.height {
             widget::Grid::set_height(&mut element, self.height);
         }

--- a/xilem/src/view/image.rs
+++ b/xilem/src/view/image.rs
@@ -6,9 +6,7 @@
 use masonry::widget::{self, ObjectFit};
 
 use crate::core::{DynMessage, Mut, ViewMarker};
-use crate::{Affine, MessageResult, Pod, View, ViewCtx, ViewId};
-
-use super::Transformable;
+use crate::{MessageResult, Pod, View, ViewCtx, ViewId};
 
 /// Displays the bitmap `image`.
 ///
@@ -27,7 +25,6 @@ pub fn image(image: &vello::peniko::Image) -> Image {
         // easier than documenting that cloning is cheap.
         image: image.clone(),
         object_fit: ObjectFit::default(),
-        transform: Affine::IDENTITY,
     }
 }
 
@@ -38,7 +35,6 @@ pub fn image(image: &vello::peniko::Image) -> Image {
 pub struct Image {
     image: vello::peniko::Image,
     object_fit: ObjectFit,
-    transform: Affine,
 }
 
 impl Image {
@@ -49,20 +45,13 @@ impl Image {
     }
 }
 
-impl Transformable for Image {
-    fn transform_mut(&mut self) -> &mut Affine {
-        &mut self.transform
-    }
-}
-
 impl ViewMarker for Image {}
 impl<State, Action> View<State, Action, ViewCtx> for Image {
     type Element = Pod<widget::Image>;
     type ViewState = ();
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        let pod =
-            ctx.new_pod_with_transform(widget::Image::new(self.image.clone()), self.transform);
+        let pod = ctx.new_pod(widget::Image::new(self.image.clone()));
         (pod, ())
     }
 
@@ -73,9 +62,6 @@ impl<State, Action> View<State, Action, ViewCtx> for Image {
         _: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        if prev.transform != self.transform {
-            element.set_transform(self.transform);
-        }
         if prev.object_fit != self.object_fit {
             widget::Image::set_fit_mode(&mut element, self.object_fit);
         }

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -7,9 +7,7 @@ use masonry::widget::{self, LineBreaking};
 use vello::peniko::Brush;
 
 use crate::core::{DynMessage, Mut, ViewMarker};
-use crate::{Affine, Color, MessageResult, Pod, TextAlignment, View, ViewCtx, ViewId};
-
-use super::Transformable;
+use crate::{Color, MessageResult, Pod, TextAlignment, View, ViewCtx, ViewId};
 
 pub fn label(label: impl Into<ArcStr>) -> Label {
     Label {
@@ -20,7 +18,6 @@ pub fn label(label: impl Into<ArcStr>) -> Label {
         weight: FontWeight::NORMAL,
         font: FontStack::List(std::borrow::Cow::Borrowed(&[])),
         line_break_mode: LineBreaking::Overflow,
-        transform: Affine::IDENTITY,
     }
 }
 
@@ -33,7 +30,6 @@ pub struct Label {
     weight: FontWeight,
     font: FontStack<'static>,
     line_break_mode: LineBreaking, // TODO: add more attributes of `masonry::widget::Label`
-    transform: Affine,
 }
 
 impl Label {
@@ -75,12 +71,6 @@ impl Label {
     }
 }
 
-impl Transformable for Label {
-    fn transform_mut(&mut self) -> &mut Affine {
-        &mut self.transform
-    }
-}
-
 impl<T> From<T> for Label
 where
     T: Into<ArcStr>,
@@ -96,7 +86,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
     type ViewState = ();
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        let widget_pod = ctx.new_pod_with_transform(
+        let widget_pod = ctx.new_pod(
             widget::Label::new(self.label.clone())
                 .with_brush(self.text_brush.clone())
                 .with_alignment(self.alignment)
@@ -104,7 +94,6 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
                 .with_style(StyleProperty::FontWeight(self.weight))
                 .with_style(StyleProperty::FontStack(self.font.clone()))
                 .with_line_break_mode(self.line_break_mode),
-            self.transform,
         );
         (widget_pod, ())
     }
@@ -116,9 +105,6 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
         _ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        if prev.transform != self.transform {
-            element.set_transform(self.transform);
-        }
         if prev.label != self.label {
             widget::Label::set_text(&mut element, self.label.clone());
         }

--- a/xilem/src/view/progress_bar.rs
+++ b/xilem/src/view/progress_bar.rs
@@ -4,26 +4,14 @@
 use masonry::widget;
 
 use crate::core::{DynMessage, Mut, ViewMarker};
-use crate::{Affine, MessageResult, Pod, View, ViewCtx, ViewId};
-
-use super::Transformable;
+use crate::{MessageResult, Pod, View, ViewCtx, ViewId};
 
 pub fn progress_bar(progress: Option<f64>) -> ProgressBar {
-    ProgressBar {
-        progress,
-        transform: Affine::IDENTITY,
-    }
+    ProgressBar { progress }
 }
 
 pub struct ProgressBar {
     progress: Option<f64>,
-    transform: Affine,
-}
-
-impl Transformable for ProgressBar {
-    fn transform_mut(&mut self) -> &mut Affine {
-        &mut self.transform
-    }
 }
 
 impl ViewMarker for ProgressBar {}
@@ -32,9 +20,7 @@ impl<State, Action> View<State, Action, ViewCtx> for ProgressBar {
     type ViewState = ();
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        ctx.with_leaf_action_widget(|ctx| {
-            ctx.new_pod_with_transform(widget::ProgressBar::new(self.progress), self.transform)
-        })
+        ctx.with_leaf_action_widget(|ctx| ctx.new_pod(widget::ProgressBar::new(self.progress)))
     }
 
     fn rebuild(
@@ -44,9 +30,6 @@ impl<State, Action> View<State, Action, ViewCtx> for ProgressBar {
         _ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        if prev.transform != self.transform {
-            element.set_transform(self.transform);
-        }
         if prev.progress != self.progress {
             widget::ProgressBar::set_progress(&mut element, self.progress);
         }

--- a/xilem/src/view/prose.rs
+++ b/xilem/src/view/prose.rs
@@ -6,9 +6,7 @@ use masonry::widget::{self, LineBreaking};
 use vello::peniko::Brush;
 
 use crate::core::{DynMessage, Mut, ViewMarker};
-use crate::{Affine, Color, MessageResult, Pod, TextAlignment, View, ViewCtx, ViewId};
-
-use super::Transformable;
+use crate::{Color, MessageResult, Pod, TextAlignment, View, ViewCtx, ViewId};
 
 pub fn prose(content: impl Into<ArcStr>) -> Prose {
     Prose {
@@ -17,7 +15,6 @@ pub fn prose(content: impl Into<ArcStr>) -> Prose {
         alignment: TextAlignment::default(),
         text_size: masonry::theme::TEXT_SIZE_NORMAL,
         line_break_mode: LineBreaking::WordWrap,
-        transform: Affine::IDENTITY,
     }
 }
 
@@ -39,7 +36,6 @@ pub struct Prose {
     alignment: TextAlignment,
     text_size: f32,
     line_break_mode: LineBreaking,
-    transform: Affine,
     // TODO: disabled: bool,
     // TODO: add more attributes of `masonry::widget::Prose`
 }
@@ -71,12 +67,6 @@ fn line_break_clips(linebreaking: LineBreaking) -> bool {
     matches!(linebreaking, LineBreaking::Clip | LineBreaking::WordWrap)
 }
 
-impl Transformable for Prose {
-    fn transform_mut(&mut self) -> &mut Affine {
-        &mut self.transform
-    }
-}
-
 impl ViewMarker for Prose {}
 impl<State, Action> View<State, Action, ViewCtx> for Prose {
     type Element = Pod<widget::Prose>;
@@ -88,10 +78,9 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
             .with_alignment(self.alignment)
             .with_style(StyleProperty::FontSize(self.text_size))
             .with_word_wrap(self.line_break_mode == LineBreaking::WordWrap);
-        let widget_pod = ctx.new_pod_with_transform(
+        let widget_pod = ctx.new_pod(
             widget::Prose::from_text_area(text_area)
                 .with_clip(line_break_clips(self.line_break_mode)),
-            self.transform,
         );
         (widget_pod, ())
     }
@@ -103,9 +92,6 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
         _ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        if prev.transform != self.transform {
-            element.set_transform(self.transform);
-        }
         let mut text_area = widget::Prose::text_mut(&mut element);
         if prev.content != self.content {
             widget::TextArea::reset_text(&mut text_area, &self.content);

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -9,9 +9,7 @@ use vello::kurbo::RoundedRectRadii;
 use vello::peniko::Brush;
 
 use crate::core::{DynMessage, Mut, View, ViewId, ViewMarker};
-use crate::{Affine, Pod, ViewCtx, WidgetView};
-
-use super::Transformable;
+use crate::{Pod, ViewCtx, WidgetView};
 
 /// A widget with predefined size.
 ///
@@ -31,7 +29,6 @@ where
         corner_radius: RoundedRectRadii::from_single_radius(0.0),
         padding: Padding::ZERO,
         phantom: PhantomData,
-        transform: Affine::IDENTITY,
     }
 }
 
@@ -45,7 +42,6 @@ pub struct SizedBox<V, State, Action = ()> {
     corner_radius: RoundedRectRadii,
     padding: Padding,
     phantom: PhantomData<fn() -> (State, Action)>,
-    transform: Affine,
 }
 
 impl<V, State, Action> SizedBox<V, State, Action> {
@@ -125,12 +121,6 @@ impl<V, State, Action> SizedBox<V, State, Action> {
     }
 }
 
-impl<V, State, Action> Transformable for SizedBox<V, State, Action> {
-    fn transform_mut(&mut self) -> &mut Affine {
-        &mut self.transform
-    }
-}
-
 impl<V, State, Action> ViewMarker for SizedBox<V, State, Action> {}
 impl<V, State, Action> View<State, Action, ViewCtx> for SizedBox<V, State, Action>
 where
@@ -154,7 +144,7 @@ where
         if let Some(border) = &self.border {
             widget = widget.border(border.brush.clone(), border.width);
         }
-        let pod = ctx.new_pod_with_transform(widget, self.transform);
+        let pod = ctx.new_pod(widget);
         (pod, child_state)
     }
 
@@ -165,9 +155,6 @@ where
         ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        if prev.transform != self.transform {
-            element.set_transform(self.transform);
-        }
         if self.width != prev.width {
             match self.width {
                 Some(width) => widget::SizedBox::set_width(&mut element, width),

--- a/xilem/src/view/spinner.rs
+++ b/xilem/src/view/spinner.rs
@@ -4,9 +4,7 @@
 use masonry::{widget, Color};
 
 use crate::core::{DynMessage, Mut, ViewMarker};
-use crate::{Affine, MessageResult, Pod, View, ViewCtx, ViewId};
-
-use super::Transformable;
+use crate::{MessageResult, Pod, View, ViewCtx, ViewId};
 
 /// An indefinite spinner.
 ///
@@ -34,10 +32,7 @@ use super::Transformable;
 /// }
 /// ```
 pub fn spinner() -> Spinner {
-    Spinner {
-        color: None,
-        transform: Affine::IDENTITY,
-    }
+    Spinner { color: None }
 }
 
 /// The [`View`] created by [`spinner`].
@@ -46,7 +41,6 @@ pub fn spinner() -> Spinner {
 #[must_use = "View values do nothing unless provided to Xilem."]
 pub struct Spinner {
     color: Option<Color>,
-    transform: Affine,
 }
 
 impl Spinner {
@@ -57,19 +51,13 @@ impl Spinner {
     }
 }
 
-impl Transformable for Spinner {
-    fn transform_mut(&mut self) -> &mut Affine {
-        &mut self.transform
-    }
-}
-
 impl ViewMarker for Spinner {}
 impl<State, Action> View<State, Action, ViewCtx> for Spinner {
     type Element = Pod<widget::Spinner>;
     type ViewState = ();
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        let pod = ctx.new_pod_with_transform(widget::Spinner::new(), self.transform);
+        let pod = ctx.new_pod(widget::Spinner::new());
         (pod, ())
     }
 
@@ -80,9 +68,6 @@ impl<State, Action> View<State, Action, ViewCtx> for Spinner {
         _: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        if prev.transform != self.transform {
-            element.set_transform(self.transform);
-        }
         if prev.color != self.color {
             match self.color {
                 Some(color) => widget::Spinner::set_color(&mut element, color),

--- a/xilem/src/view/textbox.rs
+++ b/xilem/src/view/textbox.rs
@@ -5,9 +5,7 @@ use masonry::widget;
 use vello::peniko::Brush;
 
 use crate::core::{DynMessage, Mut, View, ViewMarker};
-use crate::{Affine, Color, MessageResult, Pod, TextAlignment, ViewCtx, ViewId};
-
-use super::Transformable;
+use crate::{Color, MessageResult, Pod, TextAlignment, ViewCtx, ViewId};
 
 // FIXME - A major problem of the current approach (always setting the textbox contents)
 // is that if the user forgets to hook up the modify the state's contents in the callback,
@@ -26,7 +24,6 @@ where
         on_enter: None,
         text_brush: Color::WHITE.into(),
         alignment: TextAlignment::default(),
-        transform: Affine::IDENTITY,
         // TODO?: disabled: false,
     }
 }
@@ -38,7 +35,6 @@ pub struct Textbox<State, Action> {
     on_enter: Option<Callback<State, Action>>,
     text_brush: Brush,
     alignment: TextAlignment,
-    transform: Affine,
     // TODO: add more attributes of `masonry::widget::TextBox`
 }
 
@@ -63,12 +59,6 @@ impl<State, Action> Textbox<State, Action> {
     }
 }
 
-impl<State, Action> Transformable for Textbox<State, Action> {
-    fn transform_mut(&mut self) -> &mut Affine {
-        &mut self.transform
-    }
-}
-
 impl<State, Action> ViewMarker for Textbox<State, Action> {}
 impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<State, Action> {
     type Element = Pod<widget::Textbox>;
@@ -84,7 +74,7 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
         // Ensure that the actions from the *inner* TextArea get routed correctly.
         let id = textbox.area_pod().id();
         ctx.record_action(id);
-        let widget_pod = ctx.new_pod_with_transform(textbox, self.transform);
+        let widget_pod = ctx.new_pod(textbox);
         (widget_pod, ())
     }
 
@@ -95,9 +85,6 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
         _ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        if prev.transform != self.transform {
-            element.set_transform(self.transform);
-        }
         let mut text_area = widget::Textbox::text_mut(&mut element);
 
         // Unlike the other properties, we don't compare to the previous value;

--- a/xilem/src/view/transform.rs
+++ b/xilem/src/view/transform.rs
@@ -126,8 +126,3 @@ where
         self.child.message(view_state, id_path, message, app_state)
     }
 }
-
-/// An extension trait, to allow common transformations of the views transform.
-pub trait Transformable: Sized {
-    fn transform_mut(&mut self) -> &mut Affine;
-}

--- a/xilem/src/view/transform.rs
+++ b/xilem/src/view/transform.rs
@@ -115,16 +115,14 @@ where
         ctx: &mut ViewCtx,
         mut element: xilem_core::Mut<'_, Self::Element>,
     ) {
-        let initial_transform = element.ctx.transform();
         self.child.rebuild(
             &prev.child,
             &mut view_state.child,
             ctx,
             element.reborrow_mut(),
         );
-        let transform_changed = element.ctx.transform() != initial_transform;
-        // We detect a child view changing the transform by comparing the
-        // resulting transform before and after the child view runs.
+        let transform_changed = element.ctx.transform_has_changed();
+        // If the child view changed the transform, we know we're out of date.
         if transform_changed {
             // If it has changed the transform, then we know that it will only be due to effects
             // "below us" (that is, it will have restarted from scratch).

--- a/xilem/src/view/transform.rs
+++ b/xilem/src/view/transform.rs
@@ -1,43 +1,133 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::Affine;
+use std::marker::PhantomData;
+
+use crate::{
+    core::{DynMessage, View, ViewMarker},
+    Affine, Pod, ViewCtx, WidgetView,
+};
+
+/// A view which transforms the widget created by child.
+///
+/// Each widget can only be transformed once, and using this
+/// function in a nesting pattern may cause panics.
+/// This is due to the efficient way that Xilem calculates field changes,
+/// which is incompatible with composing non-idempotent changes to the same field.
+///
+/// The transform can be set using the methods on the return type.
+/// Transformations apply in order.
+/// That is, calling [`rotate`](Transformed::rotate) then [`translate`](Transformed::translate)
+/// will move the rotated widget.
+pub fn transformed<Child, State, Action>(child: Child) -> Transformed<Child, State, Action>
+where
+    Child: WidgetView<State, Action>,
+{
+    Transformed {
+        child,
+        transform: Affine::IDENTITY,
+        phantom: PhantomData,
+    }
+}
+
+/// The view for [`transformed`].
+pub struct Transformed<V, State, Action> {
+    child: V,
+    transform: Affine,
+    phantom: PhantomData<(State, Action)>,
+}
+
+impl<V, State, Action> Transformed<V, State, Action> {
+    #[must_use]
+    /// Rotate the widget by `radians` radians about the origin of its natural location.
+    pub fn rotate(mut self, radians: f64) -> Self {
+        self.transform = self.transform.then_rotate(radians);
+        self
+    }
+
+    /// Scale the widget by `uniform` in each axis.
+    #[must_use]
+    pub fn scale(mut self, uniform: f64) -> Self {
+        self.transform = self.transform.then_scale(uniform);
+        self
+    }
+
+    #[must_use]
+    /// Scale the widget by the given amount in each (2d) axis.
+    pub fn scale_non_uniform(mut self, x: f64, y: f64) -> Self {
+        self.transform = self.transform.then_scale_non_uniform(x, y);
+        self
+    }
+
+    #[must_use]
+    /// Displace the widget by `v` from its natural location.
+    pub fn translate(mut self, v: impl Into<crate::Vec2>) -> Self {
+        self.transform = self.transform.then_translate(v.into());
+        self
+    }
+
+    #[must_use]
+    /// Apply an arbitrary 2d transform to the widget.
+    pub fn transform(mut self, v: impl Into<Affine>) -> Self {
+        self.transform *= v.into();
+        self
+    }
+}
+
+impl<V, State, Action> ViewMarker for Transformed<V, State, Action> {}
+impl<Child, State, Action> View<State, Action, ViewCtx> for Transformed<Child, State, Action>
+where
+    Child: WidgetView<State, Action>,
+    State: 'static,
+    Action: 'static,
+{
+    type Element = Pod<Child::Widget>;
+    type ViewState = Child::ViewState;
+
+    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+        let (mut child_pod, child_state) = self.child.build(ctx);
+        // TODO: Use a marker identity value to detect this more properly
+        if child_pod.transform != Affine::IDENTITY {
+            panic!("Tried to create a `Transformed` with an already controlled Transform");
+        }
+        child_pod.transform = self.transform;
+        (child_pod, child_state)
+    }
+
+    fn rebuild(
+        &self,
+        prev: &Self,
+        view_state: &mut Self::ViewState,
+        ctx: &mut ViewCtx,
+        mut element: xilem_core::Mut<'_, Self::Element>,
+    ) {
+        if self.transform != prev.transform {
+            element.ctx.set_transform(self.transform);
+        }
+        self.child.rebuild(&prev.child, view_state, ctx, element);
+    }
+
+    fn teardown(
+        &self,
+        view_state: &mut Self::ViewState,
+        ctx: &mut ViewCtx,
+        element: xilem_core::Mut<'_, Self::Element>,
+    ) {
+        self.child.teardown(view_state, ctx, element);
+    }
+
+    fn message(
+        &self,
+        view_state: &mut Self::ViewState,
+        id_path: &[xilem_core::ViewId],
+        message: DynMessage,
+        app_state: &mut State,
+    ) -> xilem_core::MessageResult<Action, DynMessage> {
+        self.child.message(view_state, id_path, message, app_state)
+    }
+}
 
 /// An extension trait, to allow common transformations of the views transform.
 pub trait Transformable: Sized {
     fn transform_mut(&mut self) -> &mut Affine;
-
-    #[must_use]
-    fn rotate(mut self, radians: f64) -> Self {
-        let transform = self.transform_mut();
-        *transform = transform.then_rotate(radians);
-        self
-    }
-
-    #[must_use]
-    fn scale(mut self, uniform: f64) -> Self {
-        let transform = self.transform_mut();
-        *transform = transform.then_scale(uniform);
-        self
-    }
-
-    #[must_use]
-    fn scale_non_uniform(mut self, x: f64, y: f64) -> Self {
-        let transform = self.transform_mut();
-        *transform = transform.then_scale_non_uniform(x, y);
-        self
-    }
-
-    #[must_use]
-    fn translate(mut self, v: impl Into<crate::Vec2>) -> Self {
-        let transform = self.transform_mut();
-        *transform = transform.then_translate(v.into());
-        self
-    }
-
-    #[must_use]
-    fn transform(mut self, v: impl Into<Affine>) -> Self {
-        *self.transform_mut() *= v.into();
-        self
-    }
 }

--- a/xilem/src/view/transform.rs
+++ b/xilem/src/view/transform.rs
@@ -87,10 +87,10 @@ where
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let (mut child_pod, child_state) = self.child.build(ctx);
         // TODO: Use a marker identity value to detect this more properly
-        if child_pod.transform != Affine::IDENTITY {
+        if child_pod.transform.is_some() {
             panic!("Tried to create a `Transformed` with an already controlled Transform");
         }
-        child_pod.transform = self.transform;
+        child_pod.transform = Some(self.transform);
         (child_pod, child_state)
     }
 

--- a/xilem/src/view/variable_label.rs
+++ b/xilem/src/view/variable_label.rs
@@ -10,7 +10,7 @@ use xilem_core::ViewPathTracker;
 use crate::core::{DynMessage, Mut, ViewMarker};
 use crate::{MessageResult, Pod, View, ViewCtx, ViewId};
 
-use super::{label, Label, Transformable};
+use super::{label, Label};
 
 /// A view for displaying non-editable text, with a variable [weight](masonry::parley::style::FontWeight).
 pub fn variable_label(text: impl Into<ArcStr>) -> VariableLabel {
@@ -78,12 +78,6 @@ impl VariableLabel {
     pub fn text_size(mut self, text_size: f32) -> Self {
         self.label = self.label.text_size(text_size);
         self
-    }
-}
-
-impl Transformable for VariableLabel {
-    fn transform_mut(&mut self) -> &mut crate::Affine {
-        self.label.transform_mut()
     }
 }
 

--- a/xilem/src/view/zstack.rs
+++ b/xilem/src/view/zstack.rs
@@ -10,15 +10,13 @@ use crate::{
         AppendVec, DynMessage, ElementSplice, Mut, SuperElement, View, ViewElement, ViewMarker,
         ViewSequence,
     },
-    Affine, Pod, ViewCtx, WidgetView,
+    Pod, ViewCtx, WidgetView,
 };
 use masonry::{
     widget::{self, Alignment, ChildAlignment, WidgetMut},
     Widget,
 };
 use xilem_core::{MessageResult, ViewId};
-
-use super::Transformable;
 
 /// A widget that lays out its children on top of each other.
 /// The children are laid out back to front.
@@ -42,7 +40,6 @@ pub fn zstack<State, Action, Seq: ZStackSequence<State, Action>>(sequence: Seq) 
     ZStack {
         sequence,
         alignment: Alignment::default(),
-        transform: Affine::IDENTITY,
     }
 }
 
@@ -53,7 +50,6 @@ pub fn zstack<State, Action, Seq: ZStackSequence<State, Action>>(sequence: Seq) 
 pub struct ZStack<Seq> {
     sequence: Seq,
     alignment: Alignment,
-    transform: Affine,
 }
 
 impl<Seq> ZStack<Seq> {
@@ -82,7 +78,7 @@ where
         for child in elements.into_inner() {
             widget = widget.with_child_pod(child.widget.into_widget_pod(), child.alignment);
         }
-        let pod = ctx.new_pod_with_transform(widget, self.transform);
+        let pod = ctx.new_pod(widget);
         (pod, seq_state)
     }
 
@@ -93,10 +89,6 @@ where
         ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
-        if self.transform != prev.transform {
-            element.set_transform(self.transform);
-        }
-
         if self.alignment != prev.alignment {
             widget::ZStack::set_alignment(&mut element, self.alignment);
         }
@@ -127,12 +119,6 @@ where
     ) -> MessageResult<Action, DynMessage> {
         self.sequence
             .seq_message(view_state, id_path, message, app_state)
-    }
-}
-
-impl<Seq> Transformable for ZStack<Seq> {
-    fn transform_mut(&mut self) -> &mut Affine {
-        &mut self.transform
     }
 }
 


### PR DESCRIPTION
Also significantly reduces the overhead from each View for supporting transforms.

Follow-up from #806