### PR TITLE
expose winit

### DIFF
--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -163,6 +163,8 @@ pub use xilem_core as core;
 /// Tokio is the async runner used with Xilem.
 pub use tokio;
 
+pub use winit;
+
 mod any_view;
 mod driver;
 mod one_of;


### PR DESCRIPTION
I don't think there is a reason not to, and you need winit for some types so currently you must define the crate yourself, which risks version errors etc.