### PR TITLE
Change how TextBox handles its padding

### DIFF
--- a/masonry_core/src/widgets/sized_box.rs
+++ b/masonry_core/src/widgets/sized_box.rs
@@ -88,22 +88,6 @@ impl Padding {
     /// A padding of zero for all edges.
     pub const ZERO: Self = Self::all(0.);
 
-    /// An empty padding which can be used as a sentinel value.
-    ///
-    /// If parent widgets wish to override a padding only if it has not been modified by the user,
-    /// they should use [`is_unset`](Self::is_unset) to determine that there were no modifications.
-    ///
-    /// Otherwise, this padding will behave as [`Padding::ZERO`].
-    pub const UNSET: Self = Self::all(-0.0);
-
-    /// Determine if self is [`Padding::UNSET`].
-    pub fn is_unset(self) -> bool {
-        is_negative_zero(self.top)
-            && is_negative_zero(self.leading)
-            && is_negative_zero(self.trailing)
-            && is_negative_zero(self.bottom)
-    }
-
     /// Constructs a new `Padding` with equal amount of padding for all edges.
     pub const fn all(padding: f64) -> Self {
         Self::new(padding, padding, padding, padding)
@@ -150,10 +134,6 @@ impl Padding {
     pub const fn get_right(self, is_rtl: bool) -> f64 {
         if is_rtl { self.leading } else { self.trailing }
     }
-}
-
-fn is_negative_zero(val: f64) -> bool {
-    val == 0.0 && val.is_sign_negative()
 }
 
 impl From<f64> for Padding {

--- a/masonry_core/src/widgets/text_area.rs
+++ b/masonry_core/src/widgets/text_area.rs
@@ -97,10 +97,7 @@ pub struct TextArea<const USER_EDITABLE: bool> {
     hint: bool,
     /// The amount of Padding inside this text area.
     ///
-    /// This is generally expected to be set by the parent, but
-    /// can also be overridden.
     /// Can be set using [`set_padding`](Self::set_padding).
-    /// Immediate parent widgets should use [`with_padding_if_default`](Self::with_padding_if_default).
     padding: Padding,
 
     /// What key combination should trigger a newline insertion.
@@ -150,9 +147,7 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
             brush: theme::TEXT_COLOR.into(),
             disabled_brush: Some(theme::DISABLED_TEXT_COLOR.into()),
             hint: true,
-            // We use -0.0 to mark the default padding.
-            // This allows parent views to overwrite it only if another source didn't configure it.
-            padding: Padding::UNSET,
+            padding: Padding::ZERO,
             insert_newline: InsertNewline::default(),
         }
     }
@@ -272,16 +267,6 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
     /// To modify this on an active text area, use [`set_padding`](Self::set_padding).
     pub fn with_padding(mut self, padding: impl Into<Padding>) -> Self {
         self.padding = padding.into();
-        self
-    }
-
-    /// Adds `padding` unless [`with_padding`](Self::with_padding) was previously called.
-    ///
-    /// This is expected to be called when creating parent widgets.
-    pub fn with_padding_if_default(mut self, padding: Padding) -> Self {
-        if self.padding.is_unset() {
-            self.padding = padding;
-        }
         self
     }
 

--- a/masonry_core/src/widgets/textbox.rs
+++ b/masonry_core/src/widgets/textbox.rs
@@ -16,6 +16,7 @@ use crate::peniko::Color;
 use crate::util::stroke;
 use crate::widgets::{Padding, TextArea};
 
+// TODO - Replace with Padding property.
 /// Added padding between each horizontal edge of the widget
 /// and the text in logical pixels.
 ///
@@ -54,7 +55,6 @@ impl Textbox {
 
     /// Create a new `Textbox` from a styled text area.
     pub fn from_text_area(text: TextArea<true>) -> Self {
-        let text = text.with_padding_if_default(TEXTBOX_PADDING);
         Self {
             text: WidgetPod::new(text),
             clip: false,
@@ -147,17 +147,26 @@ impl Widget for Textbox {
         bc: &BoxConstraints,
     ) -> Size {
         let margin = TEXTBOX_MARGIN;
+        let padding = TEXTBOX_PADDING;
         // Shrink constraints by padding inset
         let margin_size = Size::new(margin.leading + margin.trailing, margin.top + margin.bottom);
+        let padding_size = Size::new(
+            padding.leading + padding.trailing,
+            padding.top + padding.bottom,
+        );
         let child_bc = bc.shrink(margin_size);
+        let child_bc = child_bc.shrink(padding_size);
         // TODO: Set minimum to deal with alignment
         let size = ctx.run_layout(&mut self.text, &child_bc);
         // TODO: How do we handle RTL here?
-        ctx.place_child(&mut self.text, Point::new(margin.leading, margin.top));
+        ctx.place_child(
+            &mut self.text,
+            Point::new(margin.leading + padding.leading, margin.top + padding.top),
+        );
         if self.clip {
             ctx.set_clip_path(Rect::from_origin_size(Point::ORIGIN, size));
         }
-        size + margin_size
+        size + margin_size + padding_size
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, _props: &PropertiesRef<'_>, scene: &mut Scene) {


### PR DESCRIPTION
Remove `with_padding_if_default` method and all related code.
Remove concept of "unset" padding.

Depends on #942.