### PR TITLE
Migrate to v5 of the Linebender lint set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rust.unsafe_code = "deny"
 # Intentional break from the lint set. Intended to be temporary
 rust.unexpected_cfgs = { level = "warn", check-cfg = ['cfg(FALSE)'] }
 
-# LINEBENDER LINT SET - Cargo.toml - v2
+# LINEBENDER LINT SET - Cargo.toml - v5
 # See https://linebender.org/wiki/canonical-lints/
 rust.keyword_idents_2024 = "forbid"
 rust.non_ascii_idents = "forbid"
@@ -45,60 +45,43 @@ rust.non_local_definitions = "forbid"
 rust.unsafe_op_in_unsafe_fn = "forbid"
 
 rust.elided_lifetimes_in_paths = "warn"
-rust.let_underscore_drop = "warn"
 rust.missing_debug_implementations = "warn"
 rust.missing_docs = "warn"
-rust.single_use_lifetimes = "warn"
 rust.trivial_numeric_casts = "warn"
 # rust.unexpected_cfgs = "warn"
-rust.unit_bindings = "warn"
 rust.unnameable_types = "warn"
 rust.unreachable_pub = "warn"
 rust.unused_import_braces = "warn"
 rust.unused_lifetimes = "warn"
 rust.unused_macro_rules = "warn"
-rust.unused_qualifications = "warn"
-rust.variant_size_differences = "warn"
 
-clippy.allow_attributes = "warn"
+clippy.too_many_arguments = "allow"
+
 clippy.allow_attributes_without_reason = "warn"
 clippy.cast_possible_truncation = "warn"
 clippy.collection_is_never_read = "warn"
 clippy.dbg_macro = "warn"
 clippy.debug_assert_with_mut_call = "warn"
 clippy.doc_markdown = "warn"
-clippy.exhaustive_enums = "warn"
-clippy.fn_to_numeric_cast_any = "forbid"
+clippy.fn_to_numeric_cast_any = "warn"
 clippy.infinite_loop = "warn"
-clippy.large_include_file = "warn"
 clippy.large_stack_arrays = "warn"
-clippy.match_same_arms = "warn"
 clippy.mismatching_type_param_order = "warn"
 clippy.missing_assert_message = "warn"
-clippy.missing_errors_doc = "warn"
 clippy.missing_fields_in_debug = "warn"
-clippy.missing_panics_doc = "warn"
-clippy.partial_pub_fields = "warn"
-clippy.return_self_not_must_use = "warn"
 clippy.same_functions_in_if_condition = "warn"
 clippy.semicolon_if_nothing_returned = "warn"
 clippy.shadow_unrelated = "warn"
 clippy.should_panic_without_expect = "warn"
 clippy.todo = "warn"
-clippy.trivially_copy_pass_by_ref = "warn"
 clippy.unseparated_literal_suffix = "warn"
 clippy.use_self = "warn"
-clippy.wildcard_imports = "warn"
 
 clippy.cargo_common_metadata = "warn"
 clippy.negative_feature_names = "warn"
 clippy.redundant_feature_names = "warn"
 clippy.wildcard_dependencies = "warn"
 # END LINEBENDER LINT SET
-
-# "https://github.com/rust-lang/rust-clippy/issues/13355"
-# Please remove once 1.83 is stable
-clippy.duplicated_attributes = "allow"
 
 [workspace.dependencies]
 masonry = { version = "0.2.0", path = "masonry" }

