### PR TITLE
Add multiline text input support to TextArea

### DIFF
--- a/masonry_core/src/widgets/mod.rs
+++ b/masonry_core/src/widgets/mod.rs
@@ -42,7 +42,7 @@ pub use self::scroll_bar::ScrollBar;
 pub use self::sized_box::{Padding, SizedBox};
 pub use self::spinner::Spinner;
 pub use self::split::Split;
-pub use self::text_area::TextArea;
+pub use self::text_area::{InsertNewline, TextArea};
 pub use self::textbox::Textbox;
 pub use self::variable_label::VariableLabel;
 pub use self::virtual_scroll::{VirtualScroll, VirtualScrollAction};

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -17,7 +17,8 @@ use xilem::view::{
     label, prose, task, textbox,
 };
 use xilem::{
-    Color, EventLoop, EventLoopBuilder, FontWeight, TextAlignment, WidgetView, Xilem, palette,
+    Color, EventLoop, EventLoopBuilder, FontWeight, InsertNewline, TextAlignment, WidgetView,
+    Xilem, palette,
 };
 const LOREM: &str = r"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi cursus mi sed euismod euismod. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam placerat efficitur tellus at semper. Morbi ac risus magna. Donec ut cursus ex. Etiam quis posuere tellus. Mauris posuere dui et turpis mollis, vitae luctus tellus consectetur. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eu facilisis nisl.
 
@@ -73,12 +74,15 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> + use<> {
                 // label("Disabled label").disabled(),
             ))
             .direction(Axis::Horizontal),
-            flex(textbox(
-                data.textbox_contents.clone(),
-                |data: &mut AppData, new_value| {
-                    data.textbox_contents = new_value;
-                },
-            ))
+            flex(
+                textbox(
+                    data.textbox_contents.clone(),
+                    |data: &mut AppData, new_value| {
+                        data.textbox_contents = new_value;
+                    },
+                )
+                .insert_newline(InsertNewline::OnEnter),
+            )
             .direction(Axis::Horizontal),
             prose(LOREM).alignment(TextAlignment::Middle).text_size(18.),
             button_any_pointer(button_label, |data: &mut AppData, button| match button {

--- a/xilem/examples/to_do_mvc.rs
+++ b/xilem/examples/to_do_mvc.rs
@@ -9,7 +9,7 @@
 
 use winit::error::EventLoopError;
 use xilem::view::{Axis, FlexSpacer, button, checkbox, flex, textbox};
-use xilem::{EventLoop, EventLoopBuilder, WidgetView, Xilem};
+use xilem::{EventLoop, EventLoopBuilder, InsertNewline, WidgetView, Xilem};
 
 struct Task {
     description: String,
@@ -40,6 +40,7 @@ fn app_logic(task_list: &mut TaskList) -> impl WidgetView<TaskList> + use<> {
             task_list.next_task = new_value;
         },
     )
+    .insert_newline(InsertNewline::OnShiftEnter)
     .on_enter(|task_list: &mut TaskList, _| {
         task_list.add_task();
     });

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -149,7 +149,7 @@ pub use masonry::kurbo::{Affine, Vec2};
 pub use masonry::parley::Alignment as TextAlignment;
 pub use masonry::parley::style::FontWeight;
 pub use masonry::peniko::Color;
-pub use masonry::widgets::LineBreaking;
+pub use masonry::widgets::{InsertNewline, LineBreaking};
 pub use masonry::{dpi, palette};
 pub use xilem_core as core;
 

--- a/xilem/src/view/textbox.rs
+++ b/xilem/src/view/textbox.rs
@@ -5,7 +5,7 @@ use masonry::widgets;
 use vello::peniko::Brush;
 
 use crate::core::{DynMessage, Mut, View, ViewMarker};
-use crate::{Color, MessageResult, Pod, TextAlignment, ViewCtx, ViewId};
+use crate::{Color, InsertNewline, MessageResult, Pod, TextAlignment, ViewCtx, ViewId};
 
 // FIXME - A major problem of the current approach (always setting the textbox contents)
 // is that if the user forgets to hook up the modify the state's contents in the callback,
@@ -25,6 +25,7 @@ where
         on_enter: None,
         text_brush: Color::WHITE.into(),
         alignment: TextAlignment::default(),
+        insert_newline: InsertNewline::default(),
         // TODO?: disabled: false,
     }
 }
@@ -37,6 +38,7 @@ pub struct Textbox<State, Action> {
     on_enter: Option<Callback<State, Action>>,
     text_brush: Brush,
     alignment: TextAlignment,
+    insert_newline: InsertNewline,
     // TODO: add more attributes of `masonry::widgets::TextBox`
 }
 
@@ -51,6 +53,12 @@ impl<State, Action> Textbox<State, Action> {
     /// Set the [alignment](https://en.wikipedia.org/wiki/Typographic_alignment) of the text.
     pub fn alignment(mut self, alignment: TextAlignment) -> Self {
         self.alignment = alignment;
+        self
+    }
+
+    /// Configures how this text area handles the user pressing Enter <kbd>↵</kbd>.
+    pub fn insert_newline(mut self, insert_newline: InsertNewline) -> Self {
+        self.insert_newline = insert_newline;
         self
     }
 
@@ -73,7 +81,8 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
         // TODO: Maybe we want a shared TextArea View?
         let text_area = widgets::TextArea::new_editable(&self.contents)
             .with_brush(self.text_brush.clone())
-            .with_alignment(self.alignment);
+            .with_alignment(self.alignment)
+            .with_insert_newline(self.insert_newline);
         let textbox = widgets::Textbox::from_text_area(text_area);
 
         // Ensure that the actions from the *inner* TextArea get routed correctly.
@@ -108,6 +117,9 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
         }
         if prev.alignment != self.alignment {
             widgets::TextArea::set_alignment(&mut text_area, self.alignment);
+        }
+        if prev.insert_newline != self.insert_newline {
+            widgets::TextArea::set_insert_newline(&mut text_area, self.insert_newline);
         }
     }
 


### PR DESCRIPTION
The textarea widget currently doesn't support multiline input because the Enter key is used to trigger the TextEntered action. This commit makes this behavior configurable by adding masonry_core::widgets::InsertNewline.