### PR TITLE
add canvas widget

### DIFF
--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -715,7 +715,10 @@ impl TestHarness {
             // Remove '<test_name>.new.png' file if it exists
             let _ = std::fs::remove_file(&new_path);
             new_image.save(&new_path).unwrap();
-            panic!("Snapshot test '{test_name}' failed: No reference file");
+            panic!(
+                "Snapshot test '{test_name}' failed: No reference file\n\
+            New screenshot created with `.new.png` extension. If correct, change to `.png`"
+            );
         }
     }
 }

--- a/masonry/src/widgets/canvas.rs
+++ b/masonry/src/widgets/canvas.rs
@@ -1,0 +1,137 @@
+// Copyright 2025 the Xilem Authors and the Druid Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#![warn(missing_docs)]
+
+//! A canvas widget.
+
+use accesskit::{Node, Role};
+use smallvec::SmallVec;
+use tracing::{trace_span, Span};
+use vello::kurbo::Size;
+use vello::Scene;
+
+use crate::core::{
+    AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent, QueryCtx,
+    RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut,
+};
+
+/// A widget allowing custom drawing.
+pub struct Canvas {
+    draw: Box<dyn Fn(&mut Scene, Size) + Send + Sync + 'static>,
+    // TODO: pointer events
+}
+
+// --- MARK: BUILDERS ---
+impl Canvas {
+    /// Create a new canvas with the given draw function
+    pub fn new(draw: impl Fn(&mut Scene, Size) + Send + Sync + 'static) -> Self {
+        Self {
+            draw: Box::new(draw),
+        }
+    }
+}
+
+// --- MARK: WIDGETMUT ---
+impl Canvas {
+    /// Update the draw function
+    pub fn update_draw(
+        this: &mut WidgetMut<'_, Self>,
+        draw: impl Fn(&mut Scene, Size) + Send + Sync + 'static,
+    ) {
+        this.widget.draw = Box::new(draw);
+        this.ctx.request_render();
+    }
+}
+
+// --- MARK: IMPL WIDGET ---
+impl Widget for Canvas {
+    fn on_pointer_event(&mut self, _ctx: &mut EventCtx, _event: &PointerEvent) {
+        // TODO: ensure coordinates are correct and pass to callback
+    }
+
+    fn accepts_pointer_interaction(&self) -> bool {
+        true
+    }
+
+    fn on_text_event(&mut self, _ctx: &mut EventCtx, _event: &TextEvent) {}
+
+    fn on_access_event(&mut self, _ctx: &mut EventCtx, _event: &AccessEvent) {}
+
+    fn register_children(&mut self, _ctx: &mut RegisterCtx) {}
+
+    fn update(&mut self, _ctx: &mut UpdateCtx, _event: &Update) {}
+
+    fn layout(&mut self, _ctx: &mut LayoutCtx, bc: &BoxConstraints) -> Size {
+        // use as much space as possible - caller can size it as necessary
+        bc.max()
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx, scene: &mut Scene) {
+        (self.draw)(scene, ctx.size())
+    }
+
+    fn accessibility_role(&self) -> Role {
+        Role::Canvas
+    }
+
+    fn accessibility(&mut self, _ctx: &mut AccessCtx, _node: &mut Node) {
+        // TODO: should probably give the caller the opportunity to handle accessibility
+    }
+
+    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
+        SmallVec::new()
+    }
+
+    fn make_trace_span(&self, ctx: &QueryCtx<'_>) -> Span {
+        trace_span!("Canvas", id = ctx.widget_id().trace())
+    }
+
+    fn get_debug_text(&self) -> Option<String> {
+        None
+    }
+}
+
+// --- MARK: TESTS ---
+#[cfg(test)]
+mod tests {
+    use insta::assert_debug_snapshot;
+    use vello::kurbo::{Affine, BezPath, Stroke};
+    use vello::peniko::{Color, Fill};
+
+    use super::*;
+    use crate::assert_render_snapshot;
+    use crate::testing::TestHarness;
+
+    #[test]
+    fn simple_canvas() {
+        let canvas = Canvas::new(|scene, size| {
+            let scale = Affine::scale_non_uniform(size.width, size.height);
+            let mut path = BezPath::new();
+            path.move_to((0.1, 0.1));
+            path.line_to((0.9, 0.9));
+            path.line_to((0.9, 0.1));
+            path.close_path();
+            path = scale * path;
+            scene.fill(
+                Fill::NonZero,
+                Affine::IDENTITY,
+                Color::from_rgb8(100, 240, 150),
+                None,
+                &path,
+            );
+            scene.stroke(
+                &Stroke::new(4.),
+                Affine::IDENTITY,
+                Color::from_rgb8(200, 140, 50),
+                None,
+                &path,
+            );
+        });
+
+        let mut harness = TestHarness::create(canvas);
+
+        assert_debug_snapshot!(harness.root_widget());
+        assert_render_snapshot!(harness, "hello");
+    }
+}

--- a/masonry/src/widgets/mod.rs
+++ b/masonry/src/widgets/mod.rs
@@ -11,6 +11,7 @@ mod tests;
 
 mod align;
 mod button;
+mod canvas;
 mod checkbox;
 mod flex;
 mod grid;
@@ -31,6 +32,7 @@ mod zstack;
 
 pub use self::align::Align;
 pub use self::button::Button;
+pub use self::canvas::Canvas;
 pub use self::checkbox::Checkbox;
 pub use self::flex::{Axis, CrossAxisAlignment, Flex, FlexParams, MainAxisAlignment};
 pub use self::grid::{Grid, GridParams};

--- a/masonry/src/widgets/screenshots/masonry__widgets__canvas__tests__hello.png
+++ b/masonry/src/widgets/screenshots/masonry__widgets__canvas__tests__hello.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7634b7801c3be71f13923bb9a77da9aeffe67eb3b042eab9ccffbd647655759
+size 11377

--- a/masonry/src/widgets/snapshots/masonry__widgets__canvas__tests__simple_canvas.snap
+++ b/masonry/src/widgets/snapshots/masonry__widgets__canvas__tests__simple_canvas.snap
@@ -1,0 +1,5 @@
+---
+source: masonry/src/widgets/canvas.rs
+expression: harness.root_widget()
+---
+Canvas


### PR DESCRIPTION
I'm playing with making a vector path editor in `xilem`. This requires some extra stuff over what is currently available so I'm going to maintain a fork. I will try to merge upstream anything I think is more widely useful.

This PR allows the user to draw directly onto the scene fragment for a widget. Currently, the user must recreate the draw function every time there is a change in state. I wonder if there should be separated out state and draw parts, so the function needs to be updated less often.