--- a/masonry/src/core/event.rs
+++ b/masonry/src/core/event.rs
@@ -294,7 +294,6 @@ pub enum WindowTheme {
 /// the event loop.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
-#[allow(variant_size_differences)]
 pub enum Update {
     /// Sent to a `Widget` when it is added to the widget tree. This should be
     /// the first message that each widget receives.

--- a/masonry/src/core/widget.rs
+++ b/masonry/src/core/widget.rs
@@ -440,7 +440,6 @@ impl WidgetId {
     /// The actual inner representation of the returned `WidgetId` will not
     /// be the same as the raw value that is passed in; it will be
     /// `u64::max_value() - raw`.
-    #[allow(clippy::missing_panics_doc)] // Can never panic
     pub const fn reserved(raw: u16) -> Self {
         let id = u64::MAX - raw as u64;
         match NonZeroU64::new(id) {

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -116,20 +116,14 @@
         reason = "False-positive with dev-dependencies only used in examples"
     )
 )]
-#![expect(clippy::allow_attributes, reason = "Deferred: Noisy")]
 #![expect(clippy::allow_attributes_without_reason, reason = "Deferred: Noisy")]
 // TODO: Remove any items listed as "Deferred"
 #![expect(clippy::needless_doctest_main, reason = "Deferred: Noisy")]
 #![expect(clippy::should_implement_trait, reason = "Deferred: Noisy")]
 #![cfg_attr(not(debug_assertions), expect(unused, reason = "Deferred: Noisy"))]
-#![expect(let_underscore_drop, reason = "Deferred: Noisy")]
 #![expect(missing_debug_implementations, reason = "Deferred: Noisy")]
-#![expect(unused_qualifications, reason = "Deferred: Noisy")]
-#![expect(clippy::exhaustive_enums, reason = "Deferred: Noisy")]
-#![expect(clippy::match_same_arms, reason = "Deferred: Noisy")]
 #![expect(clippy::cast_possible_truncation, reason = "Deferred: Noisy")]
 #![expect(clippy::missing_assert_message, reason = "Deferred: Noisy")]
-#![expect(clippy::return_self_not_must_use, reason = "Deferred: Noisy")]
 #![expect(elided_lifetimes_in_paths, reason = "Deferred: Noisy")]
 #![expect(unreachable_pub, reason = "Potentially controversial code style")]
 #![expect(
@@ -137,8 +131,6 @@
     reason = "Requires lint_reasons rustc feature for exceptions"
 )]
 #![expect(clippy::todo, reason = "We have a lot of 'real' todos")]
-#![expect(clippy::missing_errors_doc, reason = "Can be quite noisy?")]
-#![expect(clippy::missing_panics_doc, reason = "Can be quite noisy?")]
 #![expect(
     clippy::shadow_unrelated,
     reason = "Potentially controversial code style"

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -100,15 +100,16 @@
 // TODO: Add screenshot. This can't use include_screenshot as that doesn't work with cargo-rdme
 // See https://github.com/linebender/xilem/issues/851
 
-// LINEBENDER LINT SET - lib.rs - v1
+// LINEBENDER LINT SET - lib.rs - v3
 // See https://linebender.org/wiki/canonical-lints/
-// These lints aren't included in Cargo.toml because they
-// shouldn't apply to examples and tests
-#![warn(unused_crate_dependencies)]
+// These lints shouldn't apply to examples or tests.
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+// These lints shouldn't apply to examples.
 #![warn(clippy::print_stdout, clippy::print_stderr)]
+// Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
+#![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(
     test,
     expect(

--- a/tree_arena/src/tree_arena_safe.rs
+++ b/tree_arena/src/tree_arena_safe.rs
@@ -226,23 +226,19 @@ impl<T> TreeNode<T> {
 
 impl<T> ArenaRef<'_, T> {
     /// Id of the item this handle is associated with.
-    #[expect(
-        clippy::missing_panics_doc,
-        reason = "ArenaRefList always has a parent_id when it's a member of ArenaRef"
-    )]
     pub fn id(&self) -> NodeId {
-        self.children.parent_id.unwrap()
+        self.children
+            .parent_id
+            .expect("ArenaRefList always has a parent_id when it's a member of ArenaRef")
     }
 }
 
 impl<T> ArenaMut<'_, T> {
     /// Id of the item this handle is associated with.
-    #[expect(
-        clippy::missing_panics_doc,
-        reason = "ArenaRefList always has a parent_id when it's a member of ArenaRef"
-    )]
     pub fn id(&self) -> NodeId {
-        self.children.parent_id.unwrap()
+        self.children
+            .parent_id
+            .expect("ArenaRefList always has a parent_id when it's a member of ArenaRef")
     }
 
     /// Returns a shared reference equivalent to this one.
@@ -510,10 +506,6 @@ impl ArenaMapRef<'_> {
     /// If `start_id` is Some, the path ends just before that id instead; `start_id` is not included.
     ///
     /// If there is no path from `start_id` to id, returns an empty vector.
