### PR TITLE
Virtual Scrolling: allow setting a valid range

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -10,7 +10,8 @@ trivial-copy-size-limit = 16
 # END LINEBENDER LINT SET
 
 # Don't warn about these identifiers when using clippy::doc_markdown.
-doc-valid-idents = ["MathML", "..", "RustNL", "FizzBuzz"]
+# (`".."` means the default configuration built-in to Clippy)
+doc-valid-idents = ["FizzBuzz", "MathML", "RustNL", ".."]
 
 # The default clippy value for this is 250, which causes warnings for rather simple types
 # like Box<dyn Fn(&mut Env, &T)>, which seems overly strict. The new value of 400 is

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -10,7 +10,7 @@ trivial-copy-size-limit = 16
 # END LINEBENDER LINT SET
 
 # Don't warn about these identifiers when using clippy::doc_markdown.
-doc-valid-idents = ["MathML", "..", "RustNL"]
+doc-valid-idents = ["MathML", "..", "RustNL", "FizzBuzz"]
 
 # The default clippy value for this is 250, which causes warnings for rather simple types
 # like Box<dyn Fn(&mut Env, &T)>, which seems overly strict. The new value of 400 is

--- a/masonry/examples/virtual_demo.rs
+++ b/masonry/examples/virtual_demo.rs
@@ -1,0 +1,76 @@
+// Copyright 2024 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shows how to use a grid layout in Masonry.
+
+// On Windows platform, don't show a console when opening the app.
+#![windows_subsystem = "windows"]
+
+use masonry::app::{AppDriver, DriverCtx};
+use masonry::core::{Action, WidgetId, WidgetPod};
+use masonry::dpi::LogicalSize;
+use masonry::widgets::{Label, RootWidget, VirtualScroll, VirtualScrollAction};
+
+use winit::window::Window;
+
+struct Driver {
+    scroll_id: WidgetId,
+}
+
+impl AppDriver for Driver {
+    fn on_action(&mut self, ctx: &mut DriverCtx<'_>, widget_id: WidgetId, action: Action) {
+        if widget_id == self.scroll_id {
+            if let Action::Other(action) = action {
+                let action = action.downcast::<VirtualScrollAction>().unwrap();
+                ctx.render_root().edit_root_widget(|mut root| {
+                    let mut root = root.downcast::<RootWidget<VirtualScroll<ScrollContents>>>();
+                    let mut scroll = RootWidget::child_mut(&mut root);
+                    for idx in action.old_active.clone() {
+                        if !action.target.contains(&idx) {
+                            eprintln!("Removing {idx}");
+                            VirtualScroll::remove_child(&mut scroll, idx);
+                        }
+                    }
+                    for idx in action.target.clone() {
+                        if !action.old_active.contains(&idx) {
+                            eprintln!("Adding {idx}");
+                            VirtualScroll::add_child(
+                                &mut scroll,
+                                idx,
+                                WidgetPod::new(Label::new(format!("Child {idx}"))),
+                            );
+                        }
+                    }
+                });
+            }
+        } else {
+            tracing::warn!("Got unexpected action {action:?}");
+        }
+    }
+}
+
+type ScrollContents = Label;
+
+fn make_scroll() -> VirtualScroll<ScrollContents> {
+    VirtualScroll::new(0)
+}
+
+fn main() {
+    let main_widget = WidgetPod::new(make_scroll());
+    let driver = Driver {
+        scroll_id: main_widget.id(),
+    };
+    let window_size = LogicalSize::new(800.0, 500.0);
+    let window_attributes = Window::default_attributes()
+        .with_title("Grid Layout")
+        .with_resizable(true)
+        .with_min_inner_size(window_size);
+
+    masonry::app::run(
+        masonry::app::EventLoop::with_user_event(),
+        window_attributes,
+        RootWidget::from_pod(main_widget),
+        driver,
+    )
+    .unwrap();
+}

--- a/masonry/examples/virtual_demo.rs
+++ b/masonry/examples/virtual_demo.rs
@@ -7,7 +7,7 @@
 #![windows_subsystem = "windows"]
 
 use masonry::app::{AppDriver, DriverCtx};
-use masonry::core::{Action, WidgetId, WidgetPod};
+use masonry::core::{Action, StyleProperty, WidgetId, WidgetPod};
 use masonry::dpi::LogicalSize;
 use masonry::widgets::{Label, RootWidget, VirtualScroll, VirtualScrollAction};
 
@@ -37,7 +37,11 @@ impl AppDriver for Driver {
                             VirtualScroll::add_child(
                                 &mut scroll,
                                 idx,
-                                WidgetPod::new(Label::new(format!("Child {idx}"))),
+                                WidgetPod::new(Label::new(format!("Child {idx}")).with_style(
+                                    StyleProperty::FontSize(
+                                        8., /*  if idx % 100 == 0 { 40. } else { 8. } */
+                                    ),
+                                )),
                             );
                         }
                     }

--- a/masonry/examples/virtual_fizzbuzz.rs
+++ b/masonry/examples/virtual_fizzbuzz.rs
@@ -1,7 +1,10 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Shows how to use a grid layout in Masonry.
+//! A demonstration of the [`VirtualScroll`] widget, producing an infinite[^1] FizzBuzz.
+//!
+//! [^1]: Limited to `i64::MIN..i64::MAX-1`; that is, there are `2^64-1` possible items.
+//! However, there is (currently...) no way to jump to a specific item, so it's impossible to reach the end.
 
 // On Windows platform, don't show a console when opening the app.
 #![windows_subsystem = "windows"]
@@ -12,6 +15,18 @@ use masonry::dpi::LogicalSize;
 use masonry::widgets::{Label, RootWidget, VirtualScroll, VirtualScrollAction};
 
 use winit::window::Window;
