### PR TITLE
Add a button view+widget with up to 9 labels

### DIFF
--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -8,10 +8,10 @@ use smallvec::{smallvec, SmallVec};
 use tracing::{trace, trace_span, Span};
 use vello::Scene;
 
-use crate::core::{self,
-  AccessCtx, AccessEvent, Action, ArcStr, BoxConstraints, EventCtx, LayoutCtx, PaintCtx,
-  PointerButton, PointerEvent, QueryCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
-  WidgetMut, WidgetPod,
+use crate::core::{
+    self, AccessCtx, AccessEvent, Action, ArcStr, BoxConstraints, EventCtx, LayoutCtx, PaintCtx,
+    PointerButton, PointerEvent, QueryCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
+    WidgetMut, WidgetPod,
 };
 use crate::kurbo::{Insets, Size, Vec2};
 use crate::theme;
@@ -24,291 +24,523 @@ pub const PAD_DEF: Insets = Insets::uniform_xy(8., 2.);
 /// A button with up to 9 text Labels (allowing for custom styles) with custom padding
 /// (allowing for flexible positioning).
 pub struct Button9 {
-  /// 9 label widgets
-  label: Label9  ,
-  /// Options for those widgets or the button as a whole (only padding is implemented)
-  opt  : LabelOpt,
+    /// 9 label widgets
+    label: Label9,
+    /// Options for those widgets or the button as a whole (only padding is implemented)
+    opt: LabelOpt,
 }
 /// Label widgets for Button9 for all the 9 possible label positions in a button from top left to bottom right.<br>
 /// 1 2 3 = ↖  ↑  ↗
 /// 4 5 6 = ←  •  →
 /// 7 8 9 = ↙  ↓  ↘
 pub struct Label9 {
-  p1:WidgetPod<Label>, p2:WidgetPod<Label>, p3:WidgetPod<Label>, // ↖  ↑  ↗
-  p4:WidgetPod<Label>, p5:WidgetPod<Label>, p6:WidgetPod<Label>, // ←  •  →
-  p7:WidgetPod<Label>, p8:WidgetPod<Label>, p9:WidgetPod<Label>, // ↙  ↓  ↘
+    p1: WidgetPod<Label>,
+    p2: WidgetPod<Label>,
+    p3: WidgetPod<Label>, // ↖  ↑  ↗
+    p4: WidgetPod<Label>,
+    p5: WidgetPod<Label>,
+    p6: WidgetPod<Label>, // ←  •  →
+    p7: WidgetPod<Label>,
+    p8: WidgetPod<Label>,
+    p9: WidgetPod<Label>, // ↙  ↓  ↘
 }
 /// Custom button options. Currently only padding is supported.
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
 pub struct LabelOpt {
-  /// Per-label padding.
-  pub pad: Pad9,
+    /// Per-label padding.
+    pub pad: Pad9,
 }
 
 /// Optional padding options per label as [`Insets`]
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
 pub struct Pad9 {
-  pub p1:Option<Insets>, pub p2:Option<Insets>, pub p3:Option<Insets>, // ↖  ↑  ↗
-  pub p4:Option<Insets>, pub p5:Option<Insets>, pub p6:Option<Insets>, // ←  •  →
-  pub p7:Option<Insets>, pub p8:Option<Insets>, pub p9:Option<Insets>, // ↙  ↓  ↘
+    pub p1: Option<Insets>,
+    pub p2: Option<Insets>,
+    pub p3: Option<Insets>, // ↖  ↑  ↗
+    pub p4: Option<Insets>,
+    pub p5: Option<Insets>,
+    pub p6: Option<Insets>, // ←  •  →
+    pub p7: Option<Insets>,
+    pub p8: Option<Insets>,
+    pub p9: Option<Insets>, // ↙  ↓  ↘
 }
 
 // --- MARK: BUILDERS ---
 impl Button9 {
-  /// Create a new button with a text label at the center (p5 other labels are blank, use `.addx` methods to fill them)
-  /// ```
-  /// use masonry::widgets::Button9;
-  /// let button = Button9::new("Increment");
-  /// ```
-  pub fn new(text:impl Into<ArcStr>) -> Self {Self::from_label    (Label::new(text))}
-  /// Create a new button with the provided [`Label`]
-  /// ```
-  /// use masonry::peniko::Color;
-  /// use masonry::widgets::{Button9, Label};
-  /// let label = Label::new("Increment").with_brush(Color::new([0.5, 0.5, 0.5, 1.0]));
-  /// let button = Button9::from_label(label);
-  /// ```
-  pub fn from_label    (label:Label) -> Self {Self::from_label_pad(label, None)}
-  /// Create a new button with the provided [`Label`] and padding [`Insets`]
-  /// ```
-  /// use masonry::peniko::Color;
-  /// use masonry::widgets::{Button9, Label};
-  /// let label  = Label::new("Increment").with_brush(Color::new([0.5, 0.5, 0.5, 1.0]));
-  /// let pad    = Insets::uniform_xy(8., 2.); // pad ←→ by 8 and ↑↓ by 2
-  /// let button = Button9::from_label_pad(label, pad);
-  /// ```
-  pub fn from_label_pad(lbl:Label, pad:Option<Insets>) -> Self {
-    let label = Label9 {
-      p1:WidgetPod::new(Label::new("")), p2:WidgetPod::new(Label::new("")), p3:WidgetPod::new(Label::new("")), // ↖  ↑  ↗
-      p4:WidgetPod::new(Label::new("")), p5:WidgetPod::new(lbl           ), p6:WidgetPod::new(Label::new("")), // ←  •  →
-      p7:WidgetPod::new(Label::new("")), p8:WidgetPod::new(Label::new("")), p9:WidgetPod::new(Label::new("")), // ↙  ↓  ↘
-    };
-    let pad = Pad9 {
-      p1:None, p2:None, p3:None, // ↖  ↑  ↗
-      p4:None, p5:pad , p6:None, // ←  •  →
-      p7:None, p8:None, p9:None, // ↙  ↓  ↘
-    };
-    let opt = LabelOpt{pad};
-    Self {label, opt}
-  }
-  /// Helper .methods for adding individual labels (add=center p5)
-  pub fn add (mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p5 = WidgetPod::new(label); self.opt.pad.p5 = pad; self}
-  pub fn add1(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p1 = WidgetPod::new(label); self.opt.pad.p1 = pad; self}
-  pub fn add2(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p2 = WidgetPod::new(label); self.opt.pad.p2 = pad; self}
-  pub fn add3(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p3 = WidgetPod::new(label); self.opt.pad.p3 = pad; self}
-  pub fn add4(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p4 = WidgetPod::new(label); self.opt.pad.p4 = pad; self}
-  pub fn add5(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p5 = WidgetPod::new(label); self.opt.pad.p5 = pad; self}
-  pub fn add6(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p6 = WidgetPod::new(label); self.opt.pad.p6 = pad; self}
-  pub fn add7(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p7 = WidgetPod::new(label); self.opt.pad.p7 = pad; self}
-  pub fn add8(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p8 = WidgetPod::new(label); self.opt.pad.p8 = pad; self}
-  pub fn add9(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p9 = WidgetPod::new(label); self.opt.pad.p9 = pad; self}
-  /// Create a new button with the provided [`Label9`]s and their [`Pad9`] with predetermined IDs. This constructor is useful for toolkits which use Masonry (such as Xilem).
-  pub fn from_label_pod(label_l:[WidgetPod<Label>;9], pad:Pad9) -> Self {
-    let [l1,l2,l3,l4,l5,l6,l7,l8,l9] = label_l;
-    let label = Label9 { //numbering shifted due to 0-based array index
-      p1:l1, p2:l2, p3:l3, // ↖  ↑  ↗
-      p4:l4, p5:l5, p6:l8, // ←  •  →
-      p7:l7, p8:l6, p9:l9, // ↙  ↓  ↘
-    };
-    let opt = LabelOpt{pad};
-    Self {label, opt}
-  }
+    /// Create a new button with a text label at the center (p5 other labels are blank, use `.addx` methods to fill them)
+    /// ```
+    /// use masonry::widgets::Button9;
+    /// let button = Button9::new("Increment");
+    /// ```
+    pub fn new(text: impl Into<ArcStr>) -> Self {
+        Self::from_label(Label::new(text))
+    }
+    /// Create a new button with the provided [`Label`]
+    /// ```
+    /// use masonry::peniko::Color;
+    /// use masonry::widgets::{Button9, Label};
+    /// let label = Label::new("Increment").with_brush(Color::new([0.5, 0.5, 0.5, 1.0]));
+    /// let button = Button9::from_label(label);
+    /// ```
+    pub fn from_label(label: Label) -> Self {
+        Self::from_label_pad(label, None)
+    }
+    /// Create a new button with the provided [`Label`] and padding [`Insets`]
+    /// ```
+    /// use masonry::peniko::Color;
+    /// use masonry::widgets::{Button9, Label};
+    /// let label  = Label::new("Increment").with_brush(Color::new([0.5, 0.5, 0.5, 1.0]));
+    /// let pad    = Insets::uniform_xy(8., 2.); // pad ←→ by 8 and ↑↓ by 2
+    /// let button = Button9::from_label_pad(label, pad);
+    /// ```
+    pub fn from_label_pad(lbl: Label, pad: Option<Insets>) -> Self {
+        let label = Label9 {
+            p1: WidgetPod::new(Label::new("")),
+            p2: WidgetPod::new(Label::new("")),
+            p3: WidgetPod::new(Label::new("")), // ↖  ↑  ↗
+            p4: WidgetPod::new(Label::new("")),
+            p5: WidgetPod::new(lbl),
+            p6: WidgetPod::new(Label::new("")), // ←  •  →
+            p7: WidgetPod::new(Label::new("")),
+            p8: WidgetPod::new(Label::new("")),
+            p9: WidgetPod::new(Label::new("")), // ↙  ↓  ↘
+        };
+        let pad = Pad9 {
+            p1: None,
+            p2: None,
+            p3: None, // ↖  ↑  ↗
+            p4: None,
+            p5: pad,
+            p6: None, // ←  •  →
+            p7: None,
+            p8: None,
+            p9: None, // ↙  ↓  ↘
+        };
+        let opt = LabelOpt { pad };
+        Self { label, opt }
+    }
+    /// Helper .methods for adding individual labels (add=center p5)
+    pub fn add(mut self, label: Label, pad: Option<Insets>) -> Self {
+        self.label.p5 = WidgetPod::new(label);
+        self.opt.pad.p5 = pad;
+        self
+    }
+    pub fn add1(mut self, label: Label, pad: Option<Insets>) -> Self {
+        self.label.p1 = WidgetPod::new(label);
+        self.opt.pad.p1 = pad;
+        self
+    }
+    pub fn add2(mut self, label: Label, pad: Option<Insets>) -> Self {
+        self.label.p2 = WidgetPod::new(label);
+        self.opt.pad.p2 = pad;
+        self
+    }
+    pub fn add3(mut self, label: Label, pad: Option<Insets>) -> Self {
+        self.label.p3 = WidgetPod::new(label);
+        self.opt.pad.p3 = pad;
+        self
+    }
+    pub fn add4(mut self, label: Label, pad: Option<Insets>) -> Self {
+        self.label.p4 = WidgetPod::new(label);
+        self.opt.pad.p4 = pad;
+        self
+    }
+    pub fn add5(mut self, label: Label, pad: Option<Insets>) -> Self {
+        self.label.p5 = WidgetPod::new(label);
+        self.opt.pad.p5 = pad;
+        self
+    }
+    pub fn add6(mut self, label: Label, pad: Option<Insets>) -> Self {
+        self.label.p6 = WidgetPod::new(label);
+        self.opt.pad.p6 = pad;
+        self
+    }
+    pub fn add7(mut self, label: Label, pad: Option<Insets>) -> Self {
+        self.label.p7 = WidgetPod::new(label);
+        self.opt.pad.p7 = pad;
+        self
+    }
+    pub fn add8(mut self, label: Label, pad: Option<Insets>) -> Self {
+        self.label.p8 = WidgetPod::new(label);
+        self.opt.pad.p8 = pad;
+        self
+    }
+    pub fn add9(mut self, label: Label, pad: Option<Insets>) -> Self {
+        self.label.p9 = WidgetPod::new(label);
+        self.opt.pad.p9 = pad;
+        self
+    }
+    /// Create a new button with the provided [`Label9`]s and their [`Pad9`] with predetermined IDs. This constructor is useful for toolkits which use Masonry (such as Xilem).
+    pub fn from_label_pod(label_l: [WidgetPod<Label>; 9], pad: Pad9) -> Self {
+        let [l1, l2, l3, l4, l5, l6, l7, l8, l9] = label_l;
+        let label = Label9 {
+            //numbering shifted due to 0-based array index
+            p1: l1,
+            p2: l2,
+            p3: l3, // ↖  ↑  ↗
+            p4: l4,
+            p5: l5,
+            p6: l8, // ←  •  →
+            p7: l7,
+            p8: l6,
+            p9: l9, // ↙  ↓  ↘
+        };
+        let opt = LabelOpt { pad };
+        Self { label, opt }
+    }
 }
 
 // Helper indices for the Label9 positions (0-based unlike .Prop or fn() names!)
-const ROW_TOP: [usize;3] = [0,1,2]; //↖ ↑ ↗
-const ROW_MID: [usize;3] = [3,4,5]; //← • →
-const ROW_BOT: [usize;3] = [6,7,8]; //↙ ↓ ↘
-const COL_LHS: [usize;3] = [0,1,2]; //↖ ← ↙
-const COL_CNT: [usize;3] = [3,4,5]; //↑ • ↓
-const COL_RHS: [usize;3] = [6,7,8]; //↗ → ↘
+const ROW_TOP: [usize; 3] = [0, 1, 2]; //↖ ↑ ↗
+const ROW_MID: [usize; 3] = [3, 4, 5]; //← • →
+const ROW_BOT: [usize; 3] = [6, 7, 8]; //↙ ↓ ↘
+const COL_LHS: [usize; 3] = [0, 1, 2]; //↖ ← ↙
+const COL_CNT: [usize; 3] = [3, 4, 5]; //↑ • ↓
+const COL_RHS: [usize; 3] = [6, 7, 8]; //↗ → ↘
 
 // --- MARK: WIDGETMUT ---
 impl Button9 {
-  /// Set text helpers
-  pub fn set_text (this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label_mut (this), new_text);}
-  pub fn set_text1(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label1_mut(this), new_text);}
-  pub fn set_text2(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label2_mut(this), new_text);}
-  pub fn set_text3(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label3_mut(this), new_text);}
-  pub fn set_text4(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label4_mut(this), new_text);}
-  pub fn set_text5(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label5_mut(this), new_text);}
-  pub fn set_text6(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label6_mut(this), new_text);}
-  pub fn set_text7(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label7_mut(this), new_text);}
-  pub fn set_text8(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label8_mut(this), new_text);}
-  pub fn set_text9(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label9_mut(this), new_text);}
+    /// Set text helpers
+    pub fn set_text(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
+        Label::set_text(&mut Self::label_mut(this), new_text);
+    }
+    pub fn set_text1(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
+        Label::set_text(&mut Self::label1_mut(this), new_text);
+    }
+    pub fn set_text2(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
+        Label::set_text(&mut Self::label2_mut(this), new_text);
+    }
+    pub fn set_text3(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
+        Label::set_text(&mut Self::label3_mut(this), new_text);
+    }
+    pub fn set_text4(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
+        Label::set_text(&mut Self::label4_mut(this), new_text);
+    }
+    pub fn set_text5(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
+        Label::set_text(&mut Self::label5_mut(this), new_text);
+    }
+    pub fn set_text6(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
+        Label::set_text(&mut Self::label6_mut(this), new_text);
+    }
+    pub fn set_text7(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
+        Label::set_text(&mut Self::label7_mut(this), new_text);
+    }
+    pub fn set_text8(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
+        Label::set_text(&mut Self::label8_mut(this), new_text);
+    }
+    pub fn set_text9(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
+        Label::set_text(&mut Self::label9_mut(this), new_text);
+    }
 
-  /// Set label options helpers
-  pub fn set_opt (this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p5 = new_pad; this.ctx.request_render();}
-  pub fn set_pad1(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p1 = new_pad; this.ctx.request_render();}
-  pub fn set_pad2(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p2 = new_pad; this.ctx.request_render();}
-  pub fn set_pad3(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p3 = new_pad; this.ctx.request_render();}
-  pub fn set_pad4(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p4 = new_pad; this.ctx.request_render();}
-  pub fn set_pad5(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p5 = new_pad; this.ctx.request_render();}
-  pub fn set_pad6(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p6 = new_pad; this.ctx.request_render();}
-  pub fn set_pad7(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p7 = new_pad; this.ctx.request_render();}
-  pub fn set_pad8(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p8 = new_pad; this.ctx.request_render();}
-  pub fn set_pad9(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p9 = new_pad; this.ctx.request_render();}
+    /// Set label options helpers
+    pub fn set_opt(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
+        this.widget.opt.pad.p5 = new_pad;
+        this.ctx.request_render();
+    }
+    pub fn set_pad1(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
+        this.widget.opt.pad.p1 = new_pad;
+        this.ctx.request_render();
+    }
+    pub fn set_pad2(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
+        this.widget.opt.pad.p2 = new_pad;
+        this.ctx.request_render();
+    }
+    pub fn set_pad3(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
+        this.widget.opt.pad.p3 = new_pad;
+        this.ctx.request_render();
+    }
+    pub fn set_pad4(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
+        this.widget.opt.pad.p4 = new_pad;
+        this.ctx.request_render();
+    }
+    pub fn set_pad5(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
+        this.widget.opt.pad.p5 = new_pad;
+        this.ctx.request_render();
+    }
+    pub fn set_pad6(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
+        this.widget.opt.pad.p6 = new_pad;
+        this.ctx.request_render();
+    }
+    pub fn set_pad7(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
+        this.widget.opt.pad.p7 = new_pad;
+        this.ctx.request_render();
+    }
+    pub fn set_pad8(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
+        this.widget.opt.pad.p8 = new_pad;
+        this.ctx.request_render();
+    }
+    pub fn set_pad9(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
+        this.widget.opt.pad.p9 = new_pad;
+        this.ctx.request_render();
+    }
 
-  /// Get mutable label helpers
-  pub fn label_mut <'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p5)}
-  pub fn label1_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p1)}
-  pub fn label2_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p2)}
-  pub fn label3_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p3)}
-  pub fn label4_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p4)}
-  pub fn label5_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p5)}
-  pub fn label6_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p6)}
-  pub fn label7_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p7)}
-  pub fn label8_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p8)}
-  pub fn label9_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p9)}
+    /// Get mutable label helpers
+    pub fn label_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
+        this.ctx.get_mut(&mut this.widget.label.p5)
+    }
+    pub fn label1_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
+        this.ctx.get_mut(&mut this.widget.label.p1)
+    }
+    pub fn label2_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
+        this.ctx.get_mut(&mut this.widget.label.p2)
+    }
+    pub fn label3_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
+        this.ctx.get_mut(&mut this.widget.label.p3)
+    }
+    pub fn label4_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
+        this.ctx.get_mut(&mut this.widget.label.p4)
+    }
+    pub fn label5_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
+        this.ctx.get_mut(&mut this.widget.label.p5)
+    }
+    pub fn label6_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
+        this.ctx.get_mut(&mut this.widget.label.p6)
+    }
+    pub fn label7_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
+        this.ctx.get_mut(&mut this.widget.label.p7)
+    }
+    pub fn label8_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
+        this.ctx.get_mut(&mut this.widget.label.p8)
+    }
+    pub fn label9_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
+        this.ctx.get_mut(&mut this.widget.label.p9)
+    }
 }
 
 // --- MARK: IMPL WIDGET ---
 impl Widget for Button9 {
-  fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
-    match event {
-      PointerEvent::PointerDown(_, _) => {
-        if !ctx.is_disabled() {ctx.capture_pointer(); ctx.request_paint_only(); // Changes in pointer capture impact appearance, but not accessibility node
-          trace!("Button9 {:?} pressed", ctx.widget_id());}
-      }
-      PointerEvent::PointerUp(button, _) => {
-        if ctx.is_pointer_capture_target() && ctx.is_hovered() && !ctx.is_disabled() {
-          ctx.submit_action(Action::ButtonPressed(*button));
-          trace!("Button9 {:?} released", ctx.widget_id());}
-        ctx.request_paint_only(); // Changes in pointer capture impact appearance, but not accessibility node
-      }
-      _ => (),
-    }
-  }
-
-  fn on_text_event  (&mut self, _ctx: &mut EventCtx, _event: &TextEvent) {}
-
-  fn on_access_event(&mut self,  ctx: &mut EventCtx,  event: &AccessEvent) {
-    if ctx.target() == ctx.widget_id() { match event.action {
-      accesskit::Action::Click  => {ctx.submit_action(Action::ButtonPressed(PointerButton::Primary));}
-      _                         => {} }  }   }
-
-  fn update(&mut self, ctx: &mut UpdateCtx, event: &Update) { match event {
-     Update::HoveredChanged (_)
-    |Update::FocusChanged   (_)
-    |Update::DisabledChanged(_) => {ctx.request_paint_only();}
-    _                           => {}  }   }
-
-  fn register_children(&mut self, ctx: &mut core::RegisterCtx) {
-    ctx.register_child(&mut self.label.p1);ctx.register_child(&mut self.label.p2);ctx.register_child(&mut self.label.p3); // ↖  ↑  ↗
-    ctx.register_child(&mut self.label.p4);ctx.register_child(&mut self.label.p5);ctx.register_child(&mut self.label.p6); // ←  •  →
-    ctx.register_child(&mut self.label.p7);ctx.register_child(&mut self.label.p8);ctx.register_child(&mut self.label.p9); // ↙  ↓  ↘
-  }
-  fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size {
-    let min_height = theme::BORDERED_WIDGET_HEIGHT; // HACK: to make sure we look okay at default sizes when beside a textbox, we make sure we will have at least the same height as the default textbox.
-    let mut lbl_pad9 = [
-      (&mut self.label.p1, self.opt.pad.p1),
-      (&mut self.label.p2, self.opt.pad.p2),
-      (&mut self.label.p3, self.opt.pad.p3),
-      (&mut self.label.p4, self.opt.pad.p4),
-      (&mut self.label.p5, self.opt.pad.p5),
-      (&mut self.label.p6, self.opt.pad.p6),
-      (&mut self.label.p7, self.opt.pad.p7),
-      (&mut self.label.p8, self.opt.pad.p8),
-      (&mut self.label.p9, self.opt.pad.p9),
-      ];
-
-    let mut row_w: [f64 ;3] = [0.   ;3]; //top /middle/bottom ↖↑↗  ←•→  ↙↓↘
-    let mut col_h: [f64 ;3] = [0.   ;3]; //left/center/right  ↖←↙  ↑•↓  ↗→↘
-    let mut lsz  : [Size  ;10] = [Size::ZERO  ;10];
-    let mut lpad : [Insets;10] = [Insets::ZERO;10];
-    for (i, (lbl9, pad9)) in lbl_pad9.iter_mut().enumerate() {
-      let pad       = match pad9 {Some(inset)=>*inset, None=>PAD_DEF,};
-      let pad_sz    = Size::new(pad.x_value(), pad.y_value());
-      let lbl_bc    = bc.shrink(pad_sz).loosen();
-      let lbl_sz    = ctx.run_layout(lbl9, &lbl_bc);
-      if cfg!(debug_assertions) {let txt = ctx.get_raw_ref(lbl9).widget().text().clone();
-        trace!("{} {} set layout l_sz = {} l_bc={:?} pad_sz={} txt={}", i+1, ctx.widget_id(),lbl_sz,lbl_bc,pad_sz,txt);}
-      if i == 4 { // set baseline off the central label only?
-        let baseline = ctx.child_baseline_offset(&lbl9);
-        ctx.set_baseline_offset(baseline + pad.y1);
-      }
-      if ROW_TOP.iter().any(|x| x == &i) {row_w[0] += lbl_sz.width  + pad_sz.width ;}
-      if ROW_MID.iter().any(|x| x == &i) {row_w[1] += lbl_sz.width  + pad_sz.width ;}
-      if ROW_BOT.iter().any(|x| x == &i) {row_w[2] += lbl_sz.width  + pad_sz.width ;}
-      if COL_LHS.iter().any(|x| x == &i) {col_h[0] += lbl_sz.height + pad_sz.height;}
-      if COL_CNT.iter().any(|x| x == &i) {col_h[1] += lbl_sz.height + pad_sz.height;}
-      if COL_RHS.iter().any(|x| x == &i) {col_h[2] += lbl_sz.height + pad_sz.height;}
-      lsz[i+1] = lbl_sz; // store size for later offset calculations (after button size is known)
-      lpad[i+1] = pad;
-    }
-    let max_w = row_w[0].max(row_w[1]).max(row_w[2]);
-    let max_h = col_h[0].max(col_h[1]).max(col_h[2]).max(min_height);
-    let button_size = bc.constrain(Size::new(max_w, max_h));
-
-    let bw = button_size.width; let bh = button_size.height; // ↖0,0 (w1-w2)/2=middle@x; (h1-h2)/2=center@y
-    let lbl1_offset = Vec2::new( 0.                     + lpad[1].x0    , 0.                      + lpad[1].y0  );
-    let lbl2_offset = Vec2::new((bw - lsz[2].width)/2.0                 , 0.                      + lpad[2].y0  );
-    let lbl3_offset = Vec2::new( bw - lsz[3].width      - lpad[3].x1    , 0.                      + lpad[3].y0  );
-    let lbl4_offset = Vec2::new( 0.                     + lpad[4].x0    ,(bh - lsz[4].height)/2.0               );
-    let lbl5_offset =(button_size.to_vec2() - lsz[5].to_vec2())/2.0                                              ;
-    let lbl6_offset = Vec2::new( bw - lsz[6].width      - lpad[6].x1    ,(bh - lsz[6].height)/2.0               );
-    let lbl7_offset = Vec2::new( 0.                     + lpad[7].x0    , bh - lsz[7].height     - lpad[7].y1   );
-    let lbl8_offset = Vec2::new((bw - lsz[8].width)/2.0                 , bh - lsz[8].height     - lpad[8].y1   );
-    let lbl9_offset = Vec2::new( bw - lsz[9].width      - lpad[9].x1    , bh - lsz[9].height     - lpad[9].y1   ); // button_size.to_vec2() - lsz[3].to_vec2()
-    if cfg!(debug_assertions) {
-      trace!("button_size = {button_size:?} max_w={max_w} max_h={max_h} row_w={row_w:?} col_h={col_h:?}");
-      trace!("↖ lbl1 🆔{} offset {}", ctx.widget_id(), lbl1_offset); trace!("↑ lbl2 🆔{} offset {}", ctx.widget_id(), lbl2_offset); trace!("↗ lbl3 🆔{} offset {}", ctx.widget_id(), lbl3_offset);
-      trace!("← lbl4 🆔{} offset {}", ctx.widget_id(), lbl4_offset); trace!("• lbl5 🆔{} offset {}", ctx.widget_id(), lbl5_offset); trace!("→ lbl6 🆔{} offset {}", ctx.widget_id(), lbl6_offset);
-      trace!("↙ lbl7 🆔{} offset {}", ctx.widget_id(), lbl7_offset); trace!("↓ lbl8 🆔{} offset {}", ctx.widget_id(), lbl8_offset); trace!("↘ lbl9 🆔{} offset {}", ctx.widget_id(), lbl9_offset);
+    fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
+        match event {
+            PointerEvent::PointerDown(_, _) => {
+                if !ctx.is_disabled() {
+                    ctx.capture_pointer();
+                    ctx.request_paint_only(); // Changes in pointer capture impact appearance, but not accessibility node
+                    trace!("Button9 {:?} pressed", ctx.widget_id());
+                }
+            }
+            PointerEvent::PointerUp(button, _) => {
+                if ctx.is_pointer_capture_target() && ctx.is_hovered() && !ctx.is_disabled() {
+                    ctx.submit_action(Action::ButtonPressed(*button));
+                    trace!("Button9 {:?} released", ctx.widget_id());
+                }
+                ctx.request_paint_only(); // Changes in pointer capture impact appearance, but not accessibility node
+            }
+            _ => (),
+        }
     }
 
-    ctx.place_child(&mut self.label.p1, lbl1_offset.to_point()); ctx.place_child(&mut self.label.p2, lbl2_offset.to_point()); ctx.place_child(&mut self.label.p3, lbl3_offset.to_point());
-    ctx.place_child(&mut self.label.p4, lbl4_offset.to_point()); ctx.place_child(&mut self.label.p5, lbl5_offset.to_point()); ctx.place_child(&mut self.label.p6, lbl6_offset.to_point());
-    ctx.place_child(&mut self.label.p7, lbl7_offset.to_point()); ctx.place_child(&mut self.label.p8, lbl8_offset.to_point()); ctx.place_child(&mut self.label.p9, lbl9_offset.to_point());
-    button_size
-  }
+    fn on_text_event(&mut self, _ctx: &mut EventCtx, _event: &TextEvent) {}
 
-  fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
-    let is_active = ctx.is_pointer_capture_target() && !ctx.is_disabled();
-    let is_hovered = ctx.is_hovered();
-    let size = ctx.size();
-    let stroke_width = theme::BUTTON_BORDER_WIDTH;
-
-    let rounded_rect = size
-      .to_rect()
-      .inset(-stroke_width / 2.0)
-      .to_rounded_rect(theme::BUTTON_BORDER_RADIUS);
-
-    let bg_gradient = if ctx.is_disabled()                  {[theme::DISABLED_BUTTON_LIGHT, theme::DISABLED_BUTTON_DARK]
-    } else if is_active                                     {[theme::BUTTON_DARK          , theme::BUTTON_LIGHT]
-    } else                                                  {[theme::BUTTON_LIGHT         , theme::BUTTON_DARK]};
-    let border_color = if is_hovered && !ctx.is_disabled()  { theme::BORDER_LIGHT
-    } else                                                  { theme::BORDER_DARK};
-
-    stroke           (scene, &rounded_rect, border_color, stroke_width);
-    fill_lin_gradient(scene, &rounded_rect, bg_gradient, UnitPoint::TOP,UnitPoint::BOTTOM,);
-  }
-
-  fn accessibility_role(&self) -> Role {Role::Button}
-  fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut Node) { // IMPORTANT: We don't want to merge this code in practice, because the child label already has a 'name' property. This is more of a proof of concept of `get_raw_ref()`.
-    if false {
-      let label = ctx.get_raw_ref(&self.label.p5);
-      let name  = label.widget().text().as_ref().to_string();
-      node.set_value(name);
+    fn on_access_event(&mut self, ctx: &mut EventCtx, event: &AccessEvent) {
+        if ctx.target() == ctx.widget_id() {
+            match event.action {
+                accesskit::Action::Click => {
+                    ctx.submit_action(Action::ButtonPressed(PointerButton::Primary));
+                }
+                _ => {}
+            }
+        }
     }
-    node.add_action(accesskit::Action::Click);
-  }
 
-  fn children_ids   (&self                    ) -> SmallVec<[WidgetId; 16]> {smallvec![
-    self.label.p1.id(),self.label.p2.id(),self.label.p3.id(), // ↖  ↑  ↗
-    self.label.p4.id(),self.label.p5.id(),self.label.p6.id(), // ←  •  →
-    self.label.p7.id(),self.label.p8.id(),self.label.p9.id(), // ↙  ↓  ↘
-  ]}
-  fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {trace_span!("Button9", id = ctx.widget_id().trace())}
+    fn update(&mut self, ctx: &mut UpdateCtx, event: &Update) {
+        match event {
+            Update::HoveredChanged(_) | Update::FocusChanged(_) | Update::DisabledChanged(_) => {
+                ctx.request_paint_only();
+            }
+            _ => {}
+        }
+    }
+
+    fn register_children(&mut self, ctx: &mut core::RegisterCtx) {
+        ctx.register_child(&mut self.label.p1);
+        ctx.register_child(&mut self.label.p2);
+        ctx.register_child(&mut self.label.p3); // ↖  ↑  ↗
+        ctx.register_child(&mut self.label.p4);
+        ctx.register_child(&mut self.label.p5);
+        ctx.register_child(&mut self.label.p6); // ←  •  →
+        ctx.register_child(&mut self.label.p7);
+        ctx.register_child(&mut self.label.p8);
+        ctx.register_child(&mut self.label.p9); // ↙  ↓  ↘
+    }
+    fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size {
+        let min_height = theme::BORDERED_WIDGET_HEIGHT; // HACK: to make sure we look okay at default sizes when beside a textbox, we make sure we will have at least the same height as the default textbox.
+        let mut lbl_pad9 = [
+            (&mut self.label.p1, self.opt.pad.p1),
+            (&mut self.label.p2, self.opt.pad.p2),
+            (&mut self.label.p3, self.opt.pad.p3),
+            (&mut self.label.p4, self.opt.pad.p4),
+            (&mut self.label.p5, self.opt.pad.p5),
+            (&mut self.label.p6, self.opt.pad.p6),
+            (&mut self.label.p7, self.opt.pad.p7),
+            (&mut self.label.p8, self.opt.pad.p8),
+            (&mut self.label.p9, self.opt.pad.p9),
+        ];
+
+        let mut row_w: [f64; 3] = [0.; 3]; //top /middle/bottom ↖↑↗  ←•→  ↙↓↘
+        let mut col_h: [f64; 3] = [0.; 3]; //left/center/right  ↖←↙  ↑•↓  ↗→↘
+        let mut lsz: [Size; 10] = [Size::ZERO; 10];
+        let mut lpad: [Insets; 10] = [Insets::ZERO; 10];
+        for (i, (lbl9, pad9)) in lbl_pad9.iter_mut().enumerate() {
+            let pad = match pad9 {
+                Some(inset) => *inset,
+                None => PAD_DEF,
+            };
+            let pad_sz = Size::new(pad.x_value(), pad.y_value());
+            let lbl_bc = bc.shrink(pad_sz).loosen();
+            let lbl_sz = ctx.run_layout(lbl9, &lbl_bc);
+            if cfg!(debug_assertions) {
+                let txt = ctx.get_raw_ref(lbl9).widget().text().clone();
+                trace!(
+                    "{} {} set layout l_sz = {} l_bc={:?} pad_sz={} txt={}",
+                    i + 1,
+                    ctx.widget_id(),
+                    lbl_sz,
+                    lbl_bc,
+                    pad_sz,
+                    txt
+                );
+            }
+            if i == 4 {
+                // set baseline off the central label only?
+                let baseline = ctx.child_baseline_offset(&lbl9);
+                ctx.set_baseline_offset(baseline + pad.y1);
+            }
+            if ROW_TOP.iter().any(|x| x == &i) {
+                row_w[0] += lbl_sz.width + pad_sz.width;
+            }
+            if ROW_MID.iter().any(|x| x == &i) {
+                row_w[1] += lbl_sz.width + pad_sz.width;
+            }
+            if ROW_BOT.iter().any(|x| x == &i) {
+                row_w[2] += lbl_sz.width + pad_sz.width;
+            }
+            if COL_LHS.iter().any(|x| x == &i) {
+                col_h[0] += lbl_sz.height + pad_sz.height;
+            }
+            if COL_CNT.iter().any(|x| x == &i) {
+                col_h[1] += lbl_sz.height + pad_sz.height;
+            }
+            if COL_RHS.iter().any(|x| x == &i) {
+                col_h[2] += lbl_sz.height + pad_sz.height;
+            }
+            lsz[i + 1] = lbl_sz; // store size for later offset calculations (after button size is known)
+            lpad[i + 1] = pad;
+        }
+        let max_w = row_w[0].max(row_w[1]).max(row_w[2]);
+        let max_h = col_h[0].max(col_h[1]).max(col_h[2]).max(min_height);
+        let button_size = bc.constrain(Size::new(max_w, max_h));
+
+        let bw = button_size.width;
+        let bh = button_size.height; // ↖0,0 (w1-w2)/2=middle@x; (h1-h2)/2=center@y
+        let lbl1_offset = Vec2::new(0. + lpad[1].x0, 0. + lpad[1].y0);
+        let lbl2_offset = Vec2::new((bw - lsz[2].width) / 2.0, 0. + lpad[2].y0);
+        let lbl3_offset = Vec2::new(bw - lsz[3].width - lpad[3].x1, 0. + lpad[3].y0);
+        let lbl4_offset = Vec2::new(0. + lpad[4].x0, (bh - lsz[4].height) / 2.0);
+        let lbl5_offset = (button_size.to_vec2() - lsz[5].to_vec2()) / 2.0;
+        let lbl6_offset = Vec2::new(bw - lsz[6].width - lpad[6].x1, (bh - lsz[6].height) / 2.0);
+        let lbl7_offset = Vec2::new(0. + lpad[7].x0, bh - lsz[7].height - lpad[7].y1);
+        let lbl8_offset = Vec2::new((bw - lsz[8].width) / 2.0, bh - lsz[8].height - lpad[8].y1);
+        let lbl9_offset = Vec2::new(
+            bw - lsz[9].width - lpad[9].x1,
+            bh - lsz[9].height - lpad[9].y1,
+        ); // button_size.to_vec2() - lsz[3].to_vec2()
+        if cfg!(debug_assertions) {
+            trace!("button_size = {button_size:?} max_w={max_w} max_h={max_h} row_w={row_w:?} col_h={col_h:?}");
+            trace!("↖ lbl1 🆔{} offset {}", ctx.widget_id(), lbl1_offset);
+            trace!("↑ lbl2 🆔{} offset {}", ctx.widget_id(), lbl2_offset);
+            trace!("↗ lbl3 🆔{} offset {}", ctx.widget_id(), lbl3_offset);
+            trace!("← lbl4 🆔{} offset {}", ctx.widget_id(), lbl4_offset);
+            trace!("• lbl5 🆔{} offset {}", ctx.widget_id(), lbl5_offset);
+            trace!("→ lbl6 🆔{} offset {}", ctx.widget_id(), lbl6_offset);
+            trace!("↙ lbl7 🆔{} offset {}", ctx.widget_id(), lbl7_offset);
+            trace!("↓ lbl8 🆔{} offset {}", ctx.widget_id(), lbl8_offset);
+            trace!("↘ lbl9 🆔{} offset {}", ctx.widget_id(), lbl9_offset);
+        }
+
+        ctx.place_child(&mut self.label.p1, lbl1_offset.to_point());
+        ctx.place_child(&mut self.label.p2, lbl2_offset.to_point());
+        ctx.place_child(&mut self.label.p3, lbl3_offset.to_point());
+        ctx.place_child(&mut self.label.p4, lbl4_offset.to_point());
+        ctx.place_child(&mut self.label.p5, lbl5_offset.to_point());
+        ctx.place_child(&mut self.label.p6, lbl6_offset.to_point());
+        ctx.place_child(&mut self.label.p7, lbl7_offset.to_point());
+        ctx.place_child(&mut self.label.p8, lbl8_offset.to_point());
+        ctx.place_child(&mut self.label.p9, lbl9_offset.to_point());
+        button_size
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
+        let is_active = ctx.is_pointer_capture_target() && !ctx.is_disabled();
+        let is_hovered = ctx.is_hovered();
+        let size = ctx.size();
+        let stroke_width = theme::BUTTON_BORDER_WIDTH;
+
+        let rounded_rect = size
+            .to_rect()
+            .inset(-stroke_width / 2.0)
+            .to_rounded_rect(theme::BUTTON_BORDER_RADIUS);
+
+        let bg_gradient = if ctx.is_disabled() {
+            [theme::DISABLED_BUTTON_LIGHT, theme::DISABLED_BUTTON_DARK]
+        } else if is_active {
+            [theme::BUTTON_DARK, theme::BUTTON_LIGHT]
+        } else {
+            [theme::BUTTON_LIGHT, theme::BUTTON_DARK]
+        };
+        let border_color = if is_hovered && !ctx.is_disabled() {
+            theme::BORDER_LIGHT
+        } else {
+            theme::BORDER_DARK
+        };
+
+        stroke(scene, &rounded_rect, border_color, stroke_width);
+        fill_lin_gradient(
+            scene,
+            &rounded_rect,
+            bg_gradient,
+            UnitPoint::TOP,
+            UnitPoint::BOTTOM,
+        );
+    }
+
+    fn accessibility_role(&self) -> Role {
+        Role::Button
+    }
+    fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut Node) {
+        // IMPORTANT: We don't want to merge this code in practice, because the child label already has a 'name' property. This is more of a proof of concept of `get_raw_ref()`.
+        if false {
+            let label = ctx.get_raw_ref(&self.label.p5);
+            let name = label.widget().text().as_ref().to_string();
+            node.set_value(name);
+        }
+        node.add_action(accesskit::Action::Click);
+    }
+
+    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
+        smallvec![
+            self.label.p1.id(),
+            self.label.p2.id(),
+            self.label.p3.id(), // ↖  ↑  ↗
+            self.label.p4.id(),
+            self.label.p5.id(),
+            self.label.p6.id(), // ←  •  →
+            self.label.p7.id(),
+            self.label.p8.id(),
+            self.label.p9.id(), // ↙  ↓  ↘
+        ]
+    }
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("Button9", id = ctx.widget_id().trace())
+    }
 }
 
 // --- MARK: TESTS ---
 // #[cfg(test)] mod button9_test; //TODO
 
 // TODO:
-  // how to adjust `accessibility` for all 9 labels?
-  // add tests
-  // reformat docs
+// how to adjust `accessibility` for all 9 labels?
+// add tests
+// reformat docs
 
 // --- MARK: TESTS ---
 #[cfg(test)]

--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -309,3 +309,68 @@ impl Widget for Button9 {
   // how to adjust `accessibility` for all 9 labels?
   // add tests
   // reformat docs
+
+// --- MARK: TESTS ---
+#[cfg(test)]
+mod tests {
+    use insta::assert_debug_snapshot;
+
+    use super::*;
+    use crate::assert_render_snapshot;
+    use crate::core::StyleProperty;
+    use crate::testing::{widget_ids, TestHarness, TestWidgetExt};
+    use crate::theme::PRIMARY_LIGHT;
+
+    #[test]
+    fn simple_button() {
+        let [button_id] = widget_ids();
+        let widget = Button9::new("Hello").with_id(button_id);
+
+        let mut harness = TestHarness::create(widget);
+
+        assert_debug_snapshot!(harness.root_widget());
+        assert_render_snapshot!(harness, "hello");
+
+        assert_eq!(harness.pop_action(), None);
+
+        harness.mouse_click_on(button_id);
+        assert_eq!(
+            harness.pop_action(),
+            Some((Action::Button9Pressed(PointerButton9::Primary), button_id))
+        );
+    }
+
+    #[test]
+    fn edit_button() {
+        let image_1 = {
+            let label = Label::new("The quick brown fox jumps over the lazy dog")
+                .with_brush(PRIMARY_LIGHT)
+                .with_style(StyleProperty::FontSize(20.0));
+            let button = Button9::from_label(label);
+
+            let mut harness = TestHarness::create_with_size(button, Size::new(50.0, 50.0));
+
+            harness.render()
+        };
+
+        let image_2 = {
+            let button = Button9::new("Hello world");
+
+            let mut harness = TestHarness::create_with_size(button, Size::new(50.0, 50.0));
+
+            harness.edit_root_widget(|mut button| {
+                let mut button = button.downcast::<Button9>();
+                Button9::set_text(&mut button, "The quick brown fox jumps over the lazy dog");
+
+                let mut label = Button9::label_mut(&mut button);
+                Label::set_brush(&mut label, PRIMARY_LIGHT);
+                Label::insert_style(&mut label, StyleProperty::FontSize(20.0));
+            });
+
+            harness.render()
+        };
+
+        // We don't use assert_eq because we don't want rich assert
+        assert!(image_1 == image_2);
+    }
+}

--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -31,9 +31,9 @@ pub const pad_def: Insets = Insets::uniform_xy(8., 2.);
   /// ←  •  →
   /// ↙  ↓  ↘
 pub enum LPos {
-  TL1 = 1, TI2 = 2, TJ3 = 3,
-  HL4 = 4, HI5 = 5, HJ6 = 6,
-  LL7 = 7, LI8 = 8, LJ9 = 9,
+  tl1 = 1, ti2 = 2, tj3 = 3,
+  hl4 = 4, hi5 = 5, hj6 = 6,
+  ll7 = 7, li8 = 8, lj9 = 9,
 }
 /// A button with up to 9 text Labels (allowing for custom styles) with custom padding
 /// (allowing for flexible positioning).
@@ -45,120 +45,114 @@ pub struct Button9 {
 }
 /// Label widgets for Button9
 pub struct Label9 {
-  TL1:WidgetPod<Label>, TI2:WidgetPod<Label>, TJ3:WidgetPod<Label>, // ↖  ↑  ↗
-  HL4:WidgetPod<Label>, HI5:WidgetPod<Label>, HJ6:WidgetPod<Label>, // ←  •  →
-  LL7:WidgetPod<Label>, LI8:WidgetPod<Label>, LJ9:WidgetPod<Label>, // ↙  ↓  ↘
+  tl1:WidgetPod<Label>, ti2:WidgetPod<Label>, tj3:WidgetPod<Label>, // ↖  ↑  ↗
+  hl4:WidgetPod<Label>, hi5:WidgetPod<Label>, hj6:WidgetPod<Label>, // ←  •  →
+  ll7:WidgetPod<Label>, li8:WidgetPod<Label>, lj9:WidgetPod<Label>, // ↙  ↓  ↘
 }
 /// Custom button options. Currently only padding is supported.
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
 pub struct LabelOpt {
   /// Per-label padding.
   pub pad: Pad9,
-  // pub is : Is9, //
 }
 
 /// Optional padding options per label as [`Insets`]
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
 pub struct Pad9 {
-  pub TL1:Option<Insets>, pub TI2:Option<Insets>, pub TJ3:Option<Insets>, // ↖  ↑  ↗
-  pub HL4:Option<Insets>, pub HI5:Option<Insets>, pub HJ6:Option<Insets>, // ←  •  →
-  pub LL7:Option<Insets>, pub LI8:Option<Insets>, pub LJ9:Option<Insets>, // ↙  ↓  ↘
+  pub tl1:Option<Insets>, pub ti2:Option<Insets>, pub tj3:Option<Insets>, // ↖  ↑  ↗
+  pub hl4:Option<Insets>, pub hi5:Option<Insets>, pub hj6:Option<Insets>, // ←  •  →
+  pub ll7:Option<Insets>, pub li8:Option<Insets>, pub lj9:Option<Insets>, // ↙  ↓  ↘
 }
 // /// Track whether a label exists, useful for layout constraint calculations
 // #[derive(Default, Debug, Copy, Clone, PartialEq)]
 // pub struct Is9 {
-//   pub TL1:bool, pub TI2:bool, pub TJ3:bool, // ↖  ↑  ↗
-//   pub HL4:bool, pub HI5:bool, pub HJ6:bool, // ←  •  →
-//   pub LL7:bool, pub LI8:bool, pub LJ9:bool, // ↙  ↓  ↘
+//   pub tl1:bool, pub ti2:bool, pub tj3:bool, // ↖  ↑  ↗
+//   pub hl4:bool, pub hi5:bool, pub hj6:bool, // ←  •  →
+//   pub ll7:bool, pub li8:bool, pub lj9:bool, // ↙  ↓  ↘
 // }
 
 // --- MARK: BUILDERS ---
 impl Button9 {
-  /// Create a new button with a text label at the center (HI5m other labels are blank, use `.addx` methods to fill them)
+  /// Create a new button with a text label at the center (hi5 other labels are blank, use `.addx` methods to fill them)
   /// ```
-  /// use crate::widgets::Button9;
+  /// use masonry::widgets::Button9;
   /// let button = Button9::new("Increment");
   /// ```
   pub fn new(text:impl Into<ArcStr>) -> Self {Self::from_label    (Label::new(text))}
   /// Create a new button with the provided [`Label`]
   /// ```
-  /// use crate::peniko::Color;
-  /// use crate::widgets::{Button9, Label};
+  /// use masonry::peniko::Color;
+  /// use masonry::widgets::{Button9, Label};
   /// let label = Label::new("Increment").with_brush(Color::new([0.5, 0.5, 0.5, 1.0]));
   /// let button = Button9::from_label(label);
   /// ```
   pub fn from_label    (label:Label) -> Self {Self::from_label_pad(label, None)}
   /// Create a new button with the provided [`Label`] and padding [`Insets`]
   /// ```
-  /// use crate::peniko::Color;
-  /// use crate::widgets::{Button9, Label};
+  /// use masonry::peniko::Color;
+  /// use masonry::widgets::{Button9, Label};
   /// let label  = Label::new("Increment").with_brush(Color::new([0.5, 0.5, 0.5, 1.0]));
   /// let pad    = Insets::uniform_xy(8., 2.); // pad ←→ by 8 and ↑↓ by 2
   /// let button = Button9::from_label_pad(label, pad);
   /// ```
   pub fn from_label_pad(lbl:Label, pad:Option<Insets>) -> Self {
-    // let is = is9 {
-      // TL1:false, TI2:false                , TJ3:false, // ↖  ↑  ↗
-      // HL4:false, HI5:lbl.text().len() > 0 , HJ6:false, // ←  •  →
-      // LL7:false, LI8:false                , LJ9:false, // ↙  ↓  ↘
-    // };
     let label = Label9 {
-      TL1:WidgetPod::new(Label::new("")), TI2:WidgetPod::new(Label::new("")), TJ3:WidgetPod::new(Label::new("")), // ↖  ↑  ↗
-      HL4:WidgetPod::new(Label::new("")), HI5:WidgetPod::new(lbl           ), HJ6:WidgetPod::new(Label::new("")), // ←  •  →
-      LL7:WidgetPod::new(Label::new("")), LI8:WidgetPod::new(Label::new("")), LJ9:WidgetPod::new(Label::new("")), // ↙  ↓  ↘
+      tl1:WidgetPod::new(Label::new("")), ti2:WidgetPod::new(Label::new("")), tj3:WidgetPod::new(Label::new("")), // ↖  ↑  ↗
+      hl4:WidgetPod::new(Label::new("")), hi5:WidgetPod::new(lbl           ), hj6:WidgetPod::new(Label::new("")), // ←  •  →
+      ll7:WidgetPod::new(Label::new("")), li8:WidgetPod::new(Label::new("")), lj9:WidgetPod::new(Label::new("")), // ↙  ↓  ↘
     };
     let pad = Pad9 {
-      TL1:None, TI2:None, TJ3:None, // ↖  ↑  ↗
-      HL4:None, HI5:pad , HJ6:None, // ←  •  →
-      LL7:None, LI8:None, LJ9:None, // ↙  ↓  ↘
+      tl1:None, ti2:None, tj3:None, // ↖  ↑  ↗
+      hl4:None, hi5:pad , hj6:None, // ←  •  →
+      ll7:None, li8:None, lj9:None, // ↙  ↓  ↘
     };
-    let opt = LabelOpt{pad}; //, is
+    let opt = LabelOpt{pad};
     Self {label, opt}
   }
-  /// Helper .methods for adding individual labels (add=center HI5)
-  pub fn add (mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.HI5 = WidgetPod::new(label); self.opt.pad.HI5 = pad; self}
-  pub fn add1(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.TL1 = WidgetPod::new(label); self.opt.pad.TL1 = pad; self}
-  pub fn add2(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.TI2 = WidgetPod::new(label); self.opt.pad.TI2 = pad; self}
-  pub fn add3(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.TJ3 = WidgetPod::new(label); self.opt.pad.TJ3 = pad; self}
-  pub fn add4(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.HL4 = WidgetPod::new(label); self.opt.pad.HL4 = pad; self}
-  pub fn add5(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.HI5 = WidgetPod::new(label); self.opt.pad.HI5 = pad; self}
-  pub fn add6(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.HJ6 = WidgetPod::new(label); self.opt.pad.HJ6 = pad; self}
-  pub fn add7(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.LL7 = WidgetPod::new(label); self.opt.pad.LL7 = pad; self}
-  pub fn add8(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.LI8 = WidgetPod::new(label); self.opt.pad.LI8 = pad; self}
-  pub fn add9(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.LJ9 = WidgetPod::new(label); self.opt.pad.LJ9 = pad; self}
-  // pub fn add (mut self,         label:Label, pad:Option<Insets>) {self.addx(LPos::HI5,label,pad)}
+  /// Helper .methods for adding individual labels (add=center hi5)
+  pub fn add (mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.hi5 = WidgetPod::new(label); self.opt.pad.hi5 = pad; self}
+  pub fn add1(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.tl1 = WidgetPod::new(label); self.opt.pad.tl1 = pad; self}
+  pub fn add2(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.ti2 = WidgetPod::new(label); self.opt.pad.ti2 = pad; self}
+  pub fn add3(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.tj3 = WidgetPod::new(label); self.opt.pad.tj3 = pad; self}
+  pub fn add4(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.hl4 = WidgetPod::new(label); self.opt.pad.hl4 = pad; self}
+  pub fn add5(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.hi5 = WidgetPod::new(label); self.opt.pad.hi5 = pad; self}
+  pub fn add6(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.hj6 = WidgetPod::new(label); self.opt.pad.hj6 = pad; self}
+  pub fn add7(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.ll7 = WidgetPod::new(label); self.opt.pad.ll7 = pad; self}
+  pub fn add8(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.li8 = WidgetPod::new(label); self.opt.pad.li8 = pad; self}
+  pub fn add9(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.lj9 = WidgetPod::new(label); self.opt.pad.lj9 = pad; self}
+  // pub fn add (mut self,         label:Label, pad:Option<Insets>) {self.addx(LPos::hi5,label,pad)}
   /// Helper .method for adding a label to a given position (same as in [`LPos`])
   pub fn addx(mut self,idx:LPos,label:Label, pad:Option<Insets>) -> Self {match idx {
-    LPos::TL1 => {self.label.TL1 = WidgetPod::new(label); self.opt.pad.TL1 = pad}, //↖
-    LPos::TI2 => {self.label.TI2 = WidgetPod::new(label); self.opt.pad.TI2 = pad}, //↑
-    LPos::TJ3 => {self.label.TJ3 = WidgetPod::new(label); self.opt.pad.TJ3 = pad}, //↗
-    LPos::HL4 => {self.label.HL4 = WidgetPod::new(label); self.opt.pad.HL4 = pad}, //←
-    LPos::HI5 => {self.label.HI5 = WidgetPod::new(label); self.opt.pad.HI5 = pad}, //•
-    LPos::HJ6 => {self.label.HJ6 = WidgetPod::new(label); self.opt.pad.HJ6 = pad}, //→
-    LPos::LL7 => {self.label.LL7 = WidgetPod::new(label); self.opt.pad.LL7 = pad}, //↙
-    LPos::LI8 => {self.label.LI8 = WidgetPod::new(label); self.opt.pad.LI8 = pad}, //↓
-    LPos::LJ9 => {self.label.LJ9 = WidgetPod::new(label); self.opt.pad.LJ9 = pad}, //↘
+    LPos::tl1 => {self.label.tl1 = WidgetPod::new(label); self.opt.pad.tl1 = pad}, //↖
+    LPos::ti2 => {self.label.ti2 = WidgetPod::new(label); self.opt.pad.ti2 = pad}, //↑
+    LPos::tj3 => {self.label.tj3 = WidgetPod::new(label); self.opt.pad.tj3 = pad}, //↗
+    LPos::hl4 => {self.label.hl4 = WidgetPod::new(label); self.opt.pad.hl4 = pad}, //←
+    LPos::hi5 => {self.label.hi5 = WidgetPod::new(label); self.opt.pad.hi5 = pad}, //•
+    LPos::hj6 => {self.label.hj6 = WidgetPod::new(label); self.opt.pad.hj6 = pad}, //→
+    LPos::ll7 => {self.label.ll7 = WidgetPod::new(label); self.opt.pad.ll7 = pad}, //↙
+    LPos::li8 => {self.label.li8 = WidgetPod::new(label); self.opt.pad.li8 = pad}, //↓
+    LPos::lj9 => {self.label.lj9 = WidgetPod::new(label); self.opt.pad.lj9 = pad}, //↘
   } self }
   /// Create a new button with the provided [`Label9`]s and their [`Pad9`] with predetermined IDs. This constructor is useful for toolkits which use Masonry (such as Xilem).
-  pub fn from_label_pod(label_l:[WidgetPod<Label>;9], pad:Pad9) -> Self { //, is:is9
+  pub fn from_label_pod(label_l:[WidgetPod<Label>;9], pad:Pad9) -> Self {
     let [l1,l2,l3,l4,l5,l6,l7,l8,l9] = label_l;
     let label = Label9 { //numbering shifted due to 0-based array index
-      TL1:l1, TI2:l2, TJ3:l3, // ↖  ↑  ↗
-      HL4:l4, HI5:l5, HJ6:l8, // ←  •  →
-      LL7:l7, LI8:l6, LJ9:l9, // ↙  ↓  ↘
+      tl1:l1, ti2:l2, tj3:l3, // ↖  ↑  ↗
+      hl4:l4, hi5:l5, hj6:l8, // ←  •  →
+      ll7:l7, li8:l6, lj9:l9, // ↙  ↓  ↘
     };
-    let opt = LabelOpt{pad}; //, is
+    let opt = LabelOpt{pad};
     Self {label, opt}
   }
 }
 
 // Helper indices for the Label9 positions (0-based unlike .Prop or fn() names!)
-const row_top: [usize;3] = [0,1,2]; //↖ ↑ ↗
-const row_mid: [usize;3] = [3,4,5]; //← • →
-const row_bot: [usize;3] = [6,7,8]; //↙ ↓ ↘
-const col_lhs: [usize;3] = [0,1,2]; //↖ ← ↙
-const col_cnt: [usize;3] = [3,4,5]; //↑ • ↓
-const col_rhs: [usize;3] = [6,7,8]; //↗ → ↘
+const ROW_TOP: [usize;3] = [0,1,2]; //↖ ↑ ↗
+const ROW_MID: [usize;3] = [3,4,5]; //← • →
+const ROW_BOT: [usize;3] = [6,7,8]; //↙ ↓ ↘
+const COL_LHS: [usize;3] = [0,1,2]; //↖ ← ↙
+const COL_CNT: [usize;3] = [3,4,5]; //↑ • ↓
+const COL_RHS: [usize;3] = [6,7,8]; //↗ → ↘
 
 // --- MARK: WIDGETMUT ---
 impl Button9 {
@@ -173,62 +167,62 @@ impl Button9 {
   pub fn set_text7(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label7_mut(this), new_text);}
   pub fn set_text8(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label8_mut(this), new_text);}
   pub fn set_text9(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label9_mut(this), new_text);}
-  // pub fn set_text (this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label_mutx(this,LPos::HI5), new_text);}
+  // pub fn set_text (this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label_mutx(this,LPos::hi5), new_text);}
   /// Set label text for a given position
   pub fn set_textx(this:&mut WidgetMut<'_,Self>, idx:LPos, new_text: impl Into<ArcStr>) {
     Label::set_text(&mut Self::labelx_mut(this, idx), new_text);
   }
 
   /// Set label options helpers
-  pub fn set_opt <'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.HI5 = new_pad; this.ctx.request_render();}
-  pub fn set_pad1<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.TL1 = new_pad; this.ctx.request_render();}
-  pub fn set_pad2<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.TI2 = new_pad; this.ctx.request_render();}
-  pub fn set_pad3<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.TJ3 = new_pad; this.ctx.request_render();}
-  pub fn set_pad4<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.HL4 = new_pad; this.ctx.request_render();}
-  pub fn set_pad5<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.HI5 = new_pad; this.ctx.request_render();}
-  pub fn set_pad6<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.HJ6 = new_pad; this.ctx.request_render();}
-  pub fn set_pad7<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.LL7 = new_pad; this.ctx.request_render();}
-  pub fn set_pad8<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.LI8 = new_pad; this.ctx.request_render();}
-  pub fn set_pad9<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.LJ9 = new_pad; this.ctx.request_render();}
-  // pub fn set_opt  <'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.set_optx(LPos::HI5, new_opt);}
+  pub fn set_opt <'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hi5 = new_pad; this.ctx.request_render();}
+  pub fn set_pad1<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.tl1 = new_pad; this.ctx.request_render();}
+  pub fn set_pad2<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.ti2 = new_pad; this.ctx.request_render();}
+  pub fn set_pad3<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.tj3 = new_pad; this.ctx.request_render();}
+  pub fn set_pad4<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hl4 = new_pad; this.ctx.request_render();}
+  pub fn set_pad5<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hi5 = new_pad; this.ctx.request_render();}
+  pub fn set_pad6<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hj6 = new_pad; this.ctx.request_render();}
+  pub fn set_pad7<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.ll7 = new_pad; this.ctx.request_render();}
+  pub fn set_pad8<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.li8 = new_pad; this.ctx.request_render();}
+  pub fn set_pad9<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.lj9 = new_pad; this.ctx.request_render();}
+  // pub fn set_opt  <'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.set_optx(LPos::hi5, new_opt);}
   /// Set the label options for a given position
   pub fn set_padx(this: &mut WidgetMut<'_,Self>, idx:LPos, new_pad:Option<Insets>) {match idx {
-    LPos::TL1 => {this.widget.opt.pad.TL1 = new_pad}, //↖
-    LPos::TI2 => {this.widget.opt.pad.TI2 = new_pad}, //↑
-    LPos::TJ3 => {this.widget.opt.pad.TJ3 = new_pad}, //↗
-    LPos::HL4 => {this.widget.opt.pad.HL4 = new_pad}, //←
-    LPos::HI5 => {this.widget.opt.pad.HI5 = new_pad}, //•
-    LPos::HJ6 => {this.widget.opt.pad.HJ6 = new_pad}, //→
-    LPos::LL7 => {this.widget.opt.pad.LL7 = new_pad}, //↙
-    LPos::LI8 => {this.widget.opt.pad.LI8 = new_pad}, //↓
-    LPos::LJ9 => {this.widget.opt.pad.LJ9 = new_pad}, //↘
+    LPos::tl1 => {this.widget.opt.pad.tl1 = new_pad}, //↖
+    LPos::ti2 => {this.widget.opt.pad.ti2 = new_pad}, //↑
+    LPos::tj3 => {this.widget.opt.pad.tj3 = new_pad}, //↗
+    LPos::hl4 => {this.widget.opt.pad.hl4 = new_pad}, //←
+    LPos::hi5 => {this.widget.opt.pad.hi5 = new_pad}, //•
+    LPos::hj6 => {this.widget.opt.pad.hj6 = new_pad}, //→
+    LPos::ll7 => {this.widget.opt.pad.ll7 = new_pad}, //↙
+    LPos::li8 => {this.widget.opt.pad.li8 = new_pad}, //↓
+    LPos::lj9 => {this.widget.opt.pad.lj9 = new_pad}, //↘
     }
     this.ctx.request_render(); // label options state impacts appearance and accessibility node
   }
 
   /// Get mutable label helpers
-  pub fn label_mut <'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.HI5)}
-  pub fn label1_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.TL1)}
-  pub fn label2_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.TI2)}
-  pub fn label3_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.TJ3)}
-  pub fn label4_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.HL4)}
-  pub fn label5_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.HI5)}
-  pub fn label6_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.HJ6)}
-  pub fn label7_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.LL7)}
-  pub fn label8_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.LI8)}
-  pub fn label9_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.LJ9)}
-  // pub fn label_mut <'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.labelx_mut(LPos::HI5)}
+  pub fn label_mut <'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.hi5)}
+  pub fn label1_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.tl1)}
+  pub fn label2_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.ti2)}
+  pub fn label3_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.tj3)}
+  pub fn label4_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.hl4)}
+  pub fn label5_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.hi5)}
+  pub fn label6_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.hj6)}
+  pub fn label7_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.ll7)}
+  pub fn label8_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.li8)}
+  pub fn label9_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.lj9)}
+  // pub fn label_mut <'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.labelx_mut(LPos::hi5)}
   /// Get mutable label for a given position
   pub fn labelx_mut<'t>(this: &'t mut WidgetMut<'_,Self>, idx:LPos) -> WidgetMut<'t, Label> {match idx {
-    LPos::TL1 => {return this.ctx.get_mut(&mut this.widget.label.TL1)}, //↖
-    LPos::TI2 => {return this.ctx.get_mut(&mut this.widget.label.TI2)}, //↑
-    LPos::TJ3 => {return this.ctx.get_mut(&mut this.widget.label.TJ3)}, //↗
-    LPos::HL4 => {return this.ctx.get_mut(&mut this.widget.label.HL4)}, //←
-    LPos::HI5 => {return this.ctx.get_mut(&mut this.widget.label.HI5)}, //•
-    LPos::HJ6 => {return this.ctx.get_mut(&mut this.widget.label.HJ6)}, //→
-    LPos::LL7 => {return this.ctx.get_mut(&mut this.widget.label.LL7)}, //↙
-    LPos::LI8 => {return this.ctx.get_mut(&mut this.widget.label.LI8)}, //↓
-    LPos::LJ9 => {return this.ctx.get_mut(&mut this.widget.label.LJ9)}, //↘
+    LPos::tl1 => {return this.ctx.get_mut(&mut this.widget.label.tl1)}, //↖
+    LPos::ti2 => {return this.ctx.get_mut(&mut this.widget.label.ti2)}, //↑
+    LPos::tj3 => {return this.ctx.get_mut(&mut this.widget.label.tj3)}, //↗
+    LPos::hl4 => {return this.ctx.get_mut(&mut this.widget.label.hl4)}, //←
+    LPos::hi5 => {return this.ctx.get_mut(&mut this.widget.label.hi5)}, //•
+    LPos::hj6 => {return this.ctx.get_mut(&mut this.widget.label.hj6)}, //→
+    LPos::ll7 => {return this.ctx.get_mut(&mut this.widget.label.ll7)}, //↙
+    LPos::li8 => {return this.ctx.get_mut(&mut this.widget.label.li8)}, //↓
+    LPos::lj9 => {return this.ctx.get_mut(&mut this.widget.label.lj9)}, //↘
   }}
 }
 
@@ -264,36 +258,29 @@ impl Widget for Button9 {
     _                           => {}  }   }
 
   fn register_children(&mut self, ctx: &mut core::RegisterCtx) {
-    ctx.register_child(&mut self.label.TL1);ctx.register_child(&mut self.label.TI2);ctx.register_child(&mut self.label.TJ3); // ↖  ↑  ↗
-    ctx.register_child(&mut self.label.HL4);ctx.register_child(&mut self.label.HI5);ctx.register_child(&mut self.label.HJ6); // ←  •  →
-    ctx.register_child(&mut self.label.LL7);ctx.register_child(&mut self.label.LI8);ctx.register_child(&mut self.label.LJ9); // ↙  ↓  ↘
+    ctx.register_child(&mut self.label.tl1);ctx.register_child(&mut self.label.ti2);ctx.register_child(&mut self.label.tj3); // ↖  ↑  ↗
+    ctx.register_child(&mut self.label.hl4);ctx.register_child(&mut self.label.hi5);ctx.register_child(&mut self.label.hj6); // ←  •  →
+    ctx.register_child(&mut self.label.ll7);ctx.register_child(&mut self.label.li8);ctx.register_child(&mut self.label.lj9); // ↙  ↓  ↘
   }
   fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size {
     let min_height = theme::BORDERED_WIDGET_HEIGHT; // HACK: to make sure we look okay at default sizes when beside a textbox, we make sure we will have at least the same height as the default textbox.
     let mut lbl_pad9 = [
-      (&mut self.label.TL1, self.opt.pad.TL1),
-      (&mut self.label.TI2, self.opt.pad.TI2),
-      (&mut self.label.TJ3, self.opt.pad.TJ3),
-      (&mut self.label.HL4, self.opt.pad.HL4),
-      (&mut self.label.HI5, self.opt.pad.HI5),
-      (&mut self.label.HJ6, self.opt.pad.HJ6),
-      (&mut self.label.LL7, self.opt.pad.LL7),
-      (&mut self.label.LI8, self.opt.pad.LI8),
-      (&mut self.label.LJ9, self.opt.pad.LJ9),
+      (&mut self.label.tl1, self.opt.pad.tl1),
+      (&mut self.label.ti2, self.opt.pad.ti2),
+      (&mut self.label.tj3, self.opt.pad.tj3),
+      (&mut self.label.hl4, self.opt.pad.hl4),
+      (&mut self.label.hi5, self.opt.pad.hi5),
+      (&mut self.label.hj6, self.opt.pad.hj6),
+      (&mut self.label.ll7, self.opt.pad.ll7),
+      (&mut self.label.li8, self.opt.pad.li8),
+      (&mut self.label.lj9, self.opt.pad.lj9),
       ];
 
     let mut row_w: [f64 ;3] = [0.   ;3]; //top /middle/bottom ↖↑↗  ←•→  ↙↓↘
     let mut col_h: [f64 ;3] = [0.   ;3]; //left/center/right  ↖←↙  ↑•↓  ↗→↘
-    // let mut is   : [bool;9] = [false;9];
     let mut lsz  : [Size  ;10] = [Size::ZERO  ;10];
     let mut lpad : [Insets;10] = [Insets::ZERO;10];
-    // let mut valid = vec!();
     for (i, (lbl9, pad9)) in lbl_pad9.iter_mut().enumerate() {
-      // let is_txt = ctx.get_raw_ref(lbl9).widget().text().len() > 0;
-      // is[i] = is_txt;
-      // if is_txt || i == 4 { //todo only calc/place valid labels,
-        // but then update register_children + children_ids
-        // and call children_changed when set_txt sets what was an empty label
       let pad       = match pad9 {Some(inset)=>*inset, None=>pad_def,};
       let pad_sz    = Size::new(pad.x_value(), pad.y_value());
       let lbl_bc    = bc.shrink(pad_sz).loosen();
@@ -304,22 +291,19 @@ impl Widget for Button9 {
         let baseline = ctx.child_baseline_offset(&lbl9);
         ctx.set_baseline_offset(baseline + pad.y1);
       }
-      if row_top.iter().any(|x| x == &i) {row_w[0] += lbl_sz.width  + pad_sz.width ;}
-      if row_mid.iter().any(|x| x == &i) {row_w[1] += lbl_sz.width  + pad_sz.width ;}
-      if row_bot.iter().any(|x| x == &i) {row_w[2] += lbl_sz.width  + pad_sz.width ;}
-      if col_lhs.iter().any(|x| x == &i) {col_h[0] += lbl_sz.height + pad_sz.height;}
-      if col_cnt.iter().any(|x| x == &i) {col_h[1] += lbl_sz.height + pad_sz.height;}
-      if col_rhs.iter().any(|x| x == &i) {col_h[2] += lbl_sz.height + pad_sz.height;}
+      if ROW_TOP.iter().any(|x| x == &i) {row_w[0] += lbl_sz.width  + pad_sz.width ;}
+      if ROW_MID.iter().any(|x| x == &i) {row_w[1] += lbl_sz.width  + pad_sz.width ;}
+      if ROW_BOT.iter().any(|x| x == &i) {row_w[2] += lbl_sz.width  + pad_sz.width ;}
+      if COL_LHS.iter().any(|x| x == &i) {col_h[0] += lbl_sz.height + pad_sz.height;}
+      if COL_CNT.iter().any(|x| x == &i) {col_h[1] += lbl_sz.height + pad_sz.height;}
+      if COL_RHS.iter().any(|x| x == &i) {col_h[2] += lbl_sz.height + pad_sz.height;}
       lsz[i+1] = lbl_sz; // store size for later offset calculations (after button size is known)
       lpad[i+1] = pad;
-      // valid.push((i, lbl9));
-      // }
     }
     let max_w = row_w[0].max(row_w[1]).max(row_w[2]);
     let max_h = col_h[0].max(col_h[1]).max(col_h[2]).max(min_height);
     let button_size = bc.constrain(Size::new(max_w, max_h));
 
-    // for (i, lbl9) in valid { // for (i, (lbl9, pad9)) in lbl_pad9.iter_mut().enumerate() {
     let bw = button_size.width; let bh = button_size.height; // ↖0,0 (w1-w2)/2=middle@x; (h1-h2)/2=center@y
     let lbl1_offset = Vec2::new( 0.                     + lpad[1].x0    , 0.                      + lpad[1].y0  );
     let lbl2_offset = Vec2::new((bw - lsz[2].width)/2.0                 , 0.                      + lpad[2].y0  );
@@ -337,10 +321,9 @@ impl Widget for Button9 {
       trace!("↙ lbl7 🆔{} offset {}", ctx.widget_id(), lbl7_offset); trace!("↓ lbl8 🆔{} offset {}", ctx.widget_id(), lbl8_offset); trace!("↘ lbl9 🆔{} offset {}", ctx.widget_id(), lbl9_offset);
     }
 
-    ctx.place_child(&mut self.label.TL1, lbl1_offset.to_point()); ctx.place_child(&mut self.label.TI2, lbl2_offset.to_point()); ctx.place_child(&mut self.label.TJ3, lbl3_offset.to_point());
-    ctx.place_child(&mut self.label.HL4, lbl4_offset.to_point()); ctx.place_child(&mut self.label.HI5, lbl5_offset.to_point()); ctx.place_child(&mut self.label.HJ6, lbl6_offset.to_point());
-    ctx.place_child(&mut self.label.LL7, lbl7_offset.to_point()); ctx.place_child(&mut self.label.LI8, lbl8_offset.to_point()); ctx.place_child(&mut self.label.LJ9, lbl9_offset.to_point());
-    // }
+    ctx.place_child(&mut self.label.tl1, lbl1_offset.to_point()); ctx.place_child(&mut self.label.ti2, lbl2_offset.to_point()); ctx.place_child(&mut self.label.tj3, lbl3_offset.to_point());
+    ctx.place_child(&mut self.label.hl4, lbl4_offset.to_point()); ctx.place_child(&mut self.label.hi5, lbl5_offset.to_point()); ctx.place_child(&mut self.label.hj6, lbl6_offset.to_point());
+    ctx.place_child(&mut self.label.ll7, lbl7_offset.to_point()); ctx.place_child(&mut self.label.li8, lbl8_offset.to_point()); ctx.place_child(&mut self.label.lj9, lbl9_offset.to_point());
     button_size
   }
 
@@ -368,7 +351,7 @@ impl Widget for Button9 {
   fn accessibility_role(&self) -> Role {Role::Button}
   fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut Node) { // IMPORTANT: We don't want to merge this code in practice, because the child label already has a 'name' property. This is more of a proof of concept of `get_raw_ref()`.
     if false {
-      let label = ctx.get_raw_ref(&self.label.HI5);
+      let label = ctx.get_raw_ref(&self.label.hi5);
       let name  = label.widget().text().as_ref().to_string();
       node.set_value(name);
     }
@@ -376,9 +359,9 @@ impl Widget for Button9 {
   }
 
   fn children_ids   (&self                    ) -> SmallVec<[WidgetId; 16]> {smallvec![
-    self.label.TL1.id(),self.label.TI2.id(),self.label.TJ3.id(), // ↖  ↑  ↗
-    self.label.HL4.id(),self.label.HI5.id(),self.label.HJ6.id(), // ←  •  →
-    self.label.LL7.id(),self.label.LI8.id(),self.label.LJ9.id(), // ↙  ↓  ↘
+    self.label.tl1.id(),self.label.ti2.id(),self.label.tj3.id(), // ↖  ↑  ↗
+    self.label.hl4.id(),self.label.hi5.id(),self.label.hj6.id(), // ←  •  →
+    self.label.ll7.id(),self.label.li8.id(),self.label.lj9.id(), // ↙  ↓  ↘
   ]}
   fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {trace_span!("Button9", id = ctx.widget_id().trace())}
 }

--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -638,7 +638,7 @@ mod tests {
     }
 
     #[test]