-    #[expect(
-        clippy::missing_panics_doc,
-        reason = "All ids in the tree should have a parent in the parent map"
-    )]
     pub fn get_id_path(self, id: NodeId, start_id: Option<NodeId>) -> Vec<NodeId> {
         let mut path = Vec::new();
 
@@ -524,7 +516,10 @@ impl ArenaMapRef<'_> {
         let mut current_id = Some(id);
         while let Some(current) = current_id {
             path.push(current);
-            current_id = *self.parents_map.get(&current).unwrap();
+            current_id = *self
+                .parents_map
+                .get(&current)
+                .expect("All ids in the tree should have a parent in the parent map");
             if current_id == start_id {
                 break;
             }

--- a/tree_arena/src/tree_arena_unsafe.rs
+++ b/tree_arena/src/tree_arena_unsafe.rs
@@ -286,12 +286,10 @@ impl<T> Default for TreeArena<T> {
 
 impl<T> ArenaRef<'_, T> {
     /// Id of the item this handle is associated with.
-    #[expect(
-        clippy::missing_panics_doc,
-        reason = "ArenaRefList always has a parent_id when it's a member of ArenaRef"
-    )]
     pub fn id(&self) -> NodeId {
-        self.children.parent_id.unwrap()
+        self.children
+            .parent_id
+            .expect("ArenaRefList always has a parent_id when it's a member of ArenaRef")
     }
 }
 
@@ -374,12 +372,10 @@ impl<'arena, T> ArenaRefList<'arena, T> {
 
 impl<T> ArenaMut<'_, T> {
     /// Id of the item this handle is associated with
-    #[expect(
-        clippy::missing_panics_doc,
-        reason = "ArenaMutList always has a parent_id when it's a member of ArenaMut"
-    )]
     pub fn id(&self) -> NodeId {
-        self.children.parent_id.unwrap()
+        self.children
+            .parent_id
+            .expect("ArenaMutList always has a parent_id when it's a member of ArenaMut")
     }
 
     /// Returns a shared reference equivalent to this one.

--- a/xilem/examples/calc.rs
+++ b/xilem/examples/calc.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! A simple calculator example
-#![expect(clippy::match_same_arms, reason = "Deferred: Noisy")]
 #![expect(clippy::cast_possible_truncation, reason = "Deferred: Noisy")]
 
 use masonry::widgets::{CrossAxisAlignment, GridParams, MainAxisAlignment};

--- a/xilem/examples/http_cats.rs
+++ b/xilem/examples/http_cats.rs
@@ -4,7 +4,6 @@
 //! An example demonstrating the use of Async web requests in Xilem to access the <https://http.cat/> API.
 //! This also demonstrates image loading.
 
-#![expect(clippy::match_same_arms, reason = "Deferred: Noisy")]
 #![expect(clippy::missing_assert_message, reason = "Deferred: Noisy")]
 
 use std::sync::Arc;

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -122,19 +122,14 @@
     missing_debug_implementations,
     reason = "Deferred: Noisy. Requires same lint to be addressed in Masonry"
 )]
-#![expect(clippy::exhaustive_enums, reason = "Deferred: Noisy")]
-#![expect(clippy::match_same_arms, reason = "Deferred: Noisy")]
 #![expect(clippy::missing_assert_message, reason = "Deferred: Noisy")]
 #![expect(elided_lifetimes_in_paths, reason = "Deferred: Noisy")]
 // https://github.com/rust-lang/rust/pull/130025
 #![allow(missing_docs, reason = "We have many as-yet undocumented items")]
-#![expect(clippy::missing_errors_doc, reason = "Can be quite noisy?")]
-#![expect(clippy::missing_panics_doc, reason = "Can be quite noisy?")]
 #![expect(
     clippy::shadow_unrelated,
     reason = "Potentially controversial code style"
 )]
-#![expect(clippy::allow_attributes, reason = "Deferred: Noisy")]
 #![expect(clippy::allow_attributes_without_reason, reason = "Deferred: Noisy")]
 
 use std::collections::HashMap;

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -101,12 +101,14 @@
 //! [xilem_examples]: https://github.com/linebender/xilem/tree/main/xilem/examples
 
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46134943?s=48&v=4")]
-// LINEBENDER LINT SET - lib.rs - v1
+// LINEBENDER LINT SET - lib.rs - v3
 // See https://linebender.org/wiki/canonical-lints/
-// These lints aren't included in Cargo.toml because they
-// shouldn't apply to examples and tests
-#![warn(unused_crate_dependencies)]
+// These lints shouldn't apply to examples or tests.
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+// These lints shouldn't apply to examples.
 #![warn(clippy::print_stdout, clippy::print_stderr)]
+// Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
+#![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(

--- a/xilem_core/examples/filesystem.rs
+++ b/xilem_core/examples/filesystem.rs
@@ -3,8 +3,6 @@
 
 //! An example using Xilem Core to manipulate a filesystem.
 
