### PR TITLE
Remove some cruft

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ homepage = "https://xilem.dev/"
 rust.unsafe_code = "deny"
 
 # Intentional break from the lint set. Intended to be temporary
-rust.unexpected_cfgs = { level = "warn", check-cfg = ['cfg(FALSE)', 'cfg(tarpaulin_include)'] }
+rust.unexpected_cfgs = { level = "warn", check-cfg = ['cfg(FALSE)'] }
 
 # LINEBENDER LINT SET - Cargo.toml - v2
 # See https://linebender.org/wiki/canonical-lints/

--- a/masonry/src/event.rs
+++ b/masonry/src/event.rs
@@ -15,11 +15,6 @@ use crate::kurbo::Rect;
 // TODO - Occluded(bool) event
 // TODO - winit ActivationTokenDone thing
 // TODO - Suspended/Resume/NewEvents/MemoryWarning
-// TODO - wtf is InnerSizeWriter?
-// TODO - Move AnimFrame to Update
-// TODO - switch anim frames to being about age / an absolute timestamp
-// instead of time elapsed.
-// (this will help in cases where we want to skip anim frames)
 
 /// A global event.
 #[derive(Debug, Clone)]

--- a/masonry/src/passes/anim.rs
+++ b/masonry/src/passes/anim.rs
@@ -53,6 +53,10 @@ fn update_anim_for_widget(
     );
 }
 
+// TODO - switch anim frames to being about age / an absolute timestamp
+// instead of time elapsed.
+// (this will help in cases where we want to skip anim frames)
+
 /// Run the animation pass.
 ///
 /// See the [passes documentation](../doc/05_pass_system.md#animation-pass).

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -556,7 +556,6 @@ impl TestHarness {
         self.render_root.get_widget(id)
     }
 
-    // TODO - Link to focus definition in tutorial
     /// Return a [`WidgetRef`] to the [focused widget](crate::doc::doc_06_masonry_concepts#text-focus).
     pub fn focused_widget(&self) -> Option<WidgetRef<'_, dyn Widget>> {
         self.root_widget()

--- a/masonry/src/testing/mod.rs
+++ b/masonry/src/testing/mod.rs
@@ -3,15 +3,9 @@
 
 //! Helper tools for writing unit tests.
 
-#![cfg(not(tarpaulin_include))]
-
-#[cfg(not(tarpaulin_include))]
 mod harness;
-#[cfg(not(tarpaulin_include))]
 mod helper_widgets;
-#[cfg(not(tarpaulin_include))]
 mod screenshots;
-#[cfg(not(tarpaulin_include))]
 mod snapshot_utils;
 
 pub use harness::{TestHarness, TestHarnessParams};

--- a/masonry/src/util.rs
+++ b/masonry/src/util.rs
@@ -3,8 +3,6 @@
 
 //! Miscellaneous utility functions.
 
-#![cfg(not(tarpaulin_include))]
-
 use std::any::Any;
 use std::hash::Hash;
 

--- a/masonry/src/widget/image.rs
+++ b/masonry/src/widget/image.rs
@@ -214,7 +214,7 @@ mod tests {
             harness.render()
         };
 
-        // TODO - Use kompari instead
+        // TODO - Use Kompari instead
         // We don't use assert_eq because we don't want rich assert
         assert!(render_1 == render_2);
     }

--- a/masonry/src/widget/image.rs
+++ b/masonry/src/widget/image.rs
@@ -214,7 +214,7 @@ mod tests {
             harness.render()
         };
 
-        // TODO - write comparison function
+        // TODO - Use kompari instead
         // We don't use assert_eq because we don't want rich assert
         assert!(render_1 == render_2);
     }

--- a/masonry/src/widget/tests/mod.rs
+++ b/masonry/src/widget/tests/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO - See https://github.com/PoignardAzur/masonry-rs/issues/58
+// TODO - See https://github.com/linebender/xilem/issues/336
 
 #![allow(clippy::print_stdout, clippy::print_stderr, clippy::dbg_macro)]
 

--- a/masonry/src/widget/tests/status_change.rs
+++ b/masonry/src/widget/tests/status_change.rs
@@ -167,7 +167,7 @@ fn update_hovered_on_mouse_leave() {
     assert_eq!(next_hovered_changed(&button_rec), Some(false));
 }
 
-// TODO - https://github.com/PoignardAzur/masonry-rs/issues/58
+// TODO - https://github.com/linebender/xilem/issues/336
 #[cfg(FALSE)]
 #[test]
 fn update_hovered_from_layout() {

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -418,7 +418,6 @@ pub fn find_widget_at_pos<'c>(
 /// internal implementation detail of public widgets.
 pub trait AllowRawMut: Widget {}
 
-#[cfg(not(tarpaulin_include))]
 impl WidgetId {
     /// Allocate a new, unique `WidgetId`.
     ///

--- a/masonry/src/widget/widget.rs
+++ b/masonry/src/widget/widget.rs
@@ -99,7 +99,6 @@ impl FromDynWidget for dyn Widget {
     }
 }
 
-// TODO - Add tutorial: implementing a widget - See https://github.com/linebender/xilem/issues/376
 /// The trait implemented by all widgets.
 ///
 /// For details on how to implement this trait, see the [tutorials](crate::doc).

--- a/masonry/src/widget/widget_pod.rs
+++ b/masonry/src/widget/widget_pod.rs
@@ -8,7 +8,8 @@ use crate::{Affine, Widget, WidgetId};
 /// Generally, container widgets don't contain other widgets directly,
 /// but rather contain a `WidgetPod`, which has additional state needed
 /// for layout and for the widget to participate in event flow.
-// TODO - Add reference to container tutorial
+///
+/// See [container widget tutorial](crate::doc::doc_03_implementing_container_widget) for details.
 pub struct WidgetPod<W: ?Sized> {
     id: WidgetId,
     inner: WidgetPodInner<W>,

--- a/masonry/src/widget/widget_state.rs
+++ b/masonry/src/widget/widget_state.rs
@@ -154,7 +154,6 @@ pub(crate) struct WidgetState {
     /// This widget or an ancestor has been disabled.
     pub(crate) is_disabled: bool,
 
-    // TODO - Document concept of "stashing".
     /// This widget has been stashed.
     pub(crate) is_explicitly_stashed: bool,
     /// This widget or an ancestor has been stashed.
@@ -171,7 +170,10 @@ pub(crate) struct WidgetState {
     pub(crate) has_focus_target: bool,
 
     // --- DEBUG INFO ---
-    // TODO - document
+    /// The typename of the associated widget.
+    ///
+    /// Used in some guard rails to provide richer error messages when a parent forgets
+    /// to iterate over some children.
     #[cfg(debug_assertions)]
     pub(crate) widget_name: &'static str,
 }


### PR DESCRIPTION
Remove outdated TODO comments.
Rewrite some other TODO comments.
Remove references to tarpaulin.

(cargo-tarpaulin is a tool used for code coverage. Masonry hasn't used it for years, and anyway we'll probably use `#[coverage]` annotations once they stabilize.)