### PR TITLE
Apply rustfmt to entire project

### DIFF
--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -166,18 +166,6 @@ pub mod text;
 pub mod theme;
 pub mod widget;
 
-pub use cursor_icon;
-pub use dpi;
-pub use parley;
-pub use vello;
-pub use vello::kurbo;
-
-pub use cursor_icon::{CursorIcon, ParseError as CursorIconParseError};
-pub use kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
-pub use parley::layout::Alignment as TextAlignment;
-pub use parley::style::FontWeight;
-pub use vello::peniko::{color::palette, Color, Gradient};
-
 pub use action::Action;
 pub use app_driver::{AppDriver, DriverCtx};
 pub use box_constraints::BoxConstraints;
@@ -185,14 +173,21 @@ pub use contexts::{
     AccessCtx, ComposeCtx, EventCtx, IsContext, LayoutCtx, MutateCtx, PaintCtx, QueryCtx,
     RawWrapper, RawWrapperMut, RegisterCtx, UpdateCtx,
 };
+pub use cursor_icon::{CursorIcon, ParseError as CursorIconParseError};
 pub use event::{
     AccessEvent, PointerButton, PointerEvent, PointerState, TextEvent, Update, WindowEvent,
     WindowTheme,
 };
+pub use kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
 pub use paint_scene_helpers::UnitPoint;
+pub use parley::layout::Alignment as TextAlignment;
+pub use parley::style::FontWeight;
 pub use render_root::{RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy};
 pub use util::{AsAny, Handled};
+pub use vello::kurbo;
+pub use vello::peniko::color::palette;
+pub use vello::peniko::{Color, Gradient};
 pub use widget::widget::{AllowRawMut, FromDynWidget, Widget, WidgetId};
 pub use widget::WidgetPod;
-
 pub(crate) use widget::WidgetState;
+pub use {cursor_icon, dpi, parley, vello};

--- a/masonry/src/render_root.rs
+++ b/masonry/src/render_root.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{HashMap, VecDeque};
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 
 use accesskit::{ActionRequest, TreeUpdate};
 use parley::fontique::{self, Collection, CollectionOptions};
@@ -10,12 +12,9 @@ use tracing::{info_span, warn};
 use tree_arena::{ArenaMut, TreeArena};
 use vello::kurbo::{self, Rect};
 use vello::Scene;
-use winit::window::ResizeDirection;
-
-#[cfg(not(target_arch = "wasm32"))]
-use std::time::Instant;
 #[cfg(target_arch = "wasm32")]
 use web_time::Instant;
+use winit::window::ResizeDirection;
 
 use crate::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use crate::event::{PointerEvent, TextEvent, WindowEvent};

--- a/masonry/src/widget/mod.rs
+++ b/masonry/src/widget/mod.rs
@@ -37,7 +37,6 @@ mod variable_label;
 mod widget_arena;
 mod zstack;
 
-pub use self::image::Image;
 pub use align::Align;
 pub use button::Button;
 pub use checkbox::Checkbox;
@@ -55,15 +54,15 @@ pub use split::Split;
 pub use text_area::TextArea;
 pub use textbox::Textbox;
 pub use variable_label::VariableLabel;
+pub(crate) use widget_arena::WidgetArena;
 pub use widget_mut::WidgetMut;
+pub(crate) use widget_pod::CreateWidget;
 pub use widget_pod::WidgetPod;
 pub use widget_ref::WidgetRef;
+pub(crate) use widget_state::WidgetState;
 pub use zstack::{Alignment, ChildAlignment, HorizontalAlignment, VerticalAlignment, ZStack};
 
-pub(crate) use widget_arena::WidgetArena;
-pub(crate) use widget_pod::CreateWidget;
-pub(crate) use widget_state::WidgetState;
-
+pub use self::image::Image;
 use crate::{Affine, Size};
 
 // These are based on https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -141,23 +141,22 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use masonry::dpi::LogicalSize;
+pub use masonry::event_loop_runner::{EventLoop, EventLoopBuilder};
+pub use masonry::widget::LineBreaking;
 use masonry::widget::{RootWidget, WidgetMut};
+pub use masonry::{dpi, palette, Affine, Color, FontWeight, TextAlignment, Vec2};
 use masonry::{event_loop_runner, FromDynWidget, Widget, WidgetId, WidgetPod};
+/// Tokio is the async runner used with Xilem.
+pub use tokio;
 use view::{transformed, Transformed};
 use winit::error::EventLoopError;
 use winit::window::{Window, WindowAttributes};
+pub use xilem_core as core;
 
 use crate::core::{
     AsyncCtx, MessageResult, Mut, RawProxy, SuperElement, View, ViewElement, ViewId,
     ViewPathTracker, ViewSequence,
 };
-pub use masonry::event_loop_runner::{EventLoop, EventLoopBuilder};
-pub use masonry::widget::LineBreaking;
-pub use masonry::{dpi, palette, Affine, Color, FontWeight, TextAlignment, Vec2};
-pub use xilem_core as core;
-
-/// Tokio is the async runner used with Xilem.
-pub use tokio;
 
 mod any_view;
 mod driver;

--- a/xilem_web/src/lib.rs
+++ b/xilem_web/src/lib.rs
@@ -82,25 +82,22 @@ pub mod modifiers;
 pub mod props;
 pub mod svg;
 
-pub use self::{
-    after_update::{
-        after_build, after_rebuild, before_teardown, AfterBuild, AfterRebuild, BeforeTeardown,
-    },
-    app::App,
-    attribute_value::{AttributeValue, IntoAttributeValue},
-    context::{MessageThunk, ViewCtx},
-    dom_helpers::{document, document_body, get_element_by_id, input_event_target_value},
-    message::{DynMessage, Message},
-    optional_action::{Action, OptionalAction},
-    pod::{AnyPod, Pod, PodFlags, PodMut},
-    pointer::{Pointer, PointerDetails, PointerMsg},
-};
+use core::{Adapt, AdaptThunk, AnyView, MapAction, MapState, MessageResult, View, ViewSequence};
 
 pub use templated::{templated, Templated};
-
 pub use xilem_core as core;
 
-use core::{Adapt, AdaptThunk, AnyView, MapAction, MapState, MessageResult, View, ViewSequence};
+pub use self::after_update::{
+    after_build, after_rebuild, before_teardown, AfterBuild, AfterRebuild, BeforeTeardown,
+};
+pub use self::app::App;
+pub use self::attribute_value::{AttributeValue, IntoAttributeValue};
+pub use self::context::{MessageThunk, ViewCtx};
+pub use self::dom_helpers::{document, document_body, get_element_by_id, input_event_target_value};
+pub use self::message::{DynMessage, Message};
+pub use self::optional_action::{Action, OptionalAction};
+pub use self::pod::{AnyPod, Pod, PodFlags, PodMut};
+pub use self::pointer::{Pointer, PointerDetails, PointerMsg};
 
 /// A trait used for type erasure of [`DomNode`]s
 /// It is e.g. used in [`AnyPod`]


### PR DESCRIPTION
This PR applies Rust fmt with these two options uncommented:

```toml
imports_granularity = "Module"
group_imports = "StdExternalCrate"
```

I'm creating it as a support for explaining the problems I have with the second option.