### PR TITLE
Add Xilem view for the Split widget

### DIFF
--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -20,12 +20,10 @@ use crate::util::{fill_color, stroke};
 use crate::widgets::flex::Axis;
 use cursor_icon::CursorIcon;
 
-// TODO - Have child widget type as generic argument
-
 /// A container containing two other widgets, splitting the area either horizontally or vertically.
 ///
 #[doc = crate::include_screenshot!("widget/screenshots/masonry__widget__split__tests__columns.png", "Split panel with two labels.")]
-pub struct Split {
+pub struct Split<ChildA: Widget, ChildB: Widget> {
     split_axis: Axis,
     split_point_chosen: f64,
     split_point_effective: f64,
@@ -38,17 +36,17 @@ pub struct Split {
     /// bar was clicked. This is used to ensure a click without mouse move is a no-op,
     /// instead of re-centering the bar on the mouse.
     click_offset: f64,
-    child1: WidgetPod<dyn Widget>,
-    child2: WidgetPod<dyn Widget>,
+    child1: WidgetPod<ChildA>,
+    child2: WidgetPod<ChildB>,
 }
 
 // --- MARK: BUILDERS ---
-impl Split {
+impl<ChildA: Widget, ChildB: Widget> Split<ChildA, ChildB> {
     /// Create a new split panel, with the specified axis being split in two.
     ///
     /// Horizontal split axis means that the children are left and right.
     /// Vertical split axis means that the children are up and down.
-    fn new(split_axis: Axis, child1: impl Widget + 'static, child2: impl Widget + 'static) -> Self {
+    fn new(split_axis: Axis, child1: ChildA, child2: ChildB) -> Self {
         Self {
             split_axis,
             split_point_chosen: 0.5,
@@ -59,20 +57,20 @@ impl Split {
             solid: false,
             draggable: false,
             click_offset: 0.0,
-            child1: WidgetPod::new(child1).erased(),
-            child2: WidgetPod::new(child2).erased(),
+            child1: WidgetPod::new(child1),
+            child2: WidgetPod::new(child2),
         }
     }
 
     /// Create a new split panel, with the horizontal axis split in two by a vertical bar.
     /// The children are laid out left and right.
-    pub fn columns(child1: impl Widget + 'static, child2: impl Widget + 'static) -> Self {
+    pub fn columns(child1: ChildA, child2: ChildB) -> Self {
         Self::new(Axis::Horizontal, child1, child2)
     }
 
     /// Create a new split panel, with the vertical axis split in two by a horizontal bar.
     /// The children are laid out up and down.
-    pub fn rows(child1: impl Widget + 'static, child2: impl Widget + 'static) -> Self {
+    pub fn rows(child1: ChildA, child2: ChildB) -> Self {
         Self::new(Axis::Vertical, child1, child2)
     }
 
@@ -145,7 +143,7 @@ impl Split {
 }
 
 // --- MARK: INTERNALS ---
-impl Split {
+impl<ChildA: Widget, ChildB: Widget> Split<ChildA, ChildB> {
     /// Returns the size of the splitter bar area.
     #[inline]
     fn bar_area(&self) -> f64 {
@@ -294,7 +292,7 @@ impl Split {
 // FIXME - Add unit tests for WidgetMut<Split>
 
 // --- MARK: WIDGETMUT ---
-impl Split {
+impl<ChildA: Widget, ChildB: Widget> Split<ChildA, ChildB> {
     /// Set the split point as a fraction of the split axis.
     ///
     /// The value must be between `0.0` and `1.0`, inclusive.
@@ -367,7 +365,7 @@ impl Split {
 }
 
 // --- MARK: IMPL WIDGET ---
-impl Widget for Split {
+impl<ChildA: Widget, ChildB: Widget> Widget for Split<ChildA, ChildB> {
     fn on_pointer_event(
         &mut self,
         ctx: &mut EventCtx,
@@ -639,7 +637,7 @@ mod tests {
             let mut harness = TestHarness::create_with_size(widget, Size::new(100.0, 100.0));
 
             harness.edit_root_widget(|mut splitter| {
-                let mut splitter = splitter.downcast::<Split>();
+                let mut splitter = splitter.downcast::<Split<Label, Label>>();
 
                 Split::set_split_point(&mut splitter, 0.3);
                 Split::set_min_size(&mut splitter, 40.0, 10.0);

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -87,7 +87,7 @@ impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
     pub fn split_point(mut self, split_point: f64) -> Self {
         assert!(
             (0.0..=1.0).contains(&split_point),
-            "split_point must be in the range [0.0-1.0]!"
+            "split_point must be in the range [0.0, 1.0], got {split_point}"
         );
         self.split_point_chosen = split_point;
         self

--- a/xilem/README.md
+++ b/xilem/README.md
@@ -117,6 +117,7 @@ The primitives your `Xilem` app’s view tree will generally be constructed from
 * [`grid`][crate::view::grid]: divides a window into regions and defines the relationship
   between inner elements in terms of size and position
 * [`sized_box`][crate::view::sized_box]: forces its child to have a specific width and/or height
+* [`split`][crate::view::split]: contains two views splitting the area either vertically or horizontally which can be resized.
 * [`button`][crate::view::button]: basic button element
 * [`image`][crate::view::image]: displays a bitmap image
 * [`portal`][crate::view::portal]: a scrollable region

--- a/xilem/examples/http_cats.rs
+++ b/xilem/examples/http_cats.rs
@@ -16,8 +16,8 @@ use winit::window::Window;
 use xilem::core::fork;
 use xilem::core::one_of::OneOf3;
 use xilem::view::{
-    Axis, FlexExt, FlexSpacer, Padding, ZStackExt, button, flex, image, inline_prose, portal,
-    prose, sized_box, spinner, worker, zstack,
+    Axis, FlexSpacer, Padding, ZStackExt, button, flex, image, inline_prose, portal, prose,
+    sized_box, spinner, split, worker, zstack,
 };
 use xilem::{EventLoop, EventLoopBuilder, TextAlignment, WidgetView, Xilem, palette};
 
@@ -102,13 +102,7 @@ impl HttpCats {
             flex((
                 // Add padding to the top for Android. Still a horrible hack
                 FlexSpacer::Fixed(40.),
-                flex((
-                    left_column.flex(1.),
-                    portal(sized_box(info_area).expand_width()).flex(1.),
-                ))
-                .direction(Axis::Horizontal)
-                .must_fill_major_axis(true)
-                .flex(1.),
+                split(left_column, portal(sized_box(info_area).expand_width())).split_point(0.4),
             ))
             .must_fill_major_axis(true),
             worker(

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -73,6 +73,7 @@
 //! * [`grid`][crate::view::grid]: divides a window into regions and defines the relationship
 //!   between inner elements in terms of size and position
 //! * [`sized_box`][crate::view::sized_box]: forces its child to have a specific width and/or height
+//! * [`split`][crate::view::split]: contains two views splitting the area either vertically or horizontally which can be resized.
 //! * [`button`][crate::view::button]: basic button element
 //! * [`image`][crate::view::image]: displays a bitmap image
 //! * [`portal`][crate::view::portal]: a scrollable region

--- a/xilem/src/view/mod.rs
+++ b/xilem/src/view/mod.rs
@@ -53,3 +53,6 @@ pub use zstack::*;
 
 mod transform;
 pub use transform::*;
+
+mod split;
+pub use split::*;

--- a/xilem/src/view/split.rs
+++ b/xilem/src/view/split.rs
@@ -226,13 +226,17 @@ where
             widgets::Split::set_bar_solid(&mut element, self.solid_bar);
         }
 
-        let child1_element = widgets::Split::child1_mut(&mut element);
-        self.child1
-            .rebuild(&prev.child1, &mut view_state.0, ctx, child1_element);
+        ctx.with_id(CHILD1_VIEW_ID, |ctx| {
+            let child1_element = widgets::Split::child1_mut(&mut element);
+            self.child1
+                .rebuild(&prev.child1, &mut view_state.0, ctx, child1_element);
+        });
 
-        let child2_element = widgets::Split::child2_mut(&mut element);
-        self.child2
-            .rebuild(&prev.child2, &mut view_state.1, ctx, child2_element);
+        ctx.with_id(CHILD2_VIEW_ID, |ctx| {
+            let child2_element = widgets::Split::child2_mut(&mut element);
+            self.child2
+                .rebuild(&prev.child2, &mut view_state.1, ctx, child2_element);
+        });
     }
 
     fn teardown(

--- a/xilem/src/view/split.rs
+++ b/xilem/src/view/split.rs
@@ -157,8 +157,8 @@ impl<ChildA, ChildB, State, Action> Split<ChildA, ChildB, State, Action> {
     }
 }
 
-const CHILD1_VIEW_ID: ViewId = ViewId::new(0);
-const CHILD2_VIEW_ID: ViewId = ViewId::new(0);
+const CHILD1_VIEW_ID: ViewId = ViewId::new(5436781);
+const CHILD2_VIEW_ID: ViewId = ViewId::new(5436782);
 
 impl<ChildA, ChildB, State, Action> ViewMarker for Split<ChildA, ChildB, State, Action> {}
 impl<ChildA, ChildB, State, Action> View<State, Action, ViewCtx>
@@ -259,22 +259,16 @@ where
         message: DynMessage,
         app_state: &mut State,
     ) -> xilem_core::MessageResult<Action, DynMessage> {
-        let (view_id, rest) = id_path
-            .split_first()
-            .expect("message should contain id_path to child in Split view");
-
-        if view_id == &CHILD1_VIEW_ID {
-            return self
-                .child1
-                .message(&mut view_state.0, rest, message, app_state);
+        match id_path.split_first() {
+            Some((&CHILD1_VIEW_ID, rest)) => {
+                self.child1
+                    .message(&mut view_state.0, rest, message, app_state)
+            }
+            Some((&CHILD2_VIEW_ID, rest)) => {
+                self.child2
+                    .message(&mut view_state.1, rest, message, app_state)
+            }
+            _ => unreachable!("invalid id_path for Split view message: {:?}", id_path),
         }
-
-        if view_id == &CHILD2_VIEW_ID {
-            return self
-                .child2
-                .message(&mut view_state.1, rest, message, app_state);
-        }
-
-        unreachable!("invalid id_path for Split view message: {:?}", id_path)
     }
 }

--- a/xilem/src/view/split.rs
+++ b/xilem/src/view/split.rs
@@ -1,0 +1,235 @@
+use std::marker::PhantomData;
+
+use masonry::widgets::{self, Axis};
+use xilem_core::{DynMessage, View, ViewId, ViewMarker, ViewPathTracker};
+
+use crate::{Pod, ViewCtx, WidgetView};
+
+pub fn split<State, Action, ChildA, ChildB>(
+    child1: ChildA,
+    child2: ChildB,
+) -> Split<ChildA, ChildB, State, Action>
+where
+    ChildA: WidgetView<State, Action>,
+    ChildB: WidgetView<State, Action>,
+{
+    Split {
+        split_axis: Axis::Vertical,
+        split_point: 0.5,
+        min_size: (0.0, 0.0),
+        bar_size: 6.0,
+        min_bar_area: 6.0,
+        solid_bar: false,
+        draggable: false,
+        child1,
+        child2,
+        phantom: PhantomData,
+    }
+}
+
+/// The [`View`] created by [`split`].
+///
+/// See `split` documentation for more context.
+#[must_use = "View values do nothing unless provided to Xilem."]
+pub struct Split<ChildA, ChildB, State, Action = ()> {
+    split_axis: Axis,
+    split_point: f64,
+    min_size: (f64, f64), // Integers only
+    bar_size: f64,        // Integers only
+    min_bar_area: f64,    // Integers only
+    solid_bar: bool,
+    draggable: bool,
+    child1: ChildA,
+    child2: ChildB,
+    phantom: PhantomData<fn() -> (State, Action)>,
+}
+
+impl<ChildA, ChildB, State, Action> Split<ChildA, ChildB, State, Action> {
+    /// Set the split axis
+    pub fn split_axis(mut self, axis: Axis) -> Self {
+        self.split_axis = axis;
+        self
+    }
+
+    /// Set the split point as a fraction of the split axis.
+    ///
+    /// The value must be between `0.0` and `1.0`, inclusive.
+    /// The default split point is `0.5`.
+    pub fn split_point(mut self, split_point: f64) -> Self {
+        assert!(
+            (0.0..=1.0).contains(&split_point),
+            "split_point must be in the range [0.0-1.0]!"
+        );
+        self.split_point = split_point;
+        self
+    }
+
+    /// Set the minimum size for both sides of the split axis.
+    ///
+    /// The value must be greater than or equal to `0.0`.
+    /// The value will be rounded up to the nearest integer.
+    pub fn min_size(mut self, first: f64, second: f64) -> Self {
+        assert!(first >= 0.0);
+        assert!(second >= 0.0);
+        self.min_size = (first.ceil(), second.ceil());
+        self
+    }
+
+    /// Set the size of the splitter bar.
+    ///
+    /// The value must be positive or zero.
+    /// The value will be rounded up to the nearest integer.
+    /// The default splitter bar size is `6.0`.
+    pub fn bar_size(mut self, bar_size: f64) -> Self {
+        assert!(bar_size >= 0.0, "bar_size must be 0.0 or greater!");
+        self.bar_size = bar_size.ceil();
+        self
+    }
+
+    /// Set the minimum size of the splitter bar area.
+    ///
+    /// The minimum splitter bar area defines the minimum size of the area
+    /// where mouse hit detection is done for the splitter bar.
+    /// The final area is either this or the splitter bar size, whichever is greater.
+    ///
+    /// This can be useful when you want to use a very narrow visual splitter bar,
+    /// but don't want to sacrifice user experience by making it hard to click on.
+    ///
+    /// The value must be positive or zero.
+    /// The value will be rounded up to the nearest integer.
+    /// The default minimum splitter bar area is `6.0`.
+    pub fn min_bar_area(mut self, min_bar_area: f64) -> Self {
+        assert!(min_bar_area >= 0.0, "min_bar_area must be 0.0 or greater!");
+        self.min_bar_area = min_bar_area.ceil();
+        self
+    }
+
+    /// Set whether the split point can be changed by dragging.
+    ///
+    /// The default is false.
+    pub fn draggable(mut self, draggable: bool) -> Self {
+        self.draggable = draggable;
+        self
+    }
+
+    /// Set whether the splitter bar is drawn as a solid rectangle.
+    ///
+    /// If this is `false` (the default), the bar will be drawn as two parallel lines.
+    pub fn solid_bar(mut self, solid: bool) -> Self {
+        self.solid_bar = solid;
+        self
+    }
+}
+
+const CHILD1_VIEW_ID: ViewId = ViewId::new(0);
+const CHILD2_VIEW_ID: ViewId = ViewId::new(0);
+
+impl<ChildA, ChildB, State, Action> ViewMarker for Split<ChildA, ChildB, State, Action> {}
+impl<ChildA, ChildB, State, Action> View<State, Action, ViewCtx>
+    for Split<ChildA, ChildB, State, Action>
+where
+    State: 'static,
+    Action: 'static,
+    ChildA: WidgetView<State, Action>,
+    ChildB: WidgetView<State, Action>,
+{
+    type Element = Pod<widgets::Split<ChildA::Widget, ChildB::Widget>>;
+
+    type ViewState = (ChildA::ViewState, ChildB::ViewState);
+
+    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+        let (child1, child1_state) = ctx.with_id(CHILD1_VIEW_ID, |ctx| self.child1.build(ctx));
+        let (child2, child2_state) = ctx.with_id(CHILD2_VIEW_ID, |ctx| self.child2.build(ctx));
+
+        let widget_pod = ctx.new_pod(widgets::Split::new_pod(
+            self.split_axis,
+            child1.into_widget_pod(),
+            child2.into_widget_pod(),
+        ));
+
+        (widget_pod, (child1_state, child2_state))
+    }
+
+    fn rebuild(
+        &self,
+        prev: &Self,
+        view_state: &mut Self::ViewState,
+        ctx: &mut ViewCtx,
+        mut element: xilem_core::Mut<'_, Self::Element>,
+    ) {
+        if prev.split_axis != self.split_axis {
+            widgets::Split::set_split_axis(&mut element, self.split_axis);
+        }
+
+        if prev.split_point != self.split_point {
+            widgets::Split::set_split_point(&mut element, self.split_point);
+        }
+
+        if prev.min_size != self.min_size {
+            widgets::Split::set_min_size(&mut element, self.min_size.0, self.min_size.1);
+        }
+
+        if prev.bar_size != self.bar_size {
+            widgets::Split::set_bar_size(&mut element, self.bar_size);
+        }
+
+        if prev.min_bar_area != self.min_bar_area {
+            widgets::Split::set_min_bar_area(&mut element, self.min_bar_area);
+        }
+
+        if prev.draggable != self.draggable {
+            widgets::Split::set_draggable(&mut element, self.draggable);
+        }
+
+        if prev.solid_bar != self.solid_bar {
+            widgets::Split::set_bar_solid(&mut element, self.solid_bar);
+        }
+
+        let child1_element = widgets::Split::child1_mut(&mut element);
+        self.child1
+            .rebuild(&prev.child1, &mut view_state.0, ctx, child1_element);
+
+        let child2_element = widgets::Split::child2_mut(&mut element);
+        self.child2
+            .rebuild(&prev.child2, &mut view_state.1, ctx, child2_element);
+    }
+
+    fn teardown(
+        &self,
+        view_state: &mut Self::ViewState,
+        ctx: &mut ViewCtx,
+        mut element: xilem_core::Mut<'_, Self::Element>,
+    ) {
+        let child1_element = widgets::Split::child1_mut(&mut element);
+        self.child1.teardown(&mut view_state.0, ctx, child1_element);
+
+        let child2_element = widgets::Split::child2_mut(&mut element);
+        self.child2.teardown(&mut view_state.1, ctx, child2_element);
+    }
+
+    fn message(
+        &self,
+        view_state: &mut Self::ViewState,
+        id_path: &[xilem_core::ViewId],
+        message: DynMessage,
+        app_state: &mut State,
+    ) -> xilem_core::MessageResult<Action, DynMessage> {
+        let (view_id, rest) = id_path
+            .split_first()
+            .expect("message should contain id_path to child in Split view");
+
+        if view_id == &CHILD1_VIEW_ID {
+            return self
+                .child1
+                .message(&mut view_state.0, rest, message, app_state);
+        }
+
+        if view_id == &CHILD2_VIEW_ID {
+            return self
+                .child2
+                .message(&mut view_state.1, rest, message, app_state);
+        }
+
+        unreachable!("invalid id_path for Split view message: {:?}", id_path)
+    }
+}


### PR DESCRIPTION
### Highlights

- Make the Masonry Split widget generic over its children (fixes a todo)
- Adds a new Xilem view for the widget
- Updated the `http_cats` example to use it for the main divider.

---

I'm unsure how exactly the `message` function works on a Xilem view as it was hard to find documentation on that, so I've tried my best to implement it, by looking at other views. Please double check that I did it right.

I also changed some defaults on the split widget. First, I changed `draggable` to default to true, since I believe this is the intended behaviour for the view, similar to how a button is not disabled by default.

I changed the constructors of the widget to not include the `split_axis` but rather let it be optional with vertical (row) being the default axis. I feel this made it more ergonomic to integrate with Xilem.