### PR TITLE
Apply is/has naming convention for flags and methods

### DIFF
--- a/masonry/examples/calc_masonry.rs
+++ b/masonry/examples/calc_masonry.rs
@@ -160,7 +160,7 @@ impl Widget for CalcButton {
                 }
             }
             PointerEvent::PointerUp(_, _) => {
-                if ctx.has_pointer_capture() && !ctx.is_disabled() {
+                if ctx.is_pointer_capture_target() && !ctx.is_disabled() {
                     let color = self.base_color;
                     // See `update` for why we use `mutate_later` here.
                     ctx.mutate_later(&mut self.inner, move |mut inner| {

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -807,10 +807,10 @@ impl_context_method!(
         /// The focused widget is the one that receives keyboard events.
         ///
         /// Returns `true` if this specific widget is focused.
-        /// To check if any descendants are focused use [`has_focus`].
+        /// To check if any descendants are focused use [`has_focused`].
         ///
         /// [text focus]: crate::doc::doc_06_masonry_concepts#text-focus
-        /// [`has_focus`]: Self::has_focus
+        /// [`has_focused`]: Self::has_focused
         pub fn is_focused(&self) -> bool {
             self.global_state.focused_widget == Some(self.widget_id())
         }

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -404,7 +404,7 @@ impl EventCtx<'_> {
     /// [text focus]: crate::doc::doc_06_masonry_concepts#text-focus
     pub fn resign_focus(&mut self) {
         trace!("resign_focus");
-        if self.has_focus() {
+        if self.has_focused() {
             self.global_state.next_focused_widget = None;
         } else {
             warn!(
@@ -773,16 +773,23 @@ impl_context_method!(
         /// will respond to pointer (usually mouse) interaction.
         ///
         /// The hovered status is computed from the widget's layout rect. In a
-        /// container hierarchy, all widgets with layout rects containing the
-        /// pointer position have hovered status.
+        /// container hierarchy, the innermost widget with a layout rect containing
+        /// the pointer position has hovered status.
         ///
-        /// If the pointer is [captured], then only that widget and its parents
-        /// can have hovered status. If the pointer is captured but not hovering
-        /// over the captured widget, then no widget has the hovered status.
+        /// If the pointer is [captured], then only that widget can have hovered
+        /// status. If the pointer is captured but not hovering over the captured
+        /// widget, then no widget has the hovered status.
         ///
         /// [captured]: crate::doc::doc_06_masonry_concepts#pointer-capture
         pub fn is_hovered(&self) -> bool {
             self.widget_state.is_hovered
+        }
+
+        /// Whether this widget or any of its descendants are hovered.
+        ///
+        /// To check if only this specific widget is hovered use [`is_hovered`](Self::is_hovered).
+        pub fn has_hovered(&self) -> bool {
+            self.widget_state.has_hovered
         }
 
         /// Whether a pointer is [captured] by this widget.
@@ -791,7 +798,7 @@ impl_context_method!(
         /// function will take a pointer id as input to test a specific pointer.
         ///
         /// [captured]: crate::doc::doc_06_masonry_concepts#pointer-capture
-        pub fn has_pointer_capture(&self) -> bool {
+        pub fn is_pointer_capture_target(&self) -> bool {
             self.global_state.pointer_capture_target == Some(self.widget_state.id)
         }
 
@@ -811,8 +818,8 @@ impl_context_method!(
         /// Whether this widget or any of its descendants are focused.
         ///
         /// To check if only this specific widget is focused use [`is_focused`](Self::is_focused).
-        pub fn has_focus(&self) -> bool {
-            self.widget_state.has_focus
+        pub fn has_focused(&self) -> bool {
+            self.widget_state.has_focused
         }
 
         /// Whether this widget gets pointer events and hovered status.

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -807,10 +807,10 @@ impl_context_method!(
         /// The focused widget is the one that receives keyboard events.
         ///
         /// Returns `true` if this specific widget is focused.
-        /// To check if any descendants are focused use [`has_focused`].
+        /// To check if any descendants are focused use [`has_focus_target`].
         ///
         /// [text focus]: crate::doc::doc_06_masonry_concepts#text-focus
-        /// [`has_focused`]: Self::has_focused
+        /// [`has_focus_target`]: Self::has_focus_target
         pub fn is_focus_target(&self) -> bool {
             self.global_state.focused_widget == Some(self.widget_id())
         }

--- a/masonry/src/contexts.rs
+++ b/masonry/src/contexts.rs
@@ -404,7 +404,7 @@ impl EventCtx<'_> {
     /// [text focus]: crate::doc::doc_06_masonry_concepts#text-focus
     pub fn resign_focus(&mut self) {
         trace!("resign_focus");
-        if self.has_focused() {
+        if self.has_focus_target() {
             self.global_state.next_focused_widget = None;
         } else {
             warn!(
@@ -811,15 +811,15 @@ impl_context_method!(
         ///
         /// [text focus]: crate::doc::doc_06_masonry_concepts#text-focus
         /// [`has_focused`]: Self::has_focused
-        pub fn is_focused(&self) -> bool {
+        pub fn is_focus_target(&self) -> bool {
             self.global_state.focused_widget == Some(self.widget_id())
         }
 
         /// Whether this widget or any of its descendants are focused.
         ///
-        /// To check if only this specific widget is focused use [`is_focused`](Self::is_focused).
-        pub fn has_focused(&self) -> bool {
-            self.widget_state.has_focused
+        /// To check if only this specific widget is focused use [`is_focus_target`](Self::is_focus_target).
+        pub fn has_focus_target(&self) -> bool {
+            self.widget_state.has_focus_target
         }
 
         /// Whether this widget gets pointer events and hovered status.

--- a/masonry/src/event.rs
+++ b/masonry/src/event.rs
@@ -351,7 +351,7 @@ pub enum Update {
 
     /// Called when the [hovered] status of the current widget or a descendant changes.
     ///
-    /// This is sent before [`HoveredChanged`].
+    /// This is sent before [`Update::HoveredChanged`].
     ///
     /// [hovered]: crate::doc::doc_06_masonry_concepts#widget-status
     ChildHoveredChanged(bool),
@@ -363,7 +363,7 @@ pub enum Update {
 
     /// Called when the [focused] status of the current widget or a descendant changes.
     ///
-    /// This is sent before [`FocusChanged`].
+    /// This is sent before [`Update::FocusChanged`].
     ///
     /// [focused]: crate::doc::doc_06_masonry_concepts#text-focus
     ChildFocusChanged(bool),

--- a/masonry/src/event.rs
+++ b/masonry/src/event.rs
@@ -344,28 +344,28 @@ pub enum Update {
     /// [`EventCtx::request_scroll_to_this`](crate::EventCtx::request_scroll_to_this).
     RequestPanToChild(Rect),
 
-    /// Called when the "hovered" status changes.
+    /// Called when the [hovered] status of the current widget changes.
     ///
-    /// This will always be called _before_ the event that triggered it; that is,
-    /// when the mouse moves over a widget, that widget will receive
-    /// `Update::HoveredChanged` before it receives `Event::MouseMove`.
-    ///
-    /// See [`is_hovered`](crate::EventCtx::is_hovered) for
-    /// discussion about the hovered status.
+    /// [hovered]: crate::doc::doc_06_masonry_concepts#widget-status
     HoveredChanged(bool),
 
-    /// Called when the focus status changes.
+    /// Called when the [hovered] status of the current widget or a descendant changes.
     ///
-    /// This will always be called immediately after a new widget gains focus.
-    /// The newly focused widget will receive this with `true` and the widget
-    /// that lost focus will receive this with `false`.
+    /// This is sent before [`HoveredChanged`].
     ///
-    /// See [`EventCtx::is_focused`] for more information about focus.
+    /// [hovered]: crate::doc::doc_06_masonry_concepts#widget-status
+    ChildHoveredChanged(bool),
+
+    /// Called when the [focused] status of the current widget changes.
     ///
-    /// [`EventCtx::is_focused`]: crate::EventCtx::is_focused
+    /// [focused]: crate::doc::doc_06_masonry_concepts#text-focus
     FocusChanged(bool),
 
-    /// Called when a widget becomes or no longer is parent of a focused widget.
+    /// Called when the [focused] status of the current widget or a descendant changes.
+    ///
+    /// This is sent before [`FocusChanged`].
+    ///
+    /// [focused]: crate::doc::doc_06_masonry_concepts#text-focus
     ChildFocusChanged(bool),
 }
 
@@ -553,6 +553,7 @@ impl Update {
             Self::StashedChanged(_) => "StashedChanged",
             Self::RequestPanToChild(_) => "RequestPanToChild",
             Self::HoveredChanged(_) => "HoveredChanged",
+            Self::ChildHoveredChanged(_) => "ChildHoveredChanged",
             Self::FocusChanged(_) => "FocusChanged",
             Self::ChildFocusChanged(_) => "ChildFocusChanged",
         }

--- a/masonry/src/passes/accessibility.rs
+++ b/masonry/src/passes/accessibility.rs
@@ -125,7 +125,7 @@ fn build_access_node(
     if ctx.accepts_focus() && !ctx.is_disabled() && !ctx.is_stashed() {
         node.add_action(accesskit::Action::Focus);
     }
-    if ctx.is_focused() {
+    if ctx.is_focus_target() {
         node.add_action(accesskit::Action::Blur);
     }
 

--- a/masonry/src/passes/update.rs
+++ b/masonry/src/passes/update.rs
@@ -340,7 +340,7 @@ fn update_focus_chain_for_widget(
         return;
     }
 
-    // Replace has_focus to check if the value changed in the meantime
+    // Replace has_focused to check if the value changed in the meantime
     state.item.has_focused = global_state.focused_widget == Some(id);
     let had_focus = state.item.has_focused;
 
@@ -370,8 +370,8 @@ fn update_focus_chain_for_widget(
         parent_focus_chain.extend(&state.item.focus_chain);
     }
 
-    // had_focus is the old focus value. state.has_focus was replaced with parent_ctx.is_focused().
-    // Therefore if had_focus is true but state.has_focus is false then the widget which is
+    // had_focus is the old focus value. state.has_focused was replaced with parent_ctx.is_focused().
+    // Therefore if had_focus is true but state.has_focused is false then the widget which is
     // currently focused is not part of the functional tree anymore and should resign the focus.
     if had_focus && !state.item.has_focused {
         // Not sure about this logic, might remove
@@ -474,12 +474,12 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
             focused_set: &HashSet<WidgetId>,
         ) {
             run_targeted_update_pass(root, Some(widget_id), |widget, ctx| {
-                let has_focus = focused_set.contains(&ctx.widget_id());
+                let has_focused = focused_set.contains(&ctx.widget_id());
 
-                if ctx.widget_state.has_focused != has_focus {
-                    widget.update(ctx, &Update::ChildFocusChanged(has_focus));
+                if ctx.widget_state.has_focused != has_focused {
+                    widget.update(ctx, &Update::ChildFocusChanged(has_focused));
                 }
-                ctx.widget_state.has_focused = has_focus;
+                ctx.widget_state.has_focused = has_focused;
             });
         }
 

--- a/masonry/src/widget/button.rs
+++ b/masonry/src/widget/button.rs
@@ -95,7 +95,7 @@ impl Widget for Button {
                 }
             }
             PointerEvent::PointerUp(button, _) => {
-                if ctx.has_pointer_capture() && ctx.is_hovered() && !ctx.is_disabled() {
+                if ctx.is_pointer_capture_target() && ctx.is_hovered() && !ctx.is_disabled() {
                     ctx.submit_action(Action::ButtonPressed(*button));
                     trace!("Button {:?} released", ctx.widget_id());
                 }
@@ -157,7 +157,7 @@ impl Widget for Button {
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
-        let is_active = ctx.has_pointer_capture() && !ctx.is_disabled();
+        let is_active = ctx.is_pointer_capture_target() && !ctx.is_disabled();
         let is_hovered = ctx.is_hovered();
         let size = ctx.size();
         let stroke_width = theme::BUTTON_BORDER_WIDTH;

--- a/masonry/src/widget/checkbox.rs
+++ b/masonry/src/widget/checkbox.rs
@@ -75,7 +75,7 @@ impl Widget for Checkbox {
                 }
             }
             PointerEvent::PointerUp(_, _) => {
-                if ctx.has_pointer_capture() && ctx.is_hovered() && !ctx.is_disabled() {
+                if ctx.is_pointer_capture_target() && ctx.is_hovered() && !ctx.is_disabled() {
                     self.checked = !self.checked;
                     ctx.submit_action(Action::CheckboxToggled(self.checked));
                     trace!("Checkbox {:?} released", ctx.widget_id());

--- a/masonry/src/widget/split.rs
+++ b/masonry/src/widget/split.rs
@@ -381,7 +381,7 @@ impl Widget for Split {
                     }
                 }
                 PointerEvent::PointerMove(state) => {
-                    if ctx.has_pointer_capture() {
+                    if ctx.is_pointer_capture_target() {
                         // If widget has pointer capture, assume always it's hovered
                         let effective_pos = match self.split_axis {
                             Axis::Horizontal => {
@@ -520,7 +520,7 @@ impl Widget for Split {
         let local_mouse_pos = pos - ctx.window_origin().to_vec2();
         let is_bar_hovered = self.bar_hit_test(ctx.size(), local_mouse_pos);
 
-        if ctx.has_pointer_capture() || is_bar_hovered {
+        if ctx.is_pointer_capture_target() || is_bar_hovered {
             match self.split_axis {
                 Axis::Horizontal => CursorIcon::EwResize,
                 Axis::Vertical => CursorIcon::NsResize,

--- a/masonry/src/widget/tests/status_change.rs
+++ b/masonry/src/widget/tests/status_change.rs
@@ -152,7 +152,7 @@ fn update_hovered_on_mouse_leave() {
 
     let button_rec = Recording::default();
 
-    let widget = Button::new("hello").with_id(button_id).record(&button_rec);
+    let widget = Button::new("hello").record(&button_rec).with_id(button_id);
 
     let mut harness = TestHarness::create(widget);
 

--- a/masonry/src/widget/tests/status_change.rs
+++ b/masonry/src/widget/tests/status_change.rs
@@ -24,6 +24,10 @@ fn is_hovered(harness: &TestHarness, id: WidgetId) -> bool {
     harness.get_widget(id).ctx().is_hovered()
 }
 
+fn has_hovered(harness: &TestHarness, id: WidgetId) -> bool {
+    harness.get_widget(id).ctx().has_hovered()
+}
+
 fn next_hovered_changed(recording: &Recording) -> Option<bool> {
     while let Some(event) = recording.next() {
         match event {
@@ -34,6 +38,7 @@ fn next_hovered_changed(recording: &Recording) -> Option<bool> {
     None
 }
 
+// TODO - Rewrite test to be more clear
 #[test]
 fn propagate_hovered() {
     let [button, pad, root, empty] = widget_ids();
@@ -82,11 +87,15 @@ fn propagate_hovered() {
     eprintln!("pad: {pad:?}");
     eprintln!("button: {button:?}");
 
-    assert!(is_hovered(&harness, root));
     assert!(is_hovered(&harness, empty));
-    assert!(!is_hovered(&harness, pad));
 
-    assert_eq!(next_hovered_changed(&root_rec), Some(true));
+    assert!(!is_hovered(&harness, root));
+    assert!(has_hovered(&harness, root));
+
+    assert!(!has_hovered(&harness, pad));
+
+    // TODO - Detect ChildHoveredChanged
+    assert_eq!(next_hovered_changed(&root_rec), None);
     assert_eq!(next_hovered_changed(&padding_rec), None);
     assert_eq!(next_hovered_changed(&button_rec), None);
     root_rec.clear();
@@ -100,7 +109,6 @@ fn propagate_hovered() {
     assert!(is_hovered(&harness, pad));
     assert!(!is_hovered(&harness, empty));
     assert!(!is_hovered(&harness, button));
-    assert!(is_hovered(&harness, pad));
 
     assert_eq!(next_hovered_changed(&root_rec), None);
     assert_eq!(next_hovered_changed(&padding_rec), Some(true));
@@ -111,12 +119,13 @@ fn propagate_hovered() {
 
     harness.mouse_move_to(button);
 
-    assert!(is_hovered(&harness, root));
+    assert!(has_hovered(&harness, root));
+    assert!(has_hovered(&harness, pad));
     assert!(!is_hovered(&harness, empty));
     assert!(is_hovered(&harness, button));
-    assert!(is_hovered(&harness, pad));
 
-    assert_eq!(next_hovered_changed(&padding_rec), None);
+    // TODO - Detect ChildHoveredChanged
+    assert_eq!(next_hovered_changed(&padding_rec), Some(false));
     assert_eq!(next_hovered_changed(&button_rec), Some(true));
     root_rec.clear();
     padding_rec.clear();
@@ -126,13 +135,14 @@ fn propagate_hovered() {
 
     harness.mouse_move_to(empty);
 
-    assert!(is_hovered(&harness, root));
+    assert!(has_hovered(&harness, root));
     assert!(is_hovered(&harness, empty));
+    assert!(!has_hovered(&harness, pad));
     assert!(!is_hovered(&harness, button));
-    assert!(!is_hovered(&harness, pad));
 
+    // TODO - Detect ChildHoveredChanged
     assert_eq!(next_hovered_changed(&root_rec), None);
-    assert_eq!(next_hovered_changed(&padding_rec), Some(false));
+    assert_eq!(next_hovered_changed(&padding_rec), None);
     assert_eq!(next_hovered_changed(&button_rec), Some(false));
 }
 

--- a/masonry/src/widget/text_area.rs
+++ b/masonry/src/widget/text_area.rs
@@ -895,7 +895,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
         let is_rtl = layout.is_rtl();
         let origin = Vec2::new(self.padding.get_left(is_rtl), self.padding.top);
         let transform = Affine::translate(origin);
-        if ctx.is_focused() {
+        if ctx.is_focus_target() {
             for rect in self.editor.selection_geometry().iter() {
                 // TODO: If window not focused, use a different color
                 // TODO: Make configurable

--- a/masonry/src/widget/text_area.rs
+++ b/masonry/src/widget/text_area.rs
@@ -525,7 +525,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
                 }
             }
             PointerEvent::PointerMove(_) => {
-                if !ctx.is_disabled() && ctx.has_pointer_capture() {
+                if !ctx.is_disabled() && ctx.is_pointer_capture_target() {
                     let cursor_pos = event.local_position(ctx) - padding;
                     let (fctx, lctx) = ctx.text_contexts();
                     self.editor

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -160,11 +160,15 @@ pub(crate) struct WidgetState {
     /// This widget or an ancestor has been stashed.
     pub(crate) is_stashed: bool,
 
+    /// In the hovered path, starting from window and ending at the hovered widget.
+    /// Descendants of the hovered widget are not in the hovered path.
+    pub(crate) has_hovered: bool,
+    /// This specific widget is hovered.
     pub(crate) is_hovered: bool,
 
     /// In the focused path, starting from window and ending at the focused widget.
     /// Descendants of the focused widget are not in the focused path.
-    pub(crate) has_focus: bool,
+    pub(crate) has_focused: bool,
 
     // --- DEBUG INFO ---
     // TODO - document
@@ -194,6 +198,7 @@ impl WidgetState {
             is_stashed: false,
             baseline_offset: 0.0,
             is_new: true,
+            has_hovered: false,
             is_hovered: false,
             request_layout: true,
             needs_layout: true,
@@ -203,7 +208,7 @@ impl WidgetState {
             needs_paint: true,
             request_accessibility: true,
             needs_accessibility: true,
-            has_focus: false,
+            has_focused: false,
             request_anim: true,
             needs_anim: true,
             needs_update_disabled: true,
@@ -257,7 +262,6 @@ impl WidgetState {
         self.needs_anim |= child_state.needs_anim;
         self.needs_accessibility |= child_state.needs_accessibility;
         self.needs_update_disabled |= child_state.needs_update_disabled;
-        self.has_focus |= child_state.has_focus;
         self.children_changed |= child_state.children_changed;
         self.needs_update_focus_chain |= child_state.needs_update_focus_chain;
         self.needs_update_stashed |= child_state.needs_update_stashed;

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -168,7 +168,7 @@ pub(crate) struct WidgetState {
 
     /// In the focused path, starting from window and ending at the focused widget.
     /// Descendants of the focused widget are not in the focused path.
-    pub(crate) has_focused: bool,
+    pub(crate) has_focus_target: bool,
 
     // --- DEBUG INFO ---
     // TODO - document
@@ -208,7 +208,7 @@ impl WidgetState {
             needs_paint: true,
             request_accessibility: true,
             needs_accessibility: true,
-            has_focused: false,
+            has_focus_target: false,
             request_anim: true,
             needs_anim: true,
             needs_update_disabled: true,


### PR DESCRIPTION
Rename has_pointer_capture to is_pointer_capture_target.
Rename has_focus to has_focus_target.
Rename is_focused to is_focus_target.
Add has_hovered flag.
Add ChildHoverChanged event.