+
+/// The widget kind contained in the scroll area. This is currently a generic parameter of [`VirtualScroll`], although
+/// note that [`dyn Widget`](masonry::core::Widget) can also be used for dynamic children kinds.
+///
+/// We use a type alias for this, as any downcasting needs to know the type of W.
+type ScrollContents = Label;
+
+/// Function to create the virtual scroll area.
+fn init() -> VirtualScroll<ScrollContents> {
+    // We start our fizzbuzzing with the top of the screen at item 0
+    VirtualScroll::new(0)
+}
 
 struct Driver {
     scroll_id: WidgetId,
@@ -24,12 +39,16 @@ impl AppDriver for Driver {
     fn on_action(&mut self, ctx: &mut DriverCtx<'_>, widget_id: WidgetId, action: Action) {
         if widget_id == self.scroll_id {
             if let Action::Other(action) = action {
+                // The VirtualScroll widget will send us a VirtualScrollAction every time it wants different
+                // items to be loaded or unloaded.
                 let action = action.downcast::<VirtualScrollAction>().unwrap();
                 ctx.render_root().edit_root_widget(|mut root| {
                     let mut root = root.downcast::<RootWidget<VirtualScroll<ScrollContents>>>();
                     let mut scroll = RootWidget::child_mut(&mut root);
                     for idx in action.old_active.clone() {
                         if !action.target.contains(&idx) {
+                            // If we had different work to do in response to the item being unloaded
+                            // (for example, saving some related data?), then we'd do it here
                             VirtualScroll::remove_child(&mut scroll, idx);
                         }
                     }
@@ -37,7 +56,7 @@ impl AppDriver for Driver {
                         if !action.old_active.contains(&idx) {
                             let evil = false;
                             if evil {
-                                // Pathological implementation: we should handle this well (although we warn)
+                                // Adversarial implementation: we should handle this well (although we warn)
                                 if idx % 10 == 0 {
                                     VirtualScroll::add_child(
                                         &mut scroll,
@@ -82,14 +101,8 @@ impl AppDriver for Driver {
     }
 }
 
-type ScrollContents = Label;
-
-fn make_scroll() -> VirtualScroll<ScrollContents> {
-    VirtualScroll::new(0)
-}
-
 fn main() {
-    let main_widget = WidgetPod::new(make_scroll());
+    let main_widget = WidgetPod::new(init());
     let driver = Driver {
         scroll_id: main_widget.id(),
         fizz: "Fizz".into(),
@@ -98,7 +111,7 @@ fn main() {
     };
     let window_size = LogicalSize::new(800.0, 500.0);
     let window_attributes = Window::default_attributes()
-        .with_title("Grid Layout")
+        .with_title("Infinite FizzBuzz")
         .with_resizable(true)
         .with_min_inner_size(window_size);
 

--- a/masonry/examples/virtual_fizzbuzz.rs
+++ b/masonry/examples/virtual_fizzbuzz.rs
@@ -16,10 +16,11 @@ use masonry::widgets::{Label, RootWidget, VirtualScroll, VirtualScrollAction};
 
 use winit::window::Window;
 
-/// The widget kind contained in the scroll area. This is currently a generic parameter of [`VirtualScroll`], although
-/// note that [`dyn Widget`](masonry::core::Widget) can also be used for dynamic children kinds.
+/// The widget kind contained in the scroll area. This is a type parameter (`W`) of [`VirtualScroll`],
+/// although note that [`dyn Widget`](masonry::core::Widget) can also be used for dynamic children kinds.
 ///
-/// We use a type alias for this, as any downcasting needs to know the type of W.
+/// We use a type alias for this, as when we downcast to the `VirtualScroll`, we need to be sure to
+/// always use the same type for `W`.
 type ScrollContents = Label;
 
 /// Function to create the virtual scroll area.

--- a/masonry/examples/virtual_fizzbuzz.rs
+++ b/masonry/examples/virtual_fizzbuzz.rs
@@ -54,43 +54,19 @@ impl AppDriver for Driver {
                     }
                     for idx in action.target.clone() {
                         if !action.old_active.contains(&idx) {
-                            let evil = false;
-                            if evil {
-                                // Adversarial implementation: we should handle this well (although we warn)
-                                if idx % 10 == 0 {
-                                    VirtualScroll::add_child(
-                                        &mut scroll,
-                                        idx,
-                                        WidgetPod::new(
-                                            Label::new(format!("Child {idx}")).with_style(
-                                                StyleProperty::FontSize(if idx % 3 == 0 {
-                                                    100.
-                                                } else {
-                                                    10.
-                                                }),
-                                            ),
-                                        ),
-                                    );
-                                }
-                            } else {
-                                let label: ArcStr = match (idx % 3 == 0, idx % 5 == 0) {
-                                    (false, true) => self.buzz.clone(),
-                                    (true, false) => self.fizz.clone(),
-                                    (true, true) => self.fizzbuzz.clone(),
-                                    (false, false) => format!("{idx}").into(),
-                                };
-                                VirtualScroll::add_child(
-                                    &mut scroll,
-                                    idx,
-                                    WidgetPod::new(Label::new(label).with_style(
-                                        StyleProperty::FontSize(if idx % 100 == 0 {
-                                            40.
-                                        } else {
-                                            20.
-                                        }),
-                                    )),
-                                );
-                            }
+                            let label: ArcStr = match (idx % 3 == 0, idx % 5 == 0) {
+                                (false, true) => self.buzz.clone(),
+                                (true, false) => self.fizz.clone(),
+                                (true, true) => self.fizzbuzz.clone(),
+                                (false, false) => format!("{idx}").into(),
+                            };
+                            VirtualScroll::add_child(
+                                &mut scroll,
+                                idx,
+                                WidgetPod::new(Label::new(label).with_style(
+                                    StyleProperty::FontSize(if idx % 100 == 0 { 40. } else { 20. }),
+                                )),
+                            );
                         }
                     }
                 });

--- a/masonry/src/app/render_root.rs
+++ b/masonry/src/app/render_root.rs
@@ -747,7 +747,9 @@ impl RenderRootState {
     }
 
     pub(crate) fn needs_rewrite_passes(&self) -> bool {
-        self.needs_pointer_pass || self.focused_widget != self.next_focused_widget
+        self.needs_pointer_pass
+            || self.focused_widget != self.next_focused_widget
+            || !self.mutate_callbacks.is_empty()
     }
 }
 

--- a/masonry/src/app/render_root.rs
+++ b/masonry/src/app/render_root.rs
@@ -746,6 +746,11 @@ impl RenderRootState {
         self.focused_widget == Some(id)
     }
 
+    /// Does something in this state indicate that the rewrite passes need to be reran.
+    ///
+    /// This is checked in conjunction with [`WidgetState::needs_rewrite_passes`] - if
+    /// either returns true, the fixed point loop of the rewrite passes will be run again.
+    /// All passes have a fast-path exit check; these together are the union of those checks.
     pub(crate) fn needs_rewrite_passes(&self) -> bool {
         self.needs_pointer_pass
             || self.focused_widget != self.next_focused_widget

--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -200,6 +200,7 @@ impl_context_method!(
         ///
         /// This one isn't defined for `PaintCtx` and `AccessCtx` because those contexts
         /// can't mutate `WidgetState`.
+        #[track_caller]
         fn get_child_state_mut<Child: Widget + ?Sized>(
             &mut self,
             child: &'_ mut WidgetPod<Child>,

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -597,7 +597,9 @@ impl TestHarness {
     ///
     /// Because of how `WidgetMut` works, it can only be passed to a user-provided callback.
     pub fn edit_root_widget<R>(&mut self, f: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R) -> R {
-        self.render_root.edit_root_widget(f)
+        let ret = self.render_root.edit_root_widget(f);
+        self.process_signals();
+        ret
     }
 
     /// Get a [`WidgetMut`] to a specific widget.
@@ -608,7 +610,9 @@ impl TestHarness {
         id: WidgetId,
         f: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R,
     ) -> R {
-        self.render_root.edit_widget(id, f)
+        let ret = self.render_root.edit_widget(id, f);
+        self.process_signals();
+        ret
     }
 
     /// Pop the oldest [`Action`] emitted by the widget tree.

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -268,6 +268,8 @@ impl TestHarness {
         handled
     }
 
+    // This should be ran after any operation which runs the rewrite passes
+    // (i.e. processing an event, etc.)
     fn process_signals(&mut self) {
         while let Some(signal) = self.render_root.pop_signal() {
             match signal {

--- a/masonry/src/widgets/mod.rs
+++ b/masonry/src/widgets/mod.rs
@@ -45,4 +45,5 @@ pub use self::split::Split;
 pub use self::text_area::TextArea;
 pub use self::textbox::Textbox;
 pub use self::variable_label::VariableLabel;
+pub use self::virtual_scroll::{VirtualScroll, VirtualScrollAction};
 pub use self::zstack::{Alignment, ChildAlignment, HorizontalAlignment, VerticalAlignment, ZStack};

--- a/masonry/src/widgets/mod.rs
+++ b/masonry/src/widgets/mod.rs
@@ -24,6 +24,7 @@ mod split;
 mod text_area;
 mod textbox;
 mod variable_label;
+mod virtual_scroll;
 mod zstack;
 
 pub use self::align::Align;

--- a/masonry/src/widgets/screenshots/masonry__widgets__virtual_scroll__tests__virtual_scroll_basic.png
+++ b/masonry/src/widgets/screenshots/masonry__widgets__virtual_scroll__tests__virtual_scroll_basic.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e046e98457a12cee9128560232cd8778ecfd86289ea76ac03d04683332d5cfd3
+size 1465

--- a/masonry/src/widgets/screenshots/masonry__widgets__virtual_scroll__tests__virtual_scroll_moved.png
+++ b/masonry/src/widgets/screenshots/masonry__widgets__virtual_scroll__tests__virtual_scroll_moved.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6dac8b5e64c1843e669c4f5d3dd2297f9668a91b49c759af148e7a4e970b96e1
+size 2049

--- a/masonry/src/widgets/screenshots/masonry__widgets__virtual_scroll__tests__virtual_scroll_scrolled.png
+++ b/masonry/src/widgets/screenshots/masonry__widgets__virtual_scroll__tests__virtual_scroll_scrolled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:904dd95122e780c53fd476a62585da4398a705b70086662e93b8691a6363d749
+size 6385

--- a/masonry/src/widgets/screenshots/masonry__widgets__virtual_scroll__tests__virtual_scroll_scrolled.png
+++ b/masonry/src/widgets/screenshots/masonry__widgets__virtual_scroll__tests__virtual_scroll_scrolled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:904dd95122e780c53fd476a62585da4398a705b70086662e93b8691a6363d749
-size 6385
+oid sha256:ee3e308e1a6fb34a6fe3b5482abf2ae492f4017937fbaf1ec969bc7100f9003b
+size 2879

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -33,24 +33,31 @@ pub struct VirtualScrollAction {
 pub struct VirtualScroll<W: Widget + ?Sized> {
     /// The range of items in the "id" space which are able to be used.
     ///
-    /// This is used to cap scrolling; the items included can never scroll off-screen[^1][^2].
+    /// This is used to cap scrolling; items outside of this range will never be loaded[^1][^2][^3].
     /// For example, in an email program, this would be `[id_of_most_recent_email]..=[id_of_oldest_email]`
     /// (note that the id of the oldest email might not be known; as soon as it is known, `id_of_oldest_email`
     /// can be set).
     ///
     /// The default is `i64::MIN..i64::MAX`
     ///
+    /// Items outside of this range will be stashed.
+    ///
     /// [^1]: The exact interaction with a "drag down to refresh" feature has not been scrutinised.
     /// [^2]: Currently, we lock the bottom of the range to the bottom of the final item. This should be configurable.
+    /// [^3]: Behaviour when the range is shrunk to something containing the active range has not been considered.
     valid_range: Range<i64>,
 
     /// The range in the id space which is "active", i.e. which the virtual scrolling controller has the
     /// ability to lay out. Note that items is not necessarily dense in these; that is, if an
-    /// item has not been provided by the application, we don't fall over.
+    /// item has not been provided by the application, we avoid falling over.
     active_range: Range<i64>,
 
+    /// The range in the id space which the virtual scrolling controller *wants* to layout.
+    /// Items which are in active_range but not in this range will be stashed in the mutate pass.
+    target_range: Range<i64>,
+
     /// All children of the virtual scroller.
-    // TODO: Does this need to be a `BTreeMap`, or maybe a sparse `VecDeque`
+    // TODO: Does this need to be a `BTreeMap`, or maybe a sparse `VecDeque` (for quicker in-order iteration)
     items: HashMap<i64, WidgetPod<W>>,
     // TODO: Handle focus even if the focused item scrolls off-screen.
     // TODO: Maybe this should be the focused items and its two neighbours, so tab focusing works?
@@ -58,12 +65,24 @@ pub struct VirtualScroll<W: Widget + ?Sized> {
 
     // Question: For a given scroll position, should the anchor always be the same?
     // Answer: Let's say yes for now, and re-evaluate if it becomes necessary.
-    //  - Reason to not have this is that it adds some pathologies to an "up/down" movement
+    //  - Reason to not have this is that it adds some potential worst-case performance issues if scrolling up/down
     anchor_index: i64,
-    // TODO: Use a fixed-point scheme, because
+    // TODO: Use a fixed-point scheme, because adding and subtracting amounts could change the scale, theoretically causing visible jumps.
     // This will likely wait for layout to do something similar
     scroll_offset_from_anchor: f64,
 
+    /// The average height of items, determined experimentally.
+    /// This is used if there are no items to determine the mean item height otherwise. This approach means:
+    /// 1) For the easy case where every item is the same height (e.g. email), we get the right answer
+    /// 2) For slightly harder cases, we get as sensible a result as is reasonable, without requiring a complex API
+    ///    to get the needed information.
+    mean_item_height: f64,
+
+    /// The height of the current anchor.
+    /// Used to determine if scrolling will require a relayout (because the anchor has changed).
+    anchor_height: f64,
+
+    /// The available width in the last layout call, used so that layout of children can be skipped if it won't have changed.
     old_width: f64,
 }
 
@@ -88,6 +107,8 @@ impl<W: Widget> Widget for VirtualScroll<W> {
                 height: f64::INFINITY,
             },
         );
+        // The number of loaded items before the anchor
+        let count_before_anchor = 0;
         let mut height_before_anchor = 0.;
         // The height of all loaded items after the anchor.
         // Note that this includes the height of the anchor itself.
@@ -95,11 +116,16 @@ impl<W: Widget> Widget for VirtualScroll<W> {
         let mut count = 0_u64;
         let mut first_item = i64::MAX;
         let mut last_item = i64::MIN;
+
+        // Calculate the sizes of all children
         for (idx, child) in &mut self.items {
             if !self.active_range.contains(idx) {
+                if cfg!(debug_assertions) && ctx.child_needs_layout(child) {
+                    unreachable!("Mutate pass didn't run before layout, breaking assumptions.")
+                }
                 // This item is stashed, and so can't be used.
                 // (If we decide we want to use it, we'll do so by re-enabling
-                // it in a following mutate pass). Note that we might still access its height;
+                // it in a following mutate pass). Note that we might still access to its height;
                 // that might not be *right*, but it gives an estimate anyway
                 ctx.skip_layout(child);
                 continue;
@@ -112,6 +138,7 @@ impl<W: Widget> Widget for VirtualScroll<W> {
                 ctx.child_size(child)
             };
             if *idx < self.anchor_index {
+                count_before_anchor += 1;
                 height_before_anchor += resulting_size.height;
             } else {
                 height_after_anchor += resulting_size.height;
@@ -119,69 +146,89 @@ impl<W: Widget> Widget for VirtualScroll<W> {
             count += 1;
         }
 
-        let mean_item_size = (height_before_anchor + height_after_anchor) / count as f64;
-        let mut additions = SmallVec::new();
-        let mut removals = SmallVec::new();
+        let mean_item_height = if count > 0 {
+            (height_before_anchor + height_after_anchor) / count as f64
+        } else {
+            self.mean_item_height
+        };
+        self.mean_item_height = mean_item_height;
+
+        let items_after_anchor: u64 = (self.active_range.end - self.anchor_index)
+            .try_into()
+            .unwrap();
+        let height_after_anchor =
+        // count_before_anchor < count as only conditionally incremented, when count is unconditionally incremented
+            height_after_anchor + (items_after_anchor - count - count_before_anchor) as f64 * mean_item_height;
+        let height_before_anchor =
+            height_after_anchor + count_before_anchor as f64 * mean_item_height;
         // If we've significantly out-ran the virtual scrolling (as a loose heuristic), calculate a new anchor using a heuristic
         // and drop all currently loaded items.
-        if (self.scroll_offset_from_anchor
-            > height_after_anchor + 3. * viewport_size.height + 3000.)
-            || (self.scroll_offset_from_anchor
-                < -height_before_anchor - 3. * viewport_size.height - 3000.)
+        // if (self.scroll_offset_from_anchor
+        //     > height_after_anchor + 3. * viewport_size.height + 3000.)
+        //     || (self.scroll_offset_from_anchor
+        //         < -height_before_anchor - 3. * viewport_size.height - 3000.)
+        // {
+        // let items = core::mem::take(&mut self.current_items);
+        // // TODO: We *probably* want to slide down the items.
+        // for (idx, mut item) in items {
+        //     ctx.skip_layout(&mut item);
+        //     self.items_pending_removal.insert(idx, item);
+        //     removals.push(idx);
+        // }
+        // if mean_item_size.is_finite() {
+        //     let diff_count = self.scroll_offset_from_anchor / mean_item_size;
+        //     let diff_count = diff_count.floor();
+        //     self.anchor_index =
+        //         (self.anchor_index + diff_count as i64).clamp(self.first_item, self.last_item);
+        //     self.scroll_offset_from_anchor -= diff_count * mean_item_size;
+        // } else {
+        //     debug_assert_eq!(
+        //         count, 0,
+        //         "Assumption: If the division produced an infinite result, it's because of a divide by zero."
+        //     );
+        //     // TODO: How can we handle this sanely? We're scrolled very far down (3 pages + 3000 logical pixels),
+        //     // but we don't have any idea how big the items are; that could be within a single item.
+        //     // I guess we need to just wait for the anchor to be loaded?
+        // }
+        // } else
+
+        // Determine the new anchor
         {
-            let items = core::mem::take(&mut self.current_items);
-            // TODO: We *probably* want to slide down the items.
-            for (idx, mut item) in items {
-                ctx.skip_layout(&mut item);
-                self.items_pending_removal.insert(idx, item);
-                removals.push(idx);
-            }
-            if mean_item_size.is_finite() {
-                let diff_count = self.scroll_offset_from_anchor / mean_item_size;
-                let diff_count = diff_count.floor();
-                self.anchor_index =
-                    (self.anchor_index + diff_count as i64).clamp(self.first_item, self.last_item);
-                self.scroll_offset_from_anchor -= diff_count * mean_item_size;
-            } else {
-                debug_assert_eq!(
-                    count, 0,
-                    "Assumption: If the division produced an infinite result, it's because of a divide by zero."
-                );
-                // TODO: How can we handle this sanely? We're scrolled very far down (3 pages + 3000 logical pixels),
-                // but we don't have any idea how big the items are; that could be within a single item.
-                // I guess we need to just wait for the anchor to be loaded?
-            }
-        } else {
-            let previous_anchor = self.anchor_index;
+            // let previous_anchor = self.anchor_index;
             loop {
                 if self.scroll_offset_from_anchor < 0. {
-                    if self.anchor_index == self.first_item {
+                    if self.anchor_index <= self.active_range.start {
+                        // TODO: Is this the right time to do this clamping?
+                        self.anchor_index = self.active_range.start;
+                        // Don't scroll above the old anchor
                         self.scroll_offset_from_anchor = 0.;
                         break;
                     }
-                    let new_idx = self.anchor_index - 1;
-                    let new_anchor = self.current_items.get(&new_idx);
+                    self.anchor_index = self.anchor_index - 1;
+                    let new_anchor = self.items.get(&self.anchor_index);
                     let new_anchor_height = if let Some(new_anchor) = new_anchor {
+                        // Note: This child might be stashed, but our best estimate of its height is its old height?
+                        // This would only be the case if actions haven't been re-ran, I think?
                         ctx.child_size(new_anchor).height
                     } else {
-                        // We need to request this new anchor to be loaded
-                        break;
+                        mean_item_height
                     };
                     self.scroll_offset_from_anchor += new_anchor_height;
-                    height_before_anchor -= new_anchor_height;
-                    height_after_anchor += new_anchor_height;
-                    self.anchor_index = new_idx;
                 } else {
-                    let anchor_pod = self.current_items.get(&self.anchor_index);
-                    let anchor_height = if let Some(anchor_pod) = anchor_pod {
+                    let current_anchor = self.items.get(&self.anchor_index);
+                    let anchor_height = if let Some(anchor_pod) = current_anchor {
                         ctx.child_size(anchor_pod).height
                     } else {
-                        // We need to request this new anchor to be loaded
-                        break;
+                        mean_item_height
                     };
                     if self.scroll_offset_from_anchor > anchor_height {
-                        if self.anchor_index != self.last_item {
-                            self.scroll_offset_from_anchor = anchor_height;
+                        if self.anchor_index >= self.active_range.end {
+                            // TODO: Is this the right time to do this clamping?
+                            self.anchor_index = self.active_range.end;
+                            self.scroll_offset_from_anchor = self
+                                .scroll_offset_from_anchor
+                                // Lock scrolling to be at most a page below the last item
+                                .max(anchor_height + viewport_size.height);
                             break;
                         }
                         self.scroll_offset_from_anchor -= anchor_height;

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -1,0 +1,144 @@
+// Copyright 2025 the Xilem Authors and the Druid Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#![expect(unused, reason = "Development")]
+use std::collections::{BTreeMap, VecDeque};
+
+use vello::kurbo::Vec2;
+
+use crate::core::{Widget, WidgetPod};
+
+pub struct VirtualScrollAction;
+
+/// The model of this virtual scrolling is thus:
+///
+/// 1) The `VirtualScroll` "knows" what item "index" it is using as an anchor
+/// 2) It "knows" how far away from that anchor it is
+/// 3) It keeps the item which is focused in its awareness at all times
+/// 4) It knows how tall any item it requests is, only once layout happens
+/// 5) It importantly does not *care* about scrollbars. This has several big advantages:
+///    - It allows for "infinite" virtual up and down-scrolling
+///    - It allows for much more control by users of how the scrolling happens
+///
+pub struct VirtualScroll<W: Widget + ?Sized> {
+    current_items: VecDeque<(i64, WidgetPod<W>)>,
+    // TODO: Handle focus even if the focused item scrolls off-screen.
+    // TODO: Maybe this should be the focused items and its two neighbours, so tab focusing works?
+    // focused_item: Option<(i64, WidgetPod<W>)>,
+
+    // Question: For a given scroll position, should the anchor always be the same?
+    // Answer: Let's say yes for now, and re-evaluate if it becomes necessary.
+    //  - Reason to not have this is that it adds some pathologies to an "up/down" movement
+    anchor_index: i64,
+    // TODO: Use a fixed-point scheme, because
+    // This will likely wait for layout to do something similar
+    scroll_offset_from_anchor: f64,
+    approx_item_height: f64,
+}
+
+impl<W: Widget> Widget for VirtualScroll<W> {
+    fn layout(
+        &mut self,
+        ctx: &mut crate::core::LayoutCtx,
+        bc: &crate::core::BoxConstraints,
+    ) -> vello::kurbo::Size {
+        // Oh, OK, we actually already know the scroll_offset_from_anchor here...
+        let size = bc.max();
+        // What do we need the total size above the anchor to be?
+        ctx.set_clip_path(size.to_rect());
+        size
+        // TODO: How can we even plausibly handle arbitrary transforms?
+    }
+
+    fn compose(&mut self, ctx: &mut crate::core::ComposeCtx) {
+        let translation = Vec2 {
+            x: 0.,
+            y: self.scroll_offset_from_anchor,
+        };
+        for (_, child) in &mut self.current_items {
+            ctx.set_child_scroll_translation(child, translation);
+        }
+    }
+
+    fn accessibility_role(&self) -> accesskit::Role {
+        // TODO: accesskit::Role::ScrollView ?
+        accesskit::Role::GenericContainer
+    }
+
+    fn accessibility(&mut self, ctx: &mut crate::core::AccessCtx, node: &mut accesskit::Node) {
+        // TODO: Better virtual scrolling accessibility
+        // Intended as a follow-up collaboration with Matt
+        node.set_clips_children();
+    }
+
+    fn on_access_event(
+        &mut self,
+        ctx: &mut crate::core::EventCtx,
+        event: &crate::core::AccessEvent,
+    ) {
+        // TODO: Handle scroll events
+    }
+
+    fn on_pointer_event(
+        &mut self,
+        ctx: &mut crate::core::EventCtx,
+        event: &crate::core::PointerEvent,
+    ) {
+        // TODO: Handle scroll wheel
+    }
+    fn accepts_pointer_interaction(&self) -> bool {
+        // We handle e.g. scroll wheel events
+        true
+    }
+
+    fn children_ids(&self) -> smallvec::SmallVec<[crate::core::WidgetId; 16]> {
+        self.current_items.iter().map(|(_, pod)| pod.id()).collect()
+    }
+
+    fn register_children(&mut self, ctx: &mut crate::core::RegisterCtx) {
+        for (_, child) in &mut self.current_items {
+            ctx.register_child(child);
+        }
+    }
+
+    fn paint(&mut self, _ctx: &mut crate::core::PaintCtx, _scene: &mut vello::Scene) {}
+
+    fn on_text_event(&mut self, ctx: &mut crate::core::EventCtx, event: &crate::core::TextEvent) {
+        // Maybe? Handle pagedown? or something like escape for keyboard focus to escape the virtual list
+    }
+    fn accepts_text_input(&self) -> bool {
+        false
+    }
+
+    fn update(&mut self, ctx: &mut crate::core::UpdateCtx, event: &crate::core::Update) {
+        match event {
+            crate::core::Update::WidgetAdded => {}
+            crate::core::Update::DisabledChanged(_) => {}
+            crate::core::Update::StashedChanged(_) => {}
+            crate::core::Update::RequestPanToChild(rect) => {} // TODO,
+            crate::core::Update::HoveredChanged(_) => {}
+            crate::core::Update::ChildHoveredChanged(_) => {}
+            crate::core::Update::FocusChanged(_) => {
+                if cfg!(debug_assertions) {
+                    unreachable!()
+                }
+            }
+            crate::core::Update::ChildFocusChanged(_) => {
+                // TODO: We won't actually get this event if *which* child element is focused changes...
+                // In fact, there's *no* reliable way to detect that, which makes proper focus management impossible
+            }
+        }
+    }
+    fn accepts_focus(&self) -> bool {
+        // TODO: Maybe we should make this true, to properly capture tab?
+        false
+    }
+
+    // TODO: Optimise?
+    // fn find_widget_at_pos<'c>(
+    //     &'c self,
+    //     ctx: crate::core::QueryCtx<'c>,
+    //     pos: vello::kurbo::Point,
+    // ) -> Option<crate::core::WidgetRef<'c, dyn Widget>> {
+    // }
+}

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -10,7 +10,7 @@ use std::{
 use smallvec::SmallVec;
 use vello::kurbo::{Point, Size, Vec2};
 
-use crate::core::{BoxConstraints, Widget, WidgetPod};
+use crate::core::{BoxConstraints, PropertiesMut, PropertiesRef, Widget, WidgetPod};
 
 use super::CrossAxisAlignment;
 
@@ -96,6 +96,7 @@ impl<W: Widget> Widget for VirtualScroll<W> {
     fn layout(
         &mut self,
         ctx: &mut crate::core::LayoutCtx,
+        _props: &mut PropertiesMut<'_>,
         bc: &crate::core::BoxConstraints,
     ) -> vello::kurbo::Size {
         let viewport_size = bc.max();
@@ -350,7 +351,12 @@ impl<W: Widget> Widget for VirtualScroll<W> {
         accesskit::Role::GenericContainer
     }
 
-    fn accessibility(&mut self, ctx: &mut crate::core::AccessCtx, node: &mut accesskit::Node) {
+    fn accessibility(
+        &mut self,
+        ctx: &mut crate::core::AccessCtx,
+        _props: &PropertiesRef<'_>,
+        node: &mut accesskit::Node,
+    ) {
         // TODO: Better virtual scrolling accessibility
         // Intended as a follow-up collaboration with Matt
         node.set_clips_children();
@@ -359,6 +365,7 @@ impl<W: Widget> Widget for VirtualScroll<W> {
     fn on_access_event(
         &mut self,
         ctx: &mut crate::core::EventCtx,
+        _props: &mut PropertiesMut<'_>,
         event: &crate::core::AccessEvent,
     ) {
         // TODO: Handle scroll events
@@ -367,6 +374,7 @@ impl<W: Widget> Widget for VirtualScroll<W> {
     fn on_pointer_event(
         &mut self,
         ctx: &mut crate::core::EventCtx,
+        _props: &mut PropertiesMut<'_>,
         event: &crate::core::PointerEvent,
     ) {
         // TODO: Handle scroll wheel
@@ -386,16 +394,32 @@ impl<W: Widget> Widget for VirtualScroll<W> {
         }
     }
 
-    fn paint(&mut self, _ctx: &mut crate::core::PaintCtx, _scene: &mut vello::Scene) {}
+    fn paint(
+        &mut self,
+        _ctx: &mut crate::core::PaintCtx,
+        _props: &PropertiesRef<'_>,
+        _scene: &mut vello::Scene,
+    ) {
+    }
 
-    fn on_text_event(&mut self, ctx: &mut crate::core::EventCtx, event: &crate::core::TextEvent) {
+    fn on_text_event(
+        &mut self,
+        ctx: &mut crate::core::EventCtx,
+        _props: &mut PropertiesMut<'_>,
+        event: &crate::core::TextEvent,
+    ) {
         // Maybe? Handle pagedown? or something like escape for keyboard focus to escape the virtual list
     }
     fn accepts_text_input(&self) -> bool {
         false
     }
 
-    fn update(&mut self, ctx: &mut crate::core::UpdateCtx, event: &crate::core::Update) {
+    fn update(
+        &mut self,
+        ctx: &mut crate::core::UpdateCtx,
+        _props: &mut PropertiesMut<'_>,
+        event: &crate::core::Update,
+    ) {
         match event {
             crate::core::Update::WidgetAdded => {}
             crate::core::Update::DisabledChanged(_) => {}

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -405,7 +405,7 @@ impl<W: Widget> Widget for VirtualScroll<W> {
             crate::core::Update::ChildHoveredChanged(_) => {}
             crate::core::Update::FocusChanged(_) => {
                 if cfg!(debug_assertions) {
-                    unreachable!()
+                    unreachable!("VirtualScroll can't be focused")
                 }
             }
             crate::core::Update::ChildFocusChanged(_) => {
@@ -419,11 +419,6 @@ impl<W: Widget> Widget for VirtualScroll<W> {
         false
     }
 
-    // TODO: Optimise?
-    // fn find_widget_at_pos<'c>(
-    //     &'c self,
-    //     ctx: crate::core::QueryCtx<'c>,
-    //     pos: vello::kurbo::Point,
-    // ) -> Option<crate::core::WidgetRef<'c, dyn Widget>> {
-    // }
+    // TODO: Optimise using binary search?
+    // fn find_widget_at_pos(..);
 }

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -118,9 +118,13 @@ impl<W: Widget + ?Sized> VirtualScroll<W> {
         }
     }
 
-    pub fn remove_child(this: &mut WidgetMut<Self>, idx: i64) -> Option<WidgetPod<W>> {
-        this.ctx.children_changed();
-        this.widget.items.remove(&idx)
+    pub fn remove_child(this: &mut WidgetMut<Self>, idx: i64) {
+        let child = this.widget.items.remove(&idx);
+        if let Some(child) = child {
+            this.ctx.remove_child(child);
+        } else {
+            tracing::warn!("Tried to remove child which has already been removed");
+        }
     }
 
     pub fn add_child(this: &mut WidgetMut<Self>, idx: i64, mut child: WidgetPod<W>) {
@@ -475,7 +479,7 @@ impl<W: Widget + ?Sized> Widget for VirtualScroll<W> {
             TextEvent::KeyboardKey(key_event, modifiers_state) => {
                 // To get to this state, you currently need to press "tab" to focus this widget in the example.
                 if key_event.state.is_pressed() {
-                    let delta = 2000.;
+                    let delta = 20000.;
                     if matches!(key_event.logical_key, Key::Named(NamedKey::PageDown)) {
                         self.scroll_offset_from_anchor += delta;
                         if self.scroll_offset_from_anchor < 0.

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -767,7 +767,7 @@ mod tests {
         assert_render_snapshot!(harness, "virtual_scroll_moved");
         harness.mouse_move_to(virtual_scroll_id);
         harness.process_pointer_event(PointerEvent::MouseWheel(
-            LogicalPosition::new(0., 200.),
+            LogicalPosition::new(0., 2.5),
             PointerState::empty(),
         ));
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -479,7 +479,7 @@ impl<W: Widget + ?Sized> Widget for VirtualScroll<W> {
             TextEvent::KeyboardKey(key_event, modifiers_state) => {
                 // To get to this state, you currently need to press "tab" to focus this widget in the example.
                 if key_event.state.is_pressed() {
-                    let delta = 20000.;
+                    let delta = 2000.;
                     if matches!(key_event.logical_key, Key::Named(NamedKey::PageDown)) {
                         self.scroll_offset_from_anchor += delta;
                         if self.scroll_offset_from_anchor < 0.

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -1,13 +1,8 @@
 // Copyright 2025 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![expect(unused, reason = "Development")]
-use std::{
-    collections::{BTreeMap, HashMap, VecDeque},
-    ops::{Range, RangeInclusive},
-};
+use std::{collections::HashMap, ops::Range};
 
-use smallvec::SmallVec;
 use vello::kurbo::{Point, Size, Vec2};
 use winit::keyboard::{Key, NamedKey};
 
@@ -15,8 +10,6 @@ use crate::core::{
     BoxConstraints, PointerEvent, PropertiesMut, PropertiesRef, TextEvent, Widget, WidgetMut,
     WidgetPod,
 };
-
-use super::CrossAxisAlignment;
 
 #[derive(Debug)]
 pub struct VirtualScrollAction {
@@ -481,7 +474,7 @@ impl<W: Widget + ?Sized> Widget for VirtualScroll<W> {
 
     fn accessibility(
         &mut self,
-        ctx: &mut crate::core::AccessCtx,
+        _ctx: &mut crate::core::AccessCtx,
         _props: &PropertiesRef<'_>,
         node: &mut accesskit::Node,
     ) {
@@ -492,11 +485,11 @@ impl<W: Widget + ?Sized> Widget for VirtualScroll<W> {
 
     fn on_access_event(
         &mut self,
-        ctx: &mut crate::core::EventCtx,
+        _ctx: &mut crate::core::EventCtx,
         _props: &mut PropertiesMut<'_>,
-        event: &crate::core::AccessEvent,
+        _event: &crate::core::AccessEvent,
     ) {
-        // TODO: Handle scroll events
+        // TODO: Handle scroll-etc. eventss
     }
 
     fn on_pointer_event(
@@ -506,8 +499,6 @@ impl<W: Widget + ?Sized> Widget for VirtualScroll<W> {
         event: &crate::core::PointerEvent,
     ) {
         const SCROLLING_SPEED: f64 = 10.0;
-
-        let portal_size = ctx.size();
 
         match event {
             PointerEvent::MouseWheel(delta, _) => {
@@ -548,7 +539,7 @@ impl<W: Widget + ?Sized> Widget for VirtualScroll<W> {
         event: &TextEvent,
     ) {
         match event {
-            TextEvent::KeyboardKey(key_event, modifiers_state) => {
+            TextEvent::KeyboardKey(key_event, _) => {
                 // To get to this state, you currently need to press "tab" to focus this widget in the example.
                 if key_event.state.is_pressed() {
                     let delta = 20000.;
@@ -572,7 +563,7 @@ impl<W: Widget + ?Sized> Widget for VirtualScroll<W> {
 
     fn update(
         &mut self,
-        ctx: &mut crate::core::UpdateCtx,
+        _ctx: &mut crate::core::UpdateCtx,
         _props: &mut PropertiesMut<'_>,
         event: &crate::core::Update,
     ) {
@@ -580,7 +571,7 @@ impl<W: Widget + ?Sized> Widget for VirtualScroll<W> {
             crate::core::Update::WidgetAdded => {}
             crate::core::Update::DisabledChanged(_) => {}
             crate::core::Update::StashedChanged(_) => {}
-            crate::core::Update::RequestPanToChild(rect) => {} // TODO,
+            crate::core::Update::RequestPanToChild(_rect) => {} // TODO,
             crate::core::Update::HoveredChanged(_) => {}
             crate::core::Update::ChildHoveredChanged(_) => {}
             crate::core::Update::FocusChanged(_) => {}
@@ -633,7 +624,7 @@ mod tests {
     use crate::{
         assert_render_snapshot,
         core::{PointerEvent, PointerState, Widget, WidgetMut, WidgetPod},
-        testing::{TestHarness, widget_ids},
+        testing::TestHarness,
         widgets::{Label, VirtualScroll, VirtualScrollAction},
     };
 
@@ -868,7 +859,7 @@ mod tests {
             assert!(!action.target.is_empty());
 
             harness.edit_widget(virtual_scroll_id, |mut portal| {
-                let mut scroll = portal.downcast::<VirtualScroll<T>>();
+                let scroll = portal.downcast::<VirtualScroll<T>>();
                 f(*action, scroll);
             });
         }

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -697,21 +697,14 @@ mod tests {
         });
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
         assert_render_snapshot!(harness, "virtual_scroll_moved");
-        // let item_3_rect = harness.get_widget(item_3_id).ctx().local_layout_rect();
-        // harness.edit_root_widget(|mut portal| {
-        //     let mut portal = portal.downcast::<Portal<Flex>>();
-        //     Portal::pan_viewport_to(&mut portal, item_3_rect);
-        // });
-
-        // assert_render_snapshot!(harness, "button_list_scroll_to_item_3");
-
-        // let item_13_rect = harness.get_widget(item_13_id).ctx().local_layout_rect();
-        // harness.edit_root_widget(|mut portal| {
-        //     let mut portal = portal.downcast::<Portal<Flex>>();
-        //     Portal::pan_viewport_to(&mut portal, item_13_rect);
-        // });
-
-        // assert_render_snapshot!(harness, "button_list_scroll_to_item_13");
+        harness.mouse_move_to(virtual_scroll_id);
+        harness.process_pointer_event(PointerEvent::MouseWheel(
+            LogicalPosition::new(0., 200.),
+            PointerState::empty(),
+        ));
+        drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
+        assert_render_snapshot!(harness, "virtual_scroll_scrolled");
+    }
     }
 
     fn drive_to_fixpoint<T: Widget + ?Sized>(

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -243,6 +243,17 @@ impl<W: Widget + FromDynWidget + ?Sized> VirtualScroll<W> {
         }
     }
 
+    /// Set the range of child ids which are valid.
+    ///
+    /// Note that this is a half-open range, so the end id of the range is not valid.
+    pub fn with_valid_range(mut self, valid_range: Range<i64>) -> Self {
+        self.valid_range = valid_range;
+        self
+    }
+}
+
+// --- MARK: WIDGETMUT ---
+impl<W: Widget + FromDynWidget + ?Sized> VirtualScroll<W> {
     /// Remove the child widget with id `idx`.
     ///
     /// This will log an error if there was no child at the given index.

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -432,12 +432,12 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for VirtualScroll<W> {
 
         // Determine the new anchor
         loop {
+            if self.anchor_index <= self.valid_range.start {
+                self.anchor_index = self.valid_range.start;
+                self.cap_scroll_range_up();
+                break;
+            }
             if self.scroll_offset_from_anchor < 0. {
-                if self.anchor_index <= self.valid_range.start {
-                    self.anchor_index = self.valid_range.start;
-                    self.cap_scroll_range_up();
-                    break;
-                }
                 self.anchor_index -= 1;
                 let new_anchor_height = if self.active_range.contains(&self.anchor_index) {
                     let new_anchor = self.items.get(&self.anchor_index);

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -797,7 +797,7 @@ mod tests {
 
     use crate::{
         assert_render_snapshot,
-        core::{FromDynWidget, PointerEvent, PointerState, Widget, WidgetMut, WidgetPod},
+        core::{Action, FromDynWidget, PointerEvent, PointerState, Widget, WidgetMut, WidgetPod},
         testing::TestHarness,
         widgets::{Label, VirtualScroll, VirtualScrollAction},
     };
@@ -1001,6 +1001,78 @@ mod tests {
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
     }
 
+    #[test]
+    /// If there's a minimum range, we should behave in a sensible way.
+    fn limited_up() {
+        type ScrollContents = Label;
+
+        const MIN: i64 = 10;
+        let widget = VirtualScroll::<ScrollContents>::new(0).with_valid_range(MIN..i64::MAX);
+
+        let mut harness = TestHarness::create_with_size(widget, Size::new(100., 200.));
+        let virtual_scroll_id = harness.root_widget().id();
+        fn driver(action: VirtualScrollAction, mut scroll: WidgetMut<'_, VirtualScroll<Label>>) {
+            for idx in action.old_active {
+                VirtualScroll::remove_child(&mut scroll, idx);
+            }
+            for idx in action.target {
+                assert!(
+                    idx >= MIN,
+                    "Virtual Scroll controller should never request an invalid id. Requested {idx}"
+                );
+                VirtualScroll::add_child(
+                    &mut scroll,
+                    idx,
+                    WidgetPod::new(
+                        Label::new(format!("{idx}")).with_style(StyleProperty::FontSize(30.)),
+                    ),
+                );
+            }
+        }
+
+        drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
+        {
+            let widget = harness
+                .root_widget()
+                .downcast::<VirtualScroll<ScrollContents>>()
+                .unwrap();
+            assert_eq!(
+                widget.anchor_index, MIN,
+                "Virtual Scroll controller should lock anchor to be within active range"
+            );
+            assert_eq!(
+                widget.scroll_offset_from_anchor, 0.0,
+                "Virtual Scroll controller should lock top of the first item to the top of the screen if jumping"
+            );
+        }
+        harness.mouse_move_to(virtual_scroll_id);
+        harness.process_pointer_event(PointerEvent::MouseWheel(
+            LogicalPosition::new(0., -5.),
+            PointerState::empty(),
+        ));
+        drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
+        {
+            let widget = harness
+                .root_widget()
+                .downcast::<VirtualScroll<ScrollContents>>()
+                .unwrap();
+            assert!(widget.anchor_index != MIN || widget.scroll_offset_from_anchor != 0.0);
+        }
+        harness.process_pointer_event(PointerEvent::MouseWheel(
+            LogicalPosition::new(0., 6.),
+            PointerState::empty(),
+        ));
+        drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
+        {
+            let widget = harness
+                .root_widget()
+                .downcast::<VirtualScroll<ScrollContents>>()
+                .unwrap();
+            assert_eq!(widget.anchor_index, MIN);
+            assert_eq!(widget.scroll_offset_from_anchor, 0.0);
+        }
+    }
+
     fn drive_to_fixpoint<T: Widget + FromDynWidget + ?Sized>(
         harness: &mut TestHarness,
         virtual_scroll_id: crate::core::WidgetId,
@@ -1020,17 +1092,30 @@ mod tests {
                 id, virtual_scroll_id,
                 "Only widget in tree should give action"
             );
-            assert_eq!(harness.pop_action(), None);
-            let crate::core::Action::Other(action) = action else {
+            let Action::Other(action) = action else {
                 unreachable!()
             };
             let action = action.downcast::<VirtualScrollAction>().unwrap();
+            if let Some((action, id)) = harness.pop_action() {
+                let Action::Other(action) = action else {
+                    unreachable!();
+                };
+                panic!(
+                    "Layout shouldn't happen multiple times between driving,\
+                    got unexpected action {:?} for {id}",
+                    action.downcast::<VirtualScrollAction>()
+                );
+            }
             if let Some(old_active) = old_active.take() {
                 assert_eq!(action.old_active, old_active);
             }
             old_active = Some(action.target.clone());
+            assert!(
+                action.target != action.old_active,
+                "Shouldn't have sent an update if the target hasn't changed"
+            );
             // This could happen iff the valid range is empty, which is case I've not reasoned about yet.
-            assert!(!action.target.is_empty());
+            // assert!(!action.target.is_empty());
 
             harness.edit_widget(virtual_scroll_id, |mut portal| {
                 let scroll = portal.downcast::<VirtualScroll<T>>();

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -580,8 +580,11 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for VirtualScroll<W> {
             ..target_range
                 .end
                 .clamp(self.valid_range.start, self.valid_range.end);
-
-        if self.active_range != target_range {
+        // If both ranges are empty, then they're equivalent. This can happen due to the initial layout of size 0x0
+        // This check is mostly here to simplify writing tests
+        if self.active_range != target_range
+            && !(self.active_range.is_empty() && target_range.is_empty())
+        {
             let previous_active = self.active_range.clone();
             self.active_range = target_range;
 


### PR DESCRIPTION
Depends on #882; includes that.

This is the first follow-up from the MVP of virtual scrolling. The valid range is used to limit where in the id space can be scrolled to. This will be widely useful for many (most?) virtual scrolling use cases. Consider for example http_cats; the valid range would be the number of status codes.