### PR TITLE
Fix bounding rectangles in accessibility nodes for text runs

### DIFF
--- a/masonry_core/src/widgets/label.rs
+++ b/masonry_core/src/widgets/label.rs
@@ -447,15 +447,14 @@ impl Widget for Label {
     }
 
     fn accessibility(&mut self, ctx: &mut AccessCtx, _props: &PropertiesRef<'_>, node: &mut Node) {
-        let window_origin = ctx.window_origin();
         self.accessibility.build_nodes(
             self.text.as_ref(),
             &self.text_layout,
             ctx.tree_update,
             node,
             || NodeId::from(WidgetId::next()),
-            window_origin.x + LABEL_X_PADDING,
-            window_origin.y,
+            LABEL_X_PADDING,
+            0.0,
         );
     }
 

--- a/masonry_core/src/widgets/text_area.rs
+++ b/masonry_core/src/widgets/text_area.rs
@@ -1016,14 +1016,13 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
         let (fctx, lctx) = ctx.text_contexts();
         let layout = self.editor.layout(fctx, lctx);
         let is_rtl = layout.is_rtl();
-        let origin = ctx.window_origin();
         self.editor
             .try_accessibility(
                 ctx.tree_update,
                 node,
                 || NodeId::from(WidgetId::next()),
-                origin.x + self.padding.get_left(is_rtl),
-                origin.y + self.padding.top,
+                self.padding.get_left(is_rtl),
+                self.padding.top,
             )
             .expect("We just performed a layout");
     }


### PR DESCRIPTION
It's no longer correct to add the window-relative origin of the widget to the bounding rectangles of the text runs, since we now apply a transform on each widget's AccessKit node.