### PR TITLE
masonry: Scroll by 120 logical pixels per line scroll increment.

### DIFF
--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -557,11 +557,12 @@ impl MasonryState<'_> {
                 }
             }
             WinitWindowEvent::MouseWheel { delta, .. } => {
-                // TODO - This delta value doesn't quite make sense.
-                // Figure out and document a better standard.
                 let delta = match delta {
+                    // 120 pixels is the default in Chrome and various other software
+                    // (when not overridden by configuration).
+                    // This is arbitrary, but better than nothing.
                     winit::event::MouseScrollDelta::LineDelta(x, y) => {
-                        LogicalPosition::new(x as f64, y as f64)
+                        LogicalPosition::new(120. * x as f64, 120. * y as f64)
                     }
                     winit::event::MouseScrollDelta::PixelDelta(delta) => {
                         delta.to_logical(window.scale_factor())


### PR DESCRIPTION
This is the default behavior in Chromium (when no configuration is provided) and is a better default than individual logical pixels.