-    fn edit_button() {
+    fn edit_button9() {
         let image_1 = {
             let label = Label::new("The quick brown fox jumps over the lazy dog")
                 .with_brush(PRIMARY_LIGHT)

--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! A button widget with up to 9 labels.
+// TODO: how to adjust `accessibility` for all 9 labels?
 
 use accesskit::{Node, Role};
 use smallvec::{smallvec, SmallVec};
@@ -627,14 +628,6 @@ impl Widget for Button9 {
         trace_span!("Button9", id = ctx.widget_id().trace())
     }
 }
-
-// --- MARK: TESTS ---
-// #[cfg(test)] mod button9_test; //TODO
-
-// TODO:
-// how to adjust `accessibility` for all 9 labels?
-// add tests
-// reformat docs
 
 // --- MARK: TESTS ---
 #[cfg(test)]

--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -464,16 +464,52 @@ impl Widget for Button9 {
             bh - lsz[9].height - lpad[9].y1,
         ); // button_size.to_vec2() - lsz[3].to_vec2()
         if cfg!(debug_assertions) {
-            trace!("button_size = {button_size:?} max_w={max_w} max_h={max_h} row_w={row_w:?} col_h={col_h:?}");
-            trace!("↖ lbl1 🆔{} offset {}", ctx.widget_id(), lbl1_offset);
-            trace!("↑ lbl2 🆔{} offset {}", ctx.widget_id(), lbl2_offset);
-            trace!("↗ lbl3 🆔{} offset {}", ctx.widget_id(), lbl3_offset);
-            trace!("← lbl4 🆔{} offset {}", ctx.widget_id(), lbl4_offset);
-            trace!("• lbl5 🆔{} offset {}", ctx.widget_id(), lbl5_offset);
-            trace!("→ lbl6 🆔{} offset {}", ctx.widget_id(), lbl6_offset);
-            trace!("↙ lbl7 🆔{} offset {}", ctx.widget_id(), lbl7_offset);
-            trace!("↓ lbl8 🆔{} offset {}", ctx.widget_id(), lbl8_offset);
-            trace!("↘ lbl9 🆔{} offset {}", ctx.widget_id(), lbl9_offset);
+            trace!("🆔{} button_size={button_size:?} ∑▣ max_w={max_w} max_h={max_h} row_w={row_w:?} col_h={col_h:?}",ctx.widget_id());
+            trace!("▣ label with pads; ▫■▫ 1-dimensional with 2 pads, ▪¦▪ split, ḍọṭ marks the max pad between labels");
+            trace!("Row ∑W   ∑½    ┌─────‹W½────┐ ┌────W½›─────┐   ∑½    🛈 Label width");
+            trace!("    2⋅Max½        ▫■▫      ▫▪¦▪▫       ▫■▫            ▣   ▣   ▣ ");
+            //eg   "↖↑↗  18    9̣ ≕  1+ 4+ 3̣? 1+ 2¦ 2+ 1? 2̣+ 4+ 0 ≔   8     8   6   6"
+            for ri in 0..=2 {
+                let rs = if ri==0{"↖↑↗"} else if ri==1{"←•→"} else if ri==2{"↙↓↘"} else{"???"};
+                let l1=ri*3+1; let l2=ri*3+2; let l3=ri*3+3;
+                let dim_d = row_w;
+                let row_wh1 = lpad[l1].x0 + lsz[l1].width + f64::max(lpad[l1].x1, lpad[l2].x0) + 0.5 * lsz[l2].width;
+                let row_wh2 =               lsz[l3].width + f64::max(lpad[l2].x1, lpad[l3].x0) + 0.5 * lsz[l2].width;
+                let (mh1,mh2) = if row_wh1 >= row_wh2 {("̣","")} else {("","̣")};
+                let (mp1r,mp2l) = if lpad[l1].x1.ge(&lpad[l2].x0) {("̣","")} else {("","̣")};
+                let (mp2r,mp3l) = if lpad[l2].x1.ge(&lpad[l3].x0) {("̣","")} else {("","̣")};
+                trace!("{} {: >3}  {: >3}{} ≕ {: >2     }+{: >2        }+{: >2      }{   }?{: >2     }{   }+{: >2   }\
+                    ¦{: >2            }+{: >2      }{    }?{: >2      }{    }+{: >2        }+{: >2     } ≔ {: >3}{}   \
+                    {: >3} {: >3} {: >3}"
+                    ,rs,dim_d[ri],row_wh1,mh1, lpad[l1].x0,lsz[l1].width , lpad[l1].x1,mp1r,lpad[l2].x0,mp2l, 0.5*lsz[l2].width
+                    ,0.5*lsz[l2].width, lpad[l2].x1,mp2r , lpad[l3].x0,mp3l , lsz[l3].width,lpad[l3].x1, row_wh2,mh2
+                    ,lsz[l1].width + lpad[l1].x0+lpad[l1].x1
+                    ,lsz[l2].width + lpad[l2].x0+lpad[l2].x1
+                    ,lsz[l3].width + lpad[l3].x0+lpad[l3].x1
+                    );
+            }
+            trace!("Col ∑H   ∑½    ┌─────↑H½────┐ ┌────H½↓─────┐   ∑½    🛈 Label height");
+            trace!("    2⋅Max½        ▫■▫      ▫▪¦▪▫       ▫■▫            ▣   ▣   ▣ ");
+            //eg   "↖←↙  18    9̣ ≕  1+ 4+ 3̣? 1+ 2¦ 2+ 1? 2̣+ 4+ 0 ≔   8     8   6   6"
+            for ci in 0..=2 {
+                let cs = if ci==0{"↖←↙"} else if ci==1{"↑•↓"} else if ci==2{"↗→↘"} else{"???"};
+                let l1=ci*3+1; let l2=ci*3+2; let l3=ci*3+3;
+                let dim_d = col_h;
+                let row_hh1 = lpad[l1].y0 + lsz[l1].height + f64::max(lpad[l1].y1, lpad[l2].y0) + 0.5 * lsz[l2].height;
+                let row_hh2 =               lsz[l3].height + f64::max(lpad[l2].y1, lpad[l3].y0) + 0.5 * lsz[l2].height;
+                let (mh1,mh2) = if row_hh1 >= row_hh2 {("̣","")} else {("","̣")};
+                let (mp1b,mp2t) = if lpad[l1].y1.ge(&lpad[l2].y0) {("̣","")} else {("","̣")};
+                let (mp2b,mp3t) = if lpad[l2].y1.ge(&lpad[l3].y0) {("̣","")} else {("","̣")};
+                trace!("{} {: >3}  {: >3}{} ≕ {: >2     }+{: >2        }+{: >2      }{   }?{: >2     }{   }+{: >2   }\
+                    ¦{: >2            }+{: >2      }{    }?{: >2      }{    }+{: >2        }+{: >2     } ≔ {: >3}{}   \
+                    {: >3} {: >3} {: >3}"
+                    ,cs,dim_d[ci],row_hh1,mh1, lpad[l1].y0,lsz[l1].height , lpad[l1].y1,mp1b,lpad[l2].y0,mp2t, 0.5*lsz[l2].height
+                    ,0.5*lsz[l2].height, lpad[l2].y1,mp2b , lpad[l3].y0,mp3t , lsz[l3].height,lpad[l3].y1, row_hh2,mh2
+                    ,lsz[l1].height + lpad[l1].y0+lpad[l1].y1
+                    ,lsz[l2].height + lpad[l2].y0+lpad[l2].y1
+                    ,lsz[l3].height + lpad[l3].y0+lpad[l3].y1
+                    );
+            }
         }
 
         ctx.place_child(&mut self.label.p1, lbl1_offset.to_point());

--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -623,7 +623,7 @@ mod tests {
         harness.mouse_click_on(button_id);
         assert_eq!(
             harness.pop_action(),
-            Some((Action::Button9Pressed(PointerButton9::Primary), button_id))
+            Some((Action::Button9Pressed(PointerButton::Primary), button_id))
         );
     }
 

--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -21,7 +21,7 @@ use crate::widgets::Label;
 /// The minimum padding added to a button. NOTE: these values are chosen to match the existing look of TextBox; these should be reevaluated at some point.
 pub const PAD_DEF: Insets = Insets::uniform_xy(8., 2.);
 
-/// A button with up to 9 text Labels (allowing for custom styles) with custom padding
+/// A button with up to 9 text [`Label`]s (allowing for custom styles) with custom [`Pad9`]ing
 /// (allowing for flexible positioning).
 pub struct Button9 {
     /// 9 label widgets
@@ -30,9 +30,9 @@ pub struct Button9 {
     opt: LabelOpt,
 }
 /// Label widgets for Button9 for all the 9 possible label positions in a button from top left to bottom right.<br>
-/// 1 2 3 = ↖  ↑  ↗
-/// 4 5 6 = ←  •  →
-/// 7 8 9 = ↙  ↓  ↘
+/// p1 p2 p3 = ↖  ↑  ↗ <br>
+/// p4 p5 p6 = ←  •  → <br>
+/// p7 p8 p9 = ↙  ↓  ↘ <br>
 pub struct Label9 {
     p1: WidgetPod<Label>,
     p2: WidgetPod<Label>,
@@ -67,7 +67,8 @@ pub struct Pad9 {
 
 // --- MARK: BUILDERS ---
 impl Button9 {
-    /// Create a new button with a text label at the center (p5 other labels are blank, use `.addx` methods to fill them)
+    /// Create a new button with a text label at the center
+    /// ([`Label9`].p5, others 8 labels are blank by default, use [`Button9::add1`]–[`Button9::add9`] methods to fill them)
     /// ```
     /// use masonry::widgets::Button9;
     /// let button = Button9::new("Increment");
@@ -88,10 +89,12 @@ impl Button9 {
     /// Create a new button with the provided [`Label`] and padding [`Insets`]
     /// ```
     /// use masonry::peniko::Color;
+    /// use masonry::kurbo::Insets;
     /// use masonry::widgets::{Button9, Label};
+    ///
     /// let label  = Label::new("Increment").with_brush(Color::new([0.5, 0.5, 0.5, 1.0]));
     /// let pad    = Insets::uniform_xy(8., 2.); // pad ←→ by 8 and ↑↓ by 2
-    /// let button = Button9::from_label_pad(label, pad);
+    /// let button = Button9::from_label_pad(label, Some(pad));
     /// ```
     pub fn from_label_pad(lbl: Label, pad: Option<Insets>) -> Self {
         let label = Label9 {
@@ -119,52 +122,61 @@ impl Button9 {
         let opt = LabelOpt { pad };
         Self { label, opt }
     }
-    /// Helper .methods for adding individual labels (add=center p5)
+    /// Add label at •p5
     pub fn add(mut self, label: Label, pad: Option<Insets>) -> Self {
         self.label.p5 = WidgetPod::new(label);
         self.opt.pad.p5 = pad;
         self
     }
+    /// Add label at ↖p1
     pub fn add1(mut self, label: Label, pad: Option<Insets>) -> Self {
         self.label.p1 = WidgetPod::new(label);
         self.opt.pad.p1 = pad;
         self
     }
+    /// Add label at ↑p2
     pub fn add2(mut self, label: Label, pad: Option<Insets>) -> Self {
         self.label.p2 = WidgetPod::new(label);
         self.opt.pad.p2 = pad;
         self
     }
+    /// Add label at ↗p3
     pub fn add3(mut self, label: Label, pad: Option<Insets>) -> Self {
         self.label.p3 = WidgetPod::new(label);
         self.opt.pad.p3 = pad;
         self
     }
+    /// Add label at ←p4
     pub fn add4(mut self, label: Label, pad: Option<Insets>) -> Self {
         self.label.p4 = WidgetPod::new(label);
         self.opt.pad.p4 = pad;
         self
     }
+    /// Add label at •p5
     pub fn add5(mut self, label: Label, pad: Option<Insets>) -> Self {
         self.label.p5 = WidgetPod::new(label);
         self.opt.pad.p5 = pad;
         self
     }
+    /// Add label at →p6
     pub fn add6(mut self, label: Label, pad: Option<Insets>) -> Self {
         self.label.p6 = WidgetPod::new(label);
         self.opt.pad.p6 = pad;
         self
     }
+    /// Add label at ↙p7
     pub fn add7(mut self, label: Label, pad: Option<Insets>) -> Self {
         self.label.p7 = WidgetPod::new(label);
         self.opt.pad.p7 = pad;
         self
     }
+    /// Add label at ↓p8
     pub fn add8(mut self, label: Label, pad: Option<Insets>) -> Self {
         self.label.p8 = WidgetPod::new(label);
         self.opt.pad.p8 = pad;
         self
     }
+    /// Add label at ↘p9
     pub fn add9(mut self, label: Label, pad: Option<Insets>) -> Self {
         self.label.p9 = WidgetPod::new(label);
         self.opt.pad.p9 = pad;
@@ -192,108 +204,135 @@ impl Button9 {
 
 // --- MARK: WIDGETMUT ---
 impl Button9 {
-    /// Set text helpers
+    /// Replace the text of label at •p5
     pub fn set_text(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
         Label::set_text(&mut Self::label_mut(this), new_text);
     }
+    /// Replace the text of label at ↖p1
     pub fn set_text1(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
         Label::set_text(&mut Self::label1_mut(this), new_text);
     }
+    /// Replace the text of label at ↑p2
     pub fn set_text2(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
         Label::set_text(&mut Self::label2_mut(this), new_text);
     }
+    /// Replace the text of label at ↗p3
     pub fn set_text3(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
         Label::set_text(&mut Self::label3_mut(this), new_text);
     }
+    /// Replace the text of label at ←p4
     pub fn set_text4(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
         Label::set_text(&mut Self::label4_mut(this), new_text);
     }
+    /// Replace the text of label at •p5
     pub fn set_text5(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
         Label::set_text(&mut Self::label5_mut(this), new_text);
     }
+    /// Replace the text of label at →p6
     pub fn set_text6(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
         Label::set_text(&mut Self::label6_mut(this), new_text);
     }
+    /// Replace the text of label at ↙p7
     pub fn set_text7(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
         Label::set_text(&mut Self::label7_mut(this), new_text);
     }
+    /// Replace the text of label at ↓p8
     pub fn set_text8(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
         Label::set_text(&mut Self::label8_mut(this), new_text);
     }
+    /// Replace the text of label at ↘p9
     pub fn set_text9(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
         Label::set_text(&mut Self::label9_mut(this), new_text);
     }
 
-    /// Set label options helpers
+    /// Replace the options of label at •p5
     pub fn set_opt(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
         this.widget.opt.pad.p5 = new_pad;
         this.ctx.request_render();
     }
+    /// Replace the options of label at ↖p1
     pub fn set_pad1(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
         this.widget.opt.pad.p1 = new_pad;
         this.ctx.request_render();
     }
+    /// Replace the options of label at ↑p2
     pub fn set_pad2(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
         this.widget.opt.pad.p2 = new_pad;
         this.ctx.request_render();
     }
+    /// Replace the options of label at ↗p3
     pub fn set_pad3(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
         this.widget.opt.pad.p3 = new_pad;
         this.ctx.request_render();
     }
+    /// Replace the options of label at ←p4
     pub fn set_pad4(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
         this.widget.opt.pad.p4 = new_pad;
         this.ctx.request_render();
     }
+    /// Replace the options of label at •p5
     pub fn set_pad5(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
         this.widget.opt.pad.p5 = new_pad;
         this.ctx.request_render();
     }
+    /// Replace the options of label at →p6
     pub fn set_pad6(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
         this.widget.opt.pad.p6 = new_pad;
         this.ctx.request_render();
     }
+    /// Replace the options of label at ↙p7
     pub fn set_pad7(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
         this.widget.opt.pad.p7 = new_pad;
         this.ctx.request_render();
     }
+    /// Replace the options of label at ↓p8
     pub fn set_pad8(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
         this.widget.opt.pad.p8 = new_pad;
         this.ctx.request_render();
     }
+    /// Replace the options of label at ↘p9
     pub fn set_pad9(this: &mut WidgetMut<'_, Self>, new_pad: Option<Insets>) {
         this.widget.opt.pad.p9 = new_pad;
         this.ctx.request_render();
     }
 
-    /// Get mutable label helpers
+    /// Get mutable label at •p5
     pub fn label_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
         this.ctx.get_mut(&mut this.widget.label.p5)
     }
+    /// Get mutable label at ↖p1
     pub fn label1_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
         this.ctx.get_mut(&mut this.widget.label.p1)
     }
+    /// Get mutable label at ↑p2
     pub fn label2_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
         this.ctx.get_mut(&mut this.widget.label.p2)
     }
+    /// Get mutable label at ↗p3
     pub fn label3_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
         this.ctx.get_mut(&mut this.widget.label.p3)
     }
+    /// Get mutable label at ←p4
     pub fn label4_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
         this.ctx.get_mut(&mut this.widget.label.p4)
     }
+    /// Get mutable label at •p5
     pub fn label5_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
         this.ctx.get_mut(&mut this.widget.label.p5)
     }
+    /// Get mutable label at →p6
     pub fn label6_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
         this.ctx.get_mut(&mut this.widget.label.p6)
     }
+    /// Get mutable label at ↙p7
     pub fn label7_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
         this.ctx.get_mut(&mut this.widget.label.p7)
     }
+    /// Get mutable label at ↓p8
     pub fn label8_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
         this.ctx.get_mut(&mut this.widget.label.p8)
     }
+    /// Get mutable label at ↘p9
     pub fn label9_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
         this.ctx.get_mut(&mut this.widget.label.p9)
     }

--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -19,22 +19,8 @@ use crate::util::{fill_lin_gradient, stroke, UnitPoint};
 use crate::widgets::Label;
 
 /// The minimum padding added to a button. NOTE: these values are chosen to match the existing look of TextBox; these should be reevaluated at some point.
-pub const pad_def: Insets = Insets::uniform_xy(8., 2.);
+pub const PAD_DEF: Insets = Insets::uniform_xy(8., 2.);
 
-/// IDs for all the 9 possible label positions in a button from top left to bottom right.<br>
-  /// Letter corresponds to a visual mnemonic of its horizontal/vertical line position
-  /// ⎺	T top   	⎸ L left
-  /// -	H middle	| I middle
-  /// _	L low   	⎹ J right
-  /// ⎺T -H _L  top/middle/low
-  /// ↖  ↑  ↗
-  /// ←  •  →
-  /// ↙  ↓  ↘
-pub enum LPos {
-  tl1 = 1, ti2 = 2, tj3 = 3,
-  hl4 = 4, hi5 = 5, hj6 = 6,
-  ll7 = 7, li8 = 8, lj9 = 9,
-}
 /// A button with up to 9 text Labels (allowing for custom styles) with custom padding
 /// (allowing for flexible positioning).
 pub struct Button9 {
@@ -43,7 +29,15 @@ pub struct Button9 {
   /// Options for those widgets or the button as a whole (only padding is implemented)
   opt  : LabelOpt,
 }
-/// Label widgets for Button9
+/// Label widgets for Button9 for all the 9 possible label positions in a button from top left to bottom right.<br>
+  /// Letter in a name corresponds to a visual mnemonic of its horizontal/vertical line position
+  /// ⎺ T top     ⎸ L left
+  /// - H middle  | I middle
+  /// _ L low     ⎹ J right
+  /// ⎺T -H _L  top/middle/low
+  /// ↖  ↑  ↗
+  /// ←  •  →
+  /// ↙  ↓  ↘
 pub struct Label9 {
   tl1:WidgetPod<Label>, ti2:WidgetPod<Label>, tj3:WidgetPod<Label>, // ↖  ↑  ↗
   hl4:WidgetPod<Label>, hi5:WidgetPod<Label>, hj6:WidgetPod<Label>, // ←  •  →
@@ -63,13 +57,6 @@ pub struct Pad9 {
   pub hl4:Option<Insets>, pub hi5:Option<Insets>, pub hj6:Option<Insets>, // ←  •  →
   pub ll7:Option<Insets>, pub li8:Option<Insets>, pub lj9:Option<Insets>, // ↙  ↓  ↘
 }
-// /// Track whether a label exists, useful for layout constraint calculations
-// #[derive(Default, Debug, Copy, Clone, PartialEq)]
-// pub struct Is9 {
-//   pub tl1:bool, pub ti2:bool, pub tj3:bool, // ↖  ↑  ↗
-//   pub hl4:bool, pub hi5:bool, pub hj6:bool, // ←  •  →
-//   pub ll7:bool, pub li8:bool, pub lj9:bool, // ↙  ↓  ↘
-// }
 
 // --- MARK: BUILDERS ---
 impl Button9 {
@@ -120,19 +107,6 @@ impl Button9 {
   pub fn add7(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.ll7 = WidgetPod::new(label); self.opt.pad.ll7 = pad; self}
   pub fn add8(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.li8 = WidgetPod::new(label); self.opt.pad.li8 = pad; self}
   pub fn add9(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.lj9 = WidgetPod::new(label); self.opt.pad.lj9 = pad; self}
-  // pub fn add (mut self,         label:Label, pad:Option<Insets>) {self.addx(LPos::hi5,label,pad)}
-  /// Helper .method for adding a label to a given position (same as in [`LPos`])
-  pub fn addx(mut self,idx:LPos,label:Label, pad:Option<Insets>) -> Self {match idx {
-    LPos::tl1 => {self.label.tl1 = WidgetPod::new(label); self.opt.pad.tl1 = pad}, //↖
-    LPos::ti2 => {self.label.ti2 = WidgetPod::new(label); self.opt.pad.ti2 = pad}, //↑
-    LPos::tj3 => {self.label.tj3 = WidgetPod::new(label); self.opt.pad.tj3 = pad}, //↗
-    LPos::hl4 => {self.label.hl4 = WidgetPod::new(label); self.opt.pad.hl4 = pad}, //←
-    LPos::hi5 => {self.label.hi5 = WidgetPod::new(label); self.opt.pad.hi5 = pad}, //•
-    LPos::hj6 => {self.label.hj6 = WidgetPod::new(label); self.opt.pad.hj6 = pad}, //→
-    LPos::ll7 => {self.label.ll7 = WidgetPod::new(label); self.opt.pad.ll7 = pad}, //↙
-    LPos::li8 => {self.label.li8 = WidgetPod::new(label); self.opt.pad.li8 = pad}, //↓
-    LPos::lj9 => {self.label.lj9 = WidgetPod::new(label); self.opt.pad.lj9 = pad}, //↘
-  } self }
   /// Create a new button with the provided [`Label9`]s and their [`Pad9`] with predetermined IDs. This constructor is useful for toolkits which use Masonry (such as Xilem).
   pub fn from_label_pod(label_l:[WidgetPod<Label>;9], pad:Pad9) -> Self {
     let [l1,l2,l3,l4,l5,l6,l7,l8,l9] = label_l;
@@ -167,11 +141,6 @@ impl Button9 {
   pub fn set_text7(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label7_mut(this), new_text);}
   pub fn set_text8(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label8_mut(this), new_text);}
   pub fn set_text9(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label9_mut(this), new_text);}
-  // pub fn set_text (this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label_mutx(this,LPos::hi5), new_text);}
-  /// Set label text for a given position
-  pub fn set_textx(this:&mut WidgetMut<'_,Self>, idx:LPos, new_text: impl Into<ArcStr>) {
-    Label::set_text(&mut Self::labelx_mut(this, idx), new_text);
-  }
 
   /// Set label options helpers
   pub fn set_opt <'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hi5 = new_pad; this.ctx.request_render();}
@@ -281,7 +250,7 @@ impl Widget for Button9 {
     let mut lsz  : [Size  ;10] = [Size::ZERO  ;10];
     let mut lpad : [Insets;10] = [Insets::ZERO;10];
     for (i, (lbl9, pad9)) in lbl_pad9.iter_mut().enumerate() {
-      let pad       = match pad9 {Some(inset)=>*inset, None=>pad_def,};
+      let pad       = match pad9 {Some(inset)=>*inset, None=>PAD_DEF,};
       let pad_sz    = Size::new(pad.x_value(), pad.y_value());
       let lbl_bc    = bc.shrink(pad_sz).loosen();
       let lbl_sz    = ctx.run_layout(lbl9, &lbl_bc);

--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -1,0 +1,392 @@
+// Copyright 2025 the Xilem Authors and the Druid Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! A button widget with up to 9 labels.
+
+use accesskit::{Node, Role};
+use smallvec::{smallvec, SmallVec};
+use tracing::{trace, debug, trace_span, Span};
+use vello::Scene;
+
+use masonry::core::{
+  AccessCtx, AccessEvent, Action, ArcStr, BoxConstraints, EventCtx, LayoutCtx, PaintCtx,
+  PointerButton, PointerEvent, QueryCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
+  WidgetMut, WidgetPod,
+};
+use masonry::kurbo::{Insets, Size, Point, Vec2};
+use masonry::theme;
+use masonry::util::{fill_lin_gradient, stroke, UnitPoint};
+use masonry::widgets::Label;
+
+/// The minimum padding added to a button. NOTE: these values are chosen to match the existing look of TextBox; these should be reevaluated at some point.
+pub const pad_def: Insets = Insets::uniform_xy(8., 2.);
+
+/// IDs for all the 9 possible label positions in a button from top left to bottom right.<br>
+  /// Letter corresponds to a visual mnemonic of its horizontal/vertical line position
+  /// ⎺	T top   	⎸ L left
+  /// -	H middle	| I middle
+  /// _	L low   	⎹ J right
+  /// ⎺T -H _L  top/middle/low
+  /// ↖  ↑  ↗
+  /// ←  •  →
+  /// ↙  ↓  ↘
+pub enum LPos {
+  TL1 = 1, TI2 = 2, TJ3 = 3,
+  HL4 = 4, HI5 = 5, HJ6 = 6,
+  LL7 = 7, LI8 = 8, LJ9 = 9,
+}
+/// A button with up to 9 text Labels (allowing for custom styles) with custom padding
+/// (allowing for flexible positioning).
+pub struct Button9 {
+  /// 9 label widgets
+  label: Label9  ,
+  /// Options for those widgets or the button as a whole (only padding is implemented)
+  opt  : LabelOpt,
+}
+/// Label widgets for Button9
+pub struct Label9 {
+  TL1:WidgetPod<Label>, TI2:WidgetPod<Label>, TJ3:WidgetPod<Label>, // ↖  ↑  ↗
+  HL4:WidgetPod<Label>, HI5:WidgetPod<Label>, HJ6:WidgetPod<Label>, // ←  •  →
+  LL7:WidgetPod<Label>, LI8:WidgetPod<Label>, LJ9:WidgetPod<Label>, // ↙  ↓  ↘
+}
+/// Custom button options. Currently only padding is supported.
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
+pub struct LabelOpt {
+  /// Per-label padding.
+  pub pad: Pad9,
+  // pub is : Is9, //
+}
+
+/// Optional padding options per label as [`Insets`]
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
+pub struct Pad9 {
+  pub TL1:Option<Insets>, pub TI2:Option<Insets>, pub TJ3:Option<Insets>, // ↖  ↑  ↗
+  pub HL4:Option<Insets>, pub HI5:Option<Insets>, pub HJ6:Option<Insets>, // ←  •  →
+  pub LL7:Option<Insets>, pub LI8:Option<Insets>, pub LJ9:Option<Insets>, // ↙  ↓  ↘
+}
+// /// Track whether a label exists, useful for layout constraint calculations
+// #[derive(Default, Debug, Copy, Clone, PartialEq)]
+// pub struct Is9 {
+//   pub TL1:bool, pub TI2:bool, pub TJ3:bool, // ↖  ↑  ↗
+//   pub HL4:bool, pub HI5:bool, pub HJ6:bool, // ←  •  →
+//   pub LL7:bool, pub LI8:bool, pub LJ9:bool, // ↙  ↓  ↘
+// }
+
+// --- MARK: BUILDERS ---
+impl Button9 {
+  /// Create a new button with a text label at the center (HI5m other labels are blank, use `.addx` methods to fill them)
+  /// ```
+  /// use masonry::widgets::Button9;
+  /// let button = Button9::new("Increment");
+  /// ```
+  pub fn new(text:impl Into<ArcStr>) -> Self {Self::from_label    (Label::new(text))}
+  /// Create a new button with the provided [`Label`]
+  /// ```
+  /// use masonry::peniko::Color;
+  /// use masonry::widgets::{Button9, Label};
+  /// let label = Label::new("Increment").with_brush(Color::new([0.5, 0.5, 0.5, 1.0]));
+  /// let button = Button9::from_label(label);
+  /// ```
+  pub fn from_label    (label:Label) -> Self {Self::from_label_pad(label, None)}
+  /// Create a new button with the provided [`Label`] and padding [`Insets`]
+  /// ```
+  /// use masonry::peniko::Color;
+  /// use masonry::widgets::{Button9, Label};
+  /// let label  = Label::new("Increment").with_brush(Color::new([0.5, 0.5, 0.5, 1.0]));
+  /// let pad    = Insets::uniform_xy(8., 2.); // pad ←→ by 8 and ↑↓ by 2
+  /// let button = Button9::from_label_pad(label, pad);
+  /// ```
+  pub fn from_label_pad(lbl:Label, pad:Option<Insets>) -> Self {
+    // let is = is9 {
+      // TL1:false, TI2:false                , TJ3:false, // ↖  ↑  ↗
+      // HL4:false, HI5:lbl.text().len() > 0 , HJ6:false, // ←  •  →
+      // LL7:false, LI8:false                , LJ9:false, // ↙  ↓  ↘
+    // };
+    let label = Label9 {
+      TL1:WidgetPod::new(Label::new("")), TI2:WidgetPod::new(Label::new("")), TJ3:WidgetPod::new(Label::new("")), // ↖  ↑  ↗
+      HL4:WidgetPod::new(Label::new("")), HI5:WidgetPod::new(lbl           ), HJ6:WidgetPod::new(Label::new("")), // ←  •  →
+      LL7:WidgetPod::new(Label::new("")), LI8:WidgetPod::new(Label::new("")), LJ9:WidgetPod::new(Label::new("")), // ↙  ↓  ↘
+    };
+    let pad = Pad9 {
+      TL1:None, TI2:None, TJ3:None, // ↖  ↑  ↗
+      HL4:None, HI5:pad , HJ6:None, // ←  •  →
+      LL7:None, LI8:None, LJ9:None, // ↙  ↓  ↘
+    };
+    let opt = LabelOpt{pad}; //, is
+    Self {label, opt}
+  }
+  /// Helper .methods for adding individual labels (add=center HI5)
+  pub fn add (mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.HI5 = WidgetPod::new(label); self.opt.pad.HI5 = pad; self}
+  pub fn add1(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.TL1 = WidgetPod::new(label); self.opt.pad.TL1 = pad; self}
+  pub fn add2(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.TI2 = WidgetPod::new(label); self.opt.pad.TI2 = pad; self}
+  pub fn add3(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.TJ3 = WidgetPod::new(label); self.opt.pad.TJ3 = pad; self}
+  pub fn add4(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.HL4 = WidgetPod::new(label); self.opt.pad.HL4 = pad; self}
+  pub fn add5(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.HI5 = WidgetPod::new(label); self.opt.pad.HI5 = pad; self}
+  pub fn add6(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.HJ6 = WidgetPod::new(label); self.opt.pad.HJ6 = pad; self}
+  pub fn add7(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.LL7 = WidgetPod::new(label); self.opt.pad.LL7 = pad; self}
+  pub fn add8(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.LI8 = WidgetPod::new(label); self.opt.pad.LI8 = pad; self}
+  pub fn add9(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.LJ9 = WidgetPod::new(label); self.opt.pad.LJ9 = pad; self}
+  // pub fn add (mut self,         label:Label, pad:Option<Insets>) {self.addx(LPos::HI5,label,pad)}
+  /// Helper .method for adding a label to a given position (same as in [`LPos`])
+  pub fn addx(mut self,idx:LPos,label:Label, pad:Option<Insets>) -> Self {match idx {
+    LPos::TL1 => {self.label.TL1 = WidgetPod::new(label); self.opt.pad.TL1 = pad}, //↖
+    LPos::TI2 => {self.label.TI2 = WidgetPod::new(label); self.opt.pad.TI2 = pad}, //↑
+    LPos::TJ3 => {self.label.TJ3 = WidgetPod::new(label); self.opt.pad.TJ3 = pad}, //↗
+    LPos::HL4 => {self.label.HL4 = WidgetPod::new(label); self.opt.pad.HL4 = pad}, //←
+    LPos::HI5 => {self.label.HI5 = WidgetPod::new(label); self.opt.pad.HI5 = pad}, //•
+    LPos::HJ6 => {self.label.HJ6 = WidgetPod::new(label); self.opt.pad.HJ6 = pad}, //→
+    LPos::LL7 => {self.label.LL7 = WidgetPod::new(label); self.opt.pad.LL7 = pad}, //↙
+    LPos::LI8 => {self.label.LI8 = WidgetPod::new(label); self.opt.pad.LI8 = pad}, //↓
+    LPos::LJ9 => {self.label.LJ9 = WidgetPod::new(label); self.opt.pad.LJ9 = pad}, //↘
+  } self }
+  /// Create a new button with the provided [`Label9`]s and their [`Pad9`] with predetermined IDs. This constructor is useful for toolkits which use Masonry (such as Xilem).
+  pub fn from_label_pod(label_l:[WidgetPod<Label>;9], pad:Pad9) -> Self { //, is:is9
+    let [l1,l2,l3,l4,l5,l6,l7,l8,l9] = label_l;
+    let label = Label9 { //numbering shifted due to 0-based array index
+      TL1:l1, TI2:l2, TJ3:l3, // ↖  ↑  ↗
+      HL4:l4, HI5:l5, HJ6:l8, // ←  •  →
+      LL7:l7, LI8:l6, LJ9:l9, // ↙  ↓  ↘
+    };
+    let opt = LabelOpt{pad}; //, is
+    Self {label, opt}
+  }
+}
+
+// Helper indices for the Label9 positions (0-based unlike .Prop or fn() names!)
+const row_top: [usize;3] = [0,1,2]; //↖ ↑ ↗
+const row_mid: [usize;3] = [3,4,5]; //← • →
+const row_bot: [usize;3] = [6,7,8]; //↙ ↓ ↘
+const col_lhs: [usize;3] = [0,1,2]; //↖ ← ↙
+const col_cnt: [usize;3] = [3,4,5]; //↑ • ↓
+const col_rhs: [usize;3] = [6,7,8]; //↗ → ↘
+
+// --- MARK: WIDGETMUT ---
+impl Button9 {
+  /// Set text helpers
+  pub fn set_text (this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label_mut (this), new_text);}
+  pub fn set_text1(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label1_mut(this), new_text);}
+  pub fn set_text2(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label2_mut(this), new_text);}
+  pub fn set_text3(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label3_mut(this), new_text);}
+  pub fn set_text4(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label4_mut(this), new_text);}
+  pub fn set_text5(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label5_mut(this), new_text);}
+  pub fn set_text6(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label6_mut(this), new_text);}
+  pub fn set_text7(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label7_mut(this), new_text);}
+  pub fn set_text8(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label8_mut(this), new_text);}
+  pub fn set_text9(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label9_mut(this), new_text);}
+  // pub fn set_text (this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label_mutx(this,LPos::HI5), new_text);}
+  /// Set label text for a given position
+  pub fn set_textx(this:&mut WidgetMut<'_,Self>, idx:LPos, new_text: impl Into<ArcStr>) {
+    Label::set_text(&mut Self::labelx_mut(this, idx), new_text);
+  }
+
+  /// Set label options helpers
+  pub fn set_opt <'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.HI5 = new_pad; this.ctx.request_render();}
+  pub fn set_pad1<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.TL1 = new_pad; this.ctx.request_render();}
+  pub fn set_pad2<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.TI2 = new_pad; this.ctx.request_render();}
+  pub fn set_pad3<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.TJ3 = new_pad; this.ctx.request_render();}
+  pub fn set_pad4<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.HL4 = new_pad; this.ctx.request_render();}
+  pub fn set_pad5<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.HI5 = new_pad; this.ctx.request_render();}
+  pub fn set_pad6<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.HJ6 = new_pad; this.ctx.request_render();}
+  pub fn set_pad7<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.LL7 = new_pad; this.ctx.request_render();}
+  pub fn set_pad8<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.LI8 = new_pad; this.ctx.request_render();}
+  pub fn set_pad9<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.LJ9 = new_pad; this.ctx.request_render();}
+  // pub fn set_opt  <'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.set_optx(LPos::HI5, new_opt);}
+  /// Set the label options for a given position
+  pub fn set_padx(this: &mut WidgetMut<'_,Self>, idx:LPos, new_pad:Option<Insets>) {match idx {
+    LPos::TL1 => {this.widget.opt.pad.TL1 = new_pad}, //↖
+    LPos::TI2 => {this.widget.opt.pad.TI2 = new_pad}, //↑
+    LPos::TJ3 => {this.widget.opt.pad.TJ3 = new_pad}, //↗
+    LPos::HL4 => {this.widget.opt.pad.HL4 = new_pad}, //←
+    LPos::HI5 => {this.widget.opt.pad.HI5 = new_pad}, //•
+    LPos::HJ6 => {this.widget.opt.pad.HJ6 = new_pad}, //→
+    LPos::LL7 => {this.widget.opt.pad.LL7 = new_pad}, //↙
+    LPos::LI8 => {this.widget.opt.pad.LI8 = new_pad}, //↓
+    LPos::LJ9 => {this.widget.opt.pad.LJ9 = new_pad}, //↘
+    }
+    this.ctx.request_render(); // label options state impacts appearance and accessibility node
+  }
+
+  /// Get mutable label helpers
+  pub fn label_mut <'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.HI5)}
+  pub fn label1_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.TL1)}
+  pub fn label2_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.TI2)}
+  pub fn label3_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.TJ3)}
+  pub fn label4_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.HL4)}
+  pub fn label5_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.HI5)}
+  pub fn label6_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.HJ6)}
+  pub fn label7_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.LL7)}
+  pub fn label8_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.LI8)}
+  pub fn label9_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.LJ9)}
+  // pub fn label_mut <'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.labelx_mut(LPos::HI5)}
+  /// Get mutable label for a given position
+  pub fn labelx_mut<'t>(this: &'t mut WidgetMut<'_,Self>, idx:LPos) -> WidgetMut<'t, Label> {match idx {
+    LPos::TL1 => {return this.ctx.get_mut(&mut this.widget.label.TL1)}, //↖
+    LPos::TI2 => {return this.ctx.get_mut(&mut this.widget.label.TI2)}, //↑
+    LPos::TJ3 => {return this.ctx.get_mut(&mut this.widget.label.TJ3)}, //↗
+    LPos::HL4 => {return this.ctx.get_mut(&mut this.widget.label.HL4)}, //←
+    LPos::HI5 => {return this.ctx.get_mut(&mut this.widget.label.HI5)}, //•
+    LPos::HJ6 => {return this.ctx.get_mut(&mut this.widget.label.HJ6)}, //→
+    LPos::LL7 => {return this.ctx.get_mut(&mut this.widget.label.LL7)}, //↙
+    LPos::LI8 => {return this.ctx.get_mut(&mut this.widget.label.LI8)}, //↓
+    LPos::LJ9 => {return this.ctx.get_mut(&mut this.widget.label.LJ9)}, //↘
+  }}
+}
+
+// --- MARK: IMPL WIDGET ---
+impl Widget for Button9 {
+  fn on_pointer_event(&mut self, ctx: &mut EventCtx, event: &PointerEvent) {
+    match event {
+      PointerEvent::PointerDown(_, _) => {
+        if !ctx.is_disabled() {ctx.capture_pointer(); ctx.request_paint_only(); // Changes in pointer capture impact appearance, but not accessibility node
+          trace!("Button9 {:?} pressed", ctx.widget_id());}
+      }
+      PointerEvent::PointerUp(button, _) => {
+        if ctx.is_pointer_capture_target() && ctx.is_hovered() && !ctx.is_disabled() {
+          ctx.submit_action(Action::ButtonPressed(*button));
+          trace!("Button9 {:?} released", ctx.widget_id());}
+        ctx.request_paint_only(); // Changes in pointer capture impact appearance, but not accessibility node
+      }
+      _ => (),
+    }
+  }
+
+  fn on_text_event  (&mut self, _ctx: &mut EventCtx, _event: &TextEvent) {}
+
+  fn on_access_event(&mut self,  ctx: &mut EventCtx,  event: &AccessEvent) {
+    if ctx.target() == ctx.widget_id() { match event.action {
+      accesskit::Action::Click  => {ctx.submit_action(Action::ButtonPressed(PointerButton::Primary));}
+      _                         => {} }  }   }
+
+  fn update(&mut self, ctx: &mut UpdateCtx, event: &Update) { match event {
+     Update::HoveredChanged (_)
+    |Update::FocusChanged   (_)
+    |Update::DisabledChanged(_) => {ctx.request_paint_only();}
+    _                           => {}  }   }
+
+  fn register_children(&mut self, ctx: &mut masonry::core::RegisterCtx) {
+    ctx.register_child(&mut self.label.TL1);ctx.register_child(&mut self.label.TI2);ctx.register_child(&mut self.label.TJ3); // ↖  ↑  ↗
+    ctx.register_child(&mut self.label.HL4);ctx.register_child(&mut self.label.HI5);ctx.register_child(&mut self.label.HJ6); // ←  •  →
+    ctx.register_child(&mut self.label.LL7);ctx.register_child(&mut self.label.LI8);ctx.register_child(&mut self.label.LJ9); // ↙  ↓  ↘
+  }
+  fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size {
+    let min_height = theme::BORDERED_WIDGET_HEIGHT; // HACK: to make sure we look okay at default sizes when beside a textbox, we make sure we will have at least the same height as the default textbox.
+    let mut lbl_pad9 = [
+      (&mut self.label.TL1, self.opt.pad.TL1),
+      (&mut self.label.TI2, self.opt.pad.TI2),
+      (&mut self.label.TJ3, self.opt.pad.TJ3),
+      (&mut self.label.HL4, self.opt.pad.HL4),
+      (&mut self.label.HI5, self.opt.pad.HI5),
+      (&mut self.label.HJ6, self.opt.pad.HJ6),
+      (&mut self.label.LL7, self.opt.pad.LL7),
+      (&mut self.label.LI8, self.opt.pad.LI8),
+      (&mut self.label.LJ9, self.opt.pad.LJ9),
+      ];
+
+    let mut row_w: [f64 ;3] = [0.   ;3]; //top /middle/bottom ↖↑↗  ←•→  ↙↓↘
+    let mut col_h: [f64 ;3] = [0.   ;3]; //left/center/right  ↖←↙  ↑•↓  ↗→↘
+    // let mut is   : [bool;9] = [false;9];
+    let mut lsz  : [Size  ;10] = [Size::ZERO  ;10];
+    let mut lpad : [Insets;10] = [Insets::ZERO;10];
+    // let mut valid = vec!();
+    for (i, (lbl9, pad9)) in lbl_pad9.iter_mut().enumerate() {
+      // let is_txt = ctx.get_raw_ref(lbl9).widget().text().len() > 0;
+      // is[i] = is_txt;
+      // if is_txt || i == 4 { //todo only calc/place valid labels,
+        // but then update register_children + children_ids
+        // and call children_changed when set_txt sets what was an empty label
+      let pad       = match pad9 {Some(inset)=>*inset, None=>pad_def,};
+      let pad_sz    = Size::new(pad.x_value(), pad.y_value());
+      let lbl_bc    = bc.shrink(pad_sz).loosen();
+      let lbl_sz    = ctx.run_layout(lbl9, &lbl_bc);
+      if cfg!(debug_assertions) {let txt = ctx.get_raw_ref(lbl9).widget().text().clone();
+        trace!("{} {} set layout l_sz = {} l_bc={:?} pad_sz={} txt={}", i+1, ctx.widget_id(),lbl_sz,lbl_bc,pad_sz,txt);}
+      if i == 4 { // set baseline off the central label only?
+        let baseline = ctx.child_baseline_offset(&lbl9);
+        ctx.set_baseline_offset(baseline + pad.y1);
+      }
+      if row_top.iter().any(|x| x == &i) {row_w[0] += lbl_sz.width  + pad_sz.width ;}
+      if row_mid.iter().any(|x| x == &i) {row_w[1] += lbl_sz.width  + pad_sz.width ;}
+      if row_bot.iter().any(|x| x == &i) {row_w[2] += lbl_sz.width  + pad_sz.width ;}
+      if col_lhs.iter().any(|x| x == &i) {col_h[0] += lbl_sz.height + pad_sz.height;}
+      if col_cnt.iter().any(|x| x == &i) {col_h[1] += lbl_sz.height + pad_sz.height;}
+      if col_rhs.iter().any(|x| x == &i) {col_h[2] += lbl_sz.height + pad_sz.height;}
+      lsz[i+1] = lbl_sz; // store size for later offset calculations (after button size is known)
+      lpad[i+1] = pad;
+      // valid.push((i, lbl9));
+      // }
+    }
+    let max_w = row_w[0].max(row_w[1]).max(row_w[2]);
+    let max_h = col_h[0].max(col_h[1]).max(col_h[2]).max(min_height);
+    let button_size = bc.constrain(Size::new(max_w, max_h));
+
+    // for (i, lbl9) in valid { // for (i, (lbl9, pad9)) in lbl_pad9.iter_mut().enumerate() {
+    let bw = button_size.width; let bh = button_size.height; // ↖0,0 (w1-w2)/2=middle@x; (h1-h2)/2=center@y
+    let lbl1_offset = Vec2::new( 0.                     + lpad[1].x0    , 0.                      + lpad[1].y0  );
+    let lbl2_offset = Vec2::new((bw - lsz[2].width)/2.0                 , 0.                      + lpad[2].y0  );
+    let lbl3_offset = Vec2::new( bw - lsz[3].width      - lpad[3].x1    , 0.                      + lpad[3].y0  );
+    let lbl4_offset = Vec2::new( 0.                     + lpad[4].x0    ,(bh - lsz[4].height)/2.0               );
+    let lbl5_offset =(button_size.to_vec2() - lsz[5].to_vec2())/2.0                                              ;
+    let lbl6_offset = Vec2::new( bw - lsz[6].width      - lpad[6].x1    ,(bh - lsz[6].height)/2.0               );
+    let lbl7_offset = Vec2::new( 0.                     + lpad[7].x0    , bh - lsz[7].height     - lpad[7].y1   );
+    let lbl8_offset = Vec2::new((bw - lsz[8].width)/2.0                 , bh - lsz[8].height     - lpad[8].y1   );
+    let lbl9_offset = Vec2::new( bw - lsz[9].width      - lpad[9].x1    , bh - lsz[9].height     - lpad[9].y1   ); // button_size.to_vec2() - lsz[3].to_vec2()
+    if cfg!(debug_assertions) {
+      trace!("button_size = {button_size:?} max_w={max_w} max_h={max_h} row_w={row_w:?} col_h={col_h:?}");
+      trace!("↖ lbl1 🆔{} offset {}", ctx.widget_id(), lbl1_offset); trace!("↑ lbl2 🆔{} offset {}", ctx.widget_id(), lbl2_offset); trace!("↗ lbl3 🆔{} offset {}", ctx.widget_id(), lbl3_offset);
+      trace!("← lbl4 🆔{} offset {}", ctx.widget_id(), lbl4_offset); trace!("• lbl5 🆔{} offset {}", ctx.widget_id(), lbl5_offset); trace!("→ lbl6 🆔{} offset {}", ctx.widget_id(), lbl6_offset);
+      trace!("↙ lbl7 🆔{} offset {}", ctx.widget_id(), lbl7_offset); trace!("↓ lbl8 🆔{} offset {}", ctx.widget_id(), lbl8_offset); trace!("↘ lbl9 🆔{} offset {}", ctx.widget_id(), lbl9_offset);
+    }
+
+    ctx.place_child(&mut self.label.TL1, lbl1_offset.to_point()); ctx.place_child(&mut self.label.TI2, lbl2_offset.to_point()); ctx.place_child(&mut self.label.TJ3, lbl3_offset.to_point());
+    ctx.place_child(&mut self.label.HL4, lbl4_offset.to_point()); ctx.place_child(&mut self.label.HI5, lbl5_offset.to_point()); ctx.place_child(&mut self.label.HJ6, lbl6_offset.to_point());
+    ctx.place_child(&mut self.label.LL7, lbl7_offset.to_point()); ctx.place_child(&mut self.label.LI8, lbl8_offset.to_point()); ctx.place_child(&mut self.label.LJ9, lbl9_offset.to_point());
+    // }
+    button_size
+  }
+
+  fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
+    let is_active = ctx.is_pointer_capture_target() && !ctx.is_disabled();
+    let is_hovered = ctx.is_hovered();
+    let size = ctx.size();
+    let stroke_width = theme::BUTTON_BORDER_WIDTH;
+
+    let rounded_rect = size
+      .to_rect()
+      .inset(-stroke_width / 2.0)
+      .to_rounded_rect(theme::BUTTON_BORDER_RADIUS);
+
+    let bg_gradient = if ctx.is_disabled()                  {[theme::DISABLED_BUTTON_LIGHT, theme::DISABLED_BUTTON_DARK]
+    } else if is_active                                     {[theme::BUTTON_DARK          , theme::BUTTON_LIGHT]
+    } else                                                  {[theme::BUTTON_LIGHT         , theme::BUTTON_DARK]};
+    let border_color = if is_hovered && !ctx.is_disabled()  { theme::BORDER_LIGHT
+    } else                                                  { theme::BORDER_DARK};
+
+    stroke           (scene, &rounded_rect, border_color, stroke_width);
+    fill_lin_gradient(scene, &rounded_rect, bg_gradient, UnitPoint::TOP,UnitPoint::BOTTOM,);
+  }
+
+  fn accessibility_role(&self) -> Role {Role::Button}
+  fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut Node) { // IMPORTANT: We don't want to merge this code in practice, because the child label already has a 'name' property. This is more of a proof of concept of `get_raw_ref()`.
+    if false {
+      let label = ctx.get_raw_ref(&self.label.HI5);
+      let name  = label.widget().text().as_ref().to_string();
+      node.set_value(name);
+    }
+    node.add_action(accesskit::Action::Click);
+  }
+
+  fn children_ids   (&self                    ) -> SmallVec<[WidgetId; 16]> {smallvec![
+    self.label.TL1.id(),self.label.TI2.id(),self.label.TJ3.id(), // ↖  ↑  ↗
+    self.label.HL4.id(),self.label.HI5.id(),self.label.HJ6.id(), // ←  •  →
+    self.label.LL7.id(),self.label.LI8.id(),self.label.LJ9.id(), // ↙  ↓  ↘
+  ]}
+  fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {trace_span!("Button9", id = ctx.widget_id().trace())}
+}
+
+// --- MARK: TESTS ---
+// #[cfg(test)] mod button9_test; //TODO
+
+// TODO:
+  // how to adjust `accessibility` for all 9 labels?
+  // add tests
+  // reformat docs

