### PR TITLE
Make `allow(missing_docs)` for widgets much more tightly scoped

### DIFF
--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -79,6 +79,7 @@ impl Button {
         Label::set_text(&mut Self::label_mut(this), new_text);
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn label_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
         this.ctx.get_mut(&mut this.widget.label)
     }

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -46,6 +46,7 @@ impl Checkbox {
 
 // --- MARK: WIDGETMUT ---
 impl Checkbox {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn set_checked(this: &mut WidgetMut<'_, Self>, checked: bool) {
         this.widget.checked = checked;
         // Checked state impacts appearance and accessibility node
@@ -59,6 +60,7 @@ impl Checkbox {
         Label::set_text(&mut Self::label_mut(this), new_text);
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn label_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
         this.ctx.get_mut(&mut this.widget.label)
     }

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -226,6 +226,7 @@ impl Flex {
         self.with_child_pod(WidgetPod::new_with_id(child, id).erased())
     }
 
+    /// Builder-style method for [adding](Flex::add_child) a type-erased child to this.
     pub fn with_child_pod(mut self, widget: WidgetPod<dyn Widget>) -> Self {
         let child = Child::Fixed {
             widget,
@@ -293,10 +294,12 @@ impl Flex {
         self
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn len(&self) -> usize {
         self.children.len()
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -387,6 +390,7 @@ impl Flex {
         this.ctx.children_changed();
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn add_child_id(this: &mut WidgetMut<'_, Self>, child: impl Widget, id: WidgetId) {
         let child = Child::Fixed {
             widget: WidgetPod::new_with_id(child, id).erased(),
@@ -472,6 +476,7 @@ impl Flex {
         this.ctx.children_changed();
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn insert_flex_child(
         this: &mut WidgetMut<'_, Self>,
         idx: usize,
@@ -481,6 +486,7 @@ impl Flex {
         Self::insert_flex_child_pod(this, idx, WidgetPod::new(child).erased(), params);
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn insert_flex_child_pod(
         this: &mut WidgetMut<'_, Self>,
         idx: usize,
@@ -533,6 +539,7 @@ impl Flex {
         this.ctx.request_layout();
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn remove_child(this: &mut WidgetMut<'_, Self>, idx: usize) {
         let child = this.widget.children.remove(idx);
         if let Child::Fixed { widget, .. } | Child::Flex { widget, .. } = child {
@@ -541,6 +548,7 @@ impl Flex {
         this.ctx.request_layout();
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn child_mut<'t>(
         this: &'t mut WidgetMut<'_, Self>,
         idx: usize,
@@ -615,6 +623,7 @@ impl Flex {
         this.ctx.children_changed();
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn clear(this: &mut WidgetMut<'_, Self>) {
         if !this.widget.children.is_empty() {
             this.ctx.request_layout();

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -32,6 +32,7 @@ struct Child {
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
+#[expect(missing_docs, reason = "TODO")]
 pub struct GridParams {
     pub x: i32,
     pub y: i32,
@@ -41,6 +42,7 @@ pub struct GridParams {
 
 // --- MARK: IMPL GRID ---
 impl Grid {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn with_dimensions(width: i32, height: i32) -> Self {
         Self {
             children: Vec::new(),
@@ -50,6 +52,7 @@ impl Grid {
         }
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn with_spacing(mut self, spacing: f64) -> Self {
         self.grid_spacing = spacing;
         self
@@ -62,10 +65,12 @@ impl Grid {
         self.with_child_pod(WidgetPod::new(child).erased(), params)
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn with_child_id(self, child: impl Widget, id: WidgetId, params: GridParams) -> Self {
         self.with_child_pod(WidgetPod::new_with_id(child, id).erased(), params)
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn with_child_pod(mut self, widget: WidgetPod<dyn Widget>, params: GridParams) -> Self {
         let child = Child {
             widget,
@@ -108,6 +113,7 @@ fn new_grid_child(params: GridParams, widget: WidgetPod<dyn Widget>) -> Child {
 
 // --- MARK: IMPL GRIDPARAMS ---
 impl GridParams {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn new(mut x: i32, mut y: i32, mut width: i32, mut height: i32) -> Self {
         if x < 0 {
             debug_panic!("Grid x value should be a non-negative number; got {}", x);
@@ -152,6 +158,7 @@ impl Grid {
         Self::insert_child_pod(this, child_pod, params);
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn add_child_id(
         this: &mut WidgetMut<'_, Self>,
         child: impl Widget,
@@ -174,6 +181,7 @@ impl Grid {
         this.ctx.request_layout();
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn insert_grid_child_at(
         this: &mut WidgetMut<'_, Self>,
         idx: usize,
@@ -183,6 +191,7 @@ impl Grid {
         Self::insert_grid_child_pod(this, idx, WidgetPod::new(child).erased(), params);
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn insert_grid_child_pod(
         this: &mut WidgetMut<'_, Self>,
         idx: usize,
@@ -195,21 +204,25 @@ impl Grid {
         this.ctx.request_layout();
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn set_spacing(this: &mut WidgetMut<'_, Self>, spacing: f64) {
         this.widget.grid_spacing = spacing;
         this.ctx.request_layout();
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn set_width(this: &mut WidgetMut<'_, Self>, width: i32) {
         this.widget.grid_width = width;
         this.ctx.request_layout();
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn set_height(this: &mut WidgetMut<'_, Self>, height: i32) {
         this.widget.grid_height = height;
         this.ctx.request_layout();
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn child_mut<'t>(
         this: &'t mut WidgetMut<'_, Self>,
         idx: usize,
@@ -233,6 +246,7 @@ impl Grid {
         this.ctx.request_layout();
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn remove_child(this: &mut WidgetMut<'_, Self>, idx: usize) {
         let child = this.widget.children.remove(idx);
         this.ctx.remove_child(child.widget);

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -1,8 +1,6 @@
 // Copyright 2019 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(missing_docs)]
-
 //! A label widget.
 
 use std::mem::Discriminant;

--- a/masonry/src/widgets/mod.rs
+++ b/masonry/src/widgets/mod.rs
@@ -3,9 +3,6 @@
 
 //! Common widgets.
 
-// We use allow because expect(missing_docs) is noisy with rust-analyzer.
-#![allow(missing_docs, reason = "We have many as-yet undocumented items")]
-
 #[cfg(test)]
 mod tests;
 

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -1,8 +1,6 @@
 // Copyright 2020 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(missing_docs)]
-
 use std::ops::Range;
 
 use accesskit::{Node, Role};
@@ -23,6 +21,7 @@ use crate::widgets::{Axis, ScrollBar};
 // TODO - Document which cases need request_layout, request_compose and request_render
 // Conceptually, a Portal is a Widget giving a restricted view of a child widget
 // Imagine a very large widget, and a rect that represents the part of the widget we see
+#[expect(missing_docs, reason = "TODO")]
 pub struct Portal<W: Widget + ?Sized> {
     child: WidgetPod<W>,
     // TODO - differentiate between the "explicit" viewport pos determined
@@ -42,12 +41,14 @@ pub struct Portal<W: Widget + ?Sized> {
 
 // --- MARK: BUILDERS ---
 impl<W: Widget> Portal<W> {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn new(child: W) -> Self {
         Self::new_pod(WidgetPod::new(child))
     }
 }
 
 impl<W: Widget + ?Sized> Portal<W> {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn new_pod(child: WidgetPod<W>) -> Self {
         Self {
             child,
@@ -63,6 +64,7 @@ impl<W: Widget + ?Sized> Portal<W> {
         }
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn get_viewport_pos(&self) -> Point {
         self.viewport_pos
     }
@@ -171,16 +173,19 @@ impl<W: Widget + ?Sized> Portal<W> {
 
 // --- MARK: WIDGETMUT ---
 impl<W: Widget + FromDynWidget + ?Sized> Portal<W> {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn child_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, W> {
         this.ctx.get_mut(&mut this.widget.child)
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn horizontal_scrollbar_mut<'t>(
         this: &'t mut WidgetMut<'_, Self>,
     ) -> WidgetMut<'t, ScrollBar> {
         this.ctx.get_mut(&mut this.widget.scrollbar_horizontal)
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn vertical_scrollbar_mut<'t>(
         this: &'t mut WidgetMut<'_, Self>,
     ) -> WidgetMut<'t, ScrollBar> {
@@ -211,6 +216,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Portal<W> {
         this.ctx.request_layout();
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn set_viewport_pos(this: &mut WidgetMut<'_, Self>, position: Point) -> bool {
         let portal_size = this.ctx.local_layout_rect().size();
         let content_size = this
@@ -235,10 +241,12 @@ impl<W: Widget + FromDynWidget + ?Sized> Portal<W> {
         pos_changed
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn pan_viewport_by(this: &mut WidgetMut<'_, Self>, translation: Vec2) -> bool {
         Self::set_viewport_pos(this, this.widget.viewport_pos + translation)
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     // Note - Rect is in child coordinates
     pub fn pan_viewport_to(this: &mut WidgetMut<'_, Self>, target: Rect) -> bool {
         let viewport = Rect::from_origin_size(this.widget.viewport_pos, this.ctx.widget_state.size);

--- a/masonry/src/widgets/progress_bar.rs
+++ b/masonry/src/widgets/progress_bar.rs
@@ -63,6 +63,7 @@ impl ProgressBar {
 
 // --- MARK: WIDGETMUT ---
 impl ProgressBar {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn set_progress(this: &mut WidgetMut<'_, Self>, mut progress: Option<f64>) {
         clamp_progress(&mut progress);
         let progress_changed = this.widget.progress != progress;

--- a/masonry/src/widgets/prose.rs
+++ b/masonry/src/widgets/prose.rs
@@ -1,8 +1,6 @@
 // Copyright 2018 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(missing_docs)]
-
 use accesskit::{Node, Role};
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};

--- a/masonry/src/widgets/root_widget.rs
+++ b/masonry/src/widgets/root_widget.rs
@@ -16,11 +16,13 @@ use crate::kurbo::Size;
 
 // TODO: This is a hack to provide an accessibility node with a Window type.
 // This should eventually be removed.
+#[expect(missing_docs, reason = "TODO")]
 pub struct RootWidget<W: ?Sized> {
     pub(crate) pod: WidgetPod<W>,
 }
 
 impl<W: Widget> RootWidget<W> {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn new(widget: W) -> Self {
         Self {
             pod: WidgetPod::new(widget),
@@ -29,12 +31,14 @@ impl<W: Widget> RootWidget<W> {
 }
 
 impl<W: Widget + FromDynWidget + ?Sized> RootWidget<W> {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn from_pod(pod: WidgetPod<W>) -> Self {
         Self { pod }
     }
 }
 
 impl<W: Widget + FromDynWidget + ?Sized> RootWidget<W> {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn child_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, W> {
         this.ctx.get_mut(&mut this.widget.pod)
     }

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -1,8 +1,6 @@
 // Copyright 2022 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(missing_docs)]
-
 use accesskit::{Node, Role};
 use smallvec::SmallVec;
 use tracing::{Span, trace_span};
@@ -40,6 +38,7 @@ pub struct ScrollBar {
 
 // --- MARK: BUILDERS ---
 impl ScrollBar {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn new(axis: Axis, portal_size: f64, content_size: f64) -> Self {
         Self {
             axis,
@@ -106,6 +105,7 @@ impl ScrollBar {
 // --- MARK: WIDGETMUT ---
 impl ScrollBar {
     // TODO - Remove?
+    #[expect(missing_docs, reason = "TODO")]
     pub fn set_sizes(this: &mut WidgetMut<'_, Self>, portal_size: f64, content_size: f64) {
         this.widget.portal_size = portal_size;
         this.widget.content_size = content_size;
@@ -113,6 +113,7 @@ impl ScrollBar {
     }
 
     // TODO - Remove?
+    #[expect(missing_docs, reason = "TODO")]
     pub fn set_content_size(this: &mut WidgetMut<'_, Self>, content_size: f64) {
         // TODO - cursor_progress
         this.widget.content_size = content_size;

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -327,6 +327,7 @@ impl SizedBox {
 
 // --- MARK: WIDGETMUT ---
 impl SizedBox {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn set_child(this: &mut WidgetMut<'_, Self>, child: impl Widget) {
         if let Some(child) = this.widget.child.take() {
             this.ctx.remove_child(child);
@@ -336,6 +337,7 @@ impl SizedBox {
         this.ctx.request_layout();
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn remove_child(this: &mut WidgetMut<'_, Self>) {
         if let Some(child) = this.widget.child.take() {
             this.ctx.remove_child(child);
@@ -420,7 +422,7 @@ impl SizedBox {
         this.ctx.request_layout();
     }
 
-    // TODO - Doc
+    #[expect(missing_docs, reason = "TODO")]
     pub fn child_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> Option<WidgetMut<'t, dyn Widget>> {
         let child = this.widget.child.as_mut()?;
         Some(this.ctx.get_mut(child))

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -53,6 +53,7 @@ impl<ChildA: Widget, ChildB: Widget> Split<ChildA, ChildB> {
 }
 
 impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn new_pod(child1: WidgetPod<ChildA>, child2: WidgetPod<ChildB>) -> Self {
         Self {
             split_axis: Axis::Horizontal,
@@ -303,10 +304,12 @@ where
     ChildA: Widget + FromDynWidget + ?Sized,
     ChildB: Widget + FromDynWidget + ?Sized,
 {
+    #[expect(missing_docs, reason = "TODO")]
     pub fn child1_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, ChildA> {
         this.ctx.get_mut(&mut this.widget.child1)
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn child2_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, ChildB> {
         this.ctx.get_mut(&mut this.widget.child2)
     }

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -1,8 +1,6 @@
 // Copyright 2018 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(missing_docs)]
-
 use std::mem::Discriminant;
 use std::time::Instant;
 

--- a/masonry/src/widgets/textbox.rs
+++ b/masonry/src/widgets/textbox.rs
@@ -1,8 +1,6 @@
 // Copyright 2018 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(missing_docs)]
-
 use accesskit::{Node, Role};
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};

--- a/masonry/src/widgets/variable_label.rs
+++ b/masonry/src/widgets/variable_label.rs
@@ -133,10 +133,12 @@ impl VariableLabel {
         Self::from_label_pod(WidgetPod::new(Label::new(text)))
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn from_label(label: Label) -> Self {
         Self::from_label_pod(WidgetPod::new(label))
     }
 
+    #[expect(missing_docs, reason = "TODO")]
     pub fn from_label_pod(label: WidgetPod<Label>) -> Self {
         Self {
             label,

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -1,8 +1,6 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![warn(missing_docs)]
-
 use accesskit::{Node, Role};
 use smallvec::SmallVec;
 use tracing::trace_span;


### PR DESCRIPTION
Any new widget code needs to have full docs.
Not having `missing_docs` trigger by default for new widgets is quite bad.

See #875 and #882 for cases where this over-broad allow has bitten us.

The comment about not using `expect(missing_docs)` because of rust-analyzer is confusing to me; I don't run into an issue. It might have been https://github.com/rust-lang/rust/issues/130021, which is now fixed. That comment should have had a link to an upstream issue for more context.