### PR TITLE
Add methods to MasonryState to allow external renderer

### DIFF
--- a/masonry/src/app/event_loop_runner.rs
+++ b/masonry/src/app/event_loop_runner.rs
@@ -774,4 +774,61 @@ impl MasonryState<'_> {
             self.render_cx.set_present_mode(surface, present_mode);
         }
     }
+
+    pub fn get_render_device_and_queue(&self) -> Option<(&wgpu::Device, &wgpu::Queue)> {
+        if let WindowState::Rendering { surface, .. } = &self.window {
+            let dev_id = surface.dev_id;
+            let device = &self.render_cx.devices[dev_id].device;
+            let queue = &self.render_cx.devices[dev_id].queue;
+            Some((device, queue))
+        } else {
+            None
+        }
+    }
+
+    pub fn get_adapter(&self) -> Option<&wgpu::Adapter> {
+        if let WindowState::Rendering { surface, .. } = &self.window {
+            let dev_id = surface.dev_id;
+            Some (self.render_cx.devices[dev_id].adapter())
+        } else {
+            None
+        }
+    }
+
+    /// Get next frame to present, handling resize if necessary.
+    pub fn get_next_frame(&mut self) -> Result<wgpu::SurfaceTexture, wgpu::SurfaceError> {
+        let WindowState::Rendering {
+            window, surface, ..
+        } = &mut self.window
+        else {
+            tracing::warn!("Tried to render whilst suspended or before window created");
+            return Err(wgpu::SurfaceError::Lost);
+        };
+        // https://github.com/rust-windowing/winit/issues/2308
+        #[cfg(target_os = "ios")]
+        let size = window.outer_size();
+        #[cfg(not(target_os = "ios"))]
+        let size = window.inner_size();
+        let width = size.width;
+        let height = size.height;
+
+        if surface.config.width != width || surface.config.height != height {
+            self.render_cx.resize_surface(surface, width, height);
+        }
+
+        surface.surface.get_current_texture()
+    }
+
+    /// Handle accesskit tree updates. This is called by external renderers at the conclusion of
+    /// rendering the masonry scene.
+    pub fn handle_tree_update(&mut self, tree_update: accesskit::TreeUpdate) {
+        let WindowState::Rendering {
+            accesskit_adapter, ..
+        } = &mut self.window
+        else {
+            debug_panic!("Suspended inside event");
+            return;
+        };
+        accesskit_adapter.update_if_active(|| tree_update);
+    }
 }

--- a/masonry/src/app/event_loop_runner.rs
+++ b/masonry/src/app/event_loop_runner.rs
@@ -776,7 +776,7 @@ impl MasonryState<'_> {
     }
 
     /// Return references to the wgpu device and queue associated with current window.
-    /// TODO: multi-window interface will require more information to determine which 
+    /// TODO: multi-window interface will require more information to determine which
     /// device and queue to return.
     pub fn get_render_device_and_queue(&self) -> Option<(&wgpu::Device, &wgpu::Queue)> {
         if let WindowState::Rendering { surface, .. } = &self.window {
@@ -793,7 +793,7 @@ impl MasonryState<'_> {
     pub fn get_adapter(&self) -> Option<&wgpu::Adapter> {
         if let WindowState::Rendering { surface, .. } = &self.window {
             let dev_id = surface.dev_id;
-            Some (self.render_cx.devices[dev_id].adapter())
+            Some(self.render_cx.devices[dev_id].adapter())
         } else {
             None
         }

--- a/masonry/src/app/event_loop_runner.rs
+++ b/masonry/src/app/event_loop_runner.rs
@@ -775,6 +775,9 @@ impl MasonryState<'_> {
         }
     }
 
+    /// Return references to the wgpu device and queue associated with current window.
+    /// TODO: multi-window interface will require more information to determine which 
+    /// device and queue to return.
     pub fn get_render_device_and_queue(&self) -> Option<(&wgpu::Device, &wgpu::Queue)> {
         if let WindowState::Rendering { surface, .. } = &self.window {
             let dev_id = surface.dev_id;
@@ -786,6 +789,7 @@ impl MasonryState<'_> {
         }
     }
 
+    /// Access to the wgpu adapter.
     pub fn get_adapter(&self) -> Option<&wgpu::Adapter> {
         if let WindowState::Rendering { surface, .. } = &self.window {
             let dev_id = surface.dev_id;

--- a/masonry/src/app/event_loop_runner.rs
+++ b/masonry/src/app/event_loop_runner.rs
@@ -60,6 +60,8 @@ impl From<WinitMouseButton> for PointerButton {
     }
 }
 
+/// Represents the state of a window.
+/// Note: This is an internal representation that is provisionally being made public in order to facilitate externally driven rendering.
 pub enum WindowState<'a> {
     Uninitialized(WindowAttributes),
     Rendering {

--- a/masonry/src/app/mod.rs
+++ b/masonry/src/app/mod.rs
@@ -10,7 +10,8 @@ mod tracing_backend;
 
 pub use app_driver::{AppDriver, DriverCtx};
 pub use event_loop_runner::{
-    run, run_with, EventLoop, EventLoopBuilder, EventLoopProxy, MasonryState, MasonryUserEvent, WindowState
+    run, run_with, EventLoop, EventLoopBuilder, EventLoopProxy, MasonryState, MasonryUserEvent,
+    WindowState
 };
 pub use render_root::{RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy};
 

--- a/masonry/src/app/mod.rs
+++ b/masonry/src/app/mod.rs
@@ -10,7 +10,7 @@ mod tracing_backend;
 
 pub use app_driver::{AppDriver, DriverCtx};
 pub use event_loop_runner::{
-    run, run_with, EventLoop, EventLoopBuilder, EventLoopProxy, MasonryState, MasonryUserEvent,
+    run, run_with, EventLoop, EventLoopBuilder, EventLoopProxy, MasonryState, MasonryUserEvent, WindowState
 };
 pub use render_root::{RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy};
 

--- a/masonry/src/app/mod.rs
+++ b/masonry/src/app/mod.rs
@@ -11,7 +11,7 @@ mod tracing_backend;
 pub use app_driver::{AppDriver, DriverCtx};
 pub use event_loop_runner::{
     run, run_with, EventLoop, EventLoopBuilder, EventLoopProxy, MasonryState, MasonryUserEvent,
-    WindowState
+    WindowState,
 };
 pub use render_root::{RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy};
 


### PR DESCRIPTION
Adds methods to MasonryState that allows external renderer enough access to control rendering of Masonry/Xilem.

This pull request does not provide a good example of how this would be done, but I have a fairly simple example here: https://github.com/cfagot/space_survival. This example shows how xilem can be rendered inside an application which has other wgpu render managers.