--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -19,7 +19,7 @@ use crate::theme;
 use crate::util::{fill_lin_gradient, stroke, UnitPoint};
 use crate::widgets::Label;
 
-/// The minimum padding added to a button. NOTE: these values are chosen to match the existing look of TextBox; these should be reevaluated at some point.
+/// The minimum padding added to a button. NOTE: these values are chosen to match the existing look of `TextBox`; these should be reevaluated at some point.
 pub const PAD_DEF: Insets = Insets::uniform_xy(8., 2.);
 
 /// A button with up to 9 text [`Label`]s (allowing for custom styles) with custom [`Pad9`]ing
@@ -432,7 +432,7 @@ impl Widget for Button9 {
             }
             if i == 4 {
                 // set baseline off the central label only?
-                let baseline = ctx.child_baseline_offset(&lbl9);
+                let baseline = ctx.child_baseline_offset(lbl9);
                 ctx.set_baseline_offset(baseline + pad.y1);
             }
             lsz[i + 1] = lbl_sz; // store size for later button size/offset calculations
@@ -440,51 +440,45 @@ impl Widget for Button9 {
         }
         let mut row_w: [f64; 3] = [0.; 3]; //top /middle/bottom ↖↑↗  ←•→  ↙↓↘
         let mut col_h: [f64; 3] = [0.; 3]; //left/center/right  ↖←↙  ↑•↓  ↗→↘
-        // empty buttons have a width of 4, not 0, though it doesn't affect anything?
-        //row Width = double max of (‹half width, half› width) since 2nd label will be at the middle even if only 2 labels exist and would otherwise fully fit in a button (with the 2nd label touching the right side), so need split the 2nd label in half and do the max width calculations separately, then pick the worst
-        //↖↑↗ W    2          max( pad left← +  ‹btn› width +      max  pad     →  between  ← buttons
-        row_w[0] = 2.0 * f64::max(lpad[1].x0 + lsz[1].width + f64::max(lpad[1].x1, lpad[2].x0) +
-                                         0.5 * lsz[2].width
-            ,//                           ½     •btn  width
-                                         0.5 * lsz[2].width + f64::max(lpad[2].x1, lpad[3].x0) +
-                                               lsz[3].width +
-                                  lpad[3].x1);//pad →right
-        //←•→ W    2          max( pad left← +  ‹btn› width +      max  pad     →  between  ← buttons
-        row_w[1] = 2.0 * f64::max(lpad[4].x0 + lsz[4].width + f64::max(lpad[4].x1, lpad[5].x0) +
-                                         0.5 * lsz[5].width
-            ,//                           ½     •btn  width
-                                         0.5 * lsz[5].width + f64::max(lpad[5].x1, lpad[6].x0) +
-                                               lsz[6].width +
-                                  lpad[6].x1);//pad →right
-        //↙↓↘ W    2          max( pad left← +  ‹btn› width +      max  pad     →  between  ← buttons
-        row_w[2] = 2.0 * f64::max(lpad[7].x0 + lsz[7].width + f64::max(lpad[7].x1, lpad[8].x0) +
-                                         0.5 * lsz[8].width
-            ,//                           ½     •btn  width
-                                         0.5 * lsz[8].width + f64::max(lpad[8].x1, lpad[9].x0) +
-                                               lsz[9].width +
-                                  lpad[6].x1);//pad →right
-        //col Height = double max of (‹half height, half› height) since 2nd label will be at the center even if only 2 labels exist and would otherwise fully fit in a button (with the 2nd label touching the bottom side), so need split the 2nd label in half and do the max width calculations separately, then pick the worst
-        //↖←↙ H    2          max( pad top↑  +  ‹btn› height +      max  pad     →  between  ← buttons
-        col_h[0] = 2.0 * f64::max(lpad[1].y0 + lsz[1].height + f64::max(lpad[1].y1, lpad[4].y0) +
-                                         0.5 * lsz[4].height
-            ,//                           ½     •btn  height
-                                         0.5 * lsz[4].height + f64::max(lpad[4].y1, lpad[7].y0) +
-                                               lsz[7].height +
-                                  lpad[7].y1);//pad →right
-        //↑•↓ H    2          max( pad top↑  +  ‹btn› height +      max  pad     →  between  ← buttons
-        col_h[1] = 2.0 * f64::max(lpad[2].y0 + lsz[2].height + f64::max(lpad[2].y1, lpad[5].y0) +
-                                         0.5 * lsz[5].height
-            ,//                           ½     •btn  height
-                                         0.5 * lsz[5].height + f64::max(lpad[5].y1, lpad[2].y0) +
-                                               lsz[2].height +
-                                  lpad[2].y1);//pad →right
-        //↗→↘ H    2          max( pad top↑  +  ‹btn› height +      max  pad     →  between  ← buttons
-        col_h[2] = 2.0 * f64::max(lpad[3].y0 + lsz[3].height + f64::max(lpad[3].y1, lpad[6].y0) +
-                                         0.5 * lsz[6].height
-            ,//                           ½     •btn  height
-                                         0.5 * lsz[6].height + f64::max(lpad[6].y1, lpad[9].y0) +
-                                               lsz[9].height +
-                                  lpad[9].y1);//pad →right
+                                           // empty buttons have a width of 4, not 0, though it doesn't affect anything?
+                                           //row Width = double max of (‹half width, half› width) since 2nd label will be at the middle even if only 2 labels exist and would otherwise fully fit in a button (with the 2nd label touching the right side), so need split the 2nd label in half and do the max width calculations separately, then pick the worst
+                                           //↖↑↗ W    2          max( pad left← +  ‹btn› width +      max  pad     →  between  ← buttons
+        row_w[0] = 2.0
+            * f64::max(
+                lpad[1].x0 + lsz[1].width + f64::max(lpad[1].x1, lpad[2].x0) + 0.5 * lsz[2].width, //                           ½     •btn  width
+                0.5 * lsz[2].width + f64::max(lpad[2].x1, lpad[3].x0) + lsz[3].width + lpad[3].x1,
+            ); //pad →right
+               //←•→ W    2          max( pad left← +  ‹btn› width +      max  pad     →  between  ← buttons
+        row_w[1] = 2.0
+            * f64::max(
+                lpad[4].x0 + lsz[4].width + f64::max(lpad[4].x1, lpad[5].x0) + 0.5 * lsz[5].width, //                           ½     •btn  width
+                0.5 * lsz[5].width + f64::max(lpad[5].x1, lpad[6].x0) + lsz[6].width + lpad[6].x1,
+            ); //pad →right
+               //↙↓↘ W    2          max( pad left← +  ‹btn› width +      max  pad     →  between  ← buttons
+        row_w[2] = 2.0
+            * f64::max(
+                lpad[7].x0 + lsz[7].width + f64::max(lpad[7].x1, lpad[8].x0) + 0.5 * lsz[8].width, //                           ½     •btn  width
+                0.5 * lsz[8].width + f64::max(lpad[8].x1, lpad[9].x0) + lsz[9].width + lpad[6].x1,
+            ); //pad →right
+               //col Height = double max of (‹half height, half› height) since 2nd label will be at the center even if only 2 labels exist and would otherwise fully fit in a button (with the 2nd label touching the bottom side), so need split the 2nd label in half and do the max width calculations separately, then pick the worst
+               //↖←↙ H    2          max( pad top↑  +  ‹btn› height +      max  pad     →  between  ← buttons
+        col_h[0] = 2.0
+            * f64::max(
+                lpad[1].y0 + lsz[1].height + f64::max(lpad[1].y1, lpad[4].y0) + 0.5 * lsz[4].height, //                           ½     •btn  height
+                0.5 * lsz[4].height + f64::max(lpad[4].y1, lpad[7].y0) + lsz[7].height + lpad[7].y1,
+            ); //pad →right
+               //↑•↓ H    2          max( pad top↑  +  ‹btn› height +      max  pad     →  between  ← buttons
+        col_h[1] = 2.0
+            * f64::max(
+                lpad[2].y0 + lsz[2].height + f64::max(lpad[2].y1, lpad[5].y0) + 0.5 * lsz[5].height, //                           ½     •btn  height
+                0.5 * lsz[5].height + f64::max(lpad[5].y1, lpad[2].y0) + lsz[2].height + lpad[2].y1,
+            ); //pad →right
+               //↗→↘ H    2          max( pad top↑  +  ‹btn› height +      max  pad     →  between  ← buttons
+        col_h[2] = 2.0
+            * f64::max(
+                lpad[3].y0 + lsz[3].height + f64::max(lpad[3].y1, lpad[6].y0) + 0.5 * lsz[6].height, //                           ½     •btn  height
+                0.5 * lsz[6].height + f64::max(lpad[6].y1, lpad[9].y0) + lsz[9].height + lpad[9].y1,
+            ); //pad →right
         let max_w = row_w[0].max(row_w[1]).max(row_w[2]);
         let max_h = col_h[0].max(col_h[1]).max(col_h[2]).max(min_height);
         let button_size = bc.constrain(Size::new(max_w, max_h));
@@ -510,14 +504,40 @@ impl Widget for Button9 {
             trace!("    2⋅Max½        ▫■▫      ▫▪¦▪▫       ▫■▫            ▣   ▣   ▣ ");
             //eg   "↖↑↗  18    9̣ ≕  1+ 4+ 3̣? 1+ 2¦ 2+ 1? 2̣+ 4+ 0 ≔   8     8   6   6"
             for ri in 0..=2 {
-                let rs = if ri==0{"↖↑↗"} else if ri==1{"←•→"} else if ri==2{"↙↓↘"} else{"???"};
-                let l1=ri*3+1; let l2=ri*3+2; let l3=ri*3+3;
+                let rs = if ri == 0 {
+                    "↖↑↗"
+                } else if ri == 1 {
+                    "←•→"
+                } else if ri == 2 {
+                    "↙↓↘"
+                } else {
+                    "???"
+                };
+                let l1 = ri * 3 + 1;
+                let l2 = ri * 3 + 2;
+                let l3 = ri * 3 + 3;
                 let dim_d = row_w;
-                let row_wh1 = lpad[l1].x0 + lsz[l1].width + f64::max(lpad[l1].x1, lpad[l2].x0) + 0.5 * lsz[l2].width;
-                let row_wh2 =               lsz[l3].width + f64::max(lpad[l2].x1, lpad[l3].x0) + 0.5 * lsz[l2].width;
-                let (mh1,mh2) = if row_wh1 >= row_wh2 {("̣","")} else {("","̣")};
-                let (mp1r,mp2l) = if lpad[l1].x1.ge(&lpad[l2].x0) {("̣","")} else {("","̣")};
-                let (mp2r,mp3l) = if lpad[l2].x1.ge(&lpad[l3].x0) {("̣","")} else {("","̣")};
+                let row_wh1 = lpad[l1].x0
+                    + lsz[l1].width
+                    + f64::max(lpad[l1].x1, lpad[l2].x0)
+                    + 0.5 * lsz[l2].width;
+                let row_wh2 =
+                    lsz[l3].width + f64::max(lpad[l2].x1, lpad[l3].x0) + 0.5 * lsz[l2].width;
+                let (mh1, mh2) = if row_wh1 >= row_wh2 {
+                    ("̣", "")
+                } else {
+                    ("", "̣")
+                };
+                let (mp1r, mp2l) = if lpad[l1].x1.ge(&lpad[l2].x0) {
+                    ("̣", "")
+                } else {
+                    ("", "̣")
+                };
+                let (mp2r, mp3l) = if lpad[l2].x1.ge(&lpad[l3].x0) {
+                    ("̣", "")
+                } else {
+                    ("", "̣")
+                };
                 trace!("{} {: >3}  {: >3}{} ≕ {: >2     }+{: >2        }+{: >2      }{   }?{: >2     }{   }+{: >2   }\
                     ¦{: >2            }+{: >2      }{    }?{: >2      }{    }+{: >2        }+{: >2     } ≔ {: >3}{}   \
                     {: >3} {: >3} {: >3}"
@@ -532,14 +552,40 @@ impl Widget for Button9 {
             trace!("    2⋅Max½        ▫■▫      ▫▪¦▪▫       ▫■▫            ▣   ▣   ▣ ");
             //eg   "↖←↙  18    9̣ ≕  1+ 4+ 3̣? 1+ 2¦ 2+ 1? 2̣+ 4+ 0 ≔   8     8   6   6"
             for ci in 0..=2 {
-                let cs = if ci==0{"↖←↙"} else if ci==1{"↑•↓"} else if ci==2{"↗→↘"} else{"???"};
-                let l1=ci*3+1; let l2=ci*3+2; let l3=ci*3+3;
+                let cs = if ci == 0 {
+                    "↖←↙"
+                } else if ci == 1 {
+                    "↑•↓"
+                } else if ci == 2 {
+                    "↗→↘"
+                } else {
+                    "???"
+                };
+                let l1 = ci * 3 + 1;
+                let l2 = ci * 3 + 2;
+                let l3 = ci * 3 + 3;
                 let dim_d = col_h;
-                let row_hh1 = lpad[l1].y0 + lsz[l1].height + f64::max(lpad[l1].y1, lpad[l2].y0) + 0.5 * lsz[l2].height;
-                let row_hh2 =               lsz[l3].height + f64::max(lpad[l2].y1, lpad[l3].y0) + 0.5 * lsz[l2].height;
-                let (mh1,mh2) = if row_hh1 >= row_hh2 {("̣","")} else {("","̣")};
-                let (mp1b,mp2t) = if lpad[l1].y1.ge(&lpad[l2].y0) {("̣","")} else {("","̣")};
-                let (mp2b,mp3t) = if lpad[l2].y1.ge(&lpad[l3].y0) {("̣","")} else {("","̣")};
+                let row_hh1 = lpad[l1].y0
+                    + lsz[l1].height
+                    + f64::max(lpad[l1].y1, lpad[l2].y0)
+                    + 0.5 * lsz[l2].height;
+                let row_hh2 =
+                    lsz[l3].height + f64::max(lpad[l2].y1, lpad[l3].y0) + 0.5 * lsz[l2].height;
+                let (mh1, mh2) = if row_hh1 >= row_hh2 {
+                    ("̣", "")
+                } else {
+                    ("", "̣")
+                };
+                let (mp1b, mp2t) = if lpad[l1].y1.ge(&lpad[l2].y0) {
+                    ("̣", "")
+                } else {
+                    ("", "̣")
+                };
+                let (mp2b, mp3t) = if lpad[l2].y1.ge(&lpad[l3].y0) {
+                    ("̣", "")
+                } else {
+                    ("", "̣")
+                };
                 trace!("{} {: >3}  {: >3}{} ≕ {: >2     }+{: >2        }+{: >2      }{   }?{: >2     }{   }+{: >2   }\
                     ¦{: >2            }+{: >2      }{    }?{: >2      }{    }+{: >2        }+{: >2     } ≔ {: >3}{}   \
                     {: >3} {: >3} {: >3}"
@@ -637,23 +683,23 @@ mod tests {
     use super::*;
     use crate::assert_render_snapshot;
     use crate::core::StyleProperty;
+    use crate::kurbo::Insets;
     use crate::testing::{widget_ids, TestHarness, TestWidgetExt};
     use crate::theme::PRIMARY_LIGHT;
-    use crate::kurbo::Insets;
 
     #[test]
     fn simple_button9() {
         let [button_id] = widget_ids();
         let widget = Button9::new("5Hello")
-            .add1(Label::new("1"),Some(Insets::new(1.,0.,1.,0.)),)
-            .add2(Label::new("2"),Some(Insets::new(2.,0.,0.,0.)),)
-            .add3(Label::new("3"),Some(Insets::new(0.,0.,0.,0.)),)
-            .add4(Label::new("4"),Some(Insets::new(1.,0.,4.,0.)),)
-            .add6(Label::new("6"),Some(Insets::new(0.,0.,0.,0.)),)
-            .add7(Label::new("7"),Some(Insets::new(0.,0.,0.,0.)),)
-            .add8(Label::new("8"),Some(Insets::new(0.,0.,0.,0.)),)
-            .add9(Label::new("9"),Some(Insets::new(0.,0.,0.,0.)),)
-        .with_id(button_id);
+            .add1(Label::new("1"), Some(Insets::new(1., 0., 1., 0.)))
+            .add2(Label::new("2"), Some(Insets::new(2., 0., 0., 0.)))
+            .add3(Label::new("3"), Some(Insets::new(0., 0., 0., 0.)))
+            .add4(Label::new("4"), Some(Insets::new(1., 0., 4., 0.)))
+            .add6(Label::new("6"), Some(Insets::new(0., 0., 0., 0.)))
+            .add7(Label::new("7"), Some(Insets::new(0., 0., 0., 0.)))
+            .add8(Label::new("8"), Some(Insets::new(0., 0., 0., 0.)))
+            .add9(Label::new("9"), Some(Insets::new(0., 0., 0., 0.)))
+            .with_id(button_id);
 
         let mut harness = TestHarness::create(widget);
 

--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -143,31 +143,16 @@ impl Button9 {
   pub fn set_text9(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label9_mut(this), new_text);}
 
   /// Set label options helpers
-  pub fn set_opt <'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hi5 = new_pad; this.ctx.request_render();}
-  pub fn set_pad1<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.tl1 = new_pad; this.ctx.request_render();}
-  pub fn set_pad2<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.ti2 = new_pad; this.ctx.request_render();}
-  pub fn set_pad3<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.tj3 = new_pad; this.ctx.request_render();}
-  pub fn set_pad4<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hl4 = new_pad; this.ctx.request_render();}
-  pub fn set_pad5<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hi5 = new_pad; this.ctx.request_render();}
-  pub fn set_pad6<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hj6 = new_pad; this.ctx.request_render();}
-  pub fn set_pad7<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.ll7 = new_pad; this.ctx.request_render();}
-  pub fn set_pad8<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.li8 = new_pad; this.ctx.request_render();}
-  pub fn set_pad9<'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.lj9 = new_pad; this.ctx.request_render();}
-  // pub fn set_opt  <'t>(this: &'t mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.set_optx(LPos::hi5, new_opt);}
-  /// Set the label options for a given position
-  pub fn set_padx(this: &mut WidgetMut<'_,Self>, idx:LPos, new_pad:Option<Insets>) {match idx {
-    LPos::tl1 => {this.widget.opt.pad.tl1 = new_pad}, //↖
-    LPos::ti2 => {this.widget.opt.pad.ti2 = new_pad}, //↑
-    LPos::tj3 => {this.widget.opt.pad.tj3 = new_pad}, //↗
-    LPos::hl4 => {this.widget.opt.pad.hl4 = new_pad}, //←
-    LPos::hi5 => {this.widget.opt.pad.hi5 = new_pad}, //•
-    LPos::hj6 => {this.widget.opt.pad.hj6 = new_pad}, //→
-    LPos::ll7 => {this.widget.opt.pad.ll7 = new_pad}, //↙
-    LPos::li8 => {this.widget.opt.pad.li8 = new_pad}, //↓
-    LPos::lj9 => {this.widget.opt.pad.lj9 = new_pad}, //↘
-    }
-    this.ctx.request_render(); // label options state impacts appearance and accessibility node
-  }
+  pub fn set_opt (this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hi5 = new_pad; this.ctx.request_render();}
+  pub fn set_pad1(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.tl1 = new_pad; this.ctx.request_render();}
+  pub fn set_pad2(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.ti2 = new_pad; this.ctx.request_render();}
+  pub fn set_pad3(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.tj3 = new_pad; this.ctx.request_render();}
+  pub fn set_pad4(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hl4 = new_pad; this.ctx.request_render();}
+  pub fn set_pad5(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hi5 = new_pad; this.ctx.request_render();}
+  pub fn set_pad6(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hj6 = new_pad; this.ctx.request_render();}
+  pub fn set_pad7(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.ll7 = new_pad; this.ctx.request_render();}
+  pub fn set_pad8(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.li8 = new_pad; this.ctx.request_render();}
+  pub fn set_pad9(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.lj9 = new_pad; this.ctx.request_render();}
 
   /// Get mutable label helpers
   pub fn label_mut <'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.hi5)}
@@ -180,19 +165,6 @@ impl Button9 {
   pub fn label7_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.ll7)}
   pub fn label8_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.li8)}
   pub fn label9_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.lj9)}
-  // pub fn label_mut <'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.labelx_mut(LPos::hi5)}
-  /// Get mutable label for a given position
-  pub fn labelx_mut<'t>(this: &'t mut WidgetMut<'_,Self>, idx:LPos) -> WidgetMut<'t, Label> {match idx {
-    LPos::tl1 => {return this.ctx.get_mut(&mut this.widget.label.tl1)}, //↖
-    LPos::ti2 => {return this.ctx.get_mut(&mut this.widget.label.ti2)}, //↑
-    LPos::tj3 => {return this.ctx.get_mut(&mut this.widget.label.tj3)}, //↗
-    LPos::hl4 => {return this.ctx.get_mut(&mut this.widget.label.hl4)}, //←
-    LPos::hi5 => {return this.ctx.get_mut(&mut this.widget.label.hi5)}, //•
-    LPos::hj6 => {return this.ctx.get_mut(&mut this.widget.label.hj6)}, //→
-    LPos::ll7 => {return this.ctx.get_mut(&mut this.widget.label.ll7)}, //↙
-    LPos::li8 => {return this.ctx.get_mut(&mut this.widget.label.li8)}, //↓
-    LPos::lj9 => {return this.ctx.get_mut(&mut this.widget.label.lj9)}, //↘
-  }}
 }
 
 // --- MARK: IMPL WIDGET ---

