### PR TITLE
Remove extraneous `#[warn(...)]`

### DIFF
--- a/masonry/src/app/tracing_backend.rs
+++ b/masonry/src/app/tracing_backend.rs
@@ -1,8 +1,6 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(rustdoc::broken_intra_doc_links, clippy::doc_markdown, missing_docs)]
-
 //! Configures a suitable default [`tracing`] implementation for a Masonry application.
 //!
 //! This uses a custom log format specialised for GUI applications,


### PR DESCRIPTION
These are no longer suppressed above it in the crate, so this isn't needed now.

Related to #449.