### PR TITLE
Update to latest Parley version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,15 +20,28 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "accesskit"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d3b8f9bae46a948369bc4a03e815d4ed6d616bd00de4051133a5019dc31c5a"
+checksum = "becf0eb5215b6ecb0a739c31c21bd83c4f326524c9b46b7e882d77559b60a529"
+
+[[package]]
+name = "accesskit_android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0af881ef4f4996d3cfc7333622e4f2f059c6b5a6749e286b6d7dae7b1e00ad72"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "jni",
+ "log",
+ "once_cell",
+]
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5dd55e6e94949498698daf4d48fb5659e824d7abec0d394089656ceaf99d4f"
+checksum = "ce9928251cd5651ae983a77aeaa528471eed47cf705885e0b03249b72fe4e8e1"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -40,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47983a1084940ba9a39c077a8c63e55c619388be5476ac04c804cfbd1e63459"
+checksum = "d0bf66a7bf0b7ea4fd7742d50b64782a88f99217cf246b3f93b4162528dde520"
 dependencies = [
  "accesskit",
  "hashbrown",
@@ -51,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_macos"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7329821f3bd1101e03a7d2e03bd339e3ac0dc64c70b4c9f9ae1949e3ba8dece1"
+checksum = "09e230718177753b4e4ad9e1d9f6cfc2f4921212d4c1c480b253f526babb258d"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -65,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcee751cc20d88678c33edaf9c07e8b693cd02819fe89053776f5313492273f5"
+checksum = "2ef06642e9f02f1708ad55e1eaeb8ad6956c22917699c4f313afa4f8f1b5e664"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -83,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fcd5d23d70670992b823e735e859374d694a3d12bfd8dd32bd3bd8bedb5d81"
+checksum = "65178f3df98a51e4238e584fcb255cb1a4f9111820848eeddd37663be40a625f"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -98,11 +111,12 @@ dependencies = [
 
 [[package]]
 name = "accesskit_winit"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6a48dad5530b6deb9fc7a52cc6c3bf72cdd9eb8157ac9d32d69f2427a5e879"
+checksum = "2c28531b0a1612b46d057a724a1e3de42a4bb101ff9f18c96c32f605b6e5ef06"
 dependencies = [
  "accesskit",
+ "accesskit_android",
  "accesskit_macos",
  "accesskit_unix",
  "accesskit_windows",
@@ -394,9 +408,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atspi"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be534b16650e35237bb1ed189ba2aab86ce65e88cc84c66f4935ba38575cecbf"
+checksum = "c83247582e7508838caf5f316c00791eee0e15c0bf743e6880585b867e16815c"
 dependencies = [
  "atspi-common",
  "atspi-connection",
@@ -405,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "atspi-common"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1909ed2dc01d0a17505d89311d192518507e8a056a48148e3598fef5e7bb6ba7"
+checksum = "33dfc05e7cdf90988a197803bf24f5788f94f7c94a69efa95683e8ffe76cfdfb"
 dependencies = [
  "enumflags2",
  "serde",
@@ -421,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "atspi-connection"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430c5960624a4baaa511c9c0fcc2218e3b58f5dbcc47e6190cafee344b873333"
+checksum = "4193d51303d8332304056ae0004714256b46b6635a5c556109b319c0d3784938"
 dependencies = [
  "atspi-common",
  "atspi-proxies",
@@ -433,14 +447,13 @@ dependencies = [
 
 [[package]]
 name = "atspi-proxies"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e6c5de3e524cf967569722446bcd458d5032348554d9a17d7d72b041ab7496"
+checksum = "d2eebcb9e7e76f26d0bcfd6f0295e1cd1e6f33bedbc5698a971db8dc43d7751c"
 dependencies = [
  "atspi-common",
  "serde",
  "zbus",
- "zvariant",
 ]
 
 [[package]]
@@ -517,15 +530,6 @@ name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block2"
@@ -783,15 +787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,16 +802,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "cursor-icon"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,16 +814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -1056,17 +1031,17 @@ dependencies = [
 [[package]]
 name = "fontique"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5fcb214137f01bc842c4fd633236255c51f8a24c6d3923eb8361c6d0940737"
+source = "git+https://github.com/linebender/parley?rev=8f343fa508bf727ff5cf6d49351cda1272f3626d#8f343fa508bf727ff5cf6d49351cda1272f3626d"
 dependencies = [
  "bytemuck",
  "fontconfig-cache-parser",
  "hashbrown",
  "icu_locid",
  "memmap2",
+ "objc2 0.6.1",
  "objc2-core-foundation",
  "objc2-core-text",
- "objc2-foundation 0.3.0",
+ "objc2-foundation 0.3.1",
  "peniko",
  "read-fonts",
  "roxmltree",
@@ -1241,16 +1216,6 @@ dependencies = [
  "log",
  "rustversion",
  "windows",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -2226,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3531f65190d9cff863b77a99857e74c314dd16bf56c538c4b57c7cbc3f3a6e59"
+checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
 dependencies = [
  "objc2-encode",
 ]
@@ -2287,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
  "bitflags 2.8.0",
 ]
@@ -2320,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-text"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fde15abfe00bf9f1eda220addbdfa6c62b0e5595e98208e8cdbc2ec0f6970a6"
+checksum = "3ba833d4a1cb1aac330f8c973fd92b6ff1858e4aef5cdd00a255eefb28022fb5"
 dependencies = [
  "bitflags 2.8.0",
  "objc2-core-foundation",
@@ -2349,12 +2314,12 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
+checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
  "bitflags 2.8.0",
- "objc2 0.6.0",
+ "objc2 0.6.1",
 ]
 
 [[package]]
@@ -2544,8 +2509,7 @@ dependencies = [
 [[package]]
 name = "parley"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1c2b33b240c246f06cfceac48dc6c96040cb177d2aa5348899982b298b5577"
+source = "git+https://github.com/linebender/parley?rev=8f343fa508bf727ff5cf6d49351cda1272f3626d#8f343fa508bf727ff5cf6d49351cda1272f3626d"
 dependencies = [
  "accesskit",
  "fontique",
@@ -2722,21 +2686,12 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -3186,17 +3141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3389,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "swash"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e25b48fd1c222c9fdb61148e2203b750f9840c07922fd61b87c6015560b8f6"
+checksum = "fae9a562c7b46107d9c78cd78b75bbe1e991c16734c0aee8ff0ee711fb8b620a"
 dependencies = [
  "skrifa",
  "yazi",
@@ -3644,7 +3588,7 @@ checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.24",
 ]
 
 [[package]]
@@ -3822,12 +3766,6 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
-
-[[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uds_windows"
@@ -4139,7 +4077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.36.2",
+ "quick-xml",
  "quote",
 ]
 
@@ -4615,9 +4553,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winit"
-version = "0.30.8"
+version = "0.30.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d74280aabb958072864bff6cfbcf9025cf8bfacdde5e32b5e12920ef703b0f"
+checksum = "a809eacf18c8eca8b6635091543f02a5a06ddf3dad846398795460e6e0ae3cc0"
 dependencies = [
  "ahash",
  "android-activity",
@@ -4670,6 +4608,15 @@ name = "winnow"
 version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]
@@ -4839,9 +4786,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "4.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+checksum = "59c333f648ea1b647bc95dc1d34807c8e25ed7a6feff3394034dc4776054b236"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -4856,19 +4803,17 @@ dependencies = [
  "enumflags2",
  "event-listener",
  "futures-core",
- "futures-sink",
- "futures-util",
+ "futures-lite",
  "hex",
  "nix",
  "ordered-stream",
- "rand",
  "serde",
  "serde_repr",
- "sha1",
  "static_assertions",
  "tracing",
  "uds_windows",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+ "winnow 0.7.7",
  "xdg-home",
  "zbus_macros",
  "zbus_names",
@@ -4877,9 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca2c5dceb099bddaade154055c926bb8ae507a18756ba1d8963fd7b51d8ed1d"
+checksum = "a22426b1bc2aca91de97772506f0655fa373448e6010d79d5d5880915c388409"
 dependencies = [
  "zbus_xml",
  "zvariant",
@@ -4887,9 +4832,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep-macros"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709ab20fc57cb22af85be7b360239563209258430bccf38d8b979c5a2ae3ecce"
+checksum = "100ffec29ed51859052f4563061abe35557acb56ba574510571f8398efc70a29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4901,35 +4846,38 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "4.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+checksum = "f325ad10eb0d0a3eb060203494c3b7ec3162a01a59db75d2deee100339709fc0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
+ "zbus_names",
+ "zvariant",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "3.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
+ "winnow 0.7.7",
  "zvariant",
 ]
 
 [[package]]
 name = "zbus_xml"
-version = "4.0.0"
+version = "5.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f374552b954f6abb4bd6ce979e6c9b38fb9d0cd7cc68a7d796e70c9f3a233"
+checksum = "589e9a02bfafb9754bb2340a9e3b38f389772684c63d9637e76b1870377bec29"
 dependencies = [
- "quick-xml 0.30.0",
+ "quick-xml",
  "serde",
  "static_assertions",
  "zbus_names",
@@ -5029,22 +4977,24 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "4.2.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+checksum = "b2df9ee044893fcffbdc25de30546edef3e32341466811ca18421e3cd6c5a3ac"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "static_assertions",
+ "winnow 0.7.7",
  "zvariant_derive",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "4.2.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+checksum = "74170caa85b8b84cc4935f2d56a57c7a15ea6185ccdd7eadb57e6edd90f94b2f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5055,11 +5005,14 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "2.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
 dependencies = [
  "proc-macro2",
  "quote",
+ "serde",
+ "static_assertions",
  "syn",
+ "winnow 0.7.7",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,9 +92,11 @@ tree_arena = { version = "0.1.0", path = "tree_arena" }
 vello = "0.4.0"
 wgpu = "23.0.1"
 kurbo = "0.11.1"
-parley = { version = "0.3.0", features = ["accesskit"] }
+parley = { git = "https://github.com/linebender/parley", rev = "8f343fa508bf727ff5cf6d49351cda1272f3626d", features = [
+    "accesskit",
+] }
 peniko = "0.3.1"
-winit = "0.30.4"
+winit = "0.30.9"
 tracing = { version = "0.1.40", default-features = false }
 smallvec = "1.13.2"
 hashbrown = "0.15.2"
@@ -102,8 +104,8 @@ dpi = "0.1.1"
 image = { version = "0.25.2", default-features = false }
 web-time = "1.1.0"
 bitflags = "2.6.0"
-accesskit = "0.17.0"
-accesskit_winit = "0.23.0"
+accesskit = "0.18.0"
+accesskit_winit = "0.24.0"
 time = "0.3.36"
 
 [profile.ci]

--- a/masonry/examples/screenshots/calc_masonry__tests__initial_screenshot.png
+++ b/masonry/examples/screenshots/calc_masonry__tests__initial_screenshot.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63fd5c557c3cd8575e3e34678aa36408385c53d401708c390574de30c91bc6c1
-size 11107
+oid sha256:7740a2e407b4a4e0e3b694dff3d31a97c5fae2d91d4099b97ae1bc591ff28782
+size 6147

--- a/masonry/examples/screenshots/grid_masonry__tests__initial_screenshot.png
+++ b/masonry/examples/screenshots/grid_masonry__tests__initial_screenshot.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4fb1e0aad3dc074028a723304a04af836d4496a547bc6377acd4f0ea4caeaacd
-size 17713
+oid sha256:cd62f75c8a9dd9ed4984af3704919e813e6e0d28883dbb7c1a7cf6088ef2f0fa
+size 17719

--- a/masonry/src/event_loop_runner.rs
+++ b/masonry/src/event_loop_runner.rs
@@ -257,7 +257,8 @@ impl MasonryState<'_> {
 
                 let window = event_loop.create_window(attributes).unwrap();
 
-                let adapter = Adapter::with_event_loop_proxy(&window, self.proxy.clone());
+                let adapter =
+                    Adapter::with_event_loop_proxy(event_loop, &window, self.proxy.clone());
                 let window = Arc::new(window);
                 // https://github.com/rust-windowing/winit/issues/2308
                 #[cfg(target_os = "ios")]

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, VecDeque};
 
 use accesskit::{ActionRequest, TreeUpdate};
 use anymap3::AnyMap;
-use parley::fontique::{self, Collection, CollectionOptions, SourceCache};
+use parley::fontique::{self, Blob, Collection, CollectionOptions, SourceCache};
 use parley::{FontContext, LayoutContext};
 use tracing::{info_span, warn};
 use tree_arena::{ArenaMut, TreeArena};
@@ -191,7 +191,7 @@ pub struct RenderRootOptions {
     ///
     /// We expect to develop a much more fully-featured font API in the future, but
     /// this is necessary for our testing of Masonry.
-    pub test_font: Option<Vec<u8>>,
+    pub test_font: Option<Blob<u8>>,
 }
 
 /// Objects emitted by the [`RenderRoot`] to signal that something has changed or require external actions.
@@ -428,12 +428,12 @@ impl RenderRoot {
     /// added to that family.
     pub fn register_fonts(
         &mut self,
-        data: Vec<u8>,
+        data: Blob<u8>,
     ) -> Vec<(fontique::FamilyId, Vec<fontique::FontInfo>)> {
         self.global_state
             .font_context
             .collection
-            .register_fonts(data)
+            .register_fonts(data, None)
     }
 
     /// Redraw the window.

--- a/masonry_core/src/core/text.rs
+++ b/masonry_core/src/core/text.rs
@@ -60,6 +60,10 @@ pub fn render_text(
             let PositionedLayoutItem::GlyphRun(glyph_run) = item else {
                 continue;
             };
+            // We need to round the baseline to pixels to avoid blurry text.
+            // https://github.com/linebender/parley/pull/297#issuecomment-2751450235
+            // TODO: Better handling of fractional DPI scaling?
+            let glyph_run_baseline = glyph_run.baseline().round();
             let style = glyph_run.style();
             // We draw underlines under the text, then the strikethrough on top, following:
             // https://drafts.csswg.org/css-text-decor/#painting-order
@@ -79,7 +83,7 @@ pub fn render_text(
                 // Remember that we are using a y-down coordinate system
                 // If there's a custom width, because this is an underline, we want the custom
                 // width to go down from the default expectation
-                let y = glyph_run.baseline() - offset + width / 2.;
+                let y = glyph_run_baseline - offset + width / 2.;
 
                 let line = Line::new(
                     (glyph_run.offset() as f64, y as f64),
@@ -94,7 +98,7 @@ pub fn render_text(
                 );
             }
             let mut x = glyph_run.offset();
-            let y = glyph_run.baseline();
+            let y = glyph_run_baseline;
             let run = glyph_run.run();
             let font = run.font();
             let font_size = run.font_size();
@@ -141,7 +145,7 @@ pub fn render_text(
                 // so we calculate the middle y-position of the strikethrough based on the font's
                 // standard strikethrough width.
                 // Remember that we are using a y-down coordinate system
-                let y = glyph_run.baseline() - offset + run_metrics.strikethrough_size / 2.;
+                let y = glyph_run_baseline - offset + run_metrics.strikethrough_size / 2.;
 
                 let line = Line::new(
                     (glyph_run.offset() as f64, y as f64),

--- a/masonry_core/src/passes/accessibility.rs
+++ b/masonry_core/src/passes/accessibility.rs
@@ -152,7 +152,6 @@ pub(crate) fn run_accessibility_pass(root: &mut RenderRoot, scale_factor: f64) -
         nodes: vec![],
         tree: Some(Tree {
             root: root.root.id().into(),
-            app_name: None,
             toolkit_name: Some("Masonry".to_string()),
             toolkit_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         }),

--- a/masonry_core/src/testing/harness.rs
+++ b/masonry_core/src/testing/harness.rs
@@ -7,6 +7,7 @@ use std::collections::VecDeque;
 use std::io::Cursor;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use cursor_icon::CursorIcon;
 use dpi::LogicalSize;
@@ -31,7 +32,7 @@ use crate::core::{
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::kurbo::{Point, Size, Vec2};
 use crate::passes::anim::run_update_anim_pass;
-use crate::peniko::Color;
+use crate::peniko::{Blob, Color};
 use crate::testing::screenshots::get_image_diff;
 use crate::testing::snapshot_utils::get_cargo_workspace;
 
@@ -242,7 +243,7 @@ impl TestHarness {
             env!("CARGO_MANIFEST_DIR"),
             "/resources/fonts/roboto/Roboto-Regular.ttf"
         ));
-        let data = ROBOTO.to_vec();
+        let data = Blob::new(Arc::new(ROBOTO));
 
         let mut harness = Self {
             render_root: RenderRoot::new(

--- a/masonry_core/src/widgets/screenshots/masonry_core__widgets__prose__tests__prose_alignment_flex.png
+++ b/masonry_core/src/widgets/screenshots/masonry_core__widgets__prose__tests__prose_alignment_flex.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5053f7d46e195e08fc65d39017ae1cbfe84a7be12c4b29c8beede5e27d100980
-size 1161
+oid sha256:64e4e04edfd985f1af3ac46aa54ccacc0235317b75f87a77349ae05b7a5dd865
+size 1159

--- a/masonry_core/src/widgets/screenshots/masonry_core__widgets__textbox__tests__textbox_outline.png
+++ b/masonry_core/src/widgets/screenshots/masonry_core__widgets__textbox__tests__textbox_outline.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d1b66b9135f40393a67bdc84e03df22d4fff994ce9a0034fd465dbd4327d83da
-size 1429
+oid sha256:ef9f2879c28bb2718470bab4f41caf32a5552ae94f402e6b8fc550db35b6aec5
+size 1431

--- a/masonry_core/src/widgets/screenshots/masonry_core__widgets__textbox__tests__textbox_selection.png
+++ b/masonry_core/src/widgets/screenshots/masonry_core__widgets__textbox__tests__textbox_selection.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a276946962c366ab4508baf08e71d746c8ffd5923d8953e4895c70b7af82c23
-size 1584
+oid sha256:1d634f4eb61e71f3098854cff92ef3ab41fe581dabaef4db9b5fd1c1708b3d01
+size 1598

--- a/masonry_core/src/widgets/screenshots/masonry_core__widgets__virtual_scroll__tests__virtual_scroll_basic.png
+++ b/masonry_core/src/widgets/screenshots/masonry_core__widgets__virtual_scroll__tests__virtual_scroll_basic.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e046e98457a12cee9128560232cd8778ecfd86289ea76ac03d04683332d5cfd3
-size 1465
+oid sha256:ee278e0d45902b31037400993741da8f6ee7bd1760f81aac7d7b23e62c109fa2
+size 1555

--- a/masonry_core/src/widgets/screenshots/masonry_core__widgets__virtual_scroll__tests__virtual_scroll_limited_up_bottom.png
+++ b/masonry_core/src/widgets/screenshots/masonry_core__widgets__virtual_scroll__tests__virtual_scroll_limited_up_bottom.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ecb40fb682d66737f40db36ce2c8f9ca4fe9e3bb3e6683db3e6db675337d630a
-size 612
+oid sha256:d6f23310ee20640233ef2450cd00cad125d6f256c4812f87938212ac5278e6fa
+size 606

--- a/masonry_core/src/widgets/screenshots/masonry_core__widgets__virtual_scroll__tests__virtual_scroll_moved.png
+++ b/masonry_core/src/widgets/screenshots/masonry_core__widgets__virtual_scroll__tests__virtual_scroll_moved.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6dac8b5e64c1843e669c4f5d3dd2297f9668a91b49c759af148e7a4e970b96e1
-size 2049
+oid sha256:b084fed1b9ccc9a3a5e05ad0193b8537a11b56f6391b322b1d05f3e952e28bd4
+size 2110

--- a/masonry_core/src/widgets/screenshots/masonry_core__widgets__virtual_scroll__tests__virtual_scroll_scrolled.png
+++ b/masonry_core/src/widgets/screenshots/masonry_core__widgets__virtual_scroll__tests__virtual_scroll_scrolled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ee3e308e1a6fb34a6fe3b5482abf2ae492f4017937fbaf1ec969bc7100f9003b
-size 2879
+oid sha256:105a926fa430d7a0ae4d0b34b34124922409b46ce9b3b3ab99a3985b1c04284c
+size 2894

--- a/masonry_core/src/widgets/text_area.rs
+++ b/masonry_core/src/widgets/text_area.rs
@@ -967,7 +967,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
         let origin = Vec2::new(self.padding.get_left(is_rtl), self.padding.top);
         let transform = Affine::translate(origin);
         if ctx.is_focus_target() {
-            for rect in self.editor.selection_geometry().iter() {
+            for (rect, _) in self.editor.selection_geometry().iter() {
                 // TODO: If window not focused, use a different color
                 // TODO: Make configurable
                 scene.fill(

--- a/xilem/examples/variable_clock.rs
+++ b/xilem/examples/variable_clock.rs
@@ -4,6 +4,7 @@
 //! This example uses variable fonts in a touch sensitive digital clock.
 #![expect(clippy::shadow_unrelated, reason = "Idiomatic for Xilem users")]
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use time::error::IndeterminateOffset;
@@ -15,7 +16,7 @@ use xilem::view::{
     Axis, FlexExt, FlexSpacer, button, flex, inline_prose, label, portal, prose, sized_box, task,
     variable_label,
 };
-use xilem::{EventLoop, EventLoopBuilder, FontWeight, WidgetView, Xilem, palette};
+use xilem::{Blob, EventLoop, EventLoopBuilder, FontWeight, WidgetView, Xilem, palette};
 
 /// The state of the application, owned by Xilem and updated by the callbacks below.
 struct Clocks {
@@ -191,7 +192,7 @@ fn run(event_loop: EventLoopBuilder) -> Result<(), EventLoopError> {
     };
 
     // Load Roboto Flex so that it can be used at runtime.
-    let app = Xilem::new(data, app_logic).with_font(ROBOTO_FLEX);
+    let app = Xilem::new(data, app_logic).with_font(Blob::new(Arc::new(ROBOTO_FLEX)));
 
     app.run_windowed(event_loop, "Clocks".into())?;
     Ok(())

--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use masonry::app::{AppDriver, EventLoopProxy, MasonryState, MasonryUserEvent};
 use masonry::core::WidgetId;
+use masonry::peniko::Blob;
 use masonry::widgets::RootWidget;
 
 use crate::core::{DynMessage, MessageResult, ProxyError, RawProxy, ViewId};
@@ -19,7 +20,7 @@ pub struct MasonryDriver<State, Logic, View, ViewState> {
     pub(crate) ctx: ViewCtx,
     pub(crate) view_state: ViewState,
     // Fonts which will be registered on startup.
-    pub(crate) fonts: Vec<Vec<u8>>,
+    pub(crate) fonts: Vec<Blob<u8>>,
 }
 
 /// The `WidgetId` which async events should be sent to.

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -148,7 +148,7 @@ pub use masonry::app::{EventLoop, EventLoopBuilder};
 pub use masonry::kurbo::{Affine, Vec2};
 pub use masonry::parley::Alignment as TextAlignment;
 pub use masonry::parley::style::FontWeight;
-pub use masonry::peniko::Color;
+pub use masonry::peniko::{Blob, Color};
 pub use masonry::widgets::{InsertNewline, LineBreaking};
 pub use masonry::{dpi, palette};
 pub use xilem_core as core;
@@ -174,7 +174,7 @@ pub struct Xilem<State, Logic> {
     runtime: tokio::runtime::Runtime,
     background_color: Color,
     // Font data to include in loading.
-    fonts: Vec<Vec<u8>>,
+    fonts: Vec<Blob<u8>>,
 }
 
 #[expect(missing_docs, reason = "TODO - Document these items")]
@@ -198,7 +198,7 @@ where
     /// Load a font when this `Xilem` is run.
     ///
     /// This is an interim API whilst font lifecycles are determined.
-    pub fn with_font(mut self, data: impl Into<Vec<u8>>) -> Self {
+    pub fn with_font(mut self, data: impl Into<Blob<u8>>) -> Self {
         self.fonts.push(data.into());
         self
     }


### PR DESCRIPTION
In order to deal with #933 I think we need some Parley changes. However, we're currently using `parley` v0.3.0 which is a bit different than what `main` looks like. So in anticipation of soon needing a Parley update I wanted to split the work and first make a PR that imports all the unrelated changes.

In addition to Parley being updated to the latest `main` revision, this PR also updates Winit and AccessKit to match what Parley expects.

The breaking AccessKit changes were trivial, just a few extra arguments to pass in.

Parley changes required a bit more work. Especially notable is that [vertical metrics are no longer rounded](https://github.com/linebender/parley/pull/297). The vertical metrics change alone caused half of Masonry's tests to fail. However, by doing glyph baseline rounding in Masonry [as insisted by Chad](https://github.com/linebender/parley/pull/297#issuecomment-2751450235) I got the failing test count down to 9. Those are caused by line spacing changes, which is expected behavior.

Here's an example of how baseline rounding improves pixel alignment (*1x scale factor original output, GIF has been been nearest neighbor upscaled*).

![change](https://github.com/user-attachments/assets/d7d4514a-c69d-4c76-add4-2cbb112704a8)