-#![expect(let_underscore_drop, reason = "Deferred: Noisy")]
-
 use std::io::stdin;
 use std::path::PathBuf;
 

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -24,12 +24,10 @@
 #![cfg_attr(not(test), no_std)]
 #![forbid(unsafe_code)]
 // TODO: Remove any items listed as "Deferred"
-#![expect(clippy::exhaustive_enums, reason = "Deferred: Noisy")]
 #![expect(
     clippy::shadow_unrelated,
     reason = "Potentially controversial code style"
 )]
-#![expect(clippy::allow_attributes, reason = "Deferred: Noisy")]
 #![expect(clippy::allow_attributes_without_reason, reason = "Deferred: Noisy")]
 extern crate alloc;
 

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -13,12 +13,14 @@
 //! .rustdoc-hidden { display: none; }
 //! </style>
 #![doc = include_str!("../README.md")]
-// LINEBENDER LINT SET - lib.rs - v1
+// LINEBENDER LINT SET - lib.rs - v3
 // See https://linebender.org/wiki/canonical-lints/
-// These lints aren't included in Cargo.toml because they
-// shouldn't apply to examples and tests
-#![warn(unused_crate_dependencies)]
+// These lints shouldn't apply to examples or tests.
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+// These lints shouldn't apply to examples.
 #![warn(clippy::print_stdout, clippy::print_stderr)]
+// Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
+#![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(test), no_std)]

--- a/xilem_core/src/message.rs
+++ b/xilem_core/src/message.rs
@@ -93,8 +93,6 @@ impl dyn Message {
     /// If the message contained within `self` is not of type `T`, returns `self`
     /// (so that e.g. a different type can be used)
     pub fn downcast<T: Message>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
-        // The panic is unreachable
-        #![allow(clippy::missing_panics_doc)]
         if self.deref().as_any().is::<T>() {
             Ok(self
                 .into_any()

--- a/xilem_core/src/views/orphan.rs
+++ b/xilem_core/src/views/orphan.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(
+    // TODO: Instead of being conditionally no_std, instead conditionally use `extern crate std`
     unused_qualifications,
     reason = "We have `std` enabled when testing, which means that some items are conditionally in the prelude"
 )]

--- a/xilem_core/tests/common/mod.rs
+++ b/xilem_core/tests/common/mod.rs
@@ -6,7 +6,6 @@
     reason = "This is a utility module, which means that some exposed items aren't used in all instantiations"
 )]
 #![deny(unreachable_pub)]
-#![expect(clippy::allow_attributes, reason = "Deferred: Noisy")]
 #![expect(clippy::allow_attributes_without_reason, reason = "Deferred: Noisy")]
 #![expect(clippy::missing_assert_message, reason = "Deferred: Noisy")]
 

--- a/xilem_core/tests/one_of.rs
+++ b/xilem_core/tests/one_of.rs
@@ -5,7 +5,6 @@
 //!
 //! This is an integration test so that it can use the infrastructure in [`common`].
 
-#![expect(clippy::match_same_arms, reason = "Deferred: Noisy")]
 #![expect(clippy::missing_assert_message, reason = "Deferred: Noisy")]
 
 use xilem_core::one_of::{OneOf, OneOf2, OneOfCtx, PhantomElementCtx};

--- a/xilem_web/src/lib.rs
+++ b/xilem_web/src/lib.rs
@@ -21,14 +21,9 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // TODO: Remove any items listed as "Deferred"
 #![cfg_attr(test, expect(clippy::print_stdout, reason = "Deferred: Noisy"))]
-#![expect(let_underscore_drop, reason = "Deferred: Noisy")]
 #![expect(missing_debug_implementations, reason = "Deferred: Noisy")]
-#![expect(unused_qualifications, reason = "Deferred: Noisy")]
-#![expect(clippy::exhaustive_enums, reason = "Deferred: Noisy")]
-#![expect(clippy::match_same_arms, reason = "Deferred: Noisy")]
 #![expect(clippy::cast_possible_truncation, reason = "Deferred: Noisy")]
 #![expect(clippy::missing_assert_message, reason = "Deferred: Noisy")]
-#![expect(clippy::return_self_not_must_use, reason = "Deferred: Noisy")]
 #![expect(elided_lifetimes_in_paths, reason = "Deferred: Noisy")]
 // expect doesn't work here: https://github.com/rust-lang/rust/pull/130025
 #![allow(missing_docs, reason = "We have many as-yet undocumented items")]
