### PR TITLE
Pair image with copyright notice in http_cats example.

### DIFF
--- a/xilem/examples/http_cats.rs
+++ b/xilem/examples/http_cats.rs
@@ -175,6 +175,19 @@ impl Status {
     }
 
     fn details_view(&mut self) -> impl WidgetView<HttpCats> + use<> {
+        let image_attribution = sized_box(
+            sized_box(
+                prose("Copyright ©️ https://http.cat")
+                    .line_break_mode(LineBreaking::Clip)
+                    .alignment(TextAlignment::End),
+            )
+            .padding(4.)
+            .rounded(4.)
+            .background(palette::css::BLACK.multiply_alpha(0.5)),
+        )
+        .padding((30., 42., 0., 0.))
+        .alignment(Alignment::TopTrailing);
+
         let image = match &self.image {
             ImageState::NotRequested => OneOf3::A(
                 prose("Failed to start fetching image. This is a bug!")
@@ -182,7 +195,9 @@ impl Status {
             ),
             ImageState::Pending => OneOf3::B(sized_box(spinner()).width(80.).height(80.)),
             // TODO: Alt text?
-            ImageState::Available(image_data) => OneOf3::C(image(image_data)),
+            ImageState::Available(image_data) => {
+                OneOf3::C(zstack((image(image_data), image_attribution)))
+            }
         };
         flex((
             prose(format!("HTTP Status Code: {}", self.code)).alignment(TextAlignment::Middle),
@@ -190,21 +205,7 @@ impl Status {
                 .text_size(20.)
                 .alignment(TextAlignment::Middle),
             FlexSpacer::Fixed(10.),
-            zstack((
-                image,
-                sized_box(
-                    sized_box(
-                        prose("Copyright ©️ https://http.cat")
-                            .line_break_mode(LineBreaking::Clip)
-                            .alignment(TextAlignment::End),
-                    )
-                    .padding(4.)
-                    .rounded(4.)
-                    .background(palette::css::BLACK.multiply_alpha(0.5)),
-                )
-                .padding((30., 42., 0., 0.))
-                .alignment(Alignment::TopTrailing),
-            )),
+            image,
         ))
         .main_axis_alignment(xilem::view::MainAxisAlignment::Start)
     }

--- a/xilem/examples/http_cats.rs
+++ b/xilem/examples/http_cats.rs
@@ -193,9 +193,11 @@ impl Status {
                     .rounded(4.)
                     .background(palette::css::BLACK.multiply_alpha(0.5)),
                 )
-                .padding((30., 42., 0., 0.))
-                .alignment(Alignment::TopTrailing);
-                OneOf3::C(zstack((image(image_data), attribution)))
+                .padding((30., 42., 0., 0.));
+                OneOf3::C(zstack((
+                    image(image_data),
+                    attribution.alignment(Alignment::TopTrailing),
+                )))
             }
         };
         flex((

--- a/xilem/examples/http_cats.rs
+++ b/xilem/examples/http_cats.rs
@@ -175,19 +175,6 @@ impl Status {
     }
 
     fn details_view(&mut self) -> impl WidgetView<HttpCats> + use<> {
-        let image_attribution = sized_box(
-            sized_box(
-                prose("Copyright ©️ https://http.cat")
-                    .line_break_mode(LineBreaking::Clip)
-                    .alignment(TextAlignment::End),
-            )
-            .padding(4.)
-            .rounded(4.)
-            .background(palette::css::BLACK.multiply_alpha(0.5)),
-        )
-        .padding((30., 42., 0., 0.))
-        .alignment(Alignment::TopTrailing);
-
         let image = match &self.image {
             ImageState::NotRequested => OneOf3::A(
                 prose("Failed to start fetching image. This is a bug!")
@@ -196,7 +183,19 @@ impl Status {
             ImageState::Pending => OneOf3::B(sized_box(spinner()).width(80.).height(80.)),
             // TODO: Alt text?
             ImageState::Available(image_data) => {
-                OneOf3::C(zstack((image(image_data), image_attribution)))
+                let attribution = sized_box(
+                    sized_box(
+                        prose("Copyright ©️ https://http.cat")
+                            .line_break_mode(LineBreaking::Clip)
+                            .alignment(TextAlignment::End),
+                    )
+                    .padding(4.)
+                    .rounded(4.)
+                    .background(palette::css::BLACK.multiply_alpha(0.5)),
+                )
+                .padding((30., 42., 0., 0.))
+                .alignment(Alignment::TopTrailing);
+                OneOf3::C(zstack((image(image_data), attribution)))
             }
         };
         flex((


### PR DESCRIPTION
While on slow internet connection I noticed that copyright notice is conflicting with the spinner: 
![http_cat-screenshot](https://github.com/user-attachments/assets/e8f418d5-9a03-4497-a830-9a268e5c8455)

So I paired the image with the copyright notice to display it only when image is loaded. I hope this is not complicating the example code.