--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -607,11 +607,21 @@ mod tests {
     use crate::core::StyleProperty;
     use crate::testing::{widget_ids, TestHarness, TestWidgetExt};
     use crate::theme::PRIMARY_LIGHT;
+    use crate::kurbo::Insets;
 
     #[test]
-    fn simple_button() {
+    fn simple_button9() {
         let [button_id] = widget_ids();
-        let widget = Button9::new("Hello").with_id(button_id);
+        let widget = Button9::new("5Hello")
+            .add1(Label::new("1"),Some(Insets::new(1.,0.,1.,0.)),)
+            .add2(Label::new("2"),Some(Insets::new(2.,0.,0.,0.)),)
+            .add3(Label::new("3"),Some(Insets::new(0.,0.,0.,0.)),)
+            .add4(Label::new("4"),Some(Insets::new(1.,0.,4.,0.)),)
+            .add6(Label::new("6"),Some(Insets::new(0.,0.,0.,0.)),)
+            .add7(Label::new("7"),Some(Insets::new(0.,0.,0.,0.)),)
+            .add8(Label::new("8"),Some(Insets::new(0.,0.,0.,0.)),)
+            .add9(Label::new("9"),Some(Insets::new(0.,0.,0.,0.)),)
+        .with_id(button_id);
 
         let mut harness = TestHarness::create(widget);
 
@@ -623,7 +633,7 @@ mod tests {
         harness.mouse_click_on(button_id);
         assert_eq!(
             harness.pop_action(),
-            Some((Action::Button9Pressed(PointerButton::Primary), button_id))
+            Some((Action::ButtonPressed(PointerButton::Primary), button_id))
         );
     }
 

--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -5,18 +5,18 @@
 
 use accesskit::{Node, Role};
 use smallvec::{smallvec, SmallVec};
-use tracing::{trace, debug, trace_span, Span};
+use tracing::{trace, trace_span, Span};
 use vello::Scene;
 
-use masonry::core::{
+use crate::core::{self,
   AccessCtx, AccessEvent, Action, ArcStr, BoxConstraints, EventCtx, LayoutCtx, PaintCtx,
   PointerButton, PointerEvent, QueryCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
   WidgetMut, WidgetPod,
 };
-use masonry::kurbo::{Insets, Size, Point, Vec2};
-use masonry::theme;
-use masonry::util::{fill_lin_gradient, stroke, UnitPoint};
-use masonry::widgets::Label;
+use crate::kurbo::{Insets, Size, Vec2};
+use crate::theme;
+use crate::util::{fill_lin_gradient, stroke, UnitPoint};
+use crate::widgets::Label;
 
 /// The minimum padding added to a button. NOTE: these values are chosen to match the existing look of TextBox; these should be reevaluated at some point.
 pub const pad_def: Insets = Insets::uniform_xy(8., 2.);
@@ -76,22 +76,22 @@ pub struct Pad9 {
 impl Button9 {
   /// Create a new button with a text label at the center (HI5m other labels are blank, use `.addx` methods to fill them)
   /// ```
-  /// use masonry::widgets::Button9;
+  /// use crate::widgets::Button9;
   /// let button = Button9::new("Increment");
   /// ```
   pub fn new(text:impl Into<ArcStr>) -> Self {Self::from_label    (Label::new(text))}
   /// Create a new button with the provided [`Label`]
   /// ```
-  /// use masonry::peniko::Color;
-  /// use masonry::widgets::{Button9, Label};
+  /// use crate::peniko::Color;
+  /// use crate::widgets::{Button9, Label};
   /// let label = Label::new("Increment").with_brush(Color::new([0.5, 0.5, 0.5, 1.0]));
   /// let button = Button9::from_label(label);
   /// ```
   pub fn from_label    (label:Label) -> Self {Self::from_label_pad(label, None)}
   /// Create a new button with the provided [`Label`] and padding [`Insets`]
   /// ```
-  /// use masonry::peniko::Color;
-  /// use masonry::widgets::{Button9, Label};
+  /// use crate::peniko::Color;
+  /// use crate::widgets::{Button9, Label};
   /// let label  = Label::new("Increment").with_brush(Color::new([0.5, 0.5, 0.5, 1.0]));
   /// let pad    = Insets::uniform_xy(8., 2.); // pad ←→ by 8 and ↑↓ by 2
   /// let button = Button9::from_label_pad(label, pad);
@@ -263,7 +263,7 @@ impl Widget for Button9 {
     |Update::DisabledChanged(_) => {ctx.request_paint_only();}
     _                           => {}  }   }
 
-  fn register_children(&mut self, ctx: &mut masonry::core::RegisterCtx) {
+  fn register_children(&mut self, ctx: &mut core::RegisterCtx) {
     ctx.register_child(&mut self.label.TL1);ctx.register_child(&mut self.label.TI2);ctx.register_child(&mut self.label.TJ3); // ↖  ↑  ↗
     ctx.register_child(&mut self.label.HL4);ctx.register_child(&mut self.label.HI5);ctx.register_child(&mut self.label.HJ6); // ←  •  →
     ctx.register_child(&mut self.label.LL7);ctx.register_child(&mut self.label.LI8);ctx.register_child(&mut self.label.LJ9); // ↙  ↓  ↘

--- a/masonry/src/widgets/button9.rs
+++ b/masonry/src/widgets/button9.rs
@@ -30,18 +30,13 @@ pub struct Button9 {
   opt  : LabelOpt,
 }
 /// Label widgets for Button9 for all the 9 possible label positions in a button from top left to bottom right.<br>
-  /// Letter in a name corresponds to a visual mnemonic of its horizontal/vertical line position
-  /// ⎺ T top     ⎸ L left
-  /// - H middle  | I middle
-  /// _ L low     ⎹ J right
-  /// ⎺T -H _L  top/middle/low
-  /// ↖  ↑  ↗
-  /// ←  •  →
-  /// ↙  ↓  ↘
+/// 1 2 3 = ↖  ↑  ↗
+/// 4 5 6 = ←  •  →
+/// 7 8 9 = ↙  ↓  ↘
 pub struct Label9 {
-  tl1:WidgetPod<Label>, ti2:WidgetPod<Label>, tj3:WidgetPod<Label>, // ↖  ↑  ↗
-  hl4:WidgetPod<Label>, hi5:WidgetPod<Label>, hj6:WidgetPod<Label>, // ←  •  →
-  ll7:WidgetPod<Label>, li8:WidgetPod<Label>, lj9:WidgetPod<Label>, // ↙  ↓  ↘
+  p1:WidgetPod<Label>, p2:WidgetPod<Label>, p3:WidgetPod<Label>, // ↖  ↑  ↗
+  p4:WidgetPod<Label>, p5:WidgetPod<Label>, p6:WidgetPod<Label>, // ←  •  →
+  p7:WidgetPod<Label>, p8:WidgetPod<Label>, p9:WidgetPod<Label>, // ↙  ↓  ↘
 }
 /// Custom button options. Currently only padding is supported.
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
@@ -53,14 +48,14 @@ pub struct LabelOpt {
 /// Optional padding options per label as [`Insets`]
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
 pub struct Pad9 {
-  pub tl1:Option<Insets>, pub ti2:Option<Insets>, pub tj3:Option<Insets>, // ↖  ↑  ↗
-  pub hl4:Option<Insets>, pub hi5:Option<Insets>, pub hj6:Option<Insets>, // ←  •  →
-  pub ll7:Option<Insets>, pub li8:Option<Insets>, pub lj9:Option<Insets>, // ↙  ↓  ↘
+  pub p1:Option<Insets>, pub p2:Option<Insets>, pub p3:Option<Insets>, // ↖  ↑  ↗
+  pub p4:Option<Insets>, pub p5:Option<Insets>, pub p6:Option<Insets>, // ←  •  →
+  pub p7:Option<Insets>, pub p8:Option<Insets>, pub p9:Option<Insets>, // ↙  ↓  ↘
 }
 
 // --- MARK: BUILDERS ---
 impl Button9 {
-  /// Create a new button with a text label at the center (hi5 other labels are blank, use `.addx` methods to fill them)
+  /// Create a new button with a text label at the center (p5 other labels are blank, use `.addx` methods to fill them)
   /// ```
   /// use masonry::widgets::Button9;
   /// let button = Button9::new("Increment");
@@ -84,36 +79,36 @@ impl Button9 {
   /// ```
   pub fn from_label_pad(lbl:Label, pad:Option<Insets>) -> Self {
     let label = Label9 {
-      tl1:WidgetPod::new(Label::new("")), ti2:WidgetPod::new(Label::new("")), tj3:WidgetPod::new(Label::new("")), // ↖  ↑  ↗
-      hl4:WidgetPod::new(Label::new("")), hi5:WidgetPod::new(lbl           ), hj6:WidgetPod::new(Label::new("")), // ←  •  →
-      ll7:WidgetPod::new(Label::new("")), li8:WidgetPod::new(Label::new("")), lj9:WidgetPod::new(Label::new("")), // ↙  ↓  ↘
+      p1:WidgetPod::new(Label::new("")), p2:WidgetPod::new(Label::new("")), p3:WidgetPod::new(Label::new("")), // ↖  ↑  ↗
+      p4:WidgetPod::new(Label::new("")), p5:WidgetPod::new(lbl           ), p6:WidgetPod::new(Label::new("")), // ←  •  →
+      p7:WidgetPod::new(Label::new("")), p8:WidgetPod::new(Label::new("")), p9:WidgetPod::new(Label::new("")), // ↙  ↓  ↘
     };
     let pad = Pad9 {
-      tl1:None, ti2:None, tj3:None, // ↖  ↑  ↗
-      hl4:None, hi5:pad , hj6:None, // ←  •  →
-      ll7:None, li8:None, lj9:None, // ↙  ↓  ↘
+      p1:None, p2:None, p3:None, // ↖  ↑  ↗
+      p4:None, p5:pad , p6:None, // ←  •  →
+      p7:None, p8:None, p9:None, // ↙  ↓  ↘
     };
     let opt = LabelOpt{pad};
     Self {label, opt}
   }
-  /// Helper .methods for adding individual labels (add=center hi5)
-  pub fn add (mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.hi5 = WidgetPod::new(label); self.opt.pad.hi5 = pad; self}
-  pub fn add1(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.tl1 = WidgetPod::new(label); self.opt.pad.tl1 = pad; self}
-  pub fn add2(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.ti2 = WidgetPod::new(label); self.opt.pad.ti2 = pad; self}
-  pub fn add3(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.tj3 = WidgetPod::new(label); self.opt.pad.tj3 = pad; self}
-  pub fn add4(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.hl4 = WidgetPod::new(label); self.opt.pad.hl4 = pad; self}
-  pub fn add5(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.hi5 = WidgetPod::new(label); self.opt.pad.hi5 = pad; self}
-  pub fn add6(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.hj6 = WidgetPod::new(label); self.opt.pad.hj6 = pad; self}
-  pub fn add7(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.ll7 = WidgetPod::new(label); self.opt.pad.ll7 = pad; self}
-  pub fn add8(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.li8 = WidgetPod::new(label); self.opt.pad.li8 = pad; self}
-  pub fn add9(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.lj9 = WidgetPod::new(label); self.opt.pad.lj9 = pad; self}
+  /// Helper .methods for adding individual labels (add=center p5)
+  pub fn add (mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p5 = WidgetPod::new(label); self.opt.pad.p5 = pad; self}
+  pub fn add1(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p1 = WidgetPod::new(label); self.opt.pad.p1 = pad; self}
+  pub fn add2(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p2 = WidgetPod::new(label); self.opt.pad.p2 = pad; self}
+  pub fn add3(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p3 = WidgetPod::new(label); self.opt.pad.p3 = pad; self}
+  pub fn add4(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p4 = WidgetPod::new(label); self.opt.pad.p4 = pad; self}
+  pub fn add5(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p5 = WidgetPod::new(label); self.opt.pad.p5 = pad; self}
+  pub fn add6(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p6 = WidgetPod::new(label); self.opt.pad.p6 = pad; self}
+  pub fn add7(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p7 = WidgetPod::new(label); self.opt.pad.p7 = pad; self}
+  pub fn add8(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p8 = WidgetPod::new(label); self.opt.pad.p8 = pad; self}
+  pub fn add9(mut self,         label:Label, pad:Option<Insets>) -> Self {self.label.p9 = WidgetPod::new(label); self.opt.pad.p9 = pad; self}
   /// Create a new button with the provided [`Label9`]s and their [`Pad9`] with predetermined IDs. This constructor is useful for toolkits which use Masonry (such as Xilem).
   pub fn from_label_pod(label_l:[WidgetPod<Label>;9], pad:Pad9) -> Self {
     let [l1,l2,l3,l4,l5,l6,l7,l8,l9] = label_l;
     let label = Label9 { //numbering shifted due to 0-based array index
-      tl1:l1, ti2:l2, tj3:l3, // ↖  ↑  ↗
-      hl4:l4, hi5:l5, hj6:l8, // ←  •  →
-      ll7:l7, li8:l6, lj9:l9, // ↙  ↓  ↘
+      p1:l1, p2:l2, p3:l3, // ↖  ↑  ↗
+      p4:l4, p5:l5, p6:l8, // ←  •  →
+      p7:l7, p8:l6, p9:l9, // ↙  ↓  ↘
     };
     let opt = LabelOpt{pad};
     Self {label, opt}
@@ -143,28 +138,28 @@ impl Button9 {
   pub fn set_text9(this:&mut WidgetMut<'_,Self>, new_text:impl Into<ArcStr>) {Label::set_text(&mut Self::label9_mut(this), new_text);}
 
   /// Set label options helpers
-  pub fn set_opt (this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hi5 = new_pad; this.ctx.request_render();}
-  pub fn set_pad1(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.tl1 = new_pad; this.ctx.request_render();}
-  pub fn set_pad2(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.ti2 = new_pad; this.ctx.request_render();}
-  pub fn set_pad3(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.tj3 = new_pad; this.ctx.request_render();}
-  pub fn set_pad4(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hl4 = new_pad; this.ctx.request_render();}
-  pub fn set_pad5(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hi5 = new_pad; this.ctx.request_render();}
-  pub fn set_pad6(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.hj6 = new_pad; this.ctx.request_render();}
-  pub fn set_pad7(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.ll7 = new_pad; this.ctx.request_render();}
-  pub fn set_pad8(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.li8 = new_pad; this.ctx.request_render();}
-  pub fn set_pad9(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.lj9 = new_pad; this.ctx.request_render();}
+  pub fn set_opt (this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p5 = new_pad; this.ctx.request_render();}
+  pub fn set_pad1(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p1 = new_pad; this.ctx.request_render();}
+  pub fn set_pad2(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p2 = new_pad; this.ctx.request_render();}
+  pub fn set_pad3(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p3 = new_pad; this.ctx.request_render();}
+  pub fn set_pad4(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p4 = new_pad; this.ctx.request_render();}
+  pub fn set_pad5(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p5 = new_pad; this.ctx.request_render();}
+  pub fn set_pad6(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p6 = new_pad; this.ctx.request_render();}
+  pub fn set_pad7(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p7 = new_pad; this.ctx.request_render();}
+  pub fn set_pad8(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p8 = new_pad; this.ctx.request_render();}
+  pub fn set_pad9(this:&mut WidgetMut<'_,Self>, new_pad:Option<Insets>) {this.widget.opt.pad.p9 = new_pad; this.ctx.request_render();}
 
   /// Get mutable label helpers
-  pub fn label_mut <'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.hi5)}
-  pub fn label1_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.tl1)}
-  pub fn label2_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.ti2)}
-  pub fn label3_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.tj3)}
-  pub fn label4_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.hl4)}
-  pub fn label5_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.hi5)}
-  pub fn label6_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.hj6)}
-  pub fn label7_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.ll7)}
-  pub fn label8_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.li8)}
-  pub fn label9_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.lj9)}
+  pub fn label_mut <'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p5)}
+  pub fn label1_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p1)}
+  pub fn label2_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p2)}
+  pub fn label3_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p3)}
+  pub fn label4_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p4)}
+  pub fn label5_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p5)}
+  pub fn label6_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p6)}
+  pub fn label7_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p7)}
+  pub fn label8_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p8)}
+  pub fn label9_mut<'t>(this: &'t mut WidgetMut<'_,Self>) -> WidgetMut<'t, Label> {this.ctx.get_mut(&mut this.widget.label.p9)}
 }
 
 // --- MARK: IMPL WIDGET ---
