### PR TITLE
Fix pointer capture

### DIFF
--- a/masonry/src/app/event_loop_runner.rs
+++ b/masonry/src/app/event_loop_runner.rs
@@ -608,7 +608,7 @@ impl MasonryState<'_> {
                     }
                     winit::event::TouchPhase::Cancelled => {
                         self.render_root
-                            .handle_pointer_event(PointerEvent::PointerLeave(
+                            .handle_pointer_event(PointerEvent::PointerLost(
                                 self.pointer_state.clone(),
                             ));
                     }

--- a/masonry/src/core/events.rs
+++ b/masonry/src/core/events.rs
@@ -198,10 +198,9 @@ pub enum PointerEvent {
     /// A pointer entered the window.
     PointerEnter(PointerState),
     /// A pointer left the window.
-    ///
-    /// A synthetic `PointerLeave` event may also be sent when a widget
-    /// loses [pointer capture](crate::doc::doc_06_masonry_concepts#pointer-capture).
     PointerLeave(PointerState),
+    /// A pointer was removed from the device, or a [captured pointer](crate::doc::doc_06_masonry_concepts#pointer-capture) was forcefully released.
+    PointerLost(PointerState),
     /// A mouse wheel event.
     ///
     /// The first tuple value is the scrolled distances. In most cases with a
@@ -366,6 +365,7 @@ impl PointerEvent {
             | Self::PointerMove(state)
             | Self::PointerEnter(state)
             | Self::PointerLeave(state)
+            | Self::PointerLost(state)
             | Self::MouseWheel(_, state)
             | Self::HoverFile(_, state)
             | Self::DropFile(_, state)
@@ -392,6 +392,7 @@ impl PointerEvent {
             Self::PointerMove(_) => "PointerMove",
             Self::PointerEnter(_) => "PointerEnter",
             Self::PointerLeave(_) => "PointerLeave",
+            Self::PointerLost(_) => "PointerLost",
             Self::MouseWheel(_, _) => "MouseWheel",
             Self::HoverFile(_, _) => "HoverFile",
             Self::DropFile(_, _) => "DropFile",
@@ -411,6 +412,7 @@ impl PointerEvent {
             Self::PointerMove(_) => true,
             Self::PointerEnter(_) => false,
             Self::PointerLeave(_) => false,
+            Self::PointerLost(_) => false,
             Self::MouseWheel(_, _) => true,
             Self::HoverFile(_, _) => true,
             Self::DropFile(_, _) => false,
@@ -426,11 +428,11 @@ impl PointerEvent {
         ctx.widget_state.window_transform.inverse() * Point::new(position.x, position.y)
     }
 
-    /// Create a [`PointerEvent::PointerLeave`] event with dummy values.
+    /// Create a [`PointerEvent::PointerLost`] event with dummy values.
     ///
-    /// This is used internally to create synthetic `PointerLeave` events when pointer
+    /// This is used internally to create synthetic `PointerLost` events when pointer
     /// capture is lost.
-    pub fn new_pointer_leave() -> Self {
+    pub fn new_pointer_lost() -> Self {
         // TODO - The fact we're creating so many dummy values might be
         // a sign we should refactor that struct
         let pointer_state = PointerState {
@@ -441,7 +443,7 @@ impl PointerEvent {
             count: 0,
             force: None,
         };
-        Self::PointerLeave(pointer_state)
+        Self::PointerLost(pointer_state)
     }
 }
 

--- a/masonry/src/doc/06_masonry_concepts.md
+++ b/masonry/src/doc/06_masonry_concepts.md
@@ -43,7 +43,7 @@ Conversely, no other widget can get events from the pointer (outside of bubbling
 - The "hovered" status of other widgets won't be updated even if the pointer is over them.
 The hovered status of the capturing widget will be updated, meaning a widget that captured a pointer can still lose the "hovered" status.
 - The pointer's cursor icon will be updated as if the pointer stayed over the capturing widget.
-- If the widget loses pointer capture for some reason (e.g. the pointer is disconnected), the Widget will get a [`PointerLeave`] event.
+- If the widget loses pointer capture for some reason (e.g. the pointer is disconnected), the Widget will get a [`PointerLost`] event.
 
 Masonry should guarantee that pointers can only be captured by one widget at a time.
 Masonry should force the widget to lose pointer capture when some events occur; not just MouseLeave, but also `Tab` being pressed, the window losing focus, the widget being disabled, etc.
@@ -137,7 +137,7 @@ These checks are sometimes referred to as "safety rails".
 Safety rails aren't guaranteed to run and may be disabled even in debug mode for performance reasons.
 They should not be relied upon to check code correctness, but are meant to help you catch implementation errors early on during development.
 
-[`PointerLeave`]: crate::core::PointerEvent::PointerLeave
+[`PointerLost`]: crate::core::PointerEvent::PointerLost
 [`FocusChanged`]: crate::core::Update::FocusChanged
 [`Widget::accepts_focus`]: crate::core::Widget::accepts_focus
 [`EventCtx::request_focus`]: crate::core::EventCtx::request_focus

--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -172,7 +172,7 @@ pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEv
 
     if matches!(
         event,
-        PointerEvent::PointerUp(..) | PointerEvent::PointerLeave(..)
+        PointerEvent::PointerUp(..) | PointerEvent::PointerLost(..)
     ) {
         // Automatically release the pointer on pointer up or leave. If a widget holds the capture,
         // it is notified of the pointer event before the capture is released, so it knows it is
@@ -195,7 +195,7 @@ pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEv
 /// See the [passes documentation](../doc/05_pass_system.md#event-passes).
 pub(crate) fn run_on_text_event_pass(root: &mut RenderRoot, event: &TextEvent) -> Handled {
     if matches!(event, TextEvent::WindowFocusChange(false)) {
-        run_on_pointer_event_pass(root, &PointerEvent::new_pointer_leave());
+        run_on_pointer_event_pass(root, &PointerEvent::new_pointer_lost());
     }
 
     let _span = info_span!("dispatch_text_event").entered();

--- a/masonry/src/passes/update.rs
+++ b/masonry/src/passes/update.rs
@@ -692,8 +692,8 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
     // Release pointer capture if target can no longer hold it.
     if let Some(id) = root.global_state.pointer_capture_target {
         if !root.is_still_interactive(id) {
-            root.global_state.pointer_capture_target = None;
-            run_on_pointer_event_pass(root, &PointerEvent::new_pointer_leave());
+            // The event pass will set pointer_capture_target to None.
+            run_on_pointer_event_pass(root, &PointerEvent::new_pointer_lost());
         }
     }
 

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -130,7 +130,7 @@ impl Widget for ScrollBar {
         event: &PointerEvent,
     ) {
         match event {
-            PointerEvent::PointerDown(_, _) => {
+            PointerEvent::PointerDown(..) => {
                 ctx.capture_pointer();
 
                 let cursor_min_length = theme::SCROLLBAR_MIN_SIZE;
@@ -148,7 +148,7 @@ impl Widget for ScrollBar {
                 };
                 ctx.request_render();
             }
-            PointerEvent::PointerMove(_) => {
+            PointerEvent::PointerMove(..) => {
                 if let Some(grab_anchor) = self.grab_anchor {
                     let cursor_min_length = theme::SCROLLBAR_MIN_SIZE;
                     self.cursor_progress = self.progress_from_mouse_pos(
@@ -161,7 +161,7 @@ impl Widget for ScrollBar {
                 }
                 ctx.request_render();
             }
-            PointerEvent::PointerUp(_, _) => {
+            PointerEvent::PointerUp(..) | PointerEvent::PointerLost(..) => {
                 self.grab_anchor = None;
                 ctx.request_render();
             }

--- a/masonry/src/widgets/tests/status_change.rs
+++ b/masonry/src/widgets/tests/status_change.rs
@@ -295,7 +295,7 @@ fn get_pointer_events_while_active() {
 }
 
 #[test]
-fn automatically_lose_pointer_on_pointer_leave() {
+fn automatically_lose_pointer_on_pointer_lost() {
     let [button, root, empty] = widget_ids();
 
     let button_rec = Recording::default();
@@ -335,13 +335,13 @@ fn automatically_lose_pointer_on_pointer_leave() {
     );
     assert_eq!(harness.pointer_capture_target_id(), Some(button));
 
-    // The pointer leaves, without releasing the primary button first
-    harness.process_pointer_event(PointerEvent::PointerLeave(PointerState::empty()));
+    // The pointer is lost, without releasing the primary button first
+    harness.process_pointer_event(PointerEvent::PointerLost(PointerState::empty()));
 
-    // The button holds the capture during this event and should be notified the pointer is leaving
+    // The button holds the capture during this event and should be notified the pointer is lost
     assert_matches!(
         next_pointer_event(&button_rec),
-        Some(PointerEvent::PointerLeave(_))
+        Some(PointerEvent::PointerLost(_))
     );
 
     // The button should have lost the pointer capture


### PR DESCRIPTION
Create new PointerLost event.
No longer remove pointer capture on PointerLeave.
Fix small bugs and implementation errors.

Fixes #857.
Supersedes #858.