### PR TITLE
Update `float-cmp` and `pollster`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 
 [[package]]
 name = "fnv"
@@ -2566,9 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "pollster"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "powerfmt"

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -47,7 +47,7 @@ once_cell = "1.19.0"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 futures-intrusive = "0.5.0"
-pollster = "0.3.0"
+pollster = "0.4.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "time"] }
 accesskit.workspace = true
 accesskit_winit.workspace = true
@@ -62,7 +62,7 @@ wgpu-profiler = { optional = true, version = "0.19.0", default-features = false 
 web-time.workspace = true
 
 [dev-dependencies]
-float-cmp = { version = "0.9.0", features = ["std"], default-features = false }
+float-cmp = { version = "0.10.0", features = ["std"], default-features = false }
 image = { workspace = true, features = ["png"] }
 insta = { version = "1.39.0" }
 assert_matches = "1.5.0"


### PR DESCRIPTION
These are the direct dependencies that have non-semver compatible updates (apart from wgpu).