@@ -199,22 +194,22 @@ impl Widget for Button9 {
     _                           => {}  }   }
 
   fn register_children(&mut self, ctx: &mut core::RegisterCtx) {
-    ctx.register_child(&mut self.label.tl1);ctx.register_child(&mut self.label.ti2);ctx.register_child(&mut self.label.tj3); // ↖  ↑  ↗
-    ctx.register_child(&mut self.label.hl4);ctx.register_child(&mut self.label.hi5);ctx.register_child(&mut self.label.hj6); // ←  •  →
-    ctx.register_child(&mut self.label.ll7);ctx.register_child(&mut self.label.li8);ctx.register_child(&mut self.label.lj9); // ↙  ↓  ↘
+    ctx.register_child(&mut self.label.p1);ctx.register_child(&mut self.label.p2);ctx.register_child(&mut self.label.p3); // ↖  ↑  ↗
+    ctx.register_child(&mut self.label.p4);ctx.register_child(&mut self.label.p5);ctx.register_child(&mut self.label.p6); // ←  •  →
+    ctx.register_child(&mut self.label.p7);ctx.register_child(&mut self.label.p8);ctx.register_child(&mut self.label.p9); // ↙  ↓  ↘
   }
   fn layout(&mut self, ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size {
     let min_height = theme::BORDERED_WIDGET_HEIGHT; // HACK: to make sure we look okay at default sizes when beside a textbox, we make sure we will have at least the same height as the default textbox.
     let mut lbl_pad9 = [
-      (&mut self.label.tl1, self.opt.pad.tl1),
-      (&mut self.label.ti2, self.opt.pad.ti2),
-      (&mut self.label.tj3, self.opt.pad.tj3),
-      (&mut self.label.hl4, self.opt.pad.hl4),
-      (&mut self.label.hi5, self.opt.pad.hi5),
-      (&mut self.label.hj6, self.opt.pad.hj6),
-      (&mut self.label.ll7, self.opt.pad.ll7),
-      (&mut self.label.li8, self.opt.pad.li8),
-      (&mut self.label.lj9, self.opt.pad.lj9),
+      (&mut self.label.p1, self.opt.pad.p1),
+      (&mut self.label.p2, self.opt.pad.p2),
+      (&mut self.label.p3, self.opt.pad.p3),
+      (&mut self.label.p4, self.opt.pad.p4),
+      (&mut self.label.p5, self.opt.pad.p5),
+      (&mut self.label.p6, self.opt.pad.p6),
+      (&mut self.label.p7, self.opt.pad.p7),
+      (&mut self.label.p8, self.opt.pad.p8),
+      (&mut self.label.p9, self.opt.pad.p9),
       ];
 
     let mut row_w: [f64 ;3] = [0.   ;3]; //top /middle/bottom ↖↑↗  ←•→  ↙↓↘
@@ -262,9 +257,9 @@ impl Widget for Button9 {
       trace!("↙ lbl7 🆔{} offset {}", ctx.widget_id(), lbl7_offset); trace!("↓ lbl8 🆔{} offset {}", ctx.widget_id(), lbl8_offset); trace!("↘ lbl9 🆔{} offset {}", ctx.widget_id(), lbl9_offset);
     }
 
-    ctx.place_child(&mut self.label.tl1, lbl1_offset.to_point()); ctx.place_child(&mut self.label.ti2, lbl2_offset.to_point()); ctx.place_child(&mut self.label.tj3, lbl3_offset.to_point());
-    ctx.place_child(&mut self.label.hl4, lbl4_offset.to_point()); ctx.place_child(&mut self.label.hi5, lbl5_offset.to_point()); ctx.place_child(&mut self.label.hj6, lbl6_offset.to_point());
-    ctx.place_child(&mut self.label.ll7, lbl7_offset.to_point()); ctx.place_child(&mut self.label.li8, lbl8_offset.to_point()); ctx.place_child(&mut self.label.lj9, lbl9_offset.to_point());
+    ctx.place_child(&mut self.label.p1, lbl1_offset.to_point()); ctx.place_child(&mut self.label.p2, lbl2_offset.to_point()); ctx.place_child(&mut self.label.p3, lbl3_offset.to_point());
+    ctx.place_child(&mut self.label.p4, lbl4_offset.to_point()); ctx.place_child(&mut self.label.p5, lbl5_offset.to_point()); ctx.place_child(&mut self.label.p6, lbl6_offset.to_point());
+    ctx.place_child(&mut self.label.p7, lbl7_offset.to_point()); ctx.place_child(&mut self.label.p8, lbl8_offset.to_point()); ctx.place_child(&mut self.label.p9, lbl9_offset.to_point());
     button_size
   }
 
@@ -292,7 +287,7 @@ impl Widget for Button9 {
   fn accessibility_role(&self) -> Role {Role::Button}
   fn accessibility(&mut self, ctx: &mut AccessCtx, node: &mut Node) { // IMPORTANT: We don't want to merge this code in practice, because the child label already has a 'name' property. This is more of a proof of concept of `get_raw_ref()`.
     if false {
-      let label = ctx.get_raw_ref(&self.label.hi5);
+      let label = ctx.get_raw_ref(&self.label.p5);
       let name  = label.widget().text().as_ref().to_string();
       node.set_value(name);
     }
@@ -300,9 +295,9 @@ impl Widget for Button9 {
   }
 
   fn children_ids   (&self                    ) -> SmallVec<[WidgetId; 16]> {smallvec![
-    self.label.tl1.id(),self.label.ti2.id(),self.label.tj3.id(), // ↖  ↑  ↗
-    self.label.hl4.id(),self.label.hi5.id(),self.label.hj6.id(), // ←  •  →
-    self.label.ll7.id(),self.label.li8.id(),self.label.lj9.id(), // ↙  ↓  ↘
+    self.label.p1.id(),self.label.p2.id(),self.label.p3.id(), // ↖  ↑  ↗
+    self.label.p4.id(),self.label.p5.id(),self.label.p6.id(), // ←  •  →
+    self.label.p7.id(),self.label.p8.id(),self.label.p9.id(), // ↙  ↓  ↘
   ]}
   fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {trace_span!("Button9", id = ctx.widget_id().trace())}
 }

--- a/masonry/src/widgets/mod.rs
+++ b/masonry/src/widgets/mod.rs
@@ -32,7 +32,7 @@ mod zstack;
 
 pub use self::align::Align;
 pub use self::button::Button;
-pub use self::button9::{Button9, LabelOpt, Pad9, Label9};
+pub use self::button9::{Button9, Label9, LabelOpt, Pad9};
 pub use self::checkbox::Checkbox;
 pub use self::flex::{Axis, CrossAxisAlignment, Flex, FlexParams, MainAxisAlignment};
 pub use self::grid::{Grid, GridParams};

--- a/masonry/src/widgets/mod.rs
+++ b/masonry/src/widgets/mod.rs
@@ -32,7 +32,7 @@ mod zstack;
 
 pub use self::align::Align;
 pub use self::button::Button;
-pub use self::button9::{Button9, LabelOpt, Pad9};
+pub use self::button9::{Button9, LabelOpt, Pad9, Label9};
 pub use self::checkbox::Checkbox;
 pub use self::flex::{Axis, CrossAxisAlignment, Flex, FlexParams, MainAxisAlignment};
 pub use self::grid::{Grid, GridParams};

--- a/masonry/src/widgets/mod.rs
+++ b/masonry/src/widgets/mod.rs
@@ -11,6 +11,7 @@ mod tests;
 
 mod align;
 mod button;
+mod button9;
 mod checkbox;
 mod flex;
 mod grid;
@@ -31,6 +32,7 @@ mod zstack;
 
 pub use self::align::Align;
 pub use self::button::Button;
+pub use self::button9::{Button9, LabelOpt, Pad9};
 pub use self::checkbox::Checkbox;
 pub use self::flex::{Axis, CrossAxisAlignment, Flex, FlexParams, MainAxisAlignment};
 pub use self::grid::{Grid, GridParams};

--- a/masonry/src/widgets/screenshots/masonry__widgets__button9__tests__hello.png
+++ b/masonry/src/widgets/screenshots/masonry__widgets__button9__tests__hello.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:536d44f6fb907f98d6428af69e615799825cf77547d8fa87f3ee9ea7410cc57c
+size 7411

--- a/masonry/src/widgets/snapshots/masonry__widgets__button9__tests__simple_button9.snap
+++ b/masonry/src/widgets/snapshots/masonry__widgets__button9__tests__simple_button9.snap
@@ -1,0 +1,18 @@
+---
+source: masonry/src/widgets/button9.rs
+assertion_line: 628
+expression: harness.root_widget()
+---
+SizedBox(
+    Button9(
+        Label<1>,
+        Label<2>,
+        Label<3>,
+        Label<4>,
+        Label<5Hello>,
+        Label<6>,
+        Label<7>,
+        Label<8>,
+        Label<9>,
+    ),
+)

--- a/xilem/Cargo.toml
+++ b/xilem/Cargo.toml
@@ -86,6 +86,9 @@ crate-type = ["cdylib"]
 name = "emoji_picker"
 
 [[example]]
+name = "gallery_button_xilem_view"
+
+[[example]]
 name = "emoji_picker_android"
 path = "examples/emoji_picker.rs"
 # cdylib is required for cargo-apk

--- a/xilem/examples/gallery_button_xilem_view.rs
+++ b/xilem/examples/gallery_button_xilem_view.rs
@@ -1,0 +1,131 @@
+// Copyright 2025 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! An illustration of the various options for Xilem's Button/Button9 View
+//! (based on Masonry Button/Button9 Widgets)
+// TODOs:
+// add rust code generating each element in a tooltip
+// add the same code in a context menu as a "copy" command
+// add URL support for doc links
+// add non-desktop platforms
+#![allow(
+    unused_assignments,
+    reason = "allows NOT having to track section increments {i+=1;}, removing the last one."
+)]
+
+use masonry::dpi::LogicalSize;
+use winit::window::Window;
+#[derive(Default)]
+struct AppState {}
+
+use masonry::core::ArcStr;
+use masonry::peniko::Color;
+use winit::error::EventLoopError;
+use xilem::view::{
+    button9_pad, flex, label, portal, prose, Axis, Prose,
+};
+use xilem::{palette::css, EventLoop, FontWeight, TextAlignment, WidgetView, Xilem};
+
+fn title_prose(text: impl Into<ArcStr>) -> Prose {
+    prose(text)
+        .text_size(18.0)
+        .alignment(TextAlignment::Justified)
+        .brush(css::GREEN)
+}
+fn txt_prose(text: impl Into<ArcStr>) -> Prose {
+    prose(text)
+        .text_size(14.0)
+        .alignment(TextAlignment::Start)
+        .brush(Color::from_rgb8(0x11, 0x11, 0x11))
+}
+
+use masonry::kurbo::Insets;
+const OFF0: Insets = Insets::uniform_xy(0., 0.);
+// const OFF8: Insets = Insets::uniform_xy(8., 2.);
+fn app_logic(_d: &mut AppState) -> impl WidgetView<AppState> {
+    let _cb = |_d: &mut AppState| {}; // empty callback for empty buttons
+                                      // let m_c = Color::from_rgb8(0x11, 0x11, 0x11); //main text
+                                      // let l_c = LABEL_COLOR;
+    let mut i = 1;
+
+    portal(
+    flex((
+    (txt_prose("Xilem view::Button/Button9 formats vGit@25-02 (in a ↕-scrollable area)").text_size(18.0),
+    if cfg!(debug_assertions) {txt_prose(
+     "This is a debug build, so you can use github.com/linebender/xilem/tree/main/masonry#debugging-features:
+        • F11 to toggle a rudimentary widget inspector
+        • F12 to toggle paint widget layout rectangles")
+    } else {txt_prose("This is not a debug build, so F11 widget inspector and F12 widget rectangles tools are not available)\ngithub.com/linebender/xilem/tree/main/masonry#debugging-features")},
+    ),
+    (title_prose(format!("§{i} button TBD")),),
+    (title_prose(format!("§{i}a button9")),{i+=1;},
+    txt_prose("  A button indicating 2 keys that activate it: ⏎Enter and an 'accelerator' I, but instead of tiny i̲ with a flexible position you have a permanent position with proper size and color highlight"),
+    button9_pad(label("Confi̲rm").alignment(TextAlignment::Start).text_size(18.).weight(FontWeight::BOLD),Some(OFF0),|_|{println!("Confirm button pressed!");})
+        .add3(label("⏎"        ).alignment(TextAlignment::Start).text_size(12.).brush(css::ORANGE).font("Cambria"),Some(Insets::new(4.,4.,2.,2.)),)
+        .add4(label("I̲"        ).alignment(TextAlignment::Start).text_size(14.).brush(css::ORANGE).weight(FontWeight::BOLD),Some(Insets::new(4.,2.,4.,4.)),)
+        ,
+    ),
+    (title_prose(format!("§{i}b button9 pad (Insets)")),
+    txt_prose("  up to 9 labels added via `.add1–add9` methods, each with a per-label offset (with each of the 4 sides can be set separately)"),
+    txt_prose("  ↓offsets are all 0 unless explicitly specified in the label with arrows indicating direction to the offset"),
+    button9_pad(label("←5"  ).alignment(TextAlignment::Start),Some(Insets::new(5.,0.,0.,0.)),|_|{println!("Button1");})
+        .add4(label("←1¦4→"	),Some(Insets::new(1.,0.,4.,0.)),)
+        .add6(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add1(label("←1¦1→"	),Some(Insets::new(1.,0.,1.,0.)),)
+        .add2(label("←2"   	).brush(css::ORANGE),Some(Insets::new(2.,0.,0.,0.)),)
+        .add3(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add7(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add8(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add9(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        ,
+    button9_pad(label("←5"  ).alignment(TextAlignment::Start),Some(Insets::new(5.,0.,0.,0.)),|_|{println!("Button2");})
+        .add4(label("←1¦4→"	),Some(Insets::new(1.,0.,4.,0.)),)
+        .add6(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add1(label("←1¦1→"	),Some(Insets::new(1.,0.,1.,0.)),)
+        .add2(label("←5"   	).brush(css::ORANGE),Some(Insets::new(5.,0.,0.,0.)),)
+        .add3(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add7(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add8(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add9(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        ,
+    txt_prose("  ↑button width unchanged despite an increase in padding between ↖L1 and ↑L2 in the Top row (from max(1,2)=2 to max(1,5)=5) since it's still not bigger than padding between ←L4 and •L5 in the Middle row (max(4,5)=5), and the button width equals the max width of all rows to fit them all"),
+
+    button9_pad(label("←5"  ).alignment(TextAlignment::Start),Some(Insets::new(5.,0.,0.,0.)),|_|{println!("Button1");})
+        .add4(label("←1¦4→"	),Some(Insets::new(1.,0.,4.,0.)),)
+        .add6(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add1(label("←1¦1→"	).brush(css::ORANGE),Some(Insets::new(1.,0.,1.,0.)),)
+        .add2(label("←2"   	).brush(css::MEDIUM_SEA_GREEN),Some(Insets::new(2.,0.,0.,0.)),)
+        .add3(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add7(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add8(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add9(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        ,
+    button9_pad(label("←5"  ).alignment(TextAlignment::Start),Some(Insets::new(5.,0.,0.,0.)),|_|{println!("Button2");})
+        .add4(label("←1¦4→"	),Some(Insets::new(1.,0.,4.,0.)),)
+        .add6(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add1(label("←8¦1→"	).brush(css::ORANGE),Some(Insets::new(8.,0.,1.,0.)),)
+        .add2(label("←5"   	).brush(css::MEDIUM_SEA_GREEN),Some(Insets::new(5.,0.,0.,0.)),)
+        .add3(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add7(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add8(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        .add9(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
+        ,
+    txt_prose("  but moving ↖L1 to the right by 7 by increasing its left padding from 1 to 8 in addition to the increase in padding between ↖L1 and ↑L2 by 3 (from max(1,2)=2 to max(1,5)=5) makes the overall width of the Top row (+20 = +10⋅2 on both the left and the right sides to maintain symmetry vs. the central label) bigger than the width of the Middle row (152 vs 138), so the button accomodates by increasing its width to 152"),
+    txt_prose("❗ padding between labels are not summed up, but a maximum is used since the point of padding is to offset against a visible element, which in this case is label's text."),
+    ),
+    ))//flex
+     .direction(Axis::Vertical) //.main_axis_alignment(MainAxisAlignment::SpaceBetween).cross_axis_alignment(CrossAxisAlignment::Fill)
+    ) //portal
+}
+
+fn main() -> Result<(), EventLoopError> {
+    let app_state_init = AppState::default();
+    let xapp = Xilem::new(app_state_init, app_logic).background_color(css::SEASHELL);
+
+    let win_attr = Window::default_attributes()
+        .with_title("Label: Xilem Button")
+        .with_min_inner_size(LogicalSize::new(800., 600.));
+
+    xapp.run_windowed_in(EventLoop::with_user_event(), win_attr)?;
+    Ok(())
+}

--- a/xilem/examples/gallery_button_xilem_view.rs
+++ b/xilem/examples/gallery_button_xilem_view.rs
@@ -21,9 +21,7 @@ struct AppState {}
 use masonry::core::ArcStr;
 use masonry::peniko::Color;
 use winit::error::EventLoopError;
-use xilem::view::{
-    button9_pad, flex, label, portal, prose, Axis, Prose,
-};
+use xilem::view::{button9_pad, flex, label, portal, prose, Axis, Prose};
 use xilem::{palette::css, EventLoop, FontWeight, TextAlignment, WidgetView, Xilem};
 
 fn title_prose(text: impl Into<ArcStr>) -> Prose {
@@ -42,10 +40,10 @@ fn txt_prose(text: impl Into<ArcStr>) -> Prose {
 use masonry::kurbo::Insets;
 const OFF0: Insets = Insets::uniform_xy(0., 0.);
 // const OFF8: Insets = Insets::uniform_xy(8., 2.);
-fn app_logic(_d: &mut AppState) -> impl WidgetView<AppState> {
-    let _cb = |_d: &mut AppState| {}; // empty callback for empty buttons
-                                      // let m_c = Color::from_rgb8(0x11, 0x11, 0x11); //main text
-                                      // let l_c = LABEL_COLOR;
+fn app_logic(_: &mut AppState) -> impl WidgetView<AppState> {
+    let _cb = |_: &mut AppState| {}; // empty callback for empty buttons
+                                     // let m_c = Color::from_rgb8(0x11, 0x11, 0x11); //main text
+                                     // let l_c = LABEL_COLOR;
     let mut i = 1;
 
     portal(
@@ -110,7 +108,7 @@ fn app_logic(_d: &mut AppState) -> impl WidgetView<AppState> {
         .add8(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
         .add9(label(""     	),Some(Insets::new(0.,0.,0.,0.)),)
         ,
-    txt_prose("  but moving ↖L1 to the right by 7 by increasing its left padding from 1 to 8 in addition to the increase in padding between ↖L1 and ↑L2 by 3 (from max(1,2)=2 to max(1,5)=5) makes the overall width of the Top row (+20 = +10⋅2 on both the left and the right sides to maintain symmetry vs. the central label) bigger than the width of the Middle row (152 vs 138), so the button accomodates by increasing its width to 152"),
+    txt_prose("  but moving ↖L1 to the right by 7 by increasing its left padding from 1 to 8 in addition to the increase in padding between ↖L1 and ↑L2 by 3 (from max(1,2)=2 to max(1,5)=5) makes the overall width of the Top row (+20 = +10⋅2 on both the left and the right sides to maintain symmetry vs. the central label) bigger than the width of the Middle row (152 vs 138), so the button accommodates by increasing its width to 152"),
     txt_prose("❗ padding between labels are not summed up, but a maximum is used since the point of padding is to offset against a visible element, which in this case is label's text."),
     ),
     ))//flex

--- a/xilem/src/view/button9.rs
+++ b/xilem/src/view/button9.rs
@@ -234,15 +234,15 @@ where
             child9.into_widget_pod(), // ↙  ↓  ↘
         ];
         let pad = Pad9 {
-            p1: self.opt.pad.p1.clone(),
-            p2: self.opt.pad.p2.clone(),
-            p3: self.opt.pad.p3.clone(), // ↖  ↑  ↗
-            p4: self.opt.pad.p4.clone(),
-            p5: self.opt.pad.p5.clone(),
-            p6: self.opt.pad.p6.clone(), // ←  •  →
-            p7: self.opt.pad.p7.clone(),
-            p8: self.opt.pad.p8.clone(),
-            p9: self.opt.pad.p9.clone(), // ↙  ↓  ↘
+            p1: self.opt.pad.p1,
+            p2: self.opt.pad.p2,
+            p3: self.opt.pad.p3, // ↖  ↑  ↗
+            p4: self.opt.pad.p4,
+            p5: self.opt.pad.p5,
+            p6: self.opt.pad.p6, // ←  •  →
+            p7: self.opt.pad.p7,
+            p8: self.opt.pad.p8,
+            p9: self.opt.pad.p9, // ↙  ↓  ↘
         };
         ctx.with_leaf_action_widget(|ctx| ctx.new_pod(widgets::Button9::from_label_pod(label, pad)))
     }

--- a/xilem/src/view/button9.rs
+++ b/xilem/src/view/button9.rs
@@ -5,14 +5,14 @@ pub use masonry::core::{PointerButton, PointerButton as PointerB, WidgetPod};
 use masonry::widgets;
 use crate::binmod::custom_button_masonry as widget9;
 
-use xilem::core::{ViewPathTracker,
+use crate::core::{ViewPathTracker,
   DynMessage, Mut, View, ViewMarker,
   MessageResult, ViewId, MessageResult as MsgRes,
 };
-use xilem::view::Label;
-use xilem::{Pod, ViewCtx};
+use crate::view::Label;
+use crate::{Pod, ViewCtx};
 
-use masonry::kurbo::{Insets};
+use masonry::kurbo::Insets;
 
 /// A button which calls `callback` when the 🖰1 (normally left) is pressed<br>
 /// To use button provide it with a button text or `label` and a closure

--- a/xilem/src/view/button9.rs
+++ b/xilem/src/view/button9.rs
@@ -3,11 +3,11 @@
 
 use crate::view::PointerButton;
 pub use masonry::core::WidgetPod;
-use masonry::widgets::{self, LabelOpt, Pad9,};
+use masonry::widgets::{self, LabelOpt, Pad9};
 
-use crate::core::{ViewPathTracker,
-  DynMessage, Mut, View, ViewMarker,
-  MessageResult, ViewId, MessageResult as MsgRes,
+use crate::core::{
+    DynMessage, MessageResult, MessageResult as MsgRes, Mut, View, ViewId, ViewMarker,
+    ViewPathTracker,
 };
 use crate::view::Label;
 use crate::{Pod, ViewCtx};
@@ -24,73 +24,144 @@ use masonry::kurbo::Insets;
 /// //let label = label("Button").weight(FontWeight::BOLD);
 /// button(label, |state:&mut State| { state.increase();})
 /// ```
-pub fn button9<State,Action> (label:impl Into<Label>, callback:impl Fn(&mut State) -> Action+Send+'static)
-->Button9<impl for<'a> Fn(&'a mut State, PointerButton) -> MsgRes<Action>+Send+'static> {
-  button9_pad(label, None, callback)
+pub fn button9<State, Action>(
+    label: impl Into<Label>,
+    callback: impl Fn(&mut State) -> Action + Send + 'static,
+) -> Button9<impl for<'a> Fn(&'a mut State, PointerButton) -> MsgRes<Action> + Send + 'static> {
+    button9_pad(label, None, callback)
 }
 /// A button with custom `pad` padding which calls `callback` when 🖰1 (normally left) is pressed
-pub fn button9_pad<State,Action>(label:impl Into<Label>, pad:Option<Insets>, callback: impl Fn(&mut State) -> Action+Send+'static)
-->Button9<impl for<'a> Fn(&'a mut State, PointerButton) -> MsgRes<Action>+Send+'static> {
-  Button9::new(label, pad,
-    move |state: &mut State, button| match button {
-      PointerButton::Primary => MsgRes::Action(callback(state)),
-      _                 => MsgRes::Nop                    ,},
-  )
+pub fn button9_pad<State, Action>(
+    label: impl Into<Label>,
+    pad: Option<Insets>,
+    callback: impl Fn(&mut State) -> Action + Send + 'static,
+) -> Button9<impl for<'a> Fn(&'a mut State, PointerButton) -> MsgRes<Action> + Send + 'static> {
+    Button9::new(label, pad, move |state: &mut State, button| match button {
+        PointerButton::Primary => MsgRes::Action(callback(state)),
+        _ => MsgRes::Nop,
+    })
 }
 /// A button which calls `callback` when any 🖰 is pressed
-pub fn button9_any_pointer<State,Action>(label:impl Into<Label>, callback: impl Fn(&mut State, PointerButton) -> Action+Send+'static)
-->Button9<impl for<'a> Fn(&'a mut State, PointerButton) -> MsgRes<Action>+Send+'static> {
-  button9_any_pointer_pad(label, None, callback)
+pub fn button9_any_pointer<State, Action>(
+    label: impl Into<Label>,
+    callback: impl Fn(&mut State, PointerButton) -> Action + Send + 'static,
+) -> Button9<impl for<'a> Fn(&'a mut State, PointerButton) -> MsgRes<Action> + Send + 'static> {
+    button9_any_pointer_pad(label, None, callback)
 }
 /// A button with custom `pad` padding which calls `callback` when any 🖰 is pressed
-pub fn button9_any_pointer_pad<State,Action>(label:impl Into<Label>, pad:Option<Insets>, callback: impl Fn(&mut State, PointerButton) -> Action+Send+'static)
-->Button9<impl for<'a> Fn(&'a mut State, PointerButton) -> MsgRes<Action>+Send+'static> {
-  Button9::new(label, pad,
-    move |state: &mut State, button| MsgRes::Action(callback(state, button)),
-  )
+pub fn button9_any_pointer_pad<State, Action>(
+    label: impl Into<Label>,
+    pad: Option<Insets>,
+    callback: impl Fn(&mut State, PointerButton) -> Action + Send + 'static,
+) -> Button9<impl for<'a> Fn(&'a mut State, PointerButton) -> MsgRes<Action> + Send + 'static> {
+    Button9::new(label, pad, move |state: &mut State, button| {
+        MsgRes::Action(callback(state, button))
+    })
 }
 
 /// The [`View`] created by [`button`] from up to label(s) in one of 9 positions with custom padding and a callback.
 #[must_use = "View values do nothing unless provided to Xilem."]
 pub struct Button9<F> {
-  label: Label9,
-  opt  : LabelOpt,
-  callback: F,
+    label: Label9,
+    opt: LabelOpt,
+    callback: F,
 }
 /// Label for Button9
 pub struct Label9 {
-  p1:Label, p2:Label, p3:Label, // ↖  ↑  ↗
-  p4:Label, p5:Label, p6:Label, // ←  •  →
-  p7:Label, p8:Label, p9:Label, // ↙  ↓  ↘
+    p1: Label,
+    p2: Label,
+    p3: Label, // ↖  ↑  ↗
+    p4: Label,
+    p5: Label,
+    p6: Label, // ←  •  →
+    p7: Label,
+    p8: Label,
+    p9: Label, // ↙  ↓  ↘
 }
 
-impl<F> Button9<F>{
-  /// Create a new button with a text label at the center (p5m other labels are blank, use `.addx` methods to fill them)
-  pub fn new(                     label:impl Into<Label>, pad:Option<Insets>, callback:F) -> Self {
-    let label = Label9 {
-      p1:"".into(), p2:""   .into(), p3:"".into(), // ↖  ↑  ↗
-      p4:"".into(), p5:label.into(), p6:"".into(), // ←  •  →
-      p7:"".into(), p8:""   .into(), p9:"".into(), // ↙  ↓  ↘
-    };
-    let pad = Pad9 {
-      p1:None, p2:None, p3:None, // ↖  ↑  ↗
-      p4:None, p5:pad , p6:None, // ←  •  →
-      p7:None, p8:None, p9:None, // ↙  ↓  ↘
-    };
-    let opt = LabelOpt{pad};
-    Self {label, opt, callback}
-  }
-  /// Helper .methods for adding individual labels (add=center p5)
-  pub fn add (mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p5 = label.into(); self.opt.pad.p5 = pad; self}
-  pub fn add1(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p1 = label.into(); self.opt.pad.p1 = pad; self}
-  pub fn add2(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p2 = label.into(); self.opt.pad.p2 = pad; self}
-  pub fn add3(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p3 = label.into(); self.opt.pad.p3 = pad; self}
-  pub fn add4(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p4 = label.into(); self.opt.pad.p4 = pad; self}
-  pub fn add5(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p5 = label.into(); self.opt.pad.p5 = pad; self}
-  pub fn add6(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p6 = label.into(); self.opt.pad.p6 = pad; self}
-  pub fn add7(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p7 = label.into(); self.opt.pad.p7 = pad; self}
-  pub fn add8(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p8 = label.into(); self.opt.pad.p8 = pad; self}
-  pub fn add9(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p9 = label.into(); self.opt.pad.p9 = pad; self}
+impl<F> Button9<F> {
+    /// Create a new button with a text label at the center (p5m other labels are blank, use `.addx` methods to fill them)
+    pub fn new(label: impl Into<Label>, pad: Option<Insets>, callback: F) -> Self {
+        let label = Label9 {
+            p1: "".into(),
+            p2: "".into(),
+            p3: "".into(), // ↖  ↑  ↗
+            p4: "".into(),
+            p5: label.into(),
+            p6: "".into(), // ←  •  →
+            p7: "".into(),
+            p8: "".into(),
+            p9: "".into(), // ↙  ↓  ↘
+        };
+        let pad = Pad9 {
+            p1: None,
+            p2: None,
+            p3: None, // ↖  ↑  ↗
+            p4: None,
+            p5: pad,
+            p6: None, // ←  •  →
+            p7: None,
+            p8: None,
+            p9: None, // ↙  ↓  ↘
+        };
+        let opt = LabelOpt { pad };
+        Self {
+            label,
+            opt,
+            callback,
+        }
+    }
+    /// Helper .methods for adding individual labels (add=center p5)
+    pub fn add(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
+        self.label.p5 = label.into();
+        self.opt.pad.p5 = pad;
+        self
+    }
+    pub fn add1(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
+        self.label.p1 = label.into();
+        self.opt.pad.p1 = pad;
+        self
+    }
+    pub fn add2(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
+        self.label.p2 = label.into();
+        self.opt.pad.p2 = pad;
+        self
+    }
+    pub fn add3(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
+        self.label.p3 = label.into();
+        self.opt.pad.p3 = pad;
+        self
+    }
+    pub fn add4(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
+        self.label.p4 = label.into();
+        self.opt.pad.p4 = pad;
+        self
+    }
+    pub fn add5(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
+        self.label.p5 = label.into();
+        self.opt.pad.p5 = pad;
+        self
+    }
+    pub fn add6(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
+        self.label.p6 = label.into();
+        self.opt.pad.p6 = pad;
+        self
+    }
+    pub fn add7(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
+        self.label.p7 = label.into();
+        self.opt.pad.p7 = pad;
+        self
+    }
+    pub fn add8(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
+        self.label.p8 = label.into();
+        self.opt.pad.p8 = pad;
+        self
+    }
+    pub fn add9(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
+        self.label.p9 = label.into();
+        self.opt.pad.p9 = pad;
+        self
+    }
 }
 
 const ID_LVW1: ViewId = ViewId::new(1);
@@ -103,103 +174,308 @@ const ID_LVW7: ViewId = ViewId::new(7);
 const ID_LVW8: ViewId = ViewId::new(8);
 const ID_LVW9: ViewId = ViewId::new(9);
 
-pub fn into_widget_pod(p:Pod<widgets::Label>) -> WidgetPod<widgets::Label> {
-  WidgetPod::new_with_id_and_transform(p.widget, p.id, p.transform)
+pub fn into_widget_pod(p: Pod<widgets::Label>) -> WidgetPod<widgets::Label> {
+    WidgetPod::new_with_id_and_transform(p.widget, p.id, p.transform)
 }
 
-impl<F>              ViewMarker                 for Button9<F> {}
-impl<F,State,Action> View<State,Action,ViewCtx> for Button9<F>
-where F: Fn(&mut State, PointerButton) -> MsgRes<Action> + Send + Sync + 'static {
-  type Element = Pod<widgets::Button9>;
-  type ViewState = ();
+impl<F> ViewMarker for Button9<F> {}
+impl<F, State, Action> View<State, Action, ViewCtx> for Button9<F>
+where
+    F: Fn(&mut State, PointerButton) -> MsgRes<Action> + Send + Sync + 'static,
+{
+    type Element = Pod<widgets::Button9>;
+    type ViewState = ();
 
-  fn build(&self, ctx:&mut ViewCtx) -> (Self::Element, Self::ViewState) {
-    // build based on LabelViews, which already implement build themselves:(Self::Element, Self::ViewState)
-    let (child1,()) = ctx.with_id(ID_LVW1, |ctx|{View::<State,Action,_>::build(&self.label.p1,ctx)});
-    let (child2,()) = ctx.with_id(ID_LVW2, |ctx|{View::<State,Action,_>::build(&self.label.p2,ctx)});
-    let (child3,()) = ctx.with_id(ID_LVW3, |ctx|{View::<State,Action,_>::build(&self.label.p3,ctx)});
-    let (child4,()) = ctx.with_id(ID_LVW4, |ctx|{View::<State,Action,_>::build(&self.label.p4,ctx)});
-    let (child5,()) = ctx.with_id(ID_LVW5, |ctx|{View::<State,Action,_>::build(&self.label.p5,ctx)});
-    let (child6,()) = ctx.with_id(ID_LVW6, |ctx|{View::<State,Action,_>::build(&self.label.p6,ctx)});
-    let (child7,()) = ctx.with_id(ID_LVW7, |ctx|{View::<State,Action,_>::build(&self.label.p7,ctx)});
-    let (child8,()) = ctx.with_id(ID_LVW8, |ctx|{View::<State,Action,_>::build(&self.label.p8,ctx)});
-    let (child9,()) = ctx.with_id(ID_LVW9, |ctx|{View::<State,Action,_>::build(&self.label.p9,ctx)});
-    // pass built elements to the masonry widgets
-    let label = [
-      into_widget_pod(child1), into_widget_pod(child2), into_widget_pod(child3), // ↖  ↑  ↗
-      into_widget_pod(child4), into_widget_pod(child5), into_widget_pod(child8), // ←  •  →
-      into_widget_pod(child7), into_widget_pod(child6), into_widget_pod(child9), // ↙  ↓  ↘
-      // child1.into_widget_pod(), child2.into_widget_pod(), child3.into_widget_pod(), // ↖  ↑  ↗
-      // child4.into_widget_pod(), child5.into_widget_pod(), child8.into_widget_pod(), // ←  •  →
-      // child7.into_widget_pod(), child6.into_widget_pod(), child9.into_widget_pod(), // ↙  ↓  ↘
-    ];
-    let pad = Pad9 {
-      p1:self.opt.pad.p1.clone(), p2:self.opt.pad.p2.clone(), p3:self.opt.pad.p3.clone(), // ↖  ↑  ↗
-      p4:self.opt.pad.p4.clone(), p5:self.opt.pad.p5.clone(), p6:self.opt.pad.p6.clone(), // ←  •  →
-      p7:self.opt.pad.p7.clone(), p8:self.opt.pad.p8.clone(), p9:self.opt.pad.p9.clone(), // ↙  ↓  ↘
-    };
-    ctx.with_leaf_action_widget(|ctx| {ctx.new_pod(widgets::Button9::from_label_pod(label,pad)) } )
-  }
-
-  fn rebuild(&self, prev:&Self, state:&mut Self::ViewState, ctx:&mut ViewCtx, mut el:Mut<Self::Element>) {
-    // rebuild based on LabelViews, which already implement rebuild themselves (compare all the props)
-    ctx.with_id(ID_LVW1, |ctx|{View::<State,Action,_>::rebuild(&self.label.p1,&prev.label.p1,state,ctx, widgets::Button9::label1_mut(&mut el));});
-    ctx.with_id(ID_LVW2, |ctx|{View::<State,Action,_>::rebuild(&self.label.p2,&prev.label.p2,state,ctx, widgets::Button9::label2_mut(&mut el));});
-    ctx.with_id(ID_LVW3, |ctx|{View::<State,Action,_>::rebuild(&self.label.p3,&prev.label.p3,state,ctx, widgets::Button9::label3_mut(&mut el));});
-    ctx.with_id(ID_LVW4, |ctx|{View::<State,Action,_>::rebuild(&self.label.p4,&prev.label.p4,state,ctx, widgets::Button9::label4_mut(&mut el));});
-    ctx.with_id(ID_LVW5, |ctx|{View::<State,Action,_>::rebuild(&self.label.p5,&prev.label.p5,state,ctx, widgets::Button9::label5_mut(&mut el));});
-    ctx.with_id(ID_LVW6, |ctx|{View::<State,Action,_>::rebuild(&self.label.p6,&prev.label.p6,state,ctx, widgets::Button9::label6_mut(&mut el));});
-    ctx.with_id(ID_LVW7, |ctx|{View::<State,Action,_>::rebuild(&self.label.p7,&prev.label.p7,state,ctx, widgets::Button9::label7_mut(&mut el));});
-    ctx.with_id(ID_LVW8, |ctx|{View::<State,Action,_>::rebuild(&self.label.p8,&prev.label.p8,state,ctx, widgets::Button9::label8_mut(&mut el));});
-    ctx.with_id(ID_LVW9, |ctx|{View::<State,Action,_>::rebuild(&self.label.p9,&prev.label.p9,state,ctx, widgets::Button9::label9_mut(&mut el));});
-
-    // rebuild based on LabelOpt, do manuall diff for each prop
-    if prev.opt.pad.p1 != self.opt.pad.p1 {widgets::Button9::set_pad1 (&mut el, self.opt.pad.p1);}
-    if prev.opt.pad.p2 != self.opt.pad.p2 {widgets::Button9::set_pad2 (&mut el, self.opt.pad.p2);}
-    if prev.opt.pad.p3 != self.opt.pad.p3 {widgets::Button9::set_pad3 (&mut el, self.opt.pad.p3);}
-    if prev.opt.pad.p4 != self.opt.pad.p4 {widgets::Button9::set_pad4 (&mut el, self.opt.pad.p4);}
-    if prev.opt.pad.p5 != self.opt.pad.p5 {widgets::Button9::set_pad5 (&mut el, self.opt.pad.p5);}
-    if prev.opt.pad.p6 != self.opt.pad.p6 {widgets::Button9::set_pad6 (&mut el, self.opt.pad.p6);}
-    if prev.opt.pad.p7 != self.opt.pad.p7 {widgets::Button9::set_pad7 (&mut el, self.opt.pad.p7);}
-    if prev.opt.pad.p8 != self.opt.pad.p8 {widgets::Button9::set_pad8 (&mut el, self.opt.pad.p8);}
-    if prev.opt.pad.p9 != self.opt.pad.p9 {widgets::Button9::set_pad9 (&mut el, self.opt.pad.p9);}
-  }
-
-  fn teardown(&self, _:&mut Self::ViewState, ctx:&mut ViewCtx, mut el:Mut<Self::Element>) {
-    // teardown LabelViews, which already implement teardown themselves
-    ctx.with_id(ID_LVW1, |ctx|{View::<State,Action,_>::teardown(&self.label.p1,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
-    ctx.with_id(ID_LVW2, |ctx|{View::<State,Action,_>::teardown(&self.label.p2,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
-    ctx.with_id(ID_LVW3, |ctx|{View::<State,Action,_>::teardown(&self.label.p3,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
-    ctx.with_id(ID_LVW4, |ctx|{View::<State,Action,_>::teardown(&self.label.p4,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
-    ctx.with_id(ID_LVW5, |ctx|{View::<State,Action,_>::teardown(&self.label.p5,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
-    ctx.with_id(ID_LVW6, |ctx|{View::<State,Action,_>::teardown(&self.label.p6,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
-    ctx.with_id(ID_LVW7, |ctx|{View::<State,Action,_>::teardown(&self.label.p7,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
-    ctx.with_id(ID_LVW8, |ctx|{View::<State,Action,_>::teardown(&self.label.p8,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
-    ctx.with_id(ID_LVW9, |ctx|{View::<State,Action,_>::teardown(&self.label.p9,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
-    ctx.teardown_leaf(el); // teardown the button element itself
-  }
-
-  fn message(&self, _:&mut Self::ViewState, id_path:&[ViewId], message:DynMessage, app_state:&mut State) -> MsgRes<Action> {
-    match id_path.split_first() {
-      Some((&ID_LVW1, rest)) => self.label.p1.message(&mut(), rest, message, app_state),
-      Some((&ID_LVW2, rest)) => self.label.p2.message(&mut(), rest, message, app_state),
-      Some((&ID_LVW3, rest)) => self.label.p3.message(&mut(), rest, message, app_state),
-      Some((&ID_LVW4, rest)) => self.label.p4.message(&mut(), rest, message, app_state),
-      Some((&ID_LVW5, rest)) => self.label.p5.message(&mut(), rest, message, app_state),
-      Some((&ID_LVW6, rest)) => self.label.p6.message(&mut(), rest, message, app_state),
-      Some((&ID_LVW7, rest)) => self.label.p7.message(&mut(), rest, message, app_state),
-      Some((&ID_LVW8, rest)) => self.label.p8.message(&mut(), rest, message, app_state),
-      Some((&ID_LVW9, rest)) => self.label.p9.message(&mut(), rest, message, app_state),
-      None => match message.downcast::<masonry::core::Action>() {
-        Ok(action)   => {
-          if let masonry::core::Action::ButtonPressed(button) = *action {
-            (self.callback)(app_state, button)
-          } else        {tracing::error!("Wrong action type in Button9::message: {action:?}");
-            MessageResult::Stale(action)} }
-        Err(message) => {tracing::error!("Wrong message type in Button9::message: {message:?}");
-            MessageResult::Stale(message) }   },
-      _    =>           {tracing::warn! ("Got unexpected ID path in Button9::message");
-            MessageResult::Stale(message)      }
+    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+        // build based on LabelViews, which already implement build themselves:(Self::Element, Self::ViewState)
+        let (child1, ()) = ctx.with_id(ID_LVW1, |ctx| {
+            View::<State, Action, _>::build(&self.label.p1, ctx)
+        });
+        let (child2, ()) = ctx.with_id(ID_LVW2, |ctx| {
+            View::<State, Action, _>::build(&self.label.p2, ctx)
+        });
+        let (child3, ()) = ctx.with_id(ID_LVW3, |ctx| {
+            View::<State, Action, _>::build(&self.label.p3, ctx)
+        });
+        let (child4, ()) = ctx.with_id(ID_LVW4, |ctx| {
+            View::<State, Action, _>::build(&self.label.p4, ctx)
+        });
+        let (child5, ()) = ctx.with_id(ID_LVW5, |ctx| {
+            View::<State, Action, _>::build(&self.label.p5, ctx)
+        });
+        let (child6, ()) = ctx.with_id(ID_LVW6, |ctx| {
+            View::<State, Action, _>::build(&self.label.p6, ctx)
+        });
+        let (child7, ()) = ctx.with_id(ID_LVW7, |ctx| {
+            View::<State, Action, _>::build(&self.label.p7, ctx)
+        });
+        let (child8, ()) = ctx.with_id(ID_LVW8, |ctx| {
+            View::<State, Action, _>::build(&self.label.p8, ctx)
+        });
+        let (child9, ()) = ctx.with_id(ID_LVW9, |ctx| {
+            View::<State, Action, _>::build(&self.label.p9, ctx)
+        });
+        // pass built elements to the masonry widgets
+        let label = [
+            into_widget_pod(child1),
+            into_widget_pod(child2),
+            into_widget_pod(child3), // ↖  ↑  ↗
+            into_widget_pod(child4),
+            into_widget_pod(child5),
+            into_widget_pod(child8), // ←  •  →
+            into_widget_pod(child7),
+            into_widget_pod(child6),
+            into_widget_pod(child9), // ↙  ↓  ↘
+                                     // child1.into_widget_pod(), child2.into_widget_pod(), child3.into_widget_pod(), // ↖  ↑  ↗
+                                     // child4.into_widget_pod(), child5.into_widget_pod(), child8.into_widget_pod(), // ←  •  →
+                                     // child7.into_widget_pod(), child6.into_widget_pod(), child9.into_widget_pod(), // ↙  ↓  ↘
+        ];
+        let pad = Pad9 {
+            p1: self.opt.pad.p1.clone(),
+            p2: self.opt.pad.p2.clone(),
+            p3: self.opt.pad.p3.clone(), // ↖  ↑  ↗
+            p4: self.opt.pad.p4.clone(),
+            p5: self.opt.pad.p5.clone(),
+            p6: self.opt.pad.p6.clone(), // ←  •  →
+            p7: self.opt.pad.p7.clone(),
+            p8: self.opt.pad.p8.clone(),
+            p9: self.opt.pad.p9.clone(), // ↙  ↓  ↘
+        };
+        ctx.with_leaf_action_widget(|ctx| ctx.new_pod(widgets::Button9::from_label_pod(label, pad)))
     }
-  }
+
+    fn rebuild(
+        &self,
+        prev: &Self,
+        state: &mut Self::ViewState,
+        ctx: &mut ViewCtx,
+        mut el: Mut<Self::Element>,
+    ) {
+        // rebuild based on LabelViews, which already implement rebuild themselves (compare all the props)
+        ctx.with_id(ID_LVW1, |ctx| {
+            View::<State, Action, _>::rebuild(
+                &self.label.p1,
+                &prev.label.p1,
+                state,
+                ctx,
+                widgets::Button9::label1_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW2, |ctx| {
+            View::<State, Action, _>::rebuild(
+                &self.label.p2,
+                &prev.label.p2,
+                state,
+                ctx,
+                widgets::Button9::label2_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW3, |ctx| {
+            View::<State, Action, _>::rebuild(
+                &self.label.p3,
+                &prev.label.p3,
+                state,
+                ctx,
+                widgets::Button9::label3_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW4, |ctx| {
+            View::<State, Action, _>::rebuild(
+                &self.label.p4,
+                &prev.label.p4,
+                state,
+                ctx,
+                widgets::Button9::label4_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW5, |ctx| {
+            View::<State, Action, _>::rebuild(
+                &self.label.p5,
+                &prev.label.p5,
+                state,
+                ctx,
+                widgets::Button9::label5_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW6, |ctx| {
+            View::<State, Action, _>::rebuild(
+                &self.label.p6,
+                &prev.label.p6,
+                state,
+                ctx,
+                widgets::Button9::label6_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW7, |ctx| {
+            View::<State, Action, _>::rebuild(
+                &self.label.p7,
+                &prev.label.p7,
+                state,
+                ctx,
+                widgets::Button9::label7_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW8, |ctx| {
+            View::<State, Action, _>::rebuild(
+                &self.label.p8,
+                &prev.label.p8,
+                state,
+                ctx,
+                widgets::Button9::label8_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW9, |ctx| {
+            View::<State, Action, _>::rebuild(
+                &self.label.p9,
+                &prev.label.p9,
+                state,
+                ctx,
+                widgets::Button9::label9_mut(&mut el),
+            );
+        });
+
+        // rebuild based on LabelOpt, do manuall diff for each prop
+        if prev.opt.pad.p1 != self.opt.pad.p1 {
+            widgets::Button9::set_pad1(&mut el, self.opt.pad.p1);
+        }
+        if prev.opt.pad.p2 != self.opt.pad.p2 {
+            widgets::Button9::set_pad2(&mut el, self.opt.pad.p2);
+        }
+        if prev.opt.pad.p3 != self.opt.pad.p3 {
+            widgets::Button9::set_pad3(&mut el, self.opt.pad.p3);
+        }
+        if prev.opt.pad.p4 != self.opt.pad.p4 {
+            widgets::Button9::set_pad4(&mut el, self.opt.pad.p4);
+        }
+        if prev.opt.pad.p5 != self.opt.pad.p5 {
+            widgets::Button9::set_pad5(&mut el, self.opt.pad.p5);
+        }
+        if prev.opt.pad.p6 != self.opt.pad.p6 {
+            widgets::Button9::set_pad6(&mut el, self.opt.pad.p6);
+        }
+        if prev.opt.pad.p7 != self.opt.pad.p7 {
+            widgets::Button9::set_pad7(&mut el, self.opt.pad.p7);
+        }
+        if prev.opt.pad.p8 != self.opt.pad.p8 {
+            widgets::Button9::set_pad8(&mut el, self.opt.pad.p8);
+        }
+        if prev.opt.pad.p9 != self.opt.pad.p9 {
+            widgets::Button9::set_pad9(&mut el, self.opt.pad.p9);
+        }
+    }
+
+    fn teardown(&self, _: &mut Self::ViewState, ctx: &mut ViewCtx, mut el: Mut<Self::Element>) {
+        // teardown LabelViews, which already implement teardown themselves
+        ctx.with_id(ID_LVW1, |ctx| {
+            View::<State, Action, _>::teardown(
+                &self.label.p1,
+                &mut (),
+                ctx,
+                widgets::Button9::label1_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW2, |ctx| {
+            View::<State, Action, _>::teardown(
+                &self.label.p2,
+                &mut (),
+                ctx,
+                widgets::Button9::label1_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW3, |ctx| {
+            View::<State, Action, _>::teardown(
+                &self.label.p3,
+                &mut (),
+                ctx,
+                widgets::Button9::label1_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW4, |ctx| {
+            View::<State, Action, _>::teardown(
+                &self.label.p4,
+                &mut (),
+                ctx,
+                widgets::Button9::label1_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW5, |ctx| {
+            View::<State, Action, _>::teardown(
+                &self.label.p5,
+                &mut (),
+                ctx,
+                widgets::Button9::label1_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW6, |ctx| {
+            View::<State, Action, _>::teardown(
+                &self.label.p6,
+                &mut (),
+                ctx,
+                widgets::Button9::label1_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW7, |ctx| {
+            View::<State, Action, _>::teardown(
+                &self.label.p7,
+                &mut (),
+                ctx,
+                widgets::Button9::label1_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW8, |ctx| {
+            View::<State, Action, _>::teardown(
+                &self.label.p8,
+                &mut (),
+                ctx,
+                widgets::Button9::label1_mut(&mut el),
+            );
+        });
+        ctx.with_id(ID_LVW9, |ctx| {
+            View::<State, Action, _>::teardown(
+                &self.label.p9,
+                &mut (),
+                ctx,
+                widgets::Button9::label1_mut(&mut el),
+            );
+        });
+        ctx.teardown_leaf(el); // teardown the button element itself
+    }
+
+    fn message(
+        &self,
+        _: &mut Self::ViewState,
+        id_path: &[ViewId],
+        message: DynMessage,
+        app_state: &mut State,
+    ) -> MsgRes<Action> {
+        match id_path.split_first() {
+            Some((&ID_LVW1, rest)) => self.label.p1.message(&mut (), rest, message, app_state),
+            Some((&ID_LVW2, rest)) => self.label.p2.message(&mut (), rest, message, app_state),
+            Some((&ID_LVW3, rest)) => self.label.p3.message(&mut (), rest, message, app_state),
+            Some((&ID_LVW4, rest)) => self.label.p4.message(&mut (), rest, message, app_state),
+            Some((&ID_LVW5, rest)) => self.label.p5.message(&mut (), rest, message, app_state),
+            Some((&ID_LVW6, rest)) => self.label.p6.message(&mut (), rest, message, app_state),
+            Some((&ID_LVW7, rest)) => self.label.p7.message(&mut (), rest, message, app_state),
+            Some((&ID_LVW8, rest)) => self.label.p8.message(&mut (), rest, message, app_state),
+            Some((&ID_LVW9, rest)) => self.label.p9.message(&mut (), rest, message, app_state),
+            None => match message.downcast::<masonry::core::Action>() {
+                Ok(action) => {
+                    if let masonry::core::Action::ButtonPressed(button) = *action {
+                        (self.callback)(app_state, button)
+                    } else {
+                        tracing::error!("Wrong action type in Button9::message: {action:?}");
+                        MessageResult::Stale(action)
+                    }
+                }
+                Err(message) => {
+                    tracing::error!("Wrong message type in Button9::message: {message:?}");
+                    MessageResult::Stale(message)
+                }
+            },
+            _ => {
+                tracing::warn!("Got unexpected ID path in Button9::message");
+                MessageResult::Stale(message)
+            }
+        }
+    }
 }

--- a/xilem/src/view/button9.rs
+++ b/xilem/src/view/button9.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use masonry::core::{PointerButton, PointerButton as PointerB, WidgetPod};
-use masonry::widgets;
-use crate::binmod::custom_button_masonry as widget9;
+use masonry::widgets::{self, button9 as widget9};
 
 use crate::core::{ViewPathTracker,
   DynMessage, Mut, View, ViewMarker,
@@ -50,7 +49,7 @@ pub fn button9_any_pointer_pad<State,Action>(label:impl Into<Label>, pad:Option<
   )
 }
 
-use crate::binmod::custom_button_masonry::{LPos, LabelOpt, Pad9};
+use crate::masonry::button9::{LPos, LabelOpt, Pad9};
 
 /// The [`View`] created by [`button`] from up to label(s) in one of [`LPos`] position with custom padding and a callback.
 #[must_use = "View values do nothing unless provided to Xilem."]
@@ -61,50 +60,50 @@ pub struct ButtonL9<F> {
 }
 /// Label for ButtonL9
 pub struct Label9 {
-  TL1:Label, TI2:Label, TJ3:Label, // ↖  ↑  ↗
-  HL4:Label, HI5:Label, HJ6:Label, // ←  •  →
-  LL7:Label, LI8:Label, LJ9:Label, // ↙  ↓  ↘
+  tl1:Label, ti2:Label, tj3:Label, // ↖  ↑  ↗
+  hl4:Label, hi5:Label, hj6:Label, // ←  •  →
+  ll7:Label, li8:Label, lj9:Label, // ↙  ↓  ↘
 }
 
 impl<F> ButtonL9<F>{
-  /// Create a new button with a text label at the center (HI5m other labels are blank, use `.addx` methods to fill them)
+  /// Create a new button with a text label at the center (hi5m other labels are blank, use `.addx` methods to fill them)
   pub fn new(                     label:impl Into<Label>, pad:Option<Insets>, callback:F) -> Self {
     let label = Label9 {
-      TL1:"".into(), TI2:""   .into(), TJ3:"".into(), // ↖  ↑  ↗
-      HL4:"".into(), HI5:label.into(), HJ6:"".into(), // ←  •  →
-      LL7:"".into(), LI8:""   .into(), LJ9:"".into(), // ↙  ↓  ↘
+      tl1:"".into(), ti2:""   .into(), tj3:"".into(), // ↖  ↑  ↗
+      hl4:"".into(), hi5:label.into(), hj6:"".into(), // ←  •  →
+      ll7:"".into(), li8:""   .into(), lj9:"".into(), // ↙  ↓  ↘
     };
     let pad = Pad9 {
-      TL1:None, TI2:None, TJ3:None, // ↖  ↑  ↗
-      HL4:None, HI5:pad , HJ6:None, // ←  •  →
-      LL7:None, LI8:None, LJ9:None, // ↙  ↓  ↘
+      tl1:None, ti2:None, tj3:None, // ↖  ↑  ↗
+      hl4:None, hi5:pad , hj6:None, // ←  •  →
+      ll7:None, li8:None, lj9:None, // ↙  ↓  ↘
     };
     let opt = LabelOpt{pad};
     Self {label, opt, callback}
   }
-  /// Helper .methods for adding individual labels (add=center HI5)
-  pub fn add (mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.HI5 = label.into(); self.opt.pad.HI5 = pad; self}
-  pub fn add1(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.TL1 = label.into(); self.opt.pad.TL1 = pad; self}
-  pub fn add2(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.TI2 = label.into(); self.opt.pad.TI2 = pad; self}
-  pub fn add3(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.TJ3 = label.into(); self.opt.pad.TJ3 = pad; self}
-  pub fn add4(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.HL4 = label.into(); self.opt.pad.HL4 = pad; self}
-  pub fn add5(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.HI5 = label.into(); self.opt.pad.HI5 = pad; self}
-  pub fn add6(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.HJ6 = label.into(); self.opt.pad.HJ6 = pad; self}
-  pub fn add7(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.LL7 = label.into(); self.opt.pad.LL7 = pad; self}
-  pub fn add8(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.LI8 = label.into(); self.opt.pad.LI8 = pad; self}
-  pub fn add9(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.LJ9 = label.into(); self.opt.pad.LJ9 = pad; self}
-  // pub fn add (mut self,         label:impl Into<Label>, pad:Option<Insets>) {self.addx(LPos::HI5,label,pad)}
+  /// Helper .methods for adding individual labels (add=center hi5)
+  pub fn add (mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.hi5 = label.into(); self.opt.pad.hi5 = pad; self}
+  pub fn add1(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.tl1 = label.into(); self.opt.pad.tl1 = pad; self}
+  pub fn add2(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.ti2 = label.into(); self.opt.pad.ti2 = pad; self}
+  pub fn add3(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.tj3 = label.into(); self.opt.pad.tj3 = pad; self}
+  pub fn add4(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.hl4 = label.into(); self.opt.pad.hl4 = pad; self}
+  pub fn add5(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.hi5 = label.into(); self.opt.pad.hi5 = pad; self}
+  pub fn add6(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.hj6 = label.into(); self.opt.pad.hj6 = pad; self}
+  pub fn add7(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.ll7 = label.into(); self.opt.pad.ll7 = pad; self}
+  pub fn add8(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.li8 = label.into(); self.opt.pad.li8 = pad; self}
+  pub fn add9(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.lj9 = label.into(); self.opt.pad.lj9 = pad; self}
+  // pub fn add (mut self,         label:impl Into<Label>, pad:Option<Insets>) {self.addx(LPos::hi5,label,pad)}
   /// Helper .method for adding a label to a given position (same as in [`LPos`])
   pub fn addx(mut self,idx:LPos,label:impl Into<Label>, pad:Option<Insets>) -> Self {match idx {
-    LPos::TL1 => {self.label.TL1 = label.into(); self.opt.pad.TL1 = pad}, //↖
-    LPos::TI2 => {self.label.TI2 = label.into(); self.opt.pad.TI2 = pad}, //↑
-    LPos::TJ3 => {self.label.TJ3 = label.into(); self.opt.pad.TJ3 = pad}, //↗
-    LPos::HL4 => {self.label.HL4 = label.into(); self.opt.pad.HL4 = pad}, //←
-    LPos::HI5 => {self.label.HI5 = label.into(); self.opt.pad.HI5 = pad}, //•
-    LPos::HJ6 => {self.label.HJ6 = label.into(); self.opt.pad.HJ6 = pad}, //→
-    LPos::LL7 => {self.label.LL7 = label.into(); self.opt.pad.LL7 = pad}, //↙
-    LPos::LI8 => {self.label.LI8 = label.into(); self.opt.pad.LI8 = pad}, //↓
-    LPos::LJ9 => {self.label.LJ9 = label.into(); self.opt.pad.LJ9 = pad}, //↘
+    LPos::tl1 => {self.label.tl1 = label.into(); self.opt.pad.tl1 = pad}, //↖
+    LPos::ti2 => {self.label.ti2 = label.into(); self.opt.pad.ti2 = pad}, //↑
+    LPos::tj3 => {self.label.tj3 = label.into(); self.opt.pad.tj3 = pad}, //↗
+    LPos::hl4 => {self.label.hl4 = label.into(); self.opt.pad.hl4 = pad}, //←
+    LPos::hi5 => {self.label.hi5 = label.into(); self.opt.pad.hi5 = pad}, //•
+    LPos::hj6 => {self.label.hj6 = label.into(); self.opt.pad.hj6 = pad}, //→
+    LPos::ll7 => {self.label.ll7 = label.into(); self.opt.pad.ll7 = pad}, //↙
+    LPos::li8 => {self.label.li8 = label.into(); self.opt.pad.li8 = pad}, //↓
+    LPos::lj9 => {self.label.lj9 = label.into(); self.opt.pad.lj9 = pad}, //↘
   } self }
 }
 
@@ -130,15 +129,15 @@ where F: Fn(&mut State, PointerB) -> MsgRes<Action> + Send + Sync + 'static {
 
   fn build(&self, ctx:&mut ViewCtx) -> (Self::Element, Self::ViewState) {
     // build based on LabelViews, which already implement build themselves:(Self::Element, Self::ViewState)
-    let (child1,()) = ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::build(&self.label.TL1,ctx)});
-    let (child2,()) = ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::build(&self.label.TI2,ctx)});
-    let (child3,()) = ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::build(&self.label.TJ3,ctx)});
-    let (child4,()) = ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::build(&self.label.HL4,ctx)});
-    let (child5,()) = ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::build(&self.label.HI5,ctx)});
-    let (child6,()) = ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::build(&self.label.HJ6,ctx)});
-    let (child7,()) = ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::build(&self.label.LL7,ctx)});
-    let (child8,()) = ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::build(&self.label.LI8,ctx)});
-    let (child9,()) = ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::build(&self.label.LJ9,ctx)});
+    let (child1,()) = ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::build(&self.label.tl1,ctx)});
+    let (child2,()) = ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::build(&self.label.ti2,ctx)});
+    let (child3,()) = ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::build(&self.label.tj3,ctx)});
+    let (child4,()) = ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::build(&self.label.hl4,ctx)});
+    let (child5,()) = ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::build(&self.label.hi5,ctx)});
+    let (child6,()) = ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::build(&self.label.hj6,ctx)});
+    let (child7,()) = ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::build(&self.label.ll7,ctx)});
+    let (child8,()) = ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::build(&self.label.li8,ctx)});
+    let (child9,()) = ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::build(&self.label.lj9,ctx)});
     // pass built elements to the masonry widgets
     let label = [
       into_widget_pod(child1), into_widget_pod(child2), into_widget_pod(child3), // ↖  ↑  ↗
@@ -149,62 +148,62 @@ where F: Fn(&mut State, PointerB) -> MsgRes<Action> + Send + Sync + 'static {
       // child7.into_widget_pod(), child6.into_widget_pod(), child9.into_widget_pod(), // ↙  ↓  ↘
     ];
     let pad = Pad9 {
-      TL1:self.opt.pad.TL1.clone(), TI2:self.opt.pad.TI2.clone(), TJ3:self.opt.pad.TJ3.clone(), // ↖  ↑  ↗
-      HL4:self.opt.pad.HL4.clone(), HI5:self.opt.pad.HI5.clone(), HJ6:self.opt.pad.HJ6.clone(), // ←  •  →
-      LL7:self.opt.pad.LL7.clone(), LI8:self.opt.pad.LI8.clone(), LJ9:self.opt.pad.LJ9.clone(), // ↙  ↓  ↘
+      tl1:self.opt.pad.tl1.clone(), ti2:self.opt.pad.ti2.clone(), tj3:self.opt.pad.tj3.clone(), // ↖  ↑  ↗
+      hl4:self.opt.pad.hl4.clone(), hi5:self.opt.pad.hi5.clone(), hj6:self.opt.pad.hj6.clone(), // ←  •  →
+      ll7:self.opt.pad.ll7.clone(), li8:self.opt.pad.li8.clone(), lj9:self.opt.pad.lj9.clone(), // ↙  ↓  ↘
     };
     ctx.with_leaf_action_widget(|ctx| {ctx.new_pod(widget9::ButtonL9::from_label_pod(label,pad)) } )
   }
 
   fn rebuild(&self, prev:&Self, state:&mut Self::ViewState, ctx:&mut ViewCtx, mut el:Mut<Self::Element>) {
     // rebuild based on LabelViews, which already implement rebuild themselves (compare all the props)
-    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::rebuild(&self.label.TL1,&prev.label.TL1,state,ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::rebuild(&self.label.TI2,&prev.label.TI2,state,ctx, widget9::ButtonL9::label2_mut(&mut el));});
-    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::rebuild(&self.label.TJ3,&prev.label.TJ3,state,ctx, widget9::ButtonL9::label3_mut(&mut el));});
-    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::rebuild(&self.label.HL4,&prev.label.HL4,state,ctx, widget9::ButtonL9::label4_mut(&mut el));});
-    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::rebuild(&self.label.HI5,&prev.label.HI5,state,ctx, widget9::ButtonL9::label5_mut(&mut el));});
-    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::rebuild(&self.label.HJ6,&prev.label.HJ6,state,ctx, widget9::ButtonL9::label6_mut(&mut el));});
-    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::rebuild(&self.label.LL7,&prev.label.LL7,state,ctx, widget9::ButtonL9::label7_mut(&mut el));});
-    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::rebuild(&self.label.LI8,&prev.label.LI8,state,ctx, widget9::ButtonL9::label8_mut(&mut el));});
-    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::rebuild(&self.label.LJ9,&prev.label.LJ9,state,ctx, widget9::ButtonL9::label9_mut(&mut el));});
+    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::rebuild(&self.label.tl1,&prev.label.tl1,state,ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::rebuild(&self.label.ti2,&prev.label.ti2,state,ctx, widget9::ButtonL9::label2_mut(&mut el));});
+    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::rebuild(&self.label.tj3,&prev.label.tj3,state,ctx, widget9::ButtonL9::label3_mut(&mut el));});
+    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::rebuild(&self.label.hl4,&prev.label.hl4,state,ctx, widget9::ButtonL9::label4_mut(&mut el));});
+    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::rebuild(&self.label.hi5,&prev.label.hi5,state,ctx, widget9::ButtonL9::label5_mut(&mut el));});
+    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::rebuild(&self.label.hj6,&prev.label.hj6,state,ctx, widget9::ButtonL9::label6_mut(&mut el));});
+    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::rebuild(&self.label.ll7,&prev.label.ll7,state,ctx, widget9::ButtonL9::label7_mut(&mut el));});
+    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::rebuild(&self.label.li8,&prev.label.li8,state,ctx, widget9::ButtonL9::label8_mut(&mut el));});
+    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::rebuild(&self.label.lj9,&prev.label.lj9,state,ctx, widget9::ButtonL9::label9_mut(&mut el));});
 
     // rebuild based on LabelOpt, do manuall diff for each prop
-    if prev.opt.pad.TL1 != self.opt.pad.TL1 {widget9::ButtonL9::set_pad1 (&mut el, self.opt.pad.TL1);}
-    if prev.opt.pad.TI2 != self.opt.pad.TI2 {widget9::ButtonL9::set_pad2 (&mut el, self.opt.pad.TI2);}
-    if prev.opt.pad.TJ3 != self.opt.pad.TJ3 {widget9::ButtonL9::set_pad3 (&mut el, self.opt.pad.TJ3);}
-    if prev.opt.pad.HL4 != self.opt.pad.HL4 {widget9::ButtonL9::set_pad4 (&mut el, self.opt.pad.HL4);}
-    if prev.opt.pad.HI5 != self.opt.pad.HI5 {widget9::ButtonL9::set_pad5 (&mut el, self.opt.pad.HI5);}
-    if prev.opt.pad.HJ6 != self.opt.pad.HJ6 {widget9::ButtonL9::set_pad6 (&mut el, self.opt.pad.HJ6);}
-    if prev.opt.pad.LL7 != self.opt.pad.LL7 {widget9::ButtonL9::set_pad7 (&mut el, self.opt.pad.LL7);}
-    if prev.opt.pad.LI8 != self.opt.pad.LI8 {widget9::ButtonL9::set_pad8 (&mut el, self.opt.pad.LI8);}
-    if prev.opt.pad.LJ9 != self.opt.pad.LJ9 {widget9::ButtonL9::set_pad9 (&mut el, self.opt.pad.LJ9);}
+    if prev.opt.pad.tl1 != self.opt.pad.tl1 {widget9::ButtonL9::set_pad1 (&mut el, self.opt.pad.tl1);}
+    if prev.opt.pad.ti2 != self.opt.pad.ti2 {widget9::ButtonL9::set_pad2 (&mut el, self.opt.pad.ti2);}
+    if prev.opt.pad.tj3 != self.opt.pad.tj3 {widget9::ButtonL9::set_pad3 (&mut el, self.opt.pad.tj3);}
+    if prev.opt.pad.hl4 != self.opt.pad.hl4 {widget9::ButtonL9::set_pad4 (&mut el, self.opt.pad.hl4);}
+    if prev.opt.pad.hi5 != self.opt.pad.hi5 {widget9::ButtonL9::set_pad5 (&mut el, self.opt.pad.hi5);}
+    if prev.opt.pad.hj6 != self.opt.pad.hj6 {widget9::ButtonL9::set_pad6 (&mut el, self.opt.pad.hj6);}
+    if prev.opt.pad.ll7 != self.opt.pad.ll7 {widget9::ButtonL9::set_pad7 (&mut el, self.opt.pad.ll7);}
+    if prev.opt.pad.li8 != self.opt.pad.li8 {widget9::ButtonL9::set_pad8 (&mut el, self.opt.pad.li8);}
+    if prev.opt.pad.lj9 != self.opt.pad.lj9 {widget9::ButtonL9::set_pad9 (&mut el, self.opt.pad.lj9);}
   }
 
   fn teardown(&self, _:&mut Self::ViewState, ctx:&mut ViewCtx, mut el:Mut<Self::Element>) {
     // teardown LabelViews, which already implement teardown themselves
-    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::teardown(&self.label.TL1,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::teardown(&self.label.TI2,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::teardown(&self.label.TJ3,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::teardown(&self.label.HL4,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::teardown(&self.label.HI5,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::teardown(&self.label.HJ6,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::teardown(&self.label.LL7,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::teardown(&self.label.LI8,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::teardown(&self.label.LJ9,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::teardown(&self.label.tl1,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::teardown(&self.label.ti2,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::teardown(&self.label.tj3,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::teardown(&self.label.hl4,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::teardown(&self.label.hi5,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::teardown(&self.label.hj6,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::teardown(&self.label.ll7,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::teardown(&self.label.li8,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::teardown(&self.label.lj9,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
     ctx.teardown_leaf(el); // teardown the button element itself
   }
 
   fn message(&self, _:&mut Self::ViewState, id_path:&[ViewId], message:DynMessage, app_state:&mut State) -> MsgRes<Action> {
     match id_path.split_first() {
-      Some((&id_lvw1, rest)) => self.label.TL1.message(&mut(), rest, message, app_state),
-      Some((&id_lvw2, rest)) => self.label.TI2.message(&mut(), rest, message, app_state),
-      Some((&id_lvw3, rest)) => self.label.TJ3.message(&mut(), rest, message, app_state),
-      Some((&id_lvw4, rest)) => self.label.HL4.message(&mut(), rest, message, app_state),
-      Some((&id_lvw5, rest)) => self.label.HI5.message(&mut(), rest, message, app_state),
-      Some((&id_lvw6, rest)) => self.label.HJ6.message(&mut(), rest, message, app_state),
-      Some((&id_lvw7, rest)) => self.label.LL7.message(&mut(), rest, message, app_state),
-      Some((&id_lvw8, rest)) => self.label.LI8.message(&mut(), rest, message, app_state),
-      Some((&id_lvw9, rest)) => self.label.LJ9.message(&mut(), rest, message, app_state),
+      Some((&id_lvw1, rest)) => self.label.tl1.message(&mut(), rest, message, app_state),
+      Some((&id_lvw2, rest)) => self.label.ti2.message(&mut(), rest, message, app_state),
+      Some((&id_lvw3, rest)) => self.label.tj3.message(&mut(), rest, message, app_state),
+      Some((&id_lvw4, rest)) => self.label.hl4.message(&mut(), rest, message, app_state),
+      Some((&id_lvw5, rest)) => self.label.hi5.message(&mut(), rest, message, app_state),
+      Some((&id_lvw6, rest)) => self.label.hj6.message(&mut(), rest, message, app_state),
+      Some((&id_lvw7, rest)) => self.label.ll7.message(&mut(), rest, message, app_state),
+      Some((&id_lvw8, rest)) => self.label.li8.message(&mut(), rest, message, app_state),
+      Some((&id_lvw9, rest)) => self.label.lj9.message(&mut(), rest, message, app_state),
       None => match message.downcast::<masonry::core::Action>() {
         Ok(action)   => {
           if let masonry::core::Action::ButtonPressed(button) = *action {

--- a/xilem/src/view/button9.rs
+++ b/xilem/src/view/button9.rs
@@ -60,50 +60,50 @@ pub struct ButtonL9<F> {
 }
 /// Label for ButtonL9
 pub struct Label9 {
-  tl1:Label, ti2:Label, tj3:Label, // ↖  ↑  ↗
-  hl4:Label, hi5:Label, hj6:Label, // ←  •  →
-  ll7:Label, li8:Label, lj9:Label, // ↙  ↓  ↘
+  p1:Label, p2:Label, p3:Label, // ↖  ↑  ↗
+  p4:Label, p5:Label, p6:Label, // ←  •  →
+  p7:Label, p8:Label, p9:Label, // ↙  ↓  ↘
 }
 
 impl<F> ButtonL9<F>{
-  /// Create a new button with a text label at the center (hi5m other labels are blank, use `.addx` methods to fill them)
+  /// Create a new button with a text label at the center (p5m other labels are blank, use `.addx` methods to fill them)
   pub fn new(                     label:impl Into<Label>, pad:Option<Insets>, callback:F) -> Self {
     let label = Label9 {
-      tl1:"".into(), ti2:""   .into(), tj3:"".into(), // ↖  ↑  ↗
-      hl4:"".into(), hi5:label.into(), hj6:"".into(), // ←  •  →
-      ll7:"".into(), li8:""   .into(), lj9:"".into(), // ↙  ↓  ↘
+      p1:"".into(), p2:""   .into(), p3:"".into(), // ↖  ↑  ↗
+      p4:"".into(), p5:label.into(), p6:"".into(), // ←  •  →
+      p7:"".into(), p8:""   .into(), p9:"".into(), // ↙  ↓  ↘
     };
     let pad = Pad9 {
-      tl1:None, ti2:None, tj3:None, // ↖  ↑  ↗
-      hl4:None, hi5:pad , hj6:None, // ←  •  →
-      ll7:None, li8:None, lj9:None, // ↙  ↓  ↘
+      p1:None, p2:None, p3:None, // ↖  ↑  ↗
+      p4:None, p5:pad , p6:None, // ←  •  →
+      p7:None, p8:None, p9:None, // ↙  ↓  ↘
     };
     let opt = LabelOpt{pad};
     Self {label, opt, callback}
   }
-  /// Helper .methods for adding individual labels (add=center hi5)
-  pub fn add (mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.hi5 = label.into(); self.opt.pad.hi5 = pad; self}
-  pub fn add1(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.tl1 = label.into(); self.opt.pad.tl1 = pad; self}
-  pub fn add2(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.ti2 = label.into(); self.opt.pad.ti2 = pad; self}
-  pub fn add3(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.tj3 = label.into(); self.opt.pad.tj3 = pad; self}
-  pub fn add4(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.hl4 = label.into(); self.opt.pad.hl4 = pad; self}
-  pub fn add5(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.hi5 = label.into(); self.opt.pad.hi5 = pad; self}
-  pub fn add6(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.hj6 = label.into(); self.opt.pad.hj6 = pad; self}
-  pub fn add7(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.ll7 = label.into(); self.opt.pad.ll7 = pad; self}
-  pub fn add8(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.li8 = label.into(); self.opt.pad.li8 = pad; self}
-  pub fn add9(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.lj9 = label.into(); self.opt.pad.lj9 = pad; self}
-  // pub fn add (mut self,         label:impl Into<Label>, pad:Option<Insets>) {self.addx(LPos::hi5,label,pad)}
+  /// Helper .methods for adding individual labels (add=center p5)
+  pub fn add (mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p5 = label.into(); self.opt.pad.p5 = pad; self}
+  pub fn add1(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p1 = label.into(); self.opt.pad.p1 = pad; self}
+  pub fn add2(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p2 = label.into(); self.opt.pad.p2 = pad; self}
+  pub fn add3(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p3 = label.into(); self.opt.pad.p3 = pad; self}
+  pub fn add4(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p4 = label.into(); self.opt.pad.p4 = pad; self}
+  pub fn add5(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p5 = label.into(); self.opt.pad.p5 = pad; self}
+  pub fn add6(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p6 = label.into(); self.opt.pad.p6 = pad; self}
+  pub fn add7(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p7 = label.into(); self.opt.pad.p7 = pad; self}
+  pub fn add8(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p8 = label.into(); self.opt.pad.p8 = pad; self}
+  pub fn add9(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p9 = label.into(); self.opt.pad.p9 = pad; self}
+  // pub fn add (mut self,         label:impl Into<Label>, pad:Option<Insets>) {self.addx(LPos::p5,label,pad)}
   /// Helper .method for adding a label to a given position (same as in [`LPos`])
   pub fn addx(mut self,idx:LPos,label:impl Into<Label>, pad:Option<Insets>) -> Self {match idx {
-    LPos::tl1 => {self.label.tl1 = label.into(); self.opt.pad.tl1 = pad}, //↖
-    LPos::ti2 => {self.label.ti2 = label.into(); self.opt.pad.ti2 = pad}, //↑
-    LPos::tj3 => {self.label.tj3 = label.into(); self.opt.pad.tj3 = pad}, //↗
-    LPos::hl4 => {self.label.hl4 = label.into(); self.opt.pad.hl4 = pad}, //←
-    LPos::hi5 => {self.label.hi5 = label.into(); self.opt.pad.hi5 = pad}, //•
-    LPos::hj6 => {self.label.hj6 = label.into(); self.opt.pad.hj6 = pad}, //→
-    LPos::ll7 => {self.label.ll7 = label.into(); self.opt.pad.ll7 = pad}, //↙
-    LPos::li8 => {self.label.li8 = label.into(); self.opt.pad.li8 = pad}, //↓
-    LPos::lj9 => {self.label.lj9 = label.into(); self.opt.pad.lj9 = pad}, //↘
+    LPos::p1 => {self.label.p1 = label.into(); self.opt.pad.p1 = pad}, //↖
+    LPos::p2 => {self.label.p2 = label.into(); self.opt.pad.p2 = pad}, //↑
+    LPos::p3 => {self.label.p3 = label.into(); self.opt.pad.p3 = pad}, //↗
+    LPos::p4 => {self.label.p4 = label.into(); self.opt.pad.p4 = pad}, //←
+    LPos::p5 => {self.label.p5 = label.into(); self.opt.pad.p5 = pad}, //•
+    LPos::p6 => {self.label.p6 = label.into(); self.opt.pad.p6 = pad}, //→
+    LPos::p7 => {self.label.p7 = label.into(); self.opt.pad.p7 = pad}, //↙
+    LPos::p8 => {self.label.p8 = label.into(); self.opt.pad.p8 = pad}, //↓
+    LPos::p9 => {self.label.p9 = label.into(); self.opt.pad.p9 = pad}, //↘
   } self }
 }
 
@@ -129,15 +129,15 @@ where F: Fn(&mut State, PointerB) -> MsgRes<Action> + Send + Sync + 'static {
 
   fn build(&self, ctx:&mut ViewCtx) -> (Self::Element, Self::ViewState) {
     // build based on LabelViews, which already implement build themselves:(Self::Element, Self::ViewState)
-    let (child1,()) = ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::build(&self.label.tl1,ctx)});
-    let (child2,()) = ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::build(&self.label.ti2,ctx)});
-    let (child3,()) = ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::build(&self.label.tj3,ctx)});
-    let (child4,()) = ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::build(&self.label.hl4,ctx)});
-    let (child5,()) = ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::build(&self.label.hi5,ctx)});
-    let (child6,()) = ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::build(&self.label.hj6,ctx)});
-    let (child7,()) = ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::build(&self.label.ll7,ctx)});
-    let (child8,()) = ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::build(&self.label.li8,ctx)});
-    let (child9,()) = ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::build(&self.label.lj9,ctx)});
+    let (child1,()) = ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::build(&self.label.p1,ctx)});
+    let (child2,()) = ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::build(&self.label.p2,ctx)});
+    let (child3,()) = ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::build(&self.label.p3,ctx)});
+    let (child4,()) = ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::build(&self.label.p4,ctx)});
+    let (child5,()) = ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::build(&self.label.p5,ctx)});
+    let (child6,()) = ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::build(&self.label.p6,ctx)});
+    let (child7,()) = ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::build(&self.label.p7,ctx)});
+    let (child8,()) = ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::build(&self.label.p8,ctx)});
+    let (child9,()) = ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::build(&self.label.p9,ctx)});
     // pass built elements to the masonry widgets
     let label = [
       into_widget_pod(child1), into_widget_pod(child2), into_widget_pod(child3), // ↖  ↑  ↗
@@ -148,62 +148,62 @@ where F: Fn(&mut State, PointerB) -> MsgRes<Action> + Send + Sync + 'static {
       // child7.into_widget_pod(), child6.into_widget_pod(), child9.into_widget_pod(), // ↙  ↓  ↘
     ];
     let pad = Pad9 {
-      tl1:self.opt.pad.tl1.clone(), ti2:self.opt.pad.ti2.clone(), tj3:self.opt.pad.tj3.clone(), // ↖  ↑  ↗
-      hl4:self.opt.pad.hl4.clone(), hi5:self.opt.pad.hi5.clone(), hj6:self.opt.pad.hj6.clone(), // ←  •  →
-      ll7:self.opt.pad.ll7.clone(), li8:self.opt.pad.li8.clone(), lj9:self.opt.pad.lj9.clone(), // ↙  ↓  ↘
+      p1:self.opt.pad.p1.clone(), p2:self.opt.pad.p2.clone(), p3:self.opt.pad.p3.clone(), // ↖  ↑  ↗
+      p4:self.opt.pad.p4.clone(), p5:self.opt.pad.p5.clone(), p6:self.opt.pad.p6.clone(), // ←  •  →
+      p7:self.opt.pad.p7.clone(), p8:self.opt.pad.p8.clone(), p9:self.opt.pad.p9.clone(), // ↙  ↓  ↘
     };
     ctx.with_leaf_action_widget(|ctx| {ctx.new_pod(widget9::ButtonL9::from_label_pod(label,pad)) } )
   }
 
   fn rebuild(&self, prev:&Self, state:&mut Self::ViewState, ctx:&mut ViewCtx, mut el:Mut<Self::Element>) {
     // rebuild based on LabelViews, which already implement rebuild themselves (compare all the props)
-    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::rebuild(&self.label.tl1,&prev.label.tl1,state,ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::rebuild(&self.label.ti2,&prev.label.ti2,state,ctx, widget9::ButtonL9::label2_mut(&mut el));});
-    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::rebuild(&self.label.tj3,&prev.label.tj3,state,ctx, widget9::ButtonL9::label3_mut(&mut el));});
-    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::rebuild(&self.label.hl4,&prev.label.hl4,state,ctx, widget9::ButtonL9::label4_mut(&mut el));});
-    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::rebuild(&self.label.hi5,&prev.label.hi5,state,ctx, widget9::ButtonL9::label5_mut(&mut el));});
-    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::rebuild(&self.label.hj6,&prev.label.hj6,state,ctx, widget9::ButtonL9::label6_mut(&mut el));});
-    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::rebuild(&self.label.ll7,&prev.label.ll7,state,ctx, widget9::ButtonL9::label7_mut(&mut el));});
-    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::rebuild(&self.label.li8,&prev.label.li8,state,ctx, widget9::ButtonL9::label8_mut(&mut el));});
-    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::rebuild(&self.label.lj9,&prev.label.lj9,state,ctx, widget9::ButtonL9::label9_mut(&mut el));});
+    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::rebuild(&self.label.p1,&prev.label.p1,state,ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::rebuild(&self.label.p2,&prev.label.p2,state,ctx, widget9::ButtonL9::label2_mut(&mut el));});
+    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::rebuild(&self.label.p3,&prev.label.p3,state,ctx, widget9::ButtonL9::label3_mut(&mut el));});
+    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::rebuild(&self.label.p4,&prev.label.p4,state,ctx, widget9::ButtonL9::label4_mut(&mut el));});
+    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::rebuild(&self.label.p5,&prev.label.p5,state,ctx, widget9::ButtonL9::label5_mut(&mut el));});
+    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::rebuild(&self.label.p6,&prev.label.p6,state,ctx, widget9::ButtonL9::label6_mut(&mut el));});
+    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::rebuild(&self.label.p7,&prev.label.p7,state,ctx, widget9::ButtonL9::label7_mut(&mut el));});
+    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::rebuild(&self.label.p8,&prev.label.p8,state,ctx, widget9::ButtonL9::label8_mut(&mut el));});
+    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::rebuild(&self.label.p9,&prev.label.p9,state,ctx, widget9::ButtonL9::label9_mut(&mut el));});
 
     // rebuild based on LabelOpt, do manuall diff for each prop
