### PR TITLE
Make `DynMessage` a struct, use trait upcasting (bump MSRV to 1.86)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,
   # plus all the README.md files of the affected packages.
-  RUST_MIN_VER: "1.85"
+  RUST_MIN_VER: "1.86"
   # List of packages that can not target Wasm.
   NO_WASM_PKGS: "--exclude masonry --exclude masonry_core --exclude xilem"
   # Only some of our examples support Android (primarily due to extra required boilerplate).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 [workspace.package]
 edition = "2024"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files.
-rust-version = "1.85"
+rust-version = "1.86"
 license = "Apache-2.0"
 repository = "https://github.com/linebender/xilem"
 homepage = "https://xilem.dev/"

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ sudo apt-get install clang libwayland-dev libxkbcommon-x11-dev libvulkan-dev
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Xilem has been verified to compile with **Rust 1.85** and later.
+This version of Xilem has been verified to compile with **Rust 1.86** and later.
 
 Future versions of Xilem might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/masonry/README.md
+++ b/masonry/README.md
@@ -124,7 +124,7 @@ Masonry apps currently ship with two debugging features built in:
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Masonry has been verified to compile with **Rust 1.85** and later.
+This version of Masonry has been verified to compile with **Rust 1.86** and later.
 
 Future versions of Masonry might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/xilem/README.md
+++ b/xilem/README.md
@@ -150,7 +150,7 @@ You should also expect to use the adapters from Xilem Core, including:
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Xilem has been verified to compile with **Rust 1.85** and later.
+This version of Xilem has been verified to compile with **Rust 1.86** and later.
 
 Future versions of Xilem might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -9,7 +9,7 @@ use masonry::app::{AppDriver, EventLoopProxy, MasonryState, MasonryUserEvent};
 use masonry::core::WidgetId;
 use masonry::widgets::RootWidget;
 
