### PR TITLE
Update to Vello 0.4, Peniko 0.3.1, Color 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "color"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d9a622ee8dabcf678e18d306da59ffa4a7f8f5f50c04155903275a789ae1f7"
+checksum = "61c387f6cef110ee8eaf12fca5586d3d303c07c594f4a5f02c768b6470b70dbd"
 
 [[package]]
 name = "combine"
@@ -2472,9 +2472,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peniko"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7de2e49a1a6b7a55ec3ba866a423f46cd8f31472bfaabe42c68e144c27bc668"
+checksum = "2ec061f435b573ff602b2c5690f1a5bfcf461327194654cfbfce4412b95cf2a1"
 dependencies = [
  "color",
  "kurbo",
@@ -3807,8 +3807,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vello"
-version = "0.3.0"
-source = "git+https://github.com/linebender/vello?rev=d5ebe12737861c521d7ce6ce02b800278367d07d#d5ebe12737861c521d7ce6ce02b800278367d07d"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa359d6cc48a5afec128b6a3829116700c33bd6d4a9ce81efd0b1e6ac55e9777"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
@@ -3826,8 +3827,9 @@ dependencies = [
 
 [[package]]
 name = "vello_encoding"
-version = "0.3.0"
-source = "git+https://github.com/linebender/vello?rev=d5ebe12737861c521d7ce6ce02b800278367d07d#d5ebe12737861c521d7ce6ce02b800278367d07d"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847f24259aa73e1d5baf453856034f471eeffbf006072e41f7c8397da4f89f65"
 dependencies = [
  "bytemuck",
  "guillotiere",
@@ -3838,8 +3840,9 @@ dependencies = [
 
 [[package]]
 name = "vello_shaders"
-version = "0.3.0"
-source = "git+https://github.com/linebender/vello?rev=d5ebe12737861c521d7ce6ce02b800278367d07d#d5ebe12737861c521d7ce6ce02b800278367d07d"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88db8f16a08862b63bbbf90666d367187ff15d3bb157f3d83798497914f2c94f"
 dependencies = [
  "bytemuck",
  "naga",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,13 +104,13 @@ clippy.duplicated_attributes = "allow"
 masonry = { version = "0.2.0", path = "masonry" }
 xilem_core = { version = "0.1.0", path = "xilem_core" }
 tree_arena = { version = "0.1.0", path = "tree_arena" }
-vello = { git = "https://github.com/linebender/vello", rev = "d5ebe12737861c521d7ce6ce02b800278367d07d" }
+vello = "0.4.0"
 wgpu = "23.0.1"
 kurbo = "0.11.1"
 parley = { git = "https://github.com/linebender/parley", rev = "16b62518d467487ee15cb230fdb28530d89a8cf6", features = [
     "accesskit",
 ] }
-peniko = "0.3.0"
+peniko = "0.3.1"
 winit = "0.30.4"
 tracing = { version = "0.1.40", default-features = false }
 smallvec = "1.13.2"

--- a/masonry/examples/calc_masonry.rs
+++ b/masonry/examples/calc_masonry.rs
@@ -267,8 +267,8 @@ impl AppDriver for CalcState {
 // ---
 
 fn op_button_with_label(op: char, label: String) -> CalcButton {
-    const BLUE: Color = Color::from_rgba8(0x00, 0x8d, 0xdd, 0xff);
-    const LIGHT_BLUE: Color = Color::from_rgba8(0x5c, 0xc4, 0xff, 0xff);
+    const BLUE: Color = Color::from_rgb8(0x00, 0x8d, 0xdd);
+    const LIGHT_BLUE: Color = Color::from_rgb8(0x5c, 0xc4, 0xff);
 
     CalcButton::new(
         SizedBox::new(Align::centered(
@@ -287,8 +287,8 @@ fn op_button(op: char) -> CalcButton {
 }
 
 fn digit_button(digit: u8) -> CalcButton {
-    const GRAY: Color = Color::from_rgba8(0x3a, 0x3a, 0x3a, 0xff);
-    const LIGHT_GRAY: Color = Color::from_rgba8(0x71, 0x71, 0x71, 0xff);
+    const GRAY: Color = Color::from_rgb8(0x3a, 0x3a, 0x3a);
+    const LIGHT_GRAY: Color = Color::from_rgb8(0x71, 0x71, 0x71);
     CalcButton::new(
         SizedBox::new(Align::centered(
             Label::new(format!("{digit}")).with_style(StyleProperty::FontSize(24.)),

--- a/masonry/examples/custom_widget.rs
+++ b/masonry/examples/custom_widget.rs
@@ -86,7 +86,7 @@ impl Widget for CustomWidget {
         path.move_to(Point::ORIGIN);
         path.quad_to((60.0, 120.0), (size.width, size.height));
         // Create a color
-        let stroke_color = Color::from_rgba8(0, 128, 0, 255);
+        let stroke_color = Color::from_rgb8(0, 128, 0);
         // Stroke the path with thickness 5.0
         scene.stroke(
             &Stroke::new(5.0),

--- a/masonry/examples/grid_masonry.rs
+++ b/masonry/examples/grid_masonry.rs
@@ -50,7 +50,7 @@ fn main() {
             .with_style(StyleProperty::FontSize(14.0))
             .with_alignment(Alignment::Middle),
     ))
-    .border(Color::from_rgba8(40, 40, 80, 255), 1.0);
+    .border(Color::from_rgb8(40, 40, 80), 1.0);
     let button_inputs = vec![
         GridParams {
             x: 0,

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -158,7 +158,7 @@ impl TestHarnessParams {
     pub const DEFAULT_SIZE: Size = Size::new(400., 400.);
 
     /// Default background color for tests.
-    pub const DEFAULT_BACKGROUND_COLOR: Color = Color::from_rgba8(0x29, 0x29, 0x29, 0xff);
+    pub const DEFAULT_BACKGROUND_COLOR: Color = Color::from_rgb8(0x29, 0x29, 0x29);
 }
 
 impl Default for TestHarnessParams {

--- a/masonry/src/theme.rs
+++ b/masonry/src/theme.rs
@@ -10,31 +10,30 @@ use crate::{Color, Insets};
 // Colors are from https://sashat.me/2017/01/11/list-of-20-simple-distinct-colors/
 // They're picked for visual distinction and accessibility (99 percent)
 
-pub const WINDOW_BACKGROUND_COLOR: Color = Color::from_rgba8(0x29, 0x29, 0x29, 0xff);
-pub const TEXT_COLOR: Color = Color::from_rgba8(0xf0, 0xf0, 0xea, 0xff);
-pub const DISABLED_TEXT_COLOR: Color = Color::from_rgba8(0xa0, 0xa0, 0x9a, 0xff);
-pub const PLACEHOLDER_COLOR: Color = Color::from_rgba8(0x80, 0x80, 0x80, 0xff);
-pub const PRIMARY_LIGHT: Color = Color::from_rgba8(0x5c, 0xc4, 0xff, 0xff);
-pub const PRIMARY_DARK: Color = Color::from_rgba8(0x00, 0x8d, 0xdd, 0xff);
+pub const WINDOW_BACKGROUND_COLOR: Color = Color::from_rgb8(0x29, 0x29, 0x29);
+pub const TEXT_COLOR: Color = Color::from_rgb8(0xf0, 0xf0, 0xea);
+pub const DISABLED_TEXT_COLOR: Color = Color::from_rgb8(0xa0, 0xa0, 0x9a);
+pub const PLACEHOLDER_COLOR: Color = Color::from_rgb8(0x80, 0x80, 0x80);
+pub const PRIMARY_LIGHT: Color = Color::from_rgb8(0x5c, 0xc4, 0xff);
+pub const PRIMARY_DARK: Color = Color::from_rgb8(0x00, 0x8d, 0xdd);
 pub const PROGRESS_BAR_RADIUS: f64 = 4.;
-pub const BACKGROUND_LIGHT: Color = Color::from_rgba8(0x3a, 0x3a, 0x3a, 0xff);
-pub const BACKGROUND_DARK: Color = Color::from_rgba8(0x31, 0x31, 0x31, 0xff);
-pub const FOREGROUND_LIGHT: Color = Color::from_rgba8(0xf9, 0xf9, 0xf9, 0xff);
-pub const FOREGROUND_DARK: Color = Color::from_rgba8(0xbf, 0xbf, 0xbf, 0xff);
-pub const DISABLED_FOREGROUND_LIGHT: Color = Color::from_rgba8(0x89, 0x89, 0x89, 0xff);
-pub const DISABLED_FOREGROUND_DARK: Color = Color::from_rgba8(0x6f, 0x6f, 0x6f, 0xff);
+pub const BACKGROUND_LIGHT: Color = Color::from_rgb8(0x3a, 0x3a, 0x3a);
+pub const BACKGROUND_DARK: Color = Color::from_rgb8(0x31, 0x31, 0x31);
+pub const FOREGROUND_LIGHT: Color = Color::from_rgb8(0xf9, 0xf9, 0xf9);
+pub const FOREGROUND_DARK: Color = Color::from_rgb8(0xbf, 0xbf, 0xbf);
+pub const DISABLED_FOREGROUND_LIGHT: Color = Color::from_rgb8(0x89, 0x89, 0x89);
+pub const DISABLED_FOREGROUND_DARK: Color = Color::from_rgb8(0x6f, 0x6f, 0x6f);
 pub const BUTTON_DARK: Color = Color::BLACK;
-pub const BUTTON_LIGHT: Color = Color::from_rgba8(0x21, 0x21, 0x21, 0xff);
-pub const DISABLED_BUTTON_DARK: Color = Color::from_rgba8(0x28, 0x28, 0x28, 0xff);
-pub const DISABLED_BUTTON_LIGHT: Color = Color::from_rgba8(0x38, 0x38, 0x38, 0xff);
+pub const BUTTON_LIGHT: Color = Color::from_rgb8(0x21, 0x21, 0x21);
+pub const DISABLED_BUTTON_DARK: Color = Color::from_rgb8(0x28, 0x28, 0x28);
+pub const DISABLED_BUTTON_LIGHT: Color = Color::from_rgb8(0x38, 0x38, 0x38);
 pub const BUTTON_BORDER_RADIUS: f64 = 4.;
 pub const BUTTON_BORDER_WIDTH: f64 = 2.;
-pub const BORDER_DARK: Color = Color::from_rgba8(0x3a, 0x3a, 0x3a, 0xff);
-pub const BORDER_LIGHT: Color = Color::from_rgba8(0xa1, 0xa1, 0xa1, 0xff);
-pub const SELECTED_TEXT_BACKGROUND_COLOR: Color = Color::from_rgba8(0x43, 0x70, 0xA8, 0xff);
-pub const SELECTED_TEXT_INACTIVE_BACKGROUND_COLOR: Color =
-    Color::from_rgba8(0x74, 0x74, 0x74, 0xff);
-pub const SELECTION_TEXT_COLOR: Color = Color::from_rgba8(0x00, 0x00, 0x00, 0xff);
+pub const BORDER_DARK: Color = Color::from_rgb8(0x3a, 0x3a, 0x3a);
+pub const BORDER_LIGHT: Color = Color::from_rgb8(0xa1, 0xa1, 0xa1);
+pub const SELECTED_TEXT_BACKGROUND_COLOR: Color = Color::from_rgb8(0x43, 0x70, 0xA8);
+pub const SELECTED_TEXT_INACTIVE_BACKGROUND_COLOR: Color = Color::from_rgb8(0x74, 0x74, 0x74);
+pub const SELECTION_TEXT_COLOR: Color = Color::from_rgb8(0x00, 0x00, 0x00);
 pub const CURSOR_COLOR: Color = Color::WHITE;
 pub const TEXT_SIZE_NORMAL: f32 = 15.0;
 pub const TEXT_SIZE_LARGE: f32 = 24.0;
@@ -44,8 +43,8 @@ pub const BORDERED_WIDGET_HEIGHT: f64 = 24.0;
 pub const TEXTBOX_BORDER_RADIUS: f64 = 2.;
 pub const TEXTBOX_BORDER_WIDTH: f64 = 1.;
 pub const TEXTBOX_INSETS: Insets = Insets::new(4.0, 4.0, 4.0, 4.0);
-pub const SCROLLBAR_COLOR: Color = Color::from_rgba8(0xff, 0xff, 0xff, 0xff);
-pub const SCROLLBAR_BORDER_COLOR: Color = Color::from_rgba8(0x77, 0x77, 0x77, 0xff);
+pub const SCROLLBAR_COLOR: Color = Color::from_rgb8(0xff, 0xff, 0xff);
+pub const SCROLLBAR_BORDER_COLOR: Color = Color::from_rgb8(0x77, 0x77, 0x77);
 pub const SCROLLBAR_MAX_OPACITY: f64 = 0.7;
 pub const SCROLLBAR_FADE_DELAY: u64 = 1500;
 pub const SCROLLBAR_WIDTH: f64 = 8.;
@@ -58,24 +57,24 @@ pub const WIDGET_PADDING_HORIZONTAL: f64 = 8.0;
 pub const WIDGET_CONTROL_COMPONENT_PADDING: f64 = 4.0;
 
 static DEBUG_COLOR: &[Color] = &[
-    Color::from_rgba8(230, 25, 75, 255),
-    Color::from_rgba8(60, 180, 75, 255),
-    Color::from_rgba8(255, 225, 25, 255),
-    Color::from_rgba8(0, 130, 200, 255),
-    Color::from_rgba8(245, 130, 48, 255),
-    Color::from_rgba8(70, 240, 240, 255),
-    Color::from_rgba8(240, 50, 230, 255),
-    Color::from_rgba8(250, 190, 190, 255),
-    Color::from_rgba8(0, 128, 128, 255),
-    Color::from_rgba8(230, 190, 255, 255),
-    Color::from_rgba8(170, 110, 40, 255),
-    Color::from_rgba8(255, 250, 200, 255),
-    Color::from_rgba8(128, 0, 0, 255),
-    Color::from_rgba8(170, 255, 195, 255),
-    Color::from_rgba8(0, 0, 128, 255),
-    Color::from_rgba8(128, 128, 128, 255),
-    Color::from_rgba8(255, 255, 255, 255),
-    Color::from_rgba8(0, 0, 0, 255),
+    Color::from_rgb8(230, 25, 75),
+    Color::from_rgb8(60, 180, 75),
+    Color::from_rgb8(255, 225, 25),
+    Color::from_rgb8(0, 130, 200),
+    Color::from_rgb8(245, 130, 48),
+    Color::from_rgb8(70, 240, 240),
+    Color::from_rgb8(240, 50, 230),
+    Color::from_rgb8(250, 190, 190),
+    Color::from_rgb8(0, 128, 128),
+    Color::from_rgb8(230, 190, 255),
+    Color::from_rgb8(170, 110, 40),
+    Color::from_rgb8(255, 250, 200),
+    Color::from_rgb8(128, 0, 0),
+    Color::from_rgb8(170, 255, 195),
+    Color::from_rgb8(0, 0, 128),
+    Color::from_rgb8(128, 128, 128),
+    Color::from_rgb8(255, 255, 255),
+    Color::from_rgb8(0, 0, 0),
 ];
 
 /// A color used for debug painting.

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -151,7 +151,7 @@ fn run(event_loop: EventLoopBuilder) -> Result<(), EventLoopError> {
     };
 
     Xilem::new(data, app_logic)
-        .background_color(Color::from_rgba8(0x20, 0x20, 0x20, 0xff))
+        .background_color(Color::from_rgb8(0x20, 0x20, 0x20))
         .run_windowed(event_loop, "First Example".into())
 }
 

--- a/xilem_web/web_examples/svgdraw/src/main.rs
+++ b/xilem_web/web_examples/svgdraw/src/main.rs
@@ -17,17 +17,17 @@ use xilem_web::svg::peniko::Color;
 use xilem_web::{document_body, input_event_target_value, AnyDomView, App, DomFragment};
 
 const RAINBOW_COLORS: [Color; 11] = [
-    Color::from_rgba8(228, 3, 3, 255),     // Red
-    Color::from_rgba8(255, 140, 0, 255),   // Orange
-    Color::from_rgba8(255, 237, 0, 255),   // Yellow
-    Color::from_rgba8(0, 128, 38, 255),    // Green
-    Color::from_rgba8(0, 76, 255, 255),    // Indigo
-    Color::from_rgba8(115, 41, 130, 255),  // Violet
-    Color::from_rgba8(214, 2, 112, 255),   // Magenta
-    Color::from_rgba8(155, 79, 150, 255),  // Lavender
-    Color::from_rgba8(0, 56, 168, 255),    // Blue
-    Color::from_rgba8(91, 206, 250, 255),  // Light Blue
-    Color::from_rgba8(245, 169, 184, 255), // Pink
+    Color::from_rgb8(228, 3, 3),     // Red
+    Color::from_rgb8(255, 140, 0),   // Orange
+    Color::from_rgb8(255, 237, 0),   // Yellow
+    Color::from_rgb8(0, 128, 38),    // Green
+    Color::from_rgb8(0, 76, 255),    // Indigo
+    Color::from_rgb8(115, 41, 130),  // Violet
+    Color::from_rgb8(214, 2, 112),   // Magenta
+    Color::from_rgb8(155, 79, 150),  // Lavender
+    Color::from_rgb8(0, 56, 168),    // Blue
+    Color::from_rgb8(91, 206, 250),  // Light Blue
+    Color::from_rgb8(245, 169, 184), // Pink
 ];
 
 struct SplineLine {


### PR DESCRIPTION
This also lets us update to using `Color::from_rgb8()` when there is no need for alpha to be specified.