### PR TITLE
Merge Padding structs into one

### DIFF
--- a/masonry_core/src/properties/padding.rs
+++ b/masonry_core/src/properties/padding.rs
@@ -6,15 +6,117 @@ use std::any::TypeId;
 use crate::core::{BoxConstraints, Property, UpdateCtx};
 use crate::kurbo::{Point, Size, Vec2};
 
-/// The width of padding between a widget's border and its contents.
-#[expect(missing_docs, reason = "obvious")]
-#[derive(Default, Clone, Copy, Debug)]
+/// The amount of space between a widget's border and its contents.
+///
+/// Padding can be constructed using [`from(value: f64)`][Self::from]
+/// as well as from a `(f64, f64)` tuple, or `(f64, f64, f64, f64)` tuple, following the CSS padding conventions.
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Padding {
-    pub x: f64,
-    pub y: f64,
+    /// The amount of padding in logical pixels for the left edge.
+    pub left: f64,
+    /// The amount of padding in logical pixels for the right edge.
+    pub right: f64,
+    /// The amount of padding in logical pixels for the top edge.
+    pub top: f64,
+    /// The amount of padding in logical pixels for the bottom edge.
+    pub bottom: f64,
 }
 
 impl Property for Padding {}
+
+impl From<f64> for Padding {
+    /// Converts the value to a `Padding` object with that amount of padding on all edges.
+    fn from(value: f64) -> Self {
+        Self::all(value)
+    }
+}
+
+impl Padding {
+    /// A padding of zero for all edges.
+    pub const ZERO: Self = Self::all(0.);
+
+    /// Constructs a new `Padding` with equal amount of padding for all edges.
+    pub const fn all(padding: f64) -> Self {
+        Self {
+            top: padding,
+            bottom: padding,
+            left: padding,
+            right: padding,
+        }
+    }
+
+    /// Constructs a new `Padding` with the same amount of padding for the horizontal edges,
+    /// and zero padding for the vertical edges.
+    pub const fn horizontal(padding: f64) -> Self {
+        Self {
+            top: 0.,
+            bottom: 0.,
+            left: padding,
+            right: padding,
+        }
+    }
+
+    /// Constructs a new `Padding` with the same amount of padding for the vertical edges,
+    /// and zero padding for the horizontal edges.
+    pub const fn vertical(padding: f64) -> Self {
+        Self {
+            top: padding,
+            bottom: padding,
+            left: 0.,
+            right: 0.,
+        }
+    }
+
+    /// Constructs a new `Padding` with the same padding from both vertical edges, then both horizontal edges.
+    pub const fn from_vh(vertical: f64, horizontal: f64) -> Self {
+        Self {
+            top: vertical,
+            bottom: vertical,
+            left: horizontal,
+            right: horizontal,
+        }
+    }
+
+    /// Constructs a new `Padding` with padding only at the top edge and zero padding for all other edges.
+    pub const fn top(padding: f64) -> Self {
+        Self {
+            top: padding,
+            bottom: 0.,
+            left: 0.,
+            right: 0.,
+        }
+    }
+
+    /// Constructs a new `Padding` with padding only at the trailing edge and zero padding for all other edges.
+    pub const fn trailing(padding: f64) -> Self {
+        Self {
+            top: 0.,
+            bottom: 0.,
+            left: 0.,
+            right: padding,
+        }
+    }
+
+    /// Constructs a new `Padding` with padding only at the bottom edge and zero padding for all other edges.
+    pub const fn bottom(padding: f64) -> Self {
+        Self {
+            top: 0.,
+            bottom: padding,
+            left: 0.,
+            right: 0.,
+        }
+    }
+
+    /// Constructs a new `Padding` with padding only at the leading edge and zero padding for all other edges.
+    pub const fn leading(padding: f64) -> Self {
+        Self {
+            top: 0.,
+            bottom: 0.,
+            left: padding,
+            right: 0.,
+        }
+    }
+}
 
 impl Padding {
     /// Helper function to be called in [`Widget::property_changed`](crate::core::Widget::property_changed).
@@ -29,15 +131,18 @@ impl Padding {
     ///
     /// Helper function to be called in [`Widget::layout`](crate::core::Widget::layout).
     pub fn layout_down(&self, bc: BoxConstraints) -> BoxConstraints {
-        bc.shrink((self.x * 2., self.y * 2.))
+        bc.shrink((self.left + self.right, self.top + self.bottom))
     }
 
     /// Expands the size and raises the baseline by the padding amount.
     ///
     /// Helper function to be called in [`Widget::layout`](crate::core::Widget::layout).
     pub fn layout_up(&self, size: Size, baseline: f64) -> (Size, f64) {
-        let size = Size::new(size.width + self.x * 2., size.height + self.y * 2.);
-        let baseline = baseline + self.y;
+        let size = Size::new(
+            size.width + self.left + self.right,
+            size.height + self.top + self.bottom,
+        );
+        let baseline = baseline + self.bottom;
         (size, baseline)
     }
 
@@ -45,6 +150,6 @@ impl Padding {
     ///
     /// Helper function to be called in [`Widget::layout`](crate::core::Widget::layout).
     pub fn place_down(&self, pos: Point) -> Point {
-        pos + Vec2::new(self.x, self.y)
+        pos + Vec2::new(self.left, self.top)
     }
 }

--- a/masonry_core/src/widgets/button.rs
+++ b/masonry_core/src/widgets/button.rs
@@ -35,7 +35,7 @@ const DEFAULT_BORDER_RADII: CornerRadius = CornerRadius {
 
 // NOTE: these values are chosen to match the existing look of TextBox; these
 // should be reevaluated at some point.
-const DEFAULT_PADDING: Padding = Padding { x: 8., y: 2. };
+const DEFAULT_PADDING: Padding = Padding::from_vh(2., 8.);
 
 /// A button with a text label.
 ///
@@ -365,7 +365,7 @@ mod tests {
             button.insert_prop(BorderColor { color: red });
             button.insert_prop(BorderWidth { width: 5.0 });
             button.insert_prop(CornerRadius { radius: 20.0 });
-            button.insert_prop(Padding { x: 8.0, y: 3.0 });
+            button.insert_prop(Padding::from_vh(3., 8.));
 
             let mut label = Button::label_mut(&mut button);
             Label::set_brush(&mut label, red);

--- a/masonry_core/src/widgets/mod.rs
+++ b/masonry_core/src/widgets/mod.rs
@@ -39,7 +39,7 @@ pub use self::progress_bar::ProgressBar;
 pub use self::prose::Prose;
 pub use self::root_widget::RootWidget;
 pub use self::scroll_bar::ScrollBar;
-pub use self::sized_box::{Padding, SizedBox};
+pub use self::sized_box::SizedBox;
 pub use self::spinner::Spinner;
 pub use self::split::Split;
 pub use self::text_area::{InsertNewline, TextArea};

--- a/masonry_core/src/widgets/sized_box.rs
+++ b/masonry_core/src/widgets/sized_box.rs
@@ -18,7 +18,7 @@ use crate::core::{
     WidgetMut, WidgetPod,
 };
 use crate::kurbo::{Point, Size};
-use crate::properties::Background;
+use crate::properties::{Background, Padding};
 use crate::util::stroke;
 
 // FIXME - Improve all doc in this module ASAP.
@@ -27,26 +27,6 @@ use crate::util::stroke;
 struct BorderStyle {
     width: f64,
     brush: Brush,
-}
-
-/// Padding specifies the spacing between the edges of the box and the child view.
-///
-/// A Padding can also be constructed using [`from(value: f64)`][Self::from]
-/// as well as from a `(f64, f64)` tuple, or `(f64, f64, f64, f64)` tuple, following the CSS padding conventions.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Padding {
-    /// The amount of padding in logical pixels for the top edge.
-    pub top: f64,
-    /// The amount of padding in logical pixels for the trailing edge.
-    ///
-    /// For LTR contexts this is the right edge, for RTL it is the left edge.
-    pub trailing: f64,
-    /// The amount of padding in logical pixels for the bottom edge.
-    pub bottom: f64,
-    /// The amount of padding in logical pixels for the leading edge.
-    ///
-    /// For LTR contexts this is the left edge, for RTL it is the right edge.
-    pub leading: f64,
 }
 
 // TODO - Have Widget type as generic argument
@@ -70,93 +50,6 @@ pub struct SizedBox {
     border: Option<BorderStyle>,
     corner_radius: RoundedRectRadii,
     padding: Padding,
-}
-
-// --- MARK: IMPL PADDING ---
-
-impl Padding {
-    /// Constructs a new `Padding` by specifying the amount of padding for each edge.
-    pub const fn new(top: f64, trailing: f64, bottom: f64, leading: f64) -> Self {
-        Self {
-            top,
-            trailing,
-            bottom,
-            leading,
-        }
-    }
-
-    /// A padding of zero for all edges.
-    pub const ZERO: Self = Self::all(0.);
-
-    /// Constructs a new `Padding` with equal amount of padding for all edges.
-    pub const fn all(padding: f64) -> Self {
-        Self::new(padding, padding, padding, padding)
-    }
-
-    /// Constructs a new `Padding` with the same amount of padding for the horizontal edges,
-    /// and zero padding for the vertical edges.
-    pub const fn horizontal(padding: f64) -> Self {
-        Self::new(0., padding, 0., padding)
-    }
-
-    /// Constructs a new `Padding` with the same amount of padding for the vertical edges,
-    /// and zero padding for the horizontal edges.
-    pub const fn vertical(padding: f64) -> Self {
-        Self::new(padding, 0., padding, 0.)
-    }
-
-    /// Constructs a new `Padding` with padding only at the top edge and zero padding for all other edges.
-    pub const fn top(padding: f64) -> Self {
-        Self::new(padding, 0., 0., 0.)
-    }
-
-    /// Constructs a new `Padding` with padding only at the trailing edge and zero padding for all other edges.
-    pub const fn trailing(padding: f64) -> Self {
-        Self::new(0., padding, 0., 0.)
-    }
-
-    /// Constructs a new `Padding` with padding only at the bottom edge and zero padding for all other edges.
-    pub const fn bottom(padding: f64) -> Self {
-        Self::new(0., 0., padding, 0.)
-    }
-
-    /// Constructs a new `Padding` with padding only at the leading edge and zero padding for all other edges.
-    pub const fn leading(padding: f64) -> Self {
-        Self::new(0., 0., 0., padding)
-    }
-
-    /// Get the padding to the left, given whether we're in a right-to-left context.
-    pub const fn get_left(self, is_rtl: bool) -> f64 {
-        if is_rtl { self.trailing } else { self.leading }
-    }
-
-    /// Get the padding to the right, given whether we're in a right-to-left context.
-    pub const fn get_right(self, is_rtl: bool) -> f64 {
-        if is_rtl { self.leading } else { self.trailing }
-    }
-}
-
-impl From<f64> for Padding {
-    /// Converts the value to a `Padding` object with that amount of padding on all edges.
-    fn from(value: f64) -> Self {
-        Self::all(value)
-    }
-}
-
-impl From<(f64, f64, f64, f64)> for Padding {
-    /// Converts the tuple to a `Padding` object,
-    /// following CSS padding order for 4 values (top, trailing, bottom, leading).
-    fn from(value: (f64, f64, f64, f64)) -> Self {
-        Self::new(value.0, value.1, value.2, value.3)
-    }
-}
-
-impl From<(f64, f64)> for Padding {
-    /// Converts the tuple to a `Padding` object,
-    /// following CSS padding order for 2 values (vertical, horizontal)
-    fn from(value: (f64, f64)) -> Self {
-        Self::new(value.0, value.1, value.0, value.1)
-    }
 }
 
 // --- MARK: BUILDERS ---
@@ -495,11 +388,11 @@ impl Widget for SizedBox {
 
         // Shrink constraints by padding inset
         let padding_size = Size::new(
-            self.padding.leading + self.padding.trailing,
+            self.padding.left + self.padding.right,
             self.padding.top + self.padding.bottom,
         );
         let child_bc = child_bc.shrink(padding_size);
-        let origin = origin + (self.padding.leading, self.padding.top);
+        let origin = origin + (self.padding.left, self.padding.top);
 
         let mut size;
         match self.child.as_mut() {
@@ -668,7 +561,7 @@ mod tests {
         let widget = SizedBox::new(Label::new("hello"))
             .border(palette::css::BLUE, 5.0)
             .rounded(5.0)
-            .padding((15., 10.));
+            .padding(Padding::from_vh(15., 10.));
 
         let window_size = Size::new(100.0, 100.0);
         let mut harness = TestHarness::create_with_size(widget, window_size);

--- a/masonry_core/src/widgets/text_area.rs
+++ b/masonry_core/src/widgets/text_area.rs
@@ -11,7 +11,7 @@ use parley::layout::Alignment;
 use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Affine, Point, Rect, Size, Vec2};
+use vello::kurbo::{Affine, Point, Rect, Size};
 use vello::peniko::{Brush, Fill};
 
 use crate::core::{
@@ -21,7 +21,6 @@ use crate::core::{
     keyboard::{Key, KeyState, NamedKey},
     render_text,
 };
-use crate::widgets::Padding;
 use crate::{palette, theme};
 use cursor_icon::CursorIcon;
 
@@ -95,10 +94,6 @@ pub struct TextArea<const USER_EDITABLE: bool> {
     /// Can be set using [`set_hint`](Self::set_hint).
     // TODO: What classes of animations? I.e does scrolling count?
     hint: bool,
-    /// The amount of Padding inside this text area.
-    ///
-    /// Can be set using [`set_padding`](Self::set_padding).
-    padding: Padding,
 
     /// What key combination should trigger a newline insertion.
     /// If this is set to `InsertNewline::OnEnter` then `Enter` will insert a newline and _not_ trigger a `TextEntered` event.
@@ -147,7 +142,6 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
             brush: theme::TEXT_COLOR.into(),
             disabled_brush: Some(theme::DISABLED_TEXT_COLOR.into()),
             hint: true,
-            padding: Padding::ZERO,
             insert_newline: InsertNewline::default(),
         }
     }
@@ -260,16 +254,6 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
         self
     }
 
-    /// Set the padding around the text.
-    ///
-    /// This is the area outside the tight bound on the text where pointer events will be detected.
-    ///
-    /// To modify this on an active text area, use [`set_padding`](Self::set_padding).
-    pub fn with_padding(mut self, padding: impl Into<Padding>) -> Self {
-        self.padding = padding.into();
-        self
-    }
-
     /// Configures how this text area handles the user pressing Enter <kbd>↵</kbd>.
     pub fn with_insert_newline(mut self, insert_newline: InsertNewline) -> Self {
         self.insert_newline = insert_newline;
@@ -304,12 +288,7 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
             self.editor.try_layout().is_some(),
             "TextArea::ime_area should only be called when the editor layout is available"
         );
-        let is_rtl = self
-            .editor
-            .try_layout()
-            .map(|layout| layout.is_rtl())
-            .unwrap_or(false);
-        self.editor.ime_cursor_area() + Vec2::new(self.padding.get_left(is_rtl), self.padding.top)
+        self.editor.ime_cursor_area()
     }
 }
 
@@ -469,18 +448,6 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
         this.ctx.request_paint_only();
     }
 
-    /// Set the padding around the text.
-    ///
-    /// This is the area outside the tight bound on the text where pointer events will be detected.
-    ///
-    /// The runtime equivalent of [`with_padding`](Self::with_padding).
-    pub fn set_padding(this: &mut WidgetMut<'_, Self>, padding: impl Into<Padding>) {
-        this.widget.padding = padding.into();
-        // TODO: We could reset the width available to the editor here directly.
-        // Determine whether there's any advantage to that
-        this.ctx.request_layout();
-    }
-
     /// Set the selection to the given byte range.
     ///
     /// No-op if either index is not a char boundary.
@@ -519,9 +486,6 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
             return;
         }
 
