### PR TITLE
Fix scrollbars when pointer capture is released

### DIFF
--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -154,7 +154,7 @@ impl Widget for ScrollBar {
                 }
                 ctx.request_render();
             }
-            PointerEvent::PointerUp(_, _) => {
+            PointerEvent::PointerUp(_, _) | PointerEvent::PointerLeave(_) => {
                 self.grab_anchor = None;
                 ctx.request_render();
             }
@@ -233,7 +233,7 @@ mod tests {
 
     use super::*;
     use crate::assert_render_snapshot;
-    use crate::core::PointerButton;
+    use crate::core::{PointerButton, PointerState};
     use crate::testing::{widget_ids, TestHarness, TestWidgetExt};
 
     #[test]
@@ -260,6 +260,12 @@ mod tests {
         assert_render_snapshot!(harness, "scrollbar_down");
 
         harness.mouse_move(Point::new(30.0, 300.0));
+        assert_render_snapshot!(harness, "scrollbar_bottom");
+
+        harness.process_pointer_event(PointerEvent::PointerLeave(PointerState::empty()));
+        // Move the mouse to a place where if the scrollbar was still grabbing, it would move the scrollbar
+        harness.mouse_move(Point::new(30.0, 100.0));
+        // We can reuse the same snapshot, because scrollbars don't currently indicate they are pressed
         assert_render_snapshot!(harness, "scrollbar_bottom");
     }
 


### PR DESCRIPTION
Fixes https://github.com/linebender/xilem/issues/857

cc @PoignardAzur - I don't know that the model for pointer capture is entirely coherent from a widget's perspective at the moment. In particular, since any widget can call `release_pointer` at any time, and there's no way for the widget with pointer capture to know.

I'm also not certain that other widgets don't have this same issue. I do think something in our model might need to be refined slightly here.