-use crate::core::{DynMessage, Message, MessageResult, ProxyError, RawProxy, ViewId};
+use crate::core::{DynMessage, MessageResult, ProxyError, RawProxy, ViewId};
 use crate::{ViewCtx, WidgetView};
 
 pub struct MasonryDriver<State, Logic, View, ViewState> {
@@ -26,7 +26,7 @@ pub struct MasonryDriver<State, Logic, View, ViewState> {
 pub const ASYNC_MARKER_WIDGET: WidgetId = WidgetId::reserved(0x1000);
 
 /// The action which should be used for async events.
-pub fn async_action(path: Arc<[ViewId]>, message: Box<dyn Message>) -> masonry::core::Action {
+pub fn async_action(path: Arc<[ViewId]>, message: DynMessage) -> masonry::core::Action {
     masonry::core::Action::Other(Box::<MessagePackage>::new((path, message)))
 }
 
@@ -89,7 +89,7 @@ where
             self.current_view.message(
                 &mut self.view_state,
                 id_path.as_slice(),
-                Box::new(action),
+                DynMessage::new(action),
                 &mut self.state,
             )
         } else {

--- a/xilem/src/view/button.rs
+++ b/xilem/src/view/button.rs
@@ -158,7 +158,7 @@ where
                         (self.callback)(app_state, button)
                     } else {
                         tracing::error!("Wrong action type in Button::message: {action:?}");
-                        MessageResult::Stale(action)
+                        MessageResult::Stale(DynMessage(action))
                     }
                 }
                 Err(message) => {

--- a/xilem/src/view/checkbox.rs
+++ b/xilem/src/view/checkbox.rs
@@ -100,7 +100,7 @@ where
                     MessageResult::Action((self.callback)(app_state, checked))
                 } else {
                     tracing::error!("Wrong action type in Checkbox::message: {action:?}");
-                    MessageResult::Stale(action)
+                    MessageResult::Stale(DynMessage(action))
                 }
             }
             Err(message) => {

--- a/xilem/src/view/task.rs
+++ b/xilem/src/view/task.rs
@@ -11,7 +11,7 @@ use tokio::task::JoinHandle;
 
 use crate::ViewCtx;
 use crate::core::{
-    DynMessage, Message, MessageProxy, MessageResult, Mut, NoElement, View, ViewId, ViewMarker,
+    AnyMessage, DynMessage, MessageProxy, MessageResult, Mut, NoElement, View, ViewId, ViewMarker,
     ViewPathTracker,
 };
 
@@ -31,7 +31,7 @@ where
     F: Fn(MessageProxy<M>) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
-    M: Message + 'static,
+    M: AnyMessage + 'static,
 {
     const {
         assert!(
@@ -56,7 +56,7 @@ where
     F: Fn(MessageProxy<M>) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
-    M: Message + 'static,
+    M: AnyMessage + 'static,
 {
     Task {
         init_future,
@@ -77,7 +77,7 @@ where
     F: Fn(MessageProxy<M>) -> Fut + 'static,
     Fut: Future<Output = ()> + Send + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
-    M: Message + 'static,
+    M: AnyMessage + 'static,
 {
     type Element = NoElement;
 

--- a/xilem/src/view/textbox.rs
+++ b/xilem/src/view/textbox.rs
@@ -136,11 +136,11 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
                 }
                 masonry::core::Action::TextEntered(_) => {
                     tracing::error!("Textbox::message: on_enter is not set");
-                    MessageResult::Stale(action)
+                    MessageResult::Stale(DynMessage(action))
                 }
                 _ => {
                     tracing::error!("Wrong action type in Textbox::message: {action:?}");
-                    MessageResult::Stale(action)
+                    MessageResult::Stale(DynMessage(action))
                 }
             },
             Err(message) => {

--- a/xilem/src/view/worker.rs
+++ b/xilem/src/view/worker.rs
@@ -12,7 +12,7 @@ use tokio::task::JoinHandle;
 
 use crate::ViewCtx;
 use crate::core::{
-    DynMessage, Message, MessageProxy, MessageResult, Mut, NoElement, View, ViewId, ViewMarker,
+    AnyMessage, DynMessage, MessageProxy, MessageResult, Mut, NoElement, View, ViewId, ViewMarker,
     ViewPathTracker,
 };
 
@@ -37,7 +37,7 @@ where
     F: Fn(MessageProxy<M>, UnboundedReceiver<V>) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
-    M: Message + 'static,
+    M: AnyMessage + 'static,
 {
     const {
         assert!(
@@ -68,7 +68,7 @@ where
     F: Fn(MessageProxy<M>, UnboundedReceiver<V>) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
-    M: Message + 'static,
+    M: AnyMessage + 'static,
 {
     Worker {
         value,
@@ -99,7 +99,7 @@ where
     V: Send + PartialEq + Clone + 'static,
     Fut: Future<Output = ()> + Send + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
-    M: Message + 'static,
+    M: AnyMessage + 'static,
 {
     type Element = NoElement;
 

--- a/xilem_core/README.md
+++ b/xilem_core/README.md
@@ -47,7 +47,7 @@ If you wish to use Xilem Core in environments where an allocator is not availabl
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Xilem Core has been verified to compile with **Rust 1.85** and later.
+This version of Xilem Core has been verified to compile with **Rust 1.86** and later.
 
 Future versions of Xilem Core might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -46,7 +46,7 @@ pub use views::{
 };
 
 mod message;
-pub use message::{DynMessage, Message, MessageResult};
+pub use message::{AnyMessage, DynMessage, MessageResult};
 
 mod element;
 pub use element::{AnyElement, Mut, NoElement, SuperElement, ViewElement};

--- a/xilem_core/tests/any_view.rs
+++ b/xilem_core/tests/any_view.rs
@@ -3,7 +3,7 @@
 
 //! Tests that [`AnyView`] has the correct routing behaviour
 
-use xilem_core::{AnyView, MessageResult, View};
+use xilem_core::{AnyView, DynMessage, MessageResult, View};
 
 mod common;
 use common::*;
@@ -18,7 +18,7 @@ fn messages_to_inner_view() {
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
-    let result = view.message(&mut state, &element.view_path, Box::new(()), &mut ());
+    let result = view.message(&mut state, &element.view_path, DynMessage::new(()), &mut ());
     assert_action(result, 0);
 }
 
@@ -38,7 +38,7 @@ fn message_after_rebuild() {
         &[Operation::Build(0), Operation::Rebuild { from: 0, to: 1 }]
     );
 
-    let result = view2.message(&mut state, &path, Box::new(()), &mut ());
+    let result = view2.message(&mut state, &path, DynMessage::new(()), &mut ());
     assert_action(result, 1);
 }
 
@@ -62,7 +62,7 @@ fn no_message_after_stale() {
         ]
     );
 
-    let result = view2.message(&mut state, &path, Box::new(()), &mut ());
+    let result = view2.message(&mut state, &path, DynMessage::new(()), &mut ());
     assert!(matches!(result, MessageResult::Stale(_)));
 }
 
@@ -100,6 +100,6 @@ fn no_message_after_stale_then_same_type() {
         ]
     );
 
-    let result = view3.message(&mut state, &path, Box::new(()), &mut ());
+    let result = view3.message(&mut state, &path, DynMessage::new(()), &mut ());
     assert!(matches!(result, MessageResult::Stale(_)));
 }

--- a/xilem_core/tests/arc.rs
+++ b/xilem_core/tests/arc.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use xilem_core::{MessageResult, View};
+use xilem_core::{DynMessage, MessageResult, View};
 
 mod common;
 use common::*;
@@ -103,7 +103,7 @@ fn arc_passthrough_message() {
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
-    let result = view1.message(&mut state, &element.view_path, Box::new(()), &mut ());
+    let result = view1.message(&mut state, &element.view_path, DynMessage::new(()), &mut ());
     assert_action(result, 0);
 }
 
@@ -178,7 +178,7 @@ fn box_passthrough_message() {
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
-    let result = view1.message(&mut state, &element.view_path, Box::new(()), &mut ());
+    let result = view1.message(&mut state, &element.view_path, DynMessage::new(()), &mut ());
     let MessageResult::Action(inner) = result else {
         panic!()
     };

--- a/xilem_core/tests/array_sequence.rs
+++ b/xilem_core/tests/array_sequence.rs
@@ -10,7 +10,7 @@
 
 mod common;
 use common::*;
-use xilem_core::View;
+use xilem_core::{DynMessage, View};
 
 fn record_ops(id: u32) -> OperationView<0> {
     OperationView(id)
@@ -115,9 +115,9 @@ fn two_element_message() {
     assert_eq!(second_child.operations, &[Operation::Build(1)]);
     let second_path = second_child.view_path.to_vec();
 
-    let result = view.message(&mut state, &first_path, Box::new(()), &mut ());
+    let result = view.message(&mut state, &first_path, DynMessage::new(()), &mut ());
     assert_action(result, 0);
 
-    let result = view.message(&mut state, &second_path, Box::new(()), &mut ());
+    let result = view.message(&mut state, &second_path, DynMessage::new(()), &mut ());
     assert_action(result, 1);
 }

--- a/xilem_core/tests/base_sequence.rs
+++ b/xilem_core/tests/base_sequence.rs
@@ -12,7 +12,7 @@
 
 mod common;
 use common::*;
-use xilem_core::{MessageResult, View};
+use xilem_core::{DynMessage, MessageResult, View};
 
 fn record_ops(id: u32) -> OperationView<0> {
     OperationView(id)
@@ -56,7 +56,7 @@ fn one_element_sequence_passthrough() {
         &[Operation::Build(0), Operation::Rebuild { from: 0, to: 2 }]
     );
 
-    let result = view2.message(&mut state, &[], Box::new(()), &mut ());
+    let result = view2.message(&mut state, &[], DynMessage::new(()), &mut ());
     // The message should have been routed to the only child
     assert_action(result, 2);
 
@@ -299,7 +299,7 @@ fn option_message_some() {
     let child = seq_children.active.first().unwrap();
     let path = child.view_path.to_vec();
 
-    let result = view.message(&mut state, &path, Box::new(()), &mut ());
+    let result = view.message(&mut state, &path, DynMessage::new(()), &mut ());
     assert_action(result, 0);
 }
 
@@ -318,7 +318,7 @@ fn option_message_some_some() {
     let view2 = sequence(0, Some(record_ops(1)));
     view2.rebuild(&view, &mut state, &mut ctx, &mut element);
 
-    let result = view2.message(&mut state, &path, Box::new(()), &mut ());
+    let result = view2.message(&mut state, &path, DynMessage::new(()), &mut ());
     assert_action(result, 1);
 }
 
@@ -337,7 +337,7 @@ fn option_message_some_none_stale() {
     let view2 = sequence(0, None);
     view2.rebuild(&view, &mut state, &mut ctx, &mut element);
 
-    let result = view2.message(&mut state, &path, Box::new(()), &mut ());
+    let result = view2.message(&mut state, &path, DynMessage::new(()), &mut ());
     assert!(matches!(result, MessageResult::Stale(_)));
 }
 
@@ -359,6 +359,6 @@ fn option_message_some_none_some_stale() {
     let view3 = sequence(0, Some(record_ops(1)));
     view3.rebuild(&view2, &mut state, &mut ctx, &mut element);
 
-    let result = view2.message(&mut state, &path, Box::new(()), &mut ());
+    let result = view2.message(&mut state, &path, DynMessage::new(()), &mut ());
     assert!(matches!(result, MessageResult::Stale(_)));
 }

--- a/xilem_core/tests/one_of.rs
+++ b/xilem_core/tests/one_of.rs
@@ -8,7 +8,7 @@
 #![expect(clippy::missing_assert_message, reason = "Deferred: Noisy")]
 
 use xilem_core::one_of::{OneOf, OneOf2, OneOfCtx, PhantomElementCtx};
-use xilem_core::{MessageResult, Mut, View, ViewId};
+use xilem_core::{DynMessage, MessageResult, Mut, View, ViewId};
 
 mod common;
 use common::*;
@@ -231,7 +231,7 @@ fn one_of_passthrough_message() {
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
-    let result = view1.message(&mut state, &element.view_path, Box::new(()), &mut ());
+    let result = view1.message(&mut state, &element.view_path, DynMessage::new(()), &mut ());
     assert_action(result, 0);
 }
 
@@ -255,7 +255,7 @@ fn one_of_no_message_after_stale() {
         ]
     );
 
-    let result = view2.message(&mut state, &path, Box::new(()), &mut ());
+    let result = view2.message(&mut state, &path, DynMessage::new(()), &mut ());
     assert!(matches!(result, MessageResult::Stale(_)));
 }
 
@@ -293,6 +293,6 @@ fn one_of_no_message_after_stale_then_same_type() {
         ]
     );
 
-    let result = view3.message(&mut state, &path, Box::new(()), &mut ());
+    let result = view3.message(&mut state, &path, DynMessage::new(()), &mut ());
     assert!(matches!(result, MessageResult::Stale(_)));
 }

--- a/xilem_core/tests/tuple_sequence.rs
+++ b/xilem_core/tests/tuple_sequence.rs
@@ -10,7 +10,7 @@
 
 mod common;
 use common::*;
-use xilem_core::View;
+use xilem_core::{DynMessage, View};
 
 fn record_ops(id: u32) -> OperationView<0> {
     OperationView(id)
@@ -63,7 +63,7 @@ fn one_element_passthrough() {
         &[Operation::Build(0), Operation::Rebuild { from: 0, to: 2 }]
     );
 
-    let result = view2.message(&mut state, &[], Box::new(()), &mut ());
+    let result = view2.message(&mut state, &[], DynMessage::new(()), &mut ());
     // The message should have been routed to the only child
     assert_action(result, 2);
 
@@ -192,10 +192,10 @@ fn two_element_message() {
     assert_eq!(second_child.operations, &[Operation::Build(1)]);
     let second_path = second_child.view_path.to_vec();
 
-    let result = view.message(&mut state, &first_path, Box::new(()), &mut ());
+    let result = view.message(&mut state, &first_path, DynMessage::new(()), &mut ());
     assert_action(result, 0);
 
-    let result = view.message(&mut state, &second_path, Box::new(()), &mut ());
+    let result = view.message(&mut state, &second_path, DynMessage::new(()), &mut ());
     assert_action(result, 1);
 }
 

--- a/xilem_core/tests/vec_sequence.rs
+++ b/xilem_core/tests/vec_sequence.rs
@@ -10,7 +10,7 @@
 
 mod common;
 use common::*;
-use xilem_core::{MessageResult, View};
+use xilem_core::{DynMessage, MessageResult, View};
 
 fn record_ops(id: u32) -> OperationView<0> {
     OperationView(id)
@@ -199,18 +199,18 @@ fn normal_messages() {
     let second_child = &seq_children.active[1];
     let second_path = second_child.view_path.to_vec();
 
-    let result = view.message(&mut state, &first_path, Box::new(()), &mut ());
+    let result = view.message(&mut state, &first_path, DynMessage::new(()), &mut ());
     assert_action(result, 0);
-    let result = view.message(&mut state, &second_path, Box::new(()), &mut ());
+    let result = view.message(&mut state, &second_path, DynMessage::new(()), &mut ());
     assert_action(result, 1);
 
     let view2 = sequence(0, vec![record_ops(2), record_ops(3)]);
     view2.rebuild(&view, &mut state, &mut ctx, &mut element);
     ctx.assert_empty();
 
-    let result = view2.message(&mut state, &first_path, Box::new(()), &mut ());
+    let result = view2.message(&mut state, &first_path, DynMessage::new(()), &mut ());
     assert_action(result, 2);
-    let result = view2.message(&mut state, &second_path, Box::new(()), &mut ());
+    let result = view2.message(&mut state, &second_path, DynMessage::new(()), &mut ());
     assert_action(result, 3);
 }
 
@@ -228,20 +228,20 @@ fn stale_messages() {
     let first_child = seq_children.active.first().unwrap();
     let first_path = first_child.view_path.to_vec();
 
-    let result = view.message(&mut state, &first_path, Box::new(()), &mut ());
+    let result = view.message(&mut state, &first_path, DynMessage::new(()), &mut ());
     assert_action(result, 0);
 
     let view2 = sequence(0, vec![]);
     view2.rebuild(&view, &mut state, &mut ctx, &mut element);
     ctx.assert_empty();
 
-    let result = view2.message(&mut state, &first_path, Box::new(()), &mut ());
+    let result = view2.message(&mut state, &first_path, DynMessage::new(()), &mut ());
     assert!(matches!(result, MessageResult::Stale(_)));
 
     let view3 = sequence(0, vec![record_ops(1)]);
     view3.rebuild(&view2, &mut state, &mut ctx, &mut element);
     ctx.assert_empty();
 
-    let result = view3.message(&mut state, &first_path, Box::new(()), &mut ());
+    let result = view3.message(&mut state, &first_path, DynMessage::new(()), &mut ());
     assert!(matches!(result, MessageResult::Stale(_)));
 }

--- a/xilem_web/README.md
+++ b/xilem_web/README.md
@@ -52,7 +52,7 @@ pub fn main() {
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Xilem Web has been verified to compile with **Rust 1.85** and later.
+This version of Xilem Web has been verified to compile with **Rust 1.86** and later.
 
 Future versions of Xilem Web might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.


### PR DESCRIPTION
With trait upcasting stabilised in Rust 1.86, we can make use of it in `DynMessage`.

This also makes `DynMessage` into a struct, because that reduces the risk of Rust Analyzer messing things up; it liked to confuse the `Message` trait with the `Message` generic. That is, the prior state was effectively `trait View<Message = Box<dyn Message>>`, which sometimes led to things like: `Box<dyn Box<dyn Message>>`.