-    if prev.opt.pad.tl1 != self.opt.pad.tl1 {widget9::ButtonL9::set_pad1 (&mut el, self.opt.pad.tl1);}
-    if prev.opt.pad.ti2 != self.opt.pad.ti2 {widget9::ButtonL9::set_pad2 (&mut el, self.opt.pad.ti2);}
-    if prev.opt.pad.tj3 != self.opt.pad.tj3 {widget9::ButtonL9::set_pad3 (&mut el, self.opt.pad.tj3);}
-    if prev.opt.pad.hl4 != self.opt.pad.hl4 {widget9::ButtonL9::set_pad4 (&mut el, self.opt.pad.hl4);}
-    if prev.opt.pad.hi5 != self.opt.pad.hi5 {widget9::ButtonL9::set_pad5 (&mut el, self.opt.pad.hi5);}
-    if prev.opt.pad.hj6 != self.opt.pad.hj6 {widget9::ButtonL9::set_pad6 (&mut el, self.opt.pad.hj6);}
-    if prev.opt.pad.ll7 != self.opt.pad.ll7 {widget9::ButtonL9::set_pad7 (&mut el, self.opt.pad.ll7);}
-    if prev.opt.pad.li8 != self.opt.pad.li8 {widget9::ButtonL9::set_pad8 (&mut el, self.opt.pad.li8);}
-    if prev.opt.pad.lj9 != self.opt.pad.lj9 {widget9::ButtonL9::set_pad9 (&mut el, self.opt.pad.lj9);}
+    if prev.opt.pad.p1 != self.opt.pad.p1 {widget9::ButtonL9::set_pad1 (&mut el, self.opt.pad.p1);}
+    if prev.opt.pad.p2 != self.opt.pad.p2 {widget9::ButtonL9::set_pad2 (&mut el, self.opt.pad.p2);}
+    if prev.opt.pad.p3 != self.opt.pad.p3 {widget9::ButtonL9::set_pad3 (&mut el, self.opt.pad.p3);}
+    if prev.opt.pad.p4 != self.opt.pad.p4 {widget9::ButtonL9::set_pad4 (&mut el, self.opt.pad.p4);}
+    if prev.opt.pad.p5 != self.opt.pad.p5 {widget9::ButtonL9::set_pad5 (&mut el, self.opt.pad.p5);}
+    if prev.opt.pad.p6 != self.opt.pad.p6 {widget9::ButtonL9::set_pad6 (&mut el, self.opt.pad.p6);}
+    if prev.opt.pad.p7 != self.opt.pad.p7 {widget9::ButtonL9::set_pad7 (&mut el, self.opt.pad.p7);}
+    if prev.opt.pad.p8 != self.opt.pad.p8 {widget9::ButtonL9::set_pad8 (&mut el, self.opt.pad.p8);}
+    if prev.opt.pad.p9 != self.opt.pad.p9 {widget9::ButtonL9::set_pad9 (&mut el, self.opt.pad.p9);}
   }
 
   fn teardown(&self, _:&mut Self::ViewState, ctx:&mut ViewCtx, mut el:Mut<Self::Element>) {
     // teardown LabelViews, which already implement teardown themselves
-    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::teardown(&self.label.tl1,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::teardown(&self.label.ti2,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::teardown(&self.label.tj3,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::teardown(&self.label.hl4,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::teardown(&self.label.hi5,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::teardown(&self.label.hj6,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::teardown(&self.label.ll7,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::teardown(&self.label.li8,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::teardown(&self.label.lj9,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::teardown(&self.label.p1,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::teardown(&self.label.p2,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::teardown(&self.label.p3,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::teardown(&self.label.p4,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::teardown(&self.label.p5,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::teardown(&self.label.p6,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::teardown(&self.label.p7,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::teardown(&self.label.p8,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::teardown(&self.label.p9,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
     ctx.teardown_leaf(el); // teardown the button element itself
   }
 
   fn message(&self, _:&mut Self::ViewState, id_path:&[ViewId], message:DynMessage, app_state:&mut State) -> MsgRes<Action> {
     match id_path.split_first() {
-      Some((&id_lvw1, rest)) => self.label.tl1.message(&mut(), rest, message, app_state),
-      Some((&id_lvw2, rest)) => self.label.ti2.message(&mut(), rest, message, app_state),
-      Some((&id_lvw3, rest)) => self.label.tj3.message(&mut(), rest, message, app_state),
-      Some((&id_lvw4, rest)) => self.label.hl4.message(&mut(), rest, message, app_state),
-      Some((&id_lvw5, rest)) => self.label.hi5.message(&mut(), rest, message, app_state),
-      Some((&id_lvw6, rest)) => self.label.hj6.message(&mut(), rest, message, app_state),
-      Some((&id_lvw7, rest)) => self.label.ll7.message(&mut(), rest, message, app_state),
-      Some((&id_lvw8, rest)) => self.label.li8.message(&mut(), rest, message, app_state),
-      Some((&id_lvw9, rest)) => self.label.lj9.message(&mut(), rest, message, app_state),
+      Some((&id_lvw1, rest)) => self.label.p1.message(&mut(), rest, message, app_state),
+      Some((&id_lvw2, rest)) => self.label.p2.message(&mut(), rest, message, app_state),
+      Some((&id_lvw3, rest)) => self.label.p3.message(&mut(), rest, message, app_state),
+      Some((&id_lvw4, rest)) => self.label.p4.message(&mut(), rest, message, app_state),
+      Some((&id_lvw5, rest)) => self.label.p5.message(&mut(), rest, message, app_state),
+      Some((&id_lvw6, rest)) => self.label.p6.message(&mut(), rest, message, app_state),
+      Some((&id_lvw7, rest)) => self.label.p7.message(&mut(), rest, message, app_state),
+      Some((&id_lvw8, rest)) => self.label.p8.message(&mut(), rest, message, app_state),
+      Some((&id_lvw9, rest)) => self.label.p9.message(&mut(), rest, message, app_state),
       None => match message.downcast::<masonry::core::Action>() {
         Ok(action)   => {
           if let masonry::core::Action::ButtonPressed(button) = *action {

--- a/xilem/src/view/button9.rs
+++ b/xilem/src/view/button9.rs
@@ -24,13 +24,13 @@ use masonry::kurbo::Insets;
 /// button(label, |state:&mut State| { state.increase();})
 /// ```
 pub fn button9<State,Action> (label:impl Into<Label>, callback:impl Fn(&mut State) -> Action+Send+'static)
-->ButtonL9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
+->Button9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
   button9_pad(label, None, callback)
 }
 /// A button with custom `pad` padding which calls `callback` when 🖰1 (normally left) is pressed
 pub fn button9_pad<State,Action>(label:impl Into<Label>, pad:Option<Insets>, callback: impl Fn(&mut State) -> Action+Send+'static)
-->ButtonL9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
-  ButtonL9::new(label, pad,
+->Button9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
+  Button9::new(label, pad,
     move |state: &mut State, button| match button {
       PointerB::Primary => MsgRes::Action(callback(state)),
       _                 => MsgRes::Nop                    ,},
@@ -38,13 +38,13 @@ pub fn button9_pad<State,Action>(label:impl Into<Label>, pad:Option<Insets>, cal
 }
 /// A button which calls `callback` when any 🖰 is pressed
 pub fn button9_any_pointer<State,Action>(label:impl Into<Label>, callback: impl Fn(&mut State, PointerB) -> Action+Send+'static)
-->ButtonL9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
+->Button9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
   button9_any_pointer_pad(label, None, callback)
 }
 /// A button with custom `pad` padding which calls `callback` when any 🖰 is pressed
 pub fn button9_any_pointer_pad<State,Action>(label:impl Into<Label>, pad:Option<Insets>, callback: impl Fn(&mut State, PointerB) -> Action+Send+'static)
-->ButtonL9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
-  ButtonL9::new(label, pad,
+->Button9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
+  Button9::new(label, pad,
     move |state: &mut State, button| MsgRes::Action(callback(state, button)),
   )
 }
@@ -53,19 +53,19 @@ use crate::masonry::button9::{LPos, LabelOpt, Pad9};
 
 /// The [`View`] created by [`button`] from up to label(s) in one of [`LPos`] position with custom padding and a callback.
 #[must_use = "View values do nothing unless provided to Xilem."]
-pub struct ButtonL9<F> {
+pub struct Button9<F> {
   label: Label9,
   opt  : LabelOpt,
   callback: F,
 }
-/// Label for ButtonL9
+/// Label for Button9
 pub struct Label9 {
   p1:Label, p2:Label, p3:Label, // ↖  ↑  ↗
   p4:Label, p5:Label, p6:Label, // ←  •  →
   p7:Label, p8:Label, p9:Label, // ↙  ↓  ↘
 }
 
-impl<F> ButtonL9<F>{
+impl<F> Button9<F>{
   /// Create a new button with a text label at the center (p5m other labels are blank, use `.addx` methods to fill them)
   pub fn new(                     label:impl Into<Label>, pad:Option<Insets>, callback:F) -> Self {
     let label = Label9 {
@@ -121,10 +121,10 @@ pub fn into_widget_pod(p:Pod<widgets::Label>) -> WidgetPod<widgets::Label> {
   WidgetPod::new_with_id_and_transform(p.widget, p.id, p.transform)
 }
 
-impl<F>              ViewMarker                 for ButtonL9<F> {}
-impl<F,State,Action> View<State,Action,ViewCtx> for ButtonL9<F>
+impl<F>              ViewMarker                 for Button9<F> {}
+impl<F,State,Action> View<State,Action,ViewCtx> for Button9<F>
 where F: Fn(&mut State, PointerB) -> MsgRes<Action> + Send + Sync + 'static {
-  type Element = Pod<widget9::ButtonL9>;
+  type Element = Pod<widget9::Button9>;
   type ViewState = ();
 
   fn build(&self, ctx:&mut ViewCtx) -> (Self::Element, Self::ViewState) {
@@ -152,44 +152,44 @@ where F: Fn(&mut State, PointerB) -> MsgRes<Action> + Send + Sync + 'static {
       p4:self.opt.pad.p4.clone(), p5:self.opt.pad.p5.clone(), p6:self.opt.pad.p6.clone(), // ←  •  →
       p7:self.opt.pad.p7.clone(), p8:self.opt.pad.p8.clone(), p9:self.opt.pad.p9.clone(), // ↙  ↓  ↘
     };
-    ctx.with_leaf_action_widget(|ctx| {ctx.new_pod(widget9::ButtonL9::from_label_pod(label,pad)) } )
+    ctx.with_leaf_action_widget(|ctx| {ctx.new_pod(widget9::Button9::from_label_pod(label,pad)) } )
   }
 
   fn rebuild(&self, prev:&Self, state:&mut Self::ViewState, ctx:&mut ViewCtx, mut el:Mut<Self::Element>) {
     // rebuild based on LabelViews, which already implement rebuild themselves (compare all the props)
-    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::rebuild(&self.label.p1,&prev.label.p1,state,ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::rebuild(&self.label.p2,&prev.label.p2,state,ctx, widget9::ButtonL9::label2_mut(&mut el));});
-    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::rebuild(&self.label.p3,&prev.label.p3,state,ctx, widget9::ButtonL9::label3_mut(&mut el));});
-    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::rebuild(&self.label.p4,&prev.label.p4,state,ctx, widget9::ButtonL9::label4_mut(&mut el));});
-    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::rebuild(&self.label.p5,&prev.label.p5,state,ctx, widget9::ButtonL9::label5_mut(&mut el));});
-    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::rebuild(&self.label.p6,&prev.label.p6,state,ctx, widget9::ButtonL9::label6_mut(&mut el));});
-    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::rebuild(&self.label.p7,&prev.label.p7,state,ctx, widget9::ButtonL9::label7_mut(&mut el));});
-    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::rebuild(&self.label.p8,&prev.label.p8,state,ctx, widget9::ButtonL9::label8_mut(&mut el));});
-    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::rebuild(&self.label.p9,&prev.label.p9,state,ctx, widget9::ButtonL9::label9_mut(&mut el));});
+    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::rebuild(&self.label.p1,&prev.label.p1,state,ctx, widget9::Button9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::rebuild(&self.label.p2,&prev.label.p2,state,ctx, widget9::Button9::label2_mut(&mut el));});
+    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::rebuild(&self.label.p3,&prev.label.p3,state,ctx, widget9::Button9::label3_mut(&mut el));});
+    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::rebuild(&self.label.p4,&prev.label.p4,state,ctx, widget9::Button9::label4_mut(&mut el));});
+    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::rebuild(&self.label.p5,&prev.label.p5,state,ctx, widget9::Button9::label5_mut(&mut el));});
+    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::rebuild(&self.label.p6,&prev.label.p6,state,ctx, widget9::Button9::label6_mut(&mut el));});
+    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::rebuild(&self.label.p7,&prev.label.p7,state,ctx, widget9::Button9::label7_mut(&mut el));});
+    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::rebuild(&self.label.p8,&prev.label.p8,state,ctx, widget9::Button9::label8_mut(&mut el));});
+    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::rebuild(&self.label.p9,&prev.label.p9,state,ctx, widget9::Button9::label9_mut(&mut el));});
 
     // rebuild based on LabelOpt, do manuall diff for each prop
-    if prev.opt.pad.p1 != self.opt.pad.p1 {widget9::ButtonL9::set_pad1 (&mut el, self.opt.pad.p1);}
-    if prev.opt.pad.p2 != self.opt.pad.p2 {widget9::ButtonL9::set_pad2 (&mut el, self.opt.pad.p2);}
-    if prev.opt.pad.p3 != self.opt.pad.p3 {widget9::ButtonL9::set_pad3 (&mut el, self.opt.pad.p3);}
-    if prev.opt.pad.p4 != self.opt.pad.p4 {widget9::ButtonL9::set_pad4 (&mut el, self.opt.pad.p4);}
-    if prev.opt.pad.p5 != self.opt.pad.p5 {widget9::ButtonL9::set_pad5 (&mut el, self.opt.pad.p5);}
-    if prev.opt.pad.p6 != self.opt.pad.p6 {widget9::ButtonL9::set_pad6 (&mut el, self.opt.pad.p6);}
-    if prev.opt.pad.p7 != self.opt.pad.p7 {widget9::ButtonL9::set_pad7 (&mut el, self.opt.pad.p7);}
-    if prev.opt.pad.p8 != self.opt.pad.p8 {widget9::ButtonL9::set_pad8 (&mut el, self.opt.pad.p8);}
-    if prev.opt.pad.p9 != self.opt.pad.p9 {widget9::ButtonL9::set_pad9 (&mut el, self.opt.pad.p9);}
+    if prev.opt.pad.p1 != self.opt.pad.p1 {widget9::Button9::set_pad1 (&mut el, self.opt.pad.p1);}
+    if prev.opt.pad.p2 != self.opt.pad.p2 {widget9::Button9::set_pad2 (&mut el, self.opt.pad.p2);}
+    if prev.opt.pad.p3 != self.opt.pad.p3 {widget9::Button9::set_pad3 (&mut el, self.opt.pad.p3);}
+    if prev.opt.pad.p4 != self.opt.pad.p4 {widget9::Button9::set_pad4 (&mut el, self.opt.pad.p4);}
+    if prev.opt.pad.p5 != self.opt.pad.p5 {widget9::Button9::set_pad5 (&mut el, self.opt.pad.p5);}
+    if prev.opt.pad.p6 != self.opt.pad.p6 {widget9::Button9::set_pad6 (&mut el, self.opt.pad.p6);}
+    if prev.opt.pad.p7 != self.opt.pad.p7 {widget9::Button9::set_pad7 (&mut el, self.opt.pad.p7);}
+    if prev.opt.pad.p8 != self.opt.pad.p8 {widget9::Button9::set_pad8 (&mut el, self.opt.pad.p8);}
+    if prev.opt.pad.p9 != self.opt.pad.p9 {widget9::Button9::set_pad9 (&mut el, self.opt.pad.p9);}
   }
 
   fn teardown(&self, _:&mut Self::ViewState, ctx:&mut ViewCtx, mut el:Mut<Self::Element>) {
     // teardown LabelViews, which already implement teardown themselves
-    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::teardown(&self.label.p1,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::teardown(&self.label.p2,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::teardown(&self.label.p3,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::teardown(&self.label.p4,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::teardown(&self.label.p5,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::teardown(&self.label.p6,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::teardown(&self.label.p7,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::teardown(&self.label.p8,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::teardown(&self.label.p9,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::teardown(&self.label.p1,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::teardown(&self.label.p2,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::teardown(&self.label.p3,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::teardown(&self.label.p4,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::teardown(&self.label.p5,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::teardown(&self.label.p6,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::teardown(&self.label.p7,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::teardown(&self.label.p8,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::teardown(&self.label.p9,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
     ctx.teardown_leaf(el); // teardown the button element itself
   }
 
@@ -208,11 +208,11 @@ where F: Fn(&mut State, PointerB) -> MsgRes<Action> + Send + Sync + 'static {
         Ok(action)   => {
           if let masonry::core::Action::ButtonPressed(button) = *action {
             (self.callback)(app_state, button)
-          } else        {tracing::error!("Wrong action type in ButtonL9::message: {action:?}");
+          } else        {tracing::error!("Wrong action type in Button9::message: {action:?}");
             MessageResult::Stale(action)} }
-        Err(message) => {tracing::error!("Wrong message type in ButtonL9::message: {message:?}");
+        Err(message) => {tracing::error!("Wrong message type in Button9::message: {message:?}");
             MessageResult::Stale(message) }   },
-      _    =>           {tracing::warn! ("Got unexpected ID path in ButtonL9::message");
+      _    =>           {tracing::warn! ("Got unexpected ID path in Button9::message");
             MessageResult::Stale(message)      }
     }
   }

--- a/xilem/src/view/button9.rs
+++ b/xilem/src/view/button9.rs
@@ -1,8 +1,9 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-pub use masonry::core::{PointerButton, PointerButton as PointerB, WidgetPod};
-use masonry::widgets::{self, button9 as widget9};
+use crate::view::PointerButton;
+pub use masonry::core::WidgetPod;
+use masonry::widgets::{self, LabelOpt, Pad9,};
 
 use crate::core::{ViewPathTracker,
   DynMessage, Mut, View, ViewMarker,
@@ -24,34 +25,32 @@ use masonry::kurbo::Insets;
 /// button(label, |state:&mut State| { state.increase();})
 /// ```
 pub fn button9<State,Action> (label:impl Into<Label>, callback:impl Fn(&mut State) -> Action+Send+'static)
-->Button9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
+->Button9<impl for<'a> Fn(&'a mut State, PointerButton) -> MsgRes<Action>+Send+'static> {
   button9_pad(label, None, callback)
 }
 /// A button with custom `pad` padding which calls `callback` when 🖰1 (normally left) is pressed
 pub fn button9_pad<State,Action>(label:impl Into<Label>, pad:Option<Insets>, callback: impl Fn(&mut State) -> Action+Send+'static)
-->Button9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
+->Button9<impl for<'a> Fn(&'a mut State, PointerButton) -> MsgRes<Action>+Send+'static> {
   Button9::new(label, pad,
     move |state: &mut State, button| match button {
-      PointerB::Primary => MsgRes::Action(callback(state)),
+      PointerButton::Primary => MsgRes::Action(callback(state)),
       _                 => MsgRes::Nop                    ,},
   )
 }
 /// A button which calls `callback` when any 🖰 is pressed
-pub fn button9_any_pointer<State,Action>(label:impl Into<Label>, callback: impl Fn(&mut State, PointerB) -> Action+Send+'static)
-->Button9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
+pub fn button9_any_pointer<State,Action>(label:impl Into<Label>, callback: impl Fn(&mut State, PointerButton) -> Action+Send+'static)
+->Button9<impl for<'a> Fn(&'a mut State, PointerButton) -> MsgRes<Action>+Send+'static> {
   button9_any_pointer_pad(label, None, callback)
 }
 /// A button with custom `pad` padding which calls `callback` when any 🖰 is pressed
-pub fn button9_any_pointer_pad<State,Action>(label:impl Into<Label>, pad:Option<Insets>, callback: impl Fn(&mut State, PointerB) -> Action+Send+'static)
-->Button9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
+pub fn button9_any_pointer_pad<State,Action>(label:impl Into<Label>, pad:Option<Insets>, callback: impl Fn(&mut State, PointerButton) -> Action+Send+'static)
+->Button9<impl for<'a> Fn(&'a mut State, PointerButton) -> MsgRes<Action>+Send+'static> {
   Button9::new(label, pad,
     move |state: &mut State, button| MsgRes::Action(callback(state, button)),
   )
 }
 
-use crate::masonry::button9::{LPos, LabelOpt, Pad9};
-
-/// The [`View`] created by [`button`] from up to label(s) in one of [`LPos`] position with custom padding and a callback.
+/// The [`View`] created by [`button`] from up to label(s) in one of 9 positions with custom padding and a callback.
 #[must_use = "View values do nothing unless provided to Xilem."]
 pub struct Button9<F> {
   label: Label9,
@@ -92,30 +91,17 @@ impl<F> Button9<F>{
   pub fn add7(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p7 = label.into(); self.opt.pad.p7 = pad; self}
   pub fn add8(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p8 = label.into(); self.opt.pad.p8 = pad; self}
   pub fn add9(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.p9 = label.into(); self.opt.pad.p9 = pad; self}
-  // pub fn add (mut self,         label:impl Into<Label>, pad:Option<Insets>) {self.addx(LPos::p5,label,pad)}
-  /// Helper .method for adding a label to a given position (same as in [`LPos`])
-  pub fn addx(mut self,idx:LPos,label:impl Into<Label>, pad:Option<Insets>) -> Self {match idx {
-    LPos::p1 => {self.label.p1 = label.into(); self.opt.pad.p1 = pad}, //↖
-    LPos::p2 => {self.label.p2 = label.into(); self.opt.pad.p2 = pad}, //↑
-    LPos::p3 => {self.label.p3 = label.into(); self.opt.pad.p3 = pad}, //↗
-    LPos::p4 => {self.label.p4 = label.into(); self.opt.pad.p4 = pad}, //←
-    LPos::p5 => {self.label.p5 = label.into(); self.opt.pad.p5 = pad}, //•
-    LPos::p6 => {self.label.p6 = label.into(); self.opt.pad.p6 = pad}, //→
-    LPos::p7 => {self.label.p7 = label.into(); self.opt.pad.p7 = pad}, //↙
-    LPos::p8 => {self.label.p8 = label.into(); self.opt.pad.p8 = pad}, //↓
-    LPos::p9 => {self.label.p9 = label.into(); self.opt.pad.p9 = pad}, //↘
-  } self }
 }
 
-const id_lvw1: ViewId = ViewId::new(1);
-const id_lvw2: ViewId = ViewId::new(2);
-const id_lvw3: ViewId = ViewId::new(3);
-const id_lvw4: ViewId = ViewId::new(4);
-const id_lvw5: ViewId = ViewId::new(5);
-const id_lvw6: ViewId = ViewId::new(6);
-const id_lvw7: ViewId = ViewId::new(7);
-const id_lvw8: ViewId = ViewId::new(8);
-const id_lvw9: ViewId = ViewId::new(9);
+const ID_LVW1: ViewId = ViewId::new(1);
+const ID_LVW2: ViewId = ViewId::new(2);
+const ID_LVW3: ViewId = ViewId::new(3);
+const ID_LVW4: ViewId = ViewId::new(4);
+const ID_LVW5: ViewId = ViewId::new(5);
+const ID_LVW6: ViewId = ViewId::new(6);
+const ID_LVW7: ViewId = ViewId::new(7);
+const ID_LVW8: ViewId = ViewId::new(8);
+const ID_LVW9: ViewId = ViewId::new(9);
 
 pub fn into_widget_pod(p:Pod<widgets::Label>) -> WidgetPod<widgets::Label> {
   WidgetPod::new_with_id_and_transform(p.widget, p.id, p.transform)
@@ -123,21 +109,21 @@ pub fn into_widget_pod(p:Pod<widgets::Label>) -> WidgetPod<widgets::Label> {
 
 impl<F>              ViewMarker                 for Button9<F> {}
 impl<F,State,Action> View<State,Action,ViewCtx> for Button9<F>
-where F: Fn(&mut State, PointerB) -> MsgRes<Action> + Send + Sync + 'static {
-  type Element = Pod<widget9::Button9>;
+where F: Fn(&mut State, PointerButton) -> MsgRes<Action> + Send + Sync + 'static {
+  type Element = Pod<widgets::Button9>;
   type ViewState = ();
 
   fn build(&self, ctx:&mut ViewCtx) -> (Self::Element, Self::ViewState) {
     // build based on LabelViews, which already implement build themselves:(Self::Element, Self::ViewState)
-    let (child1,()) = ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::build(&self.label.p1,ctx)});
-    let (child2,()) = ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::build(&self.label.p2,ctx)});
-    let (child3,()) = ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::build(&self.label.p3,ctx)});
-    let (child4,()) = ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::build(&self.label.p4,ctx)});
-    let (child5,()) = ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::build(&self.label.p5,ctx)});
-    let (child6,()) = ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::build(&self.label.p6,ctx)});
-    let (child7,()) = ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::build(&self.label.p7,ctx)});
-    let (child8,()) = ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::build(&self.label.p8,ctx)});
-    let (child9,()) = ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::build(&self.label.p9,ctx)});
+    let (child1,()) = ctx.with_id(ID_LVW1, |ctx|{View::<State,Action,_>::build(&self.label.p1,ctx)});
+    let (child2,()) = ctx.with_id(ID_LVW2, |ctx|{View::<State,Action,_>::build(&self.label.p2,ctx)});
+    let (child3,()) = ctx.with_id(ID_LVW3, |ctx|{View::<State,Action,_>::build(&self.label.p3,ctx)});
+    let (child4,()) = ctx.with_id(ID_LVW4, |ctx|{View::<State,Action,_>::build(&self.label.p4,ctx)});
+    let (child5,()) = ctx.with_id(ID_LVW5, |ctx|{View::<State,Action,_>::build(&self.label.p5,ctx)});
+    let (child6,()) = ctx.with_id(ID_LVW6, |ctx|{View::<State,Action,_>::build(&self.label.p6,ctx)});
+    let (child7,()) = ctx.with_id(ID_LVW7, |ctx|{View::<State,Action,_>::build(&self.label.p7,ctx)});
+    let (child8,()) = ctx.with_id(ID_LVW8, |ctx|{View::<State,Action,_>::build(&self.label.p8,ctx)});
+    let (child9,()) = ctx.with_id(ID_LVW9, |ctx|{View::<State,Action,_>::build(&self.label.p9,ctx)});
     // pass built elements to the masonry widgets
     let label = [
       into_widget_pod(child1), into_widget_pod(child2), into_widget_pod(child3), // ↖  ↑  ↗
@@ -152,58 +138,58 @@ where F: Fn(&mut State, PointerB) -> MsgRes<Action> + Send + Sync + 'static {
       p4:self.opt.pad.p4.clone(), p5:self.opt.pad.p5.clone(), p6:self.opt.pad.p6.clone(), // ←  •  →
       p7:self.opt.pad.p7.clone(), p8:self.opt.pad.p8.clone(), p9:self.opt.pad.p9.clone(), // ↙  ↓  ↘
     };
-    ctx.with_leaf_action_widget(|ctx| {ctx.new_pod(widget9::Button9::from_label_pod(label,pad)) } )
+    ctx.with_leaf_action_widget(|ctx| {ctx.new_pod(widgets::Button9::from_label_pod(label,pad)) } )
   }
 
   fn rebuild(&self, prev:&Self, state:&mut Self::ViewState, ctx:&mut ViewCtx, mut el:Mut<Self::Element>) {
     // rebuild based on LabelViews, which already implement rebuild themselves (compare all the props)
-    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::rebuild(&self.label.p1,&prev.label.p1,state,ctx, widget9::Button9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::rebuild(&self.label.p2,&prev.label.p2,state,ctx, widget9::Button9::label2_mut(&mut el));});
-    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::rebuild(&self.label.p3,&prev.label.p3,state,ctx, widget9::Button9::label3_mut(&mut el));});
-    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::rebuild(&self.label.p4,&prev.label.p4,state,ctx, widget9::Button9::label4_mut(&mut el));});
-    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::rebuild(&self.label.p5,&prev.label.p5,state,ctx, widget9::Button9::label5_mut(&mut el));});
-    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::rebuild(&self.label.p6,&prev.label.p6,state,ctx, widget9::Button9::label6_mut(&mut el));});
-    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::rebuild(&self.label.p7,&prev.label.p7,state,ctx, widget9::Button9::label7_mut(&mut el));});
-    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::rebuild(&self.label.p8,&prev.label.p8,state,ctx, widget9::Button9::label8_mut(&mut el));});
-    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::rebuild(&self.label.p9,&prev.label.p9,state,ctx, widget9::Button9::label9_mut(&mut el));});
+    ctx.with_id(ID_LVW1, |ctx|{View::<State,Action,_>::rebuild(&self.label.p1,&prev.label.p1,state,ctx, widgets::Button9::label1_mut(&mut el));});
+    ctx.with_id(ID_LVW2, |ctx|{View::<State,Action,_>::rebuild(&self.label.p2,&prev.label.p2,state,ctx, widgets::Button9::label2_mut(&mut el));});
+    ctx.with_id(ID_LVW3, |ctx|{View::<State,Action,_>::rebuild(&self.label.p3,&prev.label.p3,state,ctx, widgets::Button9::label3_mut(&mut el));});
+    ctx.with_id(ID_LVW4, |ctx|{View::<State,Action,_>::rebuild(&self.label.p4,&prev.label.p4,state,ctx, widgets::Button9::label4_mut(&mut el));});
+    ctx.with_id(ID_LVW5, |ctx|{View::<State,Action,_>::rebuild(&self.label.p5,&prev.label.p5,state,ctx, widgets::Button9::label5_mut(&mut el));});
+    ctx.with_id(ID_LVW6, |ctx|{View::<State,Action,_>::rebuild(&self.label.p6,&prev.label.p6,state,ctx, widgets::Button9::label6_mut(&mut el));});
+    ctx.with_id(ID_LVW7, |ctx|{View::<State,Action,_>::rebuild(&self.label.p7,&prev.label.p7,state,ctx, widgets::Button9::label7_mut(&mut el));});
+    ctx.with_id(ID_LVW8, |ctx|{View::<State,Action,_>::rebuild(&self.label.p8,&prev.label.p8,state,ctx, widgets::Button9::label8_mut(&mut el));});
+    ctx.with_id(ID_LVW9, |ctx|{View::<State,Action,_>::rebuild(&self.label.p9,&prev.label.p9,state,ctx, widgets::Button9::label9_mut(&mut el));});
 
     // rebuild based on LabelOpt, do manuall diff for each prop