@@ -38,12 +33,10 @@
     reason = "Requires lint_reasons rustc feature for exceptions"
 )]
 #![expect(clippy::todo, reason = "We have a lot of 'real' todos")]
-#![expect(clippy::missing_panics_doc, reason = "Can be quite noisy?")]
 #![expect(
     clippy::shadow_unrelated,
     reason = "Potentially controversial code style"
 )]
-#![expect(clippy::allow_attributes, reason = "Deferred: Noisy")]
 #![expect(clippy::allow_attributes_without_reason, reason = "Deferred: Noisy")]
 
 use std::any::Any;

--- a/xilem_web/src/lib.rs
+++ b/xilem_web/src/lib.rs
@@ -11,12 +11,14 @@
 //! .rustdoc-hidden { display: none; }
 //! </style>
 #![doc = include_str!("../README.md")]
-// LINEBENDER LINT SET - lib.rs - v1
+// LINEBENDER LINT SET - lib.rs - v3
 // See https://linebender.org/wiki/canonical-lints/
-// These lints aren't included in Cargo.toml because they
-// shouldn't apply to examples and tests
-#![warn(unused_crate_dependencies)]
+// These lints shouldn't apply to examples or tests.
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+// These lints shouldn't apply to examples.
 #![warn(clippy::print_stdout, clippy::print_stderr)]
+// Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
+#![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // TODO: Remove any items listed as "Deferred"

--- a/xilem_web/src/message.rs
+++ b/xilem_web/src/message.rs
@@ -53,8 +53,6 @@ impl dyn Message {
     /// If the message contained within `self` is not of type `T`, returns `self`
     /// (so that e.g. a different type can be used)
     pub fn downcast<T: Message>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
-        // reason: The panic is unreachable
-        #![allow(clippy::missing_panics_doc)]
         if self.deref().as_any().is::<T>() {
             Ok(self
                 .into_any()

--- a/xilem_web/web_examples/fetch/src/main.rs
+++ b/xilem_web/web_examples/fetch/src/main.rs
@@ -4,8 +4,6 @@
 //! Demonstrates fetching other web content from Xilem Web
 
 #![expect(clippy::shadow_unrelated, reason = "Idiomatic for Xilem users")]
-// TODO: `expect` doesn't work here for unknown reasons
-#![allow(clippy::wildcard_imports, reason = "HTML elements are an exception")]
 
 use gloo_net::http::Request;
 use serde::{Deserialize, Serialize};

--- a/xilem_web/web_examples/mathml_svg/src/main.rs
+++ b/xilem_web/web_examples/mathml_svg/src/main.rs
@@ -3,8 +3,6 @@
 
 //! Shows using mathml and SVG on the web
 
-// TODO: `expect` doesn't work here for unknown reasons
-#![allow(clippy::wildcard_imports, reason = "HTML elements are an exception")]
 #![expect(clippy::cast_possible_truncation, reason = "Deferred: Noisy")]
 #![expect(clippy::shadow_unrelated, reason = "Idiomatic for Xilem users")]
 

--- a/xilem_web/web_examples/svgtoy/src/main.rs
+++ b/xilem_web/web_examples/svgtoy/src/main.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! A simple example showing the interaction between SVG and event handling
-// TODO: `expect` doesn't work here
-#![allow(clippy::wildcard_imports, reason = "HTML elements are an exception")]
 
 use xilem_web::elements::svg::{g, svg, text};
 use xilem_web::interfaces::*;

--- a/xilem_web/web_examples/todomvc/src/main.rs
+++ b/xilem_web/web_examples/todomvc/src/main.rs
@@ -4,8 +4,6 @@
 //! A recreation of todomvc in Xilem Web
 // TODO: Link
 
-// TODO: `expect` doesn't work here
-#![allow(clippy::wildcard_imports, reason = "HTML elements are an exception")]
 #![expect(clippy::shadow_unrelated, reason = "Idiomatic for Xilem users")]
 
 mod state;

--- a/xilem_web/web_examples/todomvc/src/state.rs
+++ b/xilem_web/web_examples/todomvc/src/state.rs
@@ -1,8 +1,6 @@
 // Copyright 2023 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![expect(clippy::partial_pub_fields, reason = "Deferred: Noisy")]
-
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::UnwrapThrowExt;
 


### PR DESCRIPTION
See linebender/linebender.github.io#88 (and some other earlier PRs)

A follow up like https://github.com/linebender/vello/pull/806 will also be needed, but that can come later.