### PR TITLE
Add DPI scale factor to the render root state

### DIFF
--- a/masonry/src/app/render_root.rs
+++ b/masonry/src/app/render_root.rs
@@ -147,6 +147,7 @@ pub(crate) struct RenderRootState {
     /// Pass tracing configuration, used to skip tracing to limit overhead.
     pub(crate) trace: PassTracing,
     pub(crate) inspector_state: InspectorState,
+    pub(crate) scale_factor: f64,
 }
 
 pub(crate) struct MutateCallback {
@@ -290,6 +291,7 @@ impl RenderRoot {
                     is_picking_widget: false,
                     hovered_widget: None,
                 },
+                scale_factor,
             },
             widget_arena: WidgetArena {
                 widgets: TreeArena::new(),
@@ -339,6 +341,7 @@ impl RenderRoot {
         match event {
             WindowEvent::Rescale(scale_factor) => {
                 self.scale_factor = scale_factor;
+                self.global_state.scale_factor = scale_factor;
                 self.request_render_all();
                 Handled::Yes
             }

--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -777,6 +777,11 @@ impl_context_method!(
         pub fn to_window(&self, widget_point: Point) -> Point {
             self.widget_state.window_transform * widget_point
         }
+
+        /// Get DPI scaling factor.
+        pub fn get_scale_factor(&self) -> f64 {
+            self.global_state.scale_factor
+        }
     }
 );
 


### PR DESCRIPTION
so that it's available to widgets that can fix blurry lines due to bad overlapping positioning of its internal elements

partially addresses https://github.com/linebender/xilem/issues/869
