### PR TITLE
Masonry: remove scrolling factor

### DIFF
--- a/masonry_core/src/widgets/portal.rs
+++ b/masonry_core/src/widgets/portal.rs
@@ -274,8 +274,6 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
         _props: &mut PropertiesMut<'_>,
         event: &PointerEvent,
     ) {
-        const SCROLLING_SPEED: f64 = 10.0;
-
         let portal_size = ctx.size();
         let content_size = ctx
             .get_raw_ref(&mut self.child)
@@ -285,7 +283,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
 
         match event {
             PointerEvent::MouseWheel(delta, _) => {
-                let delta = Vec2::new(delta.x * -SCROLLING_SPEED, delta.y * -SCROLLING_SPEED);
+                let delta = -Vec2::new(delta.x, delta.y);
                 self.set_viewport_pos_raw(portal_size, content_size, self.viewport_pos + delta);
                 ctx.request_compose();
 

--- a/masonry_core/src/widgets/virtual_scroll.rs
+++ b/masonry_core/src/widgets/virtual_scroll.rs
@@ -1007,7 +1007,7 @@ mod tests {
         assert_render_snapshot!(harness, "virtual_scroll_moved");
         harness.mouse_move_to(virtual_scroll_id);
         harness.process_pointer_event(PointerEvent::MouseWheel(
-            LogicalPosition::new(0., 2.5),
+            LogicalPosition::new(0., 25.),
             PointerState::empty(),
         ));
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
@@ -1199,7 +1199,7 @@ mod tests {
         }
         harness.mouse_move_to(virtual_scroll_id);
         harness.process_pointer_event(PointerEvent::MouseWheel(
-            LogicalPosition::new(0., -5.),
+            LogicalPosition::new(0., -50.),
             PointerState::empty(),
         ));
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
@@ -1212,7 +1212,7 @@ mod tests {
             assert_ne!(widget.active_range, original_range);
         }
         harness.process_pointer_event(PointerEvent::MouseWheel(
-            LogicalPosition::new(0., 6.),
+            LogicalPosition::new(0., 60.),
             PointerState::empty(),
         ));
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);

--- a/masonry_core/src/widgets/virtual_scroll.rs
+++ b/masonry_core/src/widgets/virtual_scroll.rs
@@ -472,11 +472,9 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for VirtualScroll<W> {
         _props: &mut PropertiesMut<'_>,
         event: &crate::core::PointerEvent,
     ) {
-        const SCROLLING_SPEED: f64 = 10.0;
-
         match event {
             PointerEvent::MouseWheel(delta, _) => {
-                let delta = delta.y * -SCROLLING_SPEED;
+                let delta = -delta.y;
                 self.scroll_offset_from_anchor += delta;
                 self.post_scroll(ctx);
             }


### PR DESCRIPTION
After https://github.com/linebender/xilem/pull/925, that 10x scrolling speed factor is no longer needed
