### PR TITLE
Make Xilem Core unconditionally `no_std`

### DIFF
--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -23,8 +23,8 @@
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![cfg_attr(not(test), no_std)]
 #![forbid(unsafe_code)]
+#![no_std]
 // TODO: Remove any items listed as "Deferred"
 #![expect(
     clippy::shadow_unrelated,
@@ -32,6 +32,10 @@
 )]
 #![expect(clippy::allow_attributes_without_reason, reason = "Deferred: Noisy")]
 extern crate alloc;
+
+// Used only for ad-hoc debugging of tests
+#[cfg(test)]
+extern crate std;
 
 mod deferred;
 pub use deferred::{AsyncCtx, MessageProxy, PhantomView, ProxyError, RawProxy};

--- a/xilem_core/src/message.rs
+++ b/xilem_core/src/message.rs
@@ -122,6 +122,8 @@ pub trait ViewMessage<State, Action> {
 #[cfg(test)]
 mod tests {
     use alloc::boxed::Box;
+    use alloc::format;
+    use alloc::string::{String, ToString};
     use core::fmt::Debug;
 
     use crate::DynMessage;

--- a/xilem_core/src/views/orphan.rs
+++ b/xilem_core/src/views/orphan.rs
@@ -1,12 +1,6 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(
-    // TODO: Instead of being conditionally no_std, instead conditionally use `extern crate std`
-    unused_qualifications,
-    reason = "We have `std` enabled when testing, which means that some items are conditionally in the prelude"
-)]
-
 use crate::{
     DynMessage, MessageResult, Mut, View, ViewElement, ViewId, ViewMarker, ViewPathTracker,
 };


### PR DESCRIPTION
This removes the need to ignore `unused_qualifications`.

The `extern crate std` isn't *strictly* needed, but it will make future debugging easier (you can do `println` or `dbg!`, for example).