-        let (fctx, lctx) = ctx.text_contexts();
-        let is_rtl = self.editor.layout(fctx, lctx).is_rtl();
-        let padding = Vec2::new(self.padding.get_left(is_rtl), self.padding.top);
         match event {
             PointerEvent::Down { button, state, .. } => {
                 if !ctx.is_disabled() && matches!(button, None | Some(PointerButton::Primary)) {
@@ -537,7 +501,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
                     }
                     self.last_click_time = Some(now);
                     let click_count = self.click_count;
-                    let cursor_pos = ctx.local_position(state.position) - padding;
+                    let cursor_pos = ctx.local_position(state.position);
                     let (fctx, lctx) = ctx.text_contexts();
                     let mut drv = self.editor.driver(fctx, lctx);
                     match click_count {
@@ -557,7 +521,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
             }
             PointerEvent::Move(u) => {
                 if !ctx.is_disabled() && ctx.is_pointer_capture_target() {
-                    let cursor_pos = ctx.local_position(u.current.position) - padding;
+                    let cursor_pos = ctx.local_position(u.current.position);
                     let (fctx, lctx) = ctx.text_contexts();
                     self.editor
                         .driver(fctx, lctx)
@@ -890,15 +854,8 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
         _props: &mut PropertiesMut<'_>,
         bc: &BoxConstraints,
     ) -> Size {
-        // Shrink constraints by padding inset
-        let padding_size = Size::new(
-            self.padding.leading + self.padding.trailing,
-            self.padding.top + self.padding.bottom,
-        );
-        let sub_bc = bc.shrink(padding_size);
-
         let available_width = if bc.max().width.is_finite() {
-            Some((sub_bc.max().width) as f32)
+            Some((bc.max().width) as f32)
         } else {
             None
         };
@@ -925,8 +882,8 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
         ctx.set_ime_area(self.ime_area());
 
         let area_size = Size {
-            height: text_size.height + padding_size.height,
-            width: text_size.width + padding_size.width,
+            height: text_size.height,
+            width: text_size.width,
         };
         bc.constrain(area_size)
     }
@@ -941,16 +898,13 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
             self.editor.refresh_layout(fctx, lctx);
             self.editor.try_layout().unwrap()
         };
-        let is_rtl = layout.is_rtl();
-        let origin = Vec2::new(self.padding.get_left(is_rtl), self.padding.top);
-        let transform = Affine::translate(origin);
         if ctx.is_focus_target() {
             for (rect, _) in self.editor.selection_geometry().iter() {
                 // TODO: If window not focused, use a different color
                 // TODO: Make configurable
                 scene.fill(
                     Fill::NonZero,
-                    transform,
+                    Affine::IDENTITY,
                     palette::css::STEEL_BLUE,
                     None,
                     &rect,
@@ -958,7 +912,13 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
             }
             if let Some(cursor) = self.editor.cursor_geometry(1.5) {
                 // TODO: Make configurable
-                scene.fill(Fill::NonZero, transform, palette::css::WHITE, None, &cursor);
+                scene.fill(
+                    Fill::NonZero,
+                    Affine::IDENTITY,
+                    palette::css::WHITE,
+                    None,
+                    &cursor,
+                );
             };
         }
 
@@ -969,7 +929,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
         } else {
             self.brush.clone()
         };
-        render_text(scene, transform, layout, &[brush], self.hint);
+        render_text(scene, Affine::IDENTITY, layout, &[brush], self.hint);
     }
 
     fn get_cursor(&self, _ctx: &QueryCtx, _pos: Point) -> CursorIcon {
@@ -991,16 +951,13 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
         if !EDITABLE {
             node.set_read_only();
         }
-        let (fctx, lctx) = ctx.text_contexts();
-        let layout = self.editor.layout(fctx, lctx);
-        let is_rtl = layout.is_rtl();
         self.editor
             .try_accessibility(
                 ctx.tree_update,
                 node,
                 || NodeId::from(WidgetId::next()),
-                self.padding.get_left(is_rtl),
-                self.padding.top,
+                0.,
+                0.,
             )
             .expect("We just performed a layout");
     }

--- a/masonry_core/src/widgets/textbox.rs
+++ b/masonry_core/src/widgets/textbox.rs
@@ -13,8 +13,9 @@ use crate::core::{
     WidgetId, WidgetMut, WidgetPod,
 };
 use crate::peniko::Color;
+use crate::properties::Padding;
 use crate::util::stroke;
-use crate::widgets::{Padding, TextArea};
+use crate::widgets::TextArea;
 
 // TODO - Replace with Padding property.
 /// Added padding between each horizontal edge of the widget
@@ -149,19 +150,15 @@ impl Widget for Textbox {
         let margin = TEXTBOX_MARGIN;
         let padding = TEXTBOX_PADDING;
         // Shrink constraints by padding inset
-        let margin_size = Size::new(margin.leading + margin.trailing, margin.top + margin.bottom);
-        let padding_size = Size::new(
-            padding.leading + padding.trailing,
-            padding.top + padding.bottom,
-        );
+        let margin_size = Size::new(margin.left + margin.left, margin.top + margin.bottom);
+        let padding_size = Size::new(padding.left + padding.left, padding.top + padding.bottom);
         let child_bc = bc.shrink(margin_size);
         let child_bc = child_bc.shrink(padding_size);
         // TODO: Set minimum to deal with alignment
         let size = ctx.run_layout(&mut self.text, &child_bc);
-        // TODO: How do we handle RTL here?
         ctx.place_child(
             &mut self.text,
-            Point::new(margin.leading + padding.leading, margin.top + padding.top),
+            Point::new(margin.left + padding.left, margin.top + padding.top),
         );
         if self.clip {
             ctx.set_clip_path(Rect::from_origin_size(Point::ORIGIN, size));
@@ -173,9 +170,9 @@ impl Widget for Textbox {
         let size = ctx.size();
         let border_width = 1.0;
         let outline_rect = size.to_rect().inset(Insets::new(
-            -TEXTBOX_MARGIN.leading - border_width / 2.,
+            -TEXTBOX_MARGIN.left - border_width / 2.,
             -TEXTBOX_MARGIN.top - border_width / 2.,
-            -TEXTBOX_MARGIN.trailing - border_width / 2.,
+            -TEXTBOX_MARGIN.left - border_width / 2.,
             -TEXTBOX_MARGIN.bottom - border_width / 2.,
         ));
         stroke(scene, &outline_rect, Color::WHITE, border_width);

--- a/xilem/examples/http_cats.rs
+++ b/xilem/examples/http_cats.rs
@@ -193,7 +193,12 @@ impl Status {
                     .rounded(4.)
                     .background(palette::css::BLACK.multiply_alpha(0.5)),
                 )
-                .padding((30., 42., 0., 0.));
+                .padding(Padding {
+                    left: 0.,
+                    right: 42.,
+                    top: 30.,
+                    bottom: 0.,
+                });
                 OneOf3::C(zstack((
                     image(image_data),
                     attribution.alignment(Alignment::TopTrailing),

--- a/xilem/examples/virtual_cats.rs
+++ b/xilem/examples/virtual_cats.rs
@@ -102,7 +102,12 @@ impl VirtualCats {
                 .rounded(4.)
                 .background(palette::css::BLACK.multiply_alpha(0.5)),
             )
-            .padding((30., 42., 0., 0.));
+            .padding(Padding {
+                left: 0.,
+                right: 42.,
+                top: 30.,
+                bottom: 0.,
+            });
             Either::A(zstack((
                 image(img).fit(ObjectFit::FitWidth),
                 attribution.alignment(Alignment::TopTrailing),

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -3,8 +3,8 @@
 
 use std::marker::PhantomData;
 
+pub use masonry::properties::Padding;
 use masonry::widgets;
-pub use masonry::widgets::Padding;
 use vello::kurbo::RoundedRectRadii;
 use vello::peniko::Brush;
 
@@ -23,7 +23,7 @@ use crate::{Pod, ViewCtx, WidgetView};
 /// use xilem::view::{sized_box, button};
 /// use xilem::palette;
 /// use vello::kurbo::RoundedRectRadii;
-/// use masonry::widgets::Padding;
+/// use masonry::properties::Padding;
 ///
 /// sized_box(button("Button", |data: &mut i32| *data+=1))
 ///     .expand()


### PR DESCRIPTION
Rename "leading" to "left", "trailing" to "right", remove any mentions of RTL, etc.
See https://xi.zulipchat.com/#narrow/channel/317477-masonry/topic/Remove.20bidi.20references.20from.20Masonry.20code/with/515690264 for rationale.