### PR TITLE
Remove tempfile direct dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,7 +1902,6 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "tempfile",
  "time",
  "tracing",
  "tracing-subscriber",

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -67,7 +67,6 @@ float-cmp = { version = "0.10.0", features = ["std"], default-features = false }
 image = { workspace = true, features = ["png"] }
 insta = { version = "1.39.0" }
 assert_matches = "1.5.0"
-tempfile = "3.10.1"
 
 # Make wgpu use tracing for its spans.
 profiling = { version = "1.0.15", features = ["profile-with-tracing"] }


### PR DESCRIPTION
`tempfile` on Unix pulls `rustix`, which has a 9.19s single-core build time on my machine, and was unused in our code.

`tempfile` is still a indirect dependency through `uds_windows`, which is fine because in that dependency path (windows-only) doesn't pull `rustix`.