### PR TITLE
xilem: make a Pod method pub to allow creating custom buttons in an app

### DIFF
--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -314,17 +314,29 @@ impl<W: Widget + FromDynWidget> Pod<W> {
 }
 
 impl<W: Widget + FromDynWidget + ?Sized> Pod<W> {
-    fn erased(self) -> Pod<dyn Widget> {
+    /// Type-erase the contained widget.
+    ///
+    /// Convert a `Pod` pointing to a widget of a specific concrete type
+    /// into a `Pod` pointing to a `dyn Widget`.
+    pub fn erased(self) -> Pod<dyn Widget> {
         Pod {
             widget: self.widget.as_box_dyn(),
             id: self.id,
             transform: self.transform,
         }
     }
-    fn into_widget_pod(self) -> WidgetPod<W> {
+    /// Create the Masonry widget for this view.
+    ///
+    /// In most cases, you will add the return value as a child
+    /// to another Masonry widget, using a method on that widget type.
+    pub fn into_widget_pod(self) -> WidgetPod<W> {
         WidgetPod::new_with_id_and_transform(self.widget, self.id, self.transform)
     }
-    fn erased_widget_pod(self) -> WidgetPod<dyn Widget> {
+    /// Create the type-erased Masonry widget for this view.
+    ///
+    /// Convert a Xilem `Pod` pointing to a widget of a specific concrete type
+    /// into a Masonry `WidgetPod` pointing to a `dyn Widget`.
+    pub fn erased_widget_pod(self) -> WidgetPod<dyn Widget> {
         WidgetPod::new_with_id_and_transform(self.widget, self.id, self.transform).erased()
     }
 }

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -304,11 +304,15 @@ pub struct Pod<W: Widget + FromDynWidget + ?Sized> {
 }
 
 impl<W: Widget + FromDynWidget> Pod<W> {
-    fn new(widget: W) -> Self {
+    /// Create a new `Pod` from a `widget`.
+    ///
+    /// This contains the widget value, and other metadata which will
+    /// be used when that widget is added to a Masonry tree.
+    pub fn new(widget: W) -> Self {
         Self {
             widget: Box::new(widget),
             id: WidgetId::next(),
-            transform: Default::default(),
+            transform: Affine::default(),
         }
     }
 }
@@ -317,7 +321,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Pod<W> {
     /// Type-erase the contained widget.
     ///
     /// Convert a `Pod` pointing to a widget of a specific concrete type
-    /// into a `Pod` pointing to a `dyn Widget`.
+    /// `Pod` pointing to a `dyn Widget`.
     pub fn erased(self) -> Pod<dyn Widget> {
         Pod {
             widget: self.widget.as_box_dyn(),
@@ -325,17 +329,23 @@ impl<W: Widget + FromDynWidget + ?Sized> Pod<W> {
             transform: self.transform,
         }
     }
-    /// Create the Masonry widget for this view.
+    /// Finalise this `Pod`, converting into a [`WidgetPod`].
     ///
-    /// In most cases, you will add the return value as a child
-    /// to another Masonry widget, using a method on that widget type.
+    /// In most cases, you will use the return value when creating a
+    /// widget with a single child.
+    /// For example, button widgets have a label child.
+    ///
+    /// If you're adding the widget to a layout container widget,
+    /// which can contain heterogenous widgets, you will probably
+    /// prefer to use [`Self::erased_widget_pod`].
     pub fn into_widget_pod(self) -> WidgetPod<W> {
         WidgetPod::new_with_id_and_transform(self.widget, self.id, self.transform)
     }
-    /// Create the type-erased Masonry widget for this view.
+    /// Finalise this `Pod` into a type-erased [`WidgetPod`].
     ///
-    /// Convert a Xilem `Pod` pointing to a widget of a specific concrete type
-    /// into a Masonry `WidgetPod` pointing to a `dyn Widget`.
+    /// In most cases, you will use the return value for adding to a layout
+    /// widget which supports heterogenous widgets.
+    /// For example, [`Flex`](masonry::widgets::Flex) accepts type-erased widget pods.
     pub fn erased_widget_pod(self) -> WidgetPod<dyn Widget> {
         WidgetPod::new_with_id_and_transform(self.widget, self.id, self.transform).erased()
     }


### PR DESCRIPTION
I wanted to create a custom button view, but when needing to pass to the masonry type could not convert the pod to a widgetpod.
So I'd like to make this method pub to allow that 