### PR TITLE
Emoji picker example improvements

### DIFF
--- a/xilem/examples/emoji_picker.rs
+++ b/xilem/examples/emoji_picker.rs
@@ -57,9 +57,12 @@ fn picker(data: &mut EmojiPagination) -> impl WidgetView<EmojiPagination> {
             };
             let view = flex((
                 // TODO: Expose that this button corresponds to the label below for accessibility?
-                sized_box(button(label(emoji.display).text_size(200.0 / data.size as f32), move |data: &mut EmojiPagination| {
-                    data.last_selected = Some(idx);
-                }))
+                sized_box(button(
+                    label(emoji.display).text_size(200.0 / data.size as f32),
+                    move |data: &mut EmojiPagination| {
+                        data.last_selected = Some(idx);
+                    },
+                ))
                 .expand_width(),
                 sized_box(
                     prose(emoji.name)
@@ -83,7 +86,8 @@ fn picker(data: &mut EmojiPagination) -> impl WidgetView<EmojiPagination> {
         grid_items,
         data.size.try_into().unwrap(),
         data.size.try_into().unwrap(),
-    ).spacing(10.0)
+    )
+    .spacing(10.0)
 }
 
 fn paginate(

--- a/xilem/examples/emoji_picker.rs
+++ b/xilem/examples/emoji_picker.rs
@@ -97,16 +97,20 @@ fn paginate(
 
     flex((
         // TODO: Expose that this is a previous page button to accessibility
-        (current_start != 0).then(|| button( "<-", move |data| {
-            *data = current_start.saturating_sub(count_per_page);
-        })),
+        (current_start != 0).then(|| {
+            button("<-", move |data| {
+                *data = current_start.saturating_sub(count_per_page);
+            })
+        }),
         label(format!("{percentage_start}% - {percentage_end}%")),
-        (current_end < max_count).then(|| button("->", move |data| {
-            let new_idx = current_start + count_per_page;
-            if new_idx < max_count {
-                *data = new_idx;
-            }
-        })),
+        (current_end < max_count).then(|| {
+            button("->", move |data| {
+                let new_idx = current_start + count_per_page;
+                if new_idx < max_count {
+                    *data = new_idx;
+                }
+            })
+        }),
     ))
     .direction(Axis::Horizontal)
 }

--- a/xilem/examples/emoji_picker.rs
+++ b/xilem/examples/emoji_picker.rs
@@ -57,7 +57,7 @@ fn picker(data: &mut EmojiPagination) -> impl WidgetView<EmojiPagination> {
             };
             let view = flex((
                 // TODO: Expose that this button corresponds to the label below for accessibility?
-                sized_box(button(emoji.display, move |data: &mut EmojiPagination| {
+                sized_box(button(label(emoji.display).text_size(200.0 / data.size as f32), move |data: &mut EmojiPagination| {
                     data.last_selected = Some(idx);
                 }))
                 .expand_width(),
@@ -83,7 +83,7 @@ fn picker(data: &mut EmojiPagination) -> impl WidgetView<EmojiPagination> {
         grid_items,
         data.size.try_into().unwrap(),
         data.size.try_into().unwrap(),
-    )
+    ).spacing(10.0)
 }
 
 fn paginate(

--- a/xilem/examples/emoji_picker.rs
+++ b/xilem/examples/emoji_picker.rs
@@ -98,13 +98,13 @@ fn paginate(
     flex((
         // TODO: Expose that this is a previous page button to accessibility
         (current_start != 0).then(|| {
-            button("<-", move |data| {
+            button(label("⬅️").text_size(24.0), move |data| {
                 *data = current_start.saturating_sub(count_per_page);
             })
         }),
         label(format!("{percentage_start}% - {percentage_end}%")),
         (current_end < max_count).then(|| {
-            button("->", move |data| {
+            button(label("➡️").text_size(24.0), move |data| {
                 let new_idx = current_start + count_per_page;
                 if new_idx < max_count {
                     *data = new_idx;

--- a/xilem/examples/emoji_picker.rs
+++ b/xilem/examples/emoji_picker.rs
@@ -91,20 +91,22 @@ fn paginate(
     count_per_page: usize,
     max_count: usize,
 ) -> impl WidgetView<usize> {
-    let percentage = (current_start * 100) / max_count;
+    let current_end = (current_start + count_per_page).min(max_count);
+    let percentage_start = (current_start * 100) / max_count;
+    let percentage_end = (current_end * 100) / max_count;
 
     flex((
         // TODO: Expose that this is a previous page button to accessibility
-        button("<-", move |data| {
+        (current_start != 0).then(|| button( "<-", move |data| {
             *data = current_start.saturating_sub(count_per_page);
-        }),
-        label(format!("{percentage}%")),
-        button("->", move |data| {
+        })),
+        label(format!("{percentage_start}% - {percentage_end}%")),
+        (current_end < max_count).then(move || button("->", move |data| {
             let new_idx = current_start + count_per_page;
             if new_idx < max_count {
                 *data = new_idx;
             }
-        }),
+        })),
     ))
     .direction(Axis::Horizontal)
 }

--- a/xilem/examples/emoji_picker.rs
+++ b/xilem/examples/emoji_picker.rs
@@ -101,7 +101,7 @@ fn paginate(
             *data = current_start.saturating_sub(count_per_page);
         })),
         label(format!("{percentage_start}% - {percentage_end}%")),
-        (current_end < max_count).then(move || button("->", move |data| {
+        (current_end < max_count).then(|| button("->", move |data| {
             let new_idx = current_start + count_per_page;
             if new_idx < max_count {
                 *data = new_idx;


### PR DESCRIPTION
This PR includes improvements to page selector.

Specifically it now shows the full percentage range instead of just the start of it, and it hides the buttons when you reach the end of the range.

For some reason it panics when I get to the end.