-    if prev.opt.pad.p1 != self.opt.pad.p1 {widget9::Button9::set_pad1 (&mut el, self.opt.pad.p1);}
-    if prev.opt.pad.p2 != self.opt.pad.p2 {widget9::Button9::set_pad2 (&mut el, self.opt.pad.p2);}
-    if prev.opt.pad.p3 != self.opt.pad.p3 {widget9::Button9::set_pad3 (&mut el, self.opt.pad.p3);}
-    if prev.opt.pad.p4 != self.opt.pad.p4 {widget9::Button9::set_pad4 (&mut el, self.opt.pad.p4);}
-    if prev.opt.pad.p5 != self.opt.pad.p5 {widget9::Button9::set_pad5 (&mut el, self.opt.pad.p5);}
-    if prev.opt.pad.p6 != self.opt.pad.p6 {widget9::Button9::set_pad6 (&mut el, self.opt.pad.p6);}
-    if prev.opt.pad.p7 != self.opt.pad.p7 {widget9::Button9::set_pad7 (&mut el, self.opt.pad.p7);}
-    if prev.opt.pad.p8 != self.opt.pad.p8 {widget9::Button9::set_pad8 (&mut el, self.opt.pad.p8);}
-    if prev.opt.pad.p9 != self.opt.pad.p9 {widget9::Button9::set_pad9 (&mut el, self.opt.pad.p9);}
+    if prev.opt.pad.p1 != self.opt.pad.p1 {widgets::Button9::set_pad1 (&mut el, self.opt.pad.p1);}
+    if prev.opt.pad.p2 != self.opt.pad.p2 {widgets::Button9::set_pad2 (&mut el, self.opt.pad.p2);}
+    if prev.opt.pad.p3 != self.opt.pad.p3 {widgets::Button9::set_pad3 (&mut el, self.opt.pad.p3);}
+    if prev.opt.pad.p4 != self.opt.pad.p4 {widgets::Button9::set_pad4 (&mut el, self.opt.pad.p4);}
+    if prev.opt.pad.p5 != self.opt.pad.p5 {widgets::Button9::set_pad5 (&mut el, self.opt.pad.p5);}
+    if prev.opt.pad.p6 != self.opt.pad.p6 {widgets::Button9::set_pad6 (&mut el, self.opt.pad.p6);}
+    if prev.opt.pad.p7 != self.opt.pad.p7 {widgets::Button9::set_pad7 (&mut el, self.opt.pad.p7);}
+    if prev.opt.pad.p8 != self.opt.pad.p8 {widgets::Button9::set_pad8 (&mut el, self.opt.pad.p8);}
+    if prev.opt.pad.p9 != self.opt.pad.p9 {widgets::Button9::set_pad9 (&mut el, self.opt.pad.p9);}
   }
 
   fn teardown(&self, _:&mut Self::ViewState, ctx:&mut ViewCtx, mut el:Mut<Self::Element>) {
     // teardown LabelViews, which already implement teardown themselves
-    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::teardown(&self.label.p1,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::teardown(&self.label.p2,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::teardown(&self.label.p3,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::teardown(&self.label.p4,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::teardown(&self.label.p5,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::teardown(&self.label.p6,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::teardown(&self.label.p7,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::teardown(&self.label.p8,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
-    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::teardown(&self.label.p9,&mut (),ctx, widget9::Button9::label1_mut(&mut el));});
+    ctx.with_id(ID_LVW1, |ctx|{View::<State,Action,_>::teardown(&self.label.p1,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
+    ctx.with_id(ID_LVW2, |ctx|{View::<State,Action,_>::teardown(&self.label.p2,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
+    ctx.with_id(ID_LVW3, |ctx|{View::<State,Action,_>::teardown(&self.label.p3,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
+    ctx.with_id(ID_LVW4, |ctx|{View::<State,Action,_>::teardown(&self.label.p4,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
+    ctx.with_id(ID_LVW5, |ctx|{View::<State,Action,_>::teardown(&self.label.p5,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
+    ctx.with_id(ID_LVW6, |ctx|{View::<State,Action,_>::teardown(&self.label.p6,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
+    ctx.with_id(ID_LVW7, |ctx|{View::<State,Action,_>::teardown(&self.label.p7,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
+    ctx.with_id(ID_LVW8, |ctx|{View::<State,Action,_>::teardown(&self.label.p8,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
+    ctx.with_id(ID_LVW9, |ctx|{View::<State,Action,_>::teardown(&self.label.p9,&mut (),ctx, widgets::Button9::label1_mut(&mut el));});
     ctx.teardown_leaf(el); // teardown the button element itself
   }
 
   fn message(&self, _:&mut Self::ViewState, id_path:&[ViewId], message:DynMessage, app_state:&mut State) -> MsgRes<Action> {
     match id_path.split_first() {
-      Some((&id_lvw1, rest)) => self.label.p1.message(&mut(), rest, message, app_state),
-      Some((&id_lvw2, rest)) => self.label.p2.message(&mut(), rest, message, app_state),
-      Some((&id_lvw3, rest)) => self.label.p3.message(&mut(), rest, message, app_state),
-      Some((&id_lvw4, rest)) => self.label.p4.message(&mut(), rest, message, app_state),
-      Some((&id_lvw5, rest)) => self.label.p5.message(&mut(), rest, message, app_state),
-      Some((&id_lvw6, rest)) => self.label.p6.message(&mut(), rest, message, app_state),
-      Some((&id_lvw7, rest)) => self.label.p7.message(&mut(), rest, message, app_state),
-      Some((&id_lvw8, rest)) => self.label.p8.message(&mut(), rest, message, app_state),
-      Some((&id_lvw9, rest)) => self.label.p9.message(&mut(), rest, message, app_state),
+      Some((&ID_LVW1, rest)) => self.label.p1.message(&mut(), rest, message, app_state),
+      Some((&ID_LVW2, rest)) => self.label.p2.message(&mut(), rest, message, app_state),
+      Some((&ID_LVW3, rest)) => self.label.p3.message(&mut(), rest, message, app_state),
+      Some((&ID_LVW4, rest)) => self.label.p4.message(&mut(), rest, message, app_state),
+      Some((&ID_LVW5, rest)) => self.label.p5.message(&mut(), rest, message, app_state),
+      Some((&ID_LVW6, rest)) => self.label.p6.message(&mut(), rest, message, app_state),
+      Some((&ID_LVW7, rest)) => self.label.p7.message(&mut(), rest, message, app_state),
+      Some((&ID_LVW8, rest)) => self.label.p8.message(&mut(), rest, message, app_state),
+      Some((&ID_LVW9, rest)) => self.label.p9.message(&mut(), rest, message, app_state),
       None => match message.downcast::<masonry::core::Action>() {
         Ok(action)   => {
           if let masonry::core::Action::ButtonPressed(button) = *action {

--- a/xilem/src/view/button9.rs
+++ b/xilem/src/view/button9.rs
@@ -184,10 +184,6 @@ const ID_LVW7: ViewId = ViewId::new(7);
 const ID_LVW8: ViewId = ViewId::new(8);
 const ID_LVW9: ViewId = ViewId::new(9);
 
-pub fn into_widget_pod(p: Pod<widgets::Label>) -> WidgetPod<widgets::Label> {
-    WidgetPod::new_with_id_and_transform(p.widget, p.id, p.transform)
-}
-
 impl<F> ViewMarker for Button9<F> {}
 impl<F, State, Action> View<State, Action, ViewCtx> for Button9<F>
 where
@@ -227,18 +223,15 @@ where
         });
         // pass built elements to the masonry widgets
         let label = [
-            into_widget_pod(child1),
-            into_widget_pod(child2),
-            into_widget_pod(child3), // ↖  ↑  ↗
-            into_widget_pod(child4),
-            into_widget_pod(child5),
-            into_widget_pod(child8), // ←  •  →
-            into_widget_pod(child7),
-            into_widget_pod(child6),
-            into_widget_pod(child9), // ↙  ↓  ↘
-                                     // child1.into_widget_pod(), child2.into_widget_pod(), child3.into_widget_pod(), // ↖  ↑  ↗
-                                     // child4.into_widget_pod(), child5.into_widget_pod(), child8.into_widget_pod(), // ←  •  →
-                                     // child7.into_widget_pod(), child6.into_widget_pod(), child9.into_widget_pod(), // ↙  ↓  ↘
+            child1.into_widget_pod(),
+            child2.into_widget_pod(),
+            child3.into_widget_pod(), // ↖  ↑  ↗
+            child4.into_widget_pod(),
+            child5.into_widget_pod(),
+            child8.into_widget_pod(), // ←  •  →
+            child7.into_widget_pod(),
+            child6.into_widget_pod(),
+            child9.into_widget_pod(), // ↙  ↓  ↘
         ];
         let pad = Pad9 {
             p1: self.opt.pad.p1.clone(),

--- a/xilem/src/view/button9.rs
+++ b/xilem/src/view/button9.rs
@@ -379,7 +379,7 @@ where
                 &self.label.p2,
                 &mut (),
                 ctx,
-                widgets::Button9::label1_mut(&mut el),
+                widgets::Button9::label2_mut(&mut el),
             );
         });
         ctx.with_id(ID_LVW3, |ctx| {
@@ -387,7 +387,7 @@ where
                 &self.label.p3,
                 &mut (),
                 ctx,
-                widgets::Button9::label1_mut(&mut el),
+                widgets::Button9::label3_mut(&mut el),
             );
         });
         ctx.with_id(ID_LVW4, |ctx| {
@@ -395,7 +395,7 @@ where
                 &self.label.p4,
                 &mut (),
                 ctx,
-                widgets::Button9::label1_mut(&mut el),
+                widgets::Button9::label4_mut(&mut el),
             );
         });
         ctx.with_id(ID_LVW5, |ctx| {
@@ -403,7 +403,7 @@ where
                 &self.label.p5,
                 &mut (),
                 ctx,
-                widgets::Button9::label1_mut(&mut el),
+                widgets::Button9::label5_mut(&mut el),
             );
         });
         ctx.with_id(ID_LVW6, |ctx| {
@@ -411,7 +411,7 @@ where
                 &self.label.p6,
                 &mut (),
                 ctx,
-                widgets::Button9::label1_mut(&mut el),
+                widgets::Button9::label6_mut(&mut el),
             );
         });
         ctx.with_id(ID_LVW7, |ctx| {
@@ -419,7 +419,7 @@ where
                 &self.label.p7,
                 &mut (),
                 ctx,
-                widgets::Button9::label1_mut(&mut el),
+                widgets::Button9::label7_mut(&mut el),
             );
         });
         ctx.with_id(ID_LVW8, |ctx| {
@@ -427,7 +427,7 @@ where
                 &self.label.p8,
                 &mut (),
                 ctx,
-                widgets::Button9::label1_mut(&mut el),
+                widgets::Button9::label8_mut(&mut el),
             );
         });
         ctx.with_id(ID_LVW9, |ctx| {
@@ -435,7 +435,7 @@ where
                 &self.label.p9,
                 &mut (),
                 ctx,
-                widgets::Button9::label1_mut(&mut el),
+                widgets::Button9::label9_mut(&mut el),
             );
         });
         ctx.teardown_leaf(el); // teardown the button element itself

--- a/xilem/src/view/button9.rs
+++ b/xilem/src/view/button9.rs
@@ -59,7 +59,7 @@ pub fn button9_any_pointer_pad<State, Action>(
     })
 }
 
-/// The [`View`] created by [`button`] from up to label(s) in one of 9 positions with custom padding and a callback.
+/// The [`View`] created by [`button9`] from up to label(s) in one of 9 positions with custom padding and a callback.
 #[must_use = "View values do nothing unless provided to Xilem."]
 pub struct Button9<F> {
     label: Label9,
@@ -80,7 +80,8 @@ pub struct Label9 {
 }
 
 impl<F> Button9<F> {
-    /// Create a new button with a text label at the center (p5m other labels are blank, use `.addx` methods to fill them)
+    /// Create a new button with a text label at the center
+    /// ([`Label9`].p5, others 8 labels are blank by default, use [`Button9::add1`]–[`Button9::add9`] methods to fill them)
     pub fn new(label: impl Into<Label>, pad: Option<Insets>, callback: F) -> Self {
         let label = Label9 {
             p1: "".into(),
@@ -111,52 +112,61 @@ impl<F> Button9<F> {
             callback,
         }
     }
-    /// Helper .methods for adding individual labels (add=center p5)
+    /// Add label at •p5
     pub fn add(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
         self.label.p5 = label.into();
         self.opt.pad.p5 = pad;
         self
     }
+    /// Add label at ↖p1
     pub fn add1(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
         self.label.p1 = label.into();
         self.opt.pad.p1 = pad;
         self
     }
+    /// Add label at ↑p2
     pub fn add2(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
         self.label.p2 = label.into();
         self.opt.pad.p2 = pad;
         self
     }
+    /// Add label at ↗p3
     pub fn add3(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
         self.label.p3 = label.into();
         self.opt.pad.p3 = pad;
         self
     }
+    /// Add label at ←p4
     pub fn add4(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
         self.label.p4 = label.into();
         self.opt.pad.p4 = pad;
         self
     }
+    /// Add label at •p5
     pub fn add5(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
         self.label.p5 = label.into();
         self.opt.pad.p5 = pad;
         self
     }
+    /// Add label at →p6
     pub fn add6(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
         self.label.p6 = label.into();
         self.opt.pad.p6 = pad;
         self
     }
+    /// Add label at ↙p7
     pub fn add7(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
         self.label.p7 = label.into();
         self.opt.pad.p7 = pad;
         self
     }
+    /// Add label at ↓p8
     pub fn add8(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
         self.label.p8 = label.into();
         self.opt.pad.p8 = pad;
         self
     }
+    /// Add label at ↘p9
     pub fn add9(mut self, label: impl Into<Label>, pad: Option<Insets>) -> Self {
         self.label.p9 = label.into();
         self.opt.pad.p9 = pad;

--- a/xilem/src/view/button9.rs
+++ b/xilem/src/view/button9.rs
@@ -1,0 +1,220 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+pub use masonry::core::{PointerButton, PointerButton as PointerB, WidgetPod};
+use masonry::widgets;
+use crate::binmod::custom_button_masonry as widget9;
+
+use xilem::core::{ViewPathTracker,
+  DynMessage, Mut, View, ViewMarker,
+  MessageResult, ViewId, MessageResult as MsgRes,
+};
+use xilem::view::Label;
+use xilem::{Pod, ViewCtx};
+
+use masonry::kurbo::{Insets};
+
+/// A button which calls `callback` when the 🖰1 (normally left) is pressed<br>
+/// To use button provide it with a button text or `label` and a closure
+/// ```ignore
+/// use xilem::view::{button, label};
+/// struct State { int: i32 }
+/// impl   State { fn increase(&mut self) { self.int += 1 ;} }
+/// let   label =       "Button"; // or ↓
+/// //let label = label("Button").weight(FontWeight::BOLD);
+/// button(label, |state:&mut State| { state.increase();})
+/// ```
+pub fn button9<State,Action> (label:impl Into<Label>, callback:impl Fn(&mut State) -> Action+Send+'static)
+->ButtonL9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
+  button9_pad(label, None, callback)
+}
+/// A button with custom `pad` padding which calls `callback` when 🖰1 (normally left) is pressed
+pub fn button9_pad<State,Action>(label:impl Into<Label>, pad:Option<Insets>, callback: impl Fn(&mut State) -> Action+Send+'static)
+->ButtonL9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
+  ButtonL9::new(label, pad,
+    move |state: &mut State, button| match button {
+      PointerB::Primary => MsgRes::Action(callback(state)),
+      _                 => MsgRes::Nop                    ,},
+  )
+}
+/// A button which calls `callback` when any 🖰 is pressed
+pub fn button9_any_pointer<State,Action>(label:impl Into<Label>, callback: impl Fn(&mut State, PointerB) -> Action+Send+'static)
+->ButtonL9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
+  button9_any_pointer_pad(label, None, callback)
+}
+/// A button with custom `pad` padding which calls `callback` when any 🖰 is pressed
+pub fn button9_any_pointer_pad<State,Action>(label:impl Into<Label>, pad:Option<Insets>, callback: impl Fn(&mut State, PointerB) -> Action+Send+'static)
+->ButtonL9<impl for<'a> Fn(&'a mut State, PointerB) -> MsgRes<Action>+Send+'static> {
+  ButtonL9::new(label, pad,
+    move |state: &mut State, button| MsgRes::Action(callback(state, button)),
+  )
+}
+
+use crate::binmod::custom_button_masonry::{LPos, LabelOpt, Pad9};
+
+/// The [`View`] created by [`button`] from up to label(s) in one of [`LPos`] position with custom padding and a callback.
+#[must_use = "View values do nothing unless provided to Xilem."]
+pub struct ButtonL9<F> {
+  label: Label9,
+  opt  : LabelOpt,
+  callback: F,
+}
+/// Label for ButtonL9
+pub struct Label9 {
+  TL1:Label, TI2:Label, TJ3:Label, // ↖  ↑  ↗
+  HL4:Label, HI5:Label, HJ6:Label, // ←  •  →
+  LL7:Label, LI8:Label, LJ9:Label, // ↙  ↓  ↘
+}
+
+impl<F> ButtonL9<F>{
+  /// Create a new button with a text label at the center (HI5m other labels are blank, use `.addx` methods to fill them)
+  pub fn new(                     label:impl Into<Label>, pad:Option<Insets>, callback:F) -> Self {
+    let label = Label9 {
+      TL1:"".into(), TI2:""   .into(), TJ3:"".into(), // ↖  ↑  ↗
+      HL4:"".into(), HI5:label.into(), HJ6:"".into(), // ←  •  →
+      LL7:"".into(), LI8:""   .into(), LJ9:"".into(), // ↙  ↓  ↘
+    };
+    let pad = Pad9 {
+      TL1:None, TI2:None, TJ3:None, // ↖  ↑  ↗
+      HL4:None, HI5:pad , HJ6:None, // ←  •  →
+      LL7:None, LI8:None, LJ9:None, // ↙  ↓  ↘
+    };
+    let opt = LabelOpt{pad};
+    Self {label, opt, callback}
+  }
+  /// Helper .methods for adding individual labels (add=center HI5)
+  pub fn add (mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.HI5 = label.into(); self.opt.pad.HI5 = pad; self}
+  pub fn add1(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.TL1 = label.into(); self.opt.pad.TL1 = pad; self}
+  pub fn add2(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.TI2 = label.into(); self.opt.pad.TI2 = pad; self}
+  pub fn add3(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.TJ3 = label.into(); self.opt.pad.TJ3 = pad; self}
+  pub fn add4(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.HL4 = label.into(); self.opt.pad.HL4 = pad; self}
+  pub fn add5(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.HI5 = label.into(); self.opt.pad.HI5 = pad; self}
+  pub fn add6(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.HJ6 = label.into(); self.opt.pad.HJ6 = pad; self}
+  pub fn add7(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.LL7 = label.into(); self.opt.pad.LL7 = pad; self}
+  pub fn add8(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.LI8 = label.into(); self.opt.pad.LI8 = pad; self}
+  pub fn add9(mut self,         label:impl Into<Label>, pad:Option<Insets>) -> Self {self.label.LJ9 = label.into(); self.opt.pad.LJ9 = pad; self}
+  // pub fn add (mut self,         label:impl Into<Label>, pad:Option<Insets>) {self.addx(LPos::HI5,label,pad)}
+  /// Helper .method for adding a label to a given position (same as in [`LPos`])
+  pub fn addx(mut self,idx:LPos,label:impl Into<Label>, pad:Option<Insets>) -> Self {match idx {
+    LPos::TL1 => {self.label.TL1 = label.into(); self.opt.pad.TL1 = pad}, //↖
+    LPos::TI2 => {self.label.TI2 = label.into(); self.opt.pad.TI2 = pad}, //↑
+    LPos::TJ3 => {self.label.TJ3 = label.into(); self.opt.pad.TJ3 = pad}, //↗
+    LPos::HL4 => {self.label.HL4 = label.into(); self.opt.pad.HL4 = pad}, //←
+    LPos::HI5 => {self.label.HI5 = label.into(); self.opt.pad.HI5 = pad}, //•
+    LPos::HJ6 => {self.label.HJ6 = label.into(); self.opt.pad.HJ6 = pad}, //→
+    LPos::LL7 => {self.label.LL7 = label.into(); self.opt.pad.LL7 = pad}, //↙
+    LPos::LI8 => {self.label.LI8 = label.into(); self.opt.pad.LI8 = pad}, //↓
+    LPos::LJ9 => {self.label.LJ9 = label.into(); self.opt.pad.LJ9 = pad}, //↘
+  } self }
+}
+
+const id_lvw1: ViewId = ViewId::new(1);
+const id_lvw2: ViewId = ViewId::new(2);
+const id_lvw3: ViewId = ViewId::new(3);
+const id_lvw4: ViewId = ViewId::new(4);
+const id_lvw5: ViewId = ViewId::new(5);
+const id_lvw6: ViewId = ViewId::new(6);
+const id_lvw7: ViewId = ViewId::new(7);
+const id_lvw8: ViewId = ViewId::new(8);
+const id_lvw9: ViewId = ViewId::new(9);
+
+pub fn into_widget_pod(p:Pod<widgets::Label>) -> WidgetPod<widgets::Label> {
+  WidgetPod::new_with_id_and_transform(p.widget, p.id, p.transform)
+}
+
+impl<F>              ViewMarker                 for ButtonL9<F> {}
+impl<F,State,Action> View<State,Action,ViewCtx> for ButtonL9<F>
+where F: Fn(&mut State, PointerB) -> MsgRes<Action> + Send + Sync + 'static {
+  type Element = Pod<widget9::ButtonL9>;
+  type ViewState = ();
+
+  fn build(&self, ctx:&mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    // build based on LabelViews, which already implement build themselves:(Self::Element, Self::ViewState)
+    let (child1,()) = ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::build(&self.label.TL1,ctx)});
+    let (child2,()) = ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::build(&self.label.TI2,ctx)});
+    let (child3,()) = ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::build(&self.label.TJ3,ctx)});
+    let (child4,()) = ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::build(&self.label.HL4,ctx)});
+    let (child5,()) = ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::build(&self.label.HI5,ctx)});
+    let (child6,()) = ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::build(&self.label.HJ6,ctx)});
+    let (child7,()) = ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::build(&self.label.LL7,ctx)});
+    let (child8,()) = ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::build(&self.label.LI8,ctx)});
+    let (child9,()) = ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::build(&self.label.LJ9,ctx)});
+    // pass built elements to the masonry widgets
+    let label = [
+      into_widget_pod(child1), into_widget_pod(child2), into_widget_pod(child3), // ↖  ↑  ↗
+      into_widget_pod(child4), into_widget_pod(child5), into_widget_pod(child8), // ←  •  →
+      into_widget_pod(child7), into_widget_pod(child6), into_widget_pod(child9), // ↙  ↓  ↘
+      // child1.into_widget_pod(), child2.into_widget_pod(), child3.into_widget_pod(), // ↖  ↑  ↗
+      // child4.into_widget_pod(), child5.into_widget_pod(), child8.into_widget_pod(), // ←  •  →
+      // child7.into_widget_pod(), child6.into_widget_pod(), child9.into_widget_pod(), // ↙  ↓  ↘
+    ];
+    let pad = Pad9 {
+      TL1:self.opt.pad.TL1.clone(), TI2:self.opt.pad.TI2.clone(), TJ3:self.opt.pad.TJ3.clone(), // ↖  ↑  ↗
+      HL4:self.opt.pad.HL4.clone(), HI5:self.opt.pad.HI5.clone(), HJ6:self.opt.pad.HJ6.clone(), // ←  •  →
+      LL7:self.opt.pad.LL7.clone(), LI8:self.opt.pad.LI8.clone(), LJ9:self.opt.pad.LJ9.clone(), // ↙  ↓  ↘
+    };
+    ctx.with_leaf_action_widget(|ctx| {ctx.new_pod(widget9::ButtonL9::from_label_pod(label,pad)) } )
+  }
+
+  fn rebuild(&self, prev:&Self, state:&mut Self::ViewState, ctx:&mut ViewCtx, mut el:Mut<Self::Element>) {
+    // rebuild based on LabelViews, which already implement rebuild themselves (compare all the props)
+    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::rebuild(&self.label.TL1,&prev.label.TL1,state,ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::rebuild(&self.label.TI2,&prev.label.TI2,state,ctx, widget9::ButtonL9::label2_mut(&mut el));});
+    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::rebuild(&self.label.TJ3,&prev.label.TJ3,state,ctx, widget9::ButtonL9::label3_mut(&mut el));});
+    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::rebuild(&self.label.HL4,&prev.label.HL4,state,ctx, widget9::ButtonL9::label4_mut(&mut el));});
+    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::rebuild(&self.label.HI5,&prev.label.HI5,state,ctx, widget9::ButtonL9::label5_mut(&mut el));});
+    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::rebuild(&self.label.HJ6,&prev.label.HJ6,state,ctx, widget9::ButtonL9::label6_mut(&mut el));});
+    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::rebuild(&self.label.LL7,&prev.label.LL7,state,ctx, widget9::ButtonL9::label7_mut(&mut el));});
+    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::rebuild(&self.label.LI8,&prev.label.LI8,state,ctx, widget9::ButtonL9::label8_mut(&mut el));});
+    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::rebuild(&self.label.LJ9,&prev.label.LJ9,state,ctx, widget9::ButtonL9::label9_mut(&mut el));});
+
+    // rebuild based on LabelOpt, do manuall diff for each prop
+    if prev.opt.pad.TL1 != self.opt.pad.TL1 {widget9::ButtonL9::set_pad1 (&mut el, self.opt.pad.TL1);}
+    if prev.opt.pad.TI2 != self.opt.pad.TI2 {widget9::ButtonL9::set_pad2 (&mut el, self.opt.pad.TI2);}
+    if prev.opt.pad.TJ3 != self.opt.pad.TJ3 {widget9::ButtonL9::set_pad3 (&mut el, self.opt.pad.TJ3);}
+    if prev.opt.pad.HL4 != self.opt.pad.HL4 {widget9::ButtonL9::set_pad4 (&mut el, self.opt.pad.HL4);}
+    if prev.opt.pad.HI5 != self.opt.pad.HI5 {widget9::ButtonL9::set_pad5 (&mut el, self.opt.pad.HI5);}
+    if prev.opt.pad.HJ6 != self.opt.pad.HJ6 {widget9::ButtonL9::set_pad6 (&mut el, self.opt.pad.HJ6);}
+    if prev.opt.pad.LL7 != self.opt.pad.LL7 {widget9::ButtonL9::set_pad7 (&mut el, self.opt.pad.LL7);}
+    if prev.opt.pad.LI8 != self.opt.pad.LI8 {widget9::ButtonL9::set_pad8 (&mut el, self.opt.pad.LI8);}
+    if prev.opt.pad.LJ9 != self.opt.pad.LJ9 {widget9::ButtonL9::set_pad9 (&mut el, self.opt.pad.LJ9);}
+  }
+
+  fn teardown(&self, _:&mut Self::ViewState, ctx:&mut ViewCtx, mut el:Mut<Self::Element>) {
+    // teardown LabelViews, which already implement teardown themselves
+    ctx.with_id(id_lvw1, |ctx|{View::<State,Action,_>::teardown(&self.label.TL1,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw2, |ctx|{View::<State,Action,_>::teardown(&self.label.TI2,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw3, |ctx|{View::<State,Action,_>::teardown(&self.label.TJ3,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw4, |ctx|{View::<State,Action,_>::teardown(&self.label.HL4,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw5, |ctx|{View::<State,Action,_>::teardown(&self.label.HI5,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw6, |ctx|{View::<State,Action,_>::teardown(&self.label.HJ6,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw7, |ctx|{View::<State,Action,_>::teardown(&self.label.LL7,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw8, |ctx|{View::<State,Action,_>::teardown(&self.label.LI8,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.with_id(id_lvw9, |ctx|{View::<State,Action,_>::teardown(&self.label.LJ9,&mut (),ctx, widget9::ButtonL9::label1_mut(&mut el));});
+    ctx.teardown_leaf(el); // teardown the button element itself
+  }
+
+  fn message(&self, _:&mut Self::ViewState, id_path:&[ViewId], message:DynMessage, app_state:&mut State) -> MsgRes<Action> {
+    match id_path.split_first() {
+      Some((&id_lvw1, rest)) => self.label.TL1.message(&mut(), rest, message, app_state),
+      Some((&id_lvw2, rest)) => self.label.TI2.message(&mut(), rest, message, app_state),
+      Some((&id_lvw3, rest)) => self.label.TJ3.message(&mut(), rest, message, app_state),
+      Some((&id_lvw4, rest)) => self.label.HL4.message(&mut(), rest, message, app_state),
+      Some((&id_lvw5, rest)) => self.label.HI5.message(&mut(), rest, message, app_state),
+      Some((&id_lvw6, rest)) => self.label.HJ6.message(&mut(), rest, message, app_state),
+      Some((&id_lvw7, rest)) => self.label.LL7.message(&mut(), rest, message, app_state),
+      Some((&id_lvw8, rest)) => self.label.LI8.message(&mut(), rest, message, app_state),
+      Some((&id_lvw9, rest)) => self.label.LJ9.message(&mut(), rest, message, app_state),
+      None => match message.downcast::<masonry::core::Action>() {
+        Ok(action)   => {
+          if let masonry::core::Action::ButtonPressed(button) = *action {
+            (self.callback)(app_state, button)
+          } else        {tracing::error!("Wrong action type in ButtonL9::message: {action:?}");
+            MessageResult::Stale(action)} }
+        Err(message) => {tracing::error!("Wrong message type in ButtonL9::message: {message:?}");
+            MessageResult::Stale(message) }   },
+      _    =>           {tracing::warn! ("Got unexpected ID path in ButtonL9::message");
+            MessageResult::Stale(message)      }
+    }
+  }
+}

--- a/xilem/src/view/mod.rs
+++ b/xilem/src/view/mod.rs
@@ -9,6 +9,9 @@ pub use task::*;
 mod worker;
 pub use worker::*;
 
+mod button9;
+pub use button9::*;
+
 mod button;
 pub use button::*;
 


### PR DESCRIPTION
Allowing the creation of helpful UI buttons like this, documenting which keys activate it
<img width="88" alt="button9" src="https://github.com/user-attachments/assets/31a17602-7e92-4eb1-ad47-511dfa8812aa" />

It supports label padding as well, so you could in principle position labels wherever you like

I've noticed that even empty labels have >0 size (4) and, I guess, makes the button slightly bigger than necessary. Is this an effect of some global layout constant?
- Is it possible to disable it for all labels but the middle one?

My idea is for this to be identical in its default instance to a regular button.

I've also thought about skipping empty children (though currently it's suprisingy cumbersome to test whether a label is empty, so thought of adding some `is` method to the label to check whether its string is empty), but then wasn't clear on the proper mechanism for instantiating such children once their text is changed, so thought it might not be an issue if empty labels always exist. 
- Or is it an issue that empty labels are always created/tracked?

Updated docs/tests and added a `gallery` type example similar to https://github.com/linebender/xilem/pull/864

<img width="592" alt="Button9Help" src="https://github.com/user-attachments/assets/8ef069a2-b6d4-4305-8774-1671545690be" />
