### PR TITLE
Add default property values and a default theme.

### DIFF
--- a/masonry/src/app/render_root.rs
+++ b/masonry/src/app/render_root.rs
@@ -40,7 +40,6 @@ use crate::passes::update::{
     run_update_widget_tree_pass,
 };
 use crate::passes::{PassTracing, recurse_on_children};
-use crate::theme::default_property_set;
 use crate::util::AnyMap;
 use cursor_icon::CursorIcon;
 
@@ -174,6 +173,9 @@ pub enum WindowSizePolicy {
 
 /// Options for creating a [`RenderRoot`].
 pub struct RenderRootOptions {
+    /// Default values that Properties will have if not defined per-widget.
+    pub default_properties: DefaultProperties,
+
     /// If true, `fontique` will provide access to system fonts
     /// using platform-specific APIs.
     pub use_system_fonts: bool,
@@ -252,6 +254,7 @@ impl RenderRoot {
     /// look for `masonry_winit::app::run` instead.
     pub fn new(root_widget: impl Widget, options: RenderRootOptions) -> Self {
         let RenderRootOptions {
+            default_properties,
             use_system_fonts,
             size_policy,
             scale_factor,
@@ -265,7 +268,7 @@ impl RenderRoot {
             size: PhysicalSize::new(0, 0),
             last_anim: None,
             last_mouse_pos: None,
-            default_properties: default_property_set(),
+            default_properties,
             global_state: RenderRootState {
                 signal_queue: VecDeque::new(),
                 focused_widget: None,

--- a/masonry/src/app/render_root.rs
+++ b/masonry/src/app/render_root.rs
@@ -71,6 +71,9 @@ pub struct RenderRoot {
     /// Last mouse position. Updated by `on_pointer_event` pass, used by other passes.
     pub(crate) last_mouse_pos: Option<LogicalPosition<f64>>,
 
+    /// Default values that Properties will have if not defined per-widget.
+    pub(crate) default_properties: AnyMap,
+
     /// State passed to context types.
     pub(crate) global_state: RenderRootState,
 
@@ -261,6 +264,7 @@ impl RenderRoot {
             size: PhysicalSize::new(0, 0),
             last_anim: None,
             last_mouse_pos: None,
+            default_properties: AnyMap::new(),
             global_state: RenderRootState {
                 signal_queue: VecDeque::new(),
                 focused_widget: None,
@@ -494,16 +498,13 @@ impl RenderRoot {
             widget_state_children: state_ref.children,
             widget_children: widget_ref.children,
             widget_state: state_ref.item,
+            properties: PropertiesRef {
+                map: properties_ref.item,
+                default_map: &self.default_properties,
+            },
             properties_children: properties_ref.children,
         };
-        let properties = PropertiesRef {
-            map: properties_ref.item,
-        };
-        WidgetRef {
-            ctx,
-            properties,
-            widget,
-        }
+        WidgetRef { ctx, widget }
     }
 
     /// Get a [`WidgetRef`] to a specific widget.
@@ -526,16 +527,13 @@ impl RenderRoot {
             widget_state_children: state_ref.children,
             widget_children: widget_ref.children,
             widget_state: state_ref.item,
+            properties: PropertiesRef {
+                map: properties_ref.item,
+                default_map: &self.default_properties,
+            },
             properties_children: properties_ref.children,
         };
-        let properties = PropertiesRef {
-            map: properties_ref.item,
-        };
-        Some(WidgetRef {
-            ctx,
-            properties,
-            widget,
-        })
+        Some(WidgetRef { ctx, widget })
     }
 
     /// Get a [`WidgetMut`] to the root widget.

--- a/masonry/src/app/render_root.rs
+++ b/masonry/src/app/render_root.rs
@@ -20,9 +20,9 @@ use web_time::Instant;
 
 use crate::Handled;
 use crate::core::{
-    AccessEvent, Action, BrushIndex, Ime, PointerEvent, PropertiesRef, QueryCtx, ResizeDirection,
-    TextEvent, Widget, WidgetArena, WidgetId, WidgetMut, WidgetPod, WidgetRef, WidgetState,
-    WindowEvent,
+    AccessEvent, Action, BrushIndex, DefaultProperties, Ime, PointerEvent, PropertiesRef, QueryCtx,
+    ResizeDirection, TextEvent, Widget, WidgetArena, WidgetId, WidgetMut, WidgetPod, WidgetRef,
+    WidgetState, WindowEvent,
 };
 use crate::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use crate::passes::accessibility::run_accessibility_pass;
@@ -72,7 +72,7 @@ pub struct RenderRoot {
     pub(crate) last_mouse_pos: Option<LogicalPosition<f64>>,
 
     /// Default values that Properties will have if not defined per-widget.
-    pub(crate) default_properties: AnyMap,
+    pub(crate) default_properties: DefaultProperties,
 
     /// State passed to context types.
     pub(crate) global_state: RenderRootState,
@@ -264,7 +264,7 @@ impl RenderRoot {
             size: PhysicalSize::new(0, 0),
             last_anim: None,
             last_mouse_pos: None,
-            default_properties: AnyMap::new(),
+            default_properties: DefaultProperties::new(),
             global_state: RenderRootState {
                 signal_queue: VecDeque::new(),
                 focused_widget: None,
@@ -500,7 +500,7 @@ impl RenderRoot {
             widget_state: state_ref.item,
             properties: PropertiesRef {
                 map: properties_ref.item,
-                default_map: &self.default_properties,
+                default_map: self.default_properties.for_widget(widget.type_id()),
             },
             properties_children: properties_ref.children,
         };
@@ -529,7 +529,7 @@ impl RenderRoot {
             widget_state: state_ref.item,
             properties: PropertiesRef {
                 map: properties_ref.item,
-                default_map: &self.default_properties,
+                default_map: self.default_properties.for_widget(widget.type_id()),
             },
             properties_children: properties_ref.children,
         };

--- a/masonry/src/app/render_root.rs
+++ b/masonry/src/app/render_root.rs
@@ -40,6 +40,7 @@ use crate::passes::update::{
     run_update_widget_tree_pass,
 };
 use crate::passes::{PassTracing, recurse_on_children};
+use crate::theme::default_property_set;
 use crate::util::AnyMap;
 use cursor_icon::CursorIcon;
 
@@ -264,7 +265,7 @@ impl RenderRoot {
             size: PhysicalSize::new(0, 0),
             last_anim: None,
             last_mouse_pos: None,
-            default_properties: DefaultProperties::new(),
+            default_properties: default_property_set(),
             global_state: RenderRootState {
                 signal_queue: VecDeque::new(),
                 focused_widget: None,

--- a/masonry/src/app/render_root.rs
+++ b/masonry/src/app/render_root.rs
@@ -71,7 +71,7 @@ pub struct RenderRoot {
     /// Last mouse position. Updated by `on_pointer_event` pass, used by other passes.
     pub(crate) last_mouse_pos: Option<LogicalPosition<f64>>,
 
-    /// Default values that Properties will have if not defined per-widget.
+    /// Default values that properties will have if not defined per-widget.
     pub(crate) default_properties: DefaultProperties,
 
     /// State passed to context types.
@@ -173,7 +173,7 @@ pub enum WindowSizePolicy {
 
 /// Options for creating a [`RenderRoot`].
 pub struct RenderRootOptions {
-    /// Default values that Properties will have if not defined per-widget.
+    /// Default values that properties will have if not defined per-widget.
     pub default_properties: DefaultProperties,
 
     /// If true, `fontique` will provide access to system fonts

--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -65,6 +65,7 @@ pub struct QueryCtx<'a> {
     pub(crate) widget_state: &'a WidgetState,
     pub(crate) widget_state_children: ArenaRefList<'a, WidgetState>,
     pub(crate) widget_children: ArenaRefList<'a, Box<dyn Widget>>,
+    pub(crate) properties: PropertiesRef<'a>,
     pub(crate) properties_children: ArenaRefList<'a, AnyMap>,
 }
 
@@ -106,6 +107,7 @@ pub struct LayoutCtx<'a> {
     pub(crate) widget_state_children: ArenaMutList<'a, WidgetState>,
     pub(crate) widget_children: ArenaMutList<'a, Box<dyn Widget>>,
     pub(crate) properties_children: ArenaMutList<'a, AnyMap>,
+    pub(crate) default_properties: &'a AnyMap,
 }
 
 /// A context provided to the [`Widget::compose`] method.
@@ -245,6 +247,7 @@ impl MutateCtx<'_> {
             widget_children: child_mut.children,
             properties: PropertiesMut {
                 map: child_properties.item,
+                default_map: self.properties.default_map,
             },
             properties_children: child_properties.children,
         };
@@ -312,15 +315,14 @@ impl<'w> QueryCtx<'w> {
             widget_state_children: child_state.children,
             widget_children: child_widget.children,
             widget_state: child_state.item,
+            properties: PropertiesRef {
+                map: child_properties.item,
+                default_map: self.properties.default_map,
+            },
             properties_children: child_properties.children,
         };
-        let properties = PropertiesRef {
-            map: child_properties.item,
-        };
-
         WidgetRef {
             ctx,
-            properties,
             widget: &**child_widget.item,
         }
     }

--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -13,16 +13,15 @@ use tree_arena::{ArenaMutList, ArenaRefList};
 
 use crate::app::{MutateCallback, RenderRootSignal, RenderRootState};
 use crate::core::{
-    Action, AllowRawMut, BoxConstraints, BrushIndex, CreateWidget, FromDynWidget, PropertiesMut,
-    PropertiesRef, ResizeDirection, Widget, WidgetId, WidgetMut, WidgetPod, WidgetRef, WidgetState,
+    Action, AllowRawMut, BoxConstraints, BrushIndex, CreateWidget, DefaultProperties,
+    FromDynWidget, PropertiesMut, PropertiesRef, ResizeDirection, Widget, WidgetId, WidgetMut,
+    WidgetPod, WidgetRef, WidgetState,
 };
 use crate::kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
 use crate::passes::layout::run_layout_on;
 use crate::peniko::Color;
 use crate::theme::get_debug_color;
 use crate::util::AnyMap;
-
-use super::DefaultProperties;
 
 // Note - Most methods defined in this file revolve around `WidgetState` fields.
 // Consider reading `WidgetState` documentation (especially the documented naming scheme)

--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -22,6 +22,8 @@ use crate::peniko::Color;
 use crate::theme::get_debug_color;
 use crate::util::AnyMap;
 
+use super::DefaultProperties;
+
 // Note - Most methods defined in this file revolve around `WidgetState` fields.
 // Consider reading `WidgetState` documentation (especially the documented naming scheme)
 // before editing context method code.
@@ -107,7 +109,7 @@ pub struct LayoutCtx<'a> {
     pub(crate) widget_state_children: ArenaMutList<'a, WidgetState>,
     pub(crate) widget_children: ArenaMutList<'a, Box<dyn Widget>>,
     pub(crate) properties_children: ArenaMutList<'a, AnyMap>,
-    pub(crate) default_properties: &'a AnyMap,
+    pub(crate) default_properties: &'a DefaultProperties,
 }
 
 /// A context provided to the [`Widget::compose`] method.

--- a/masonry/src/core/mod.rs
+++ b/masonry/src/core/mod.rs
@@ -25,7 +25,7 @@ pub use contexts::{
 };
 pub use events::{AccessEvent, Ime, ResizeDirection, TextEvent, Update, WindowEvent, WindowTheme};
 pub use object_fit::ObjectFit;
-pub use properties::{Properties, PropertiesMut, PropertiesRef, Property};
+pub use properties::{DefaultProperties, Properties, PropertiesMut, PropertiesRef, Property};
 pub use text::{ArcStr, BrushIndex, StyleProperty, StyleSet, render_text};
 pub use widget::find_widget_under_pointer;
 pub use widget::{AllowRawMut, FromDynWidget, Widget, WidgetId};

--- a/masonry/src/core/properties.rs
+++ b/masonry/src/core/properties.rs
@@ -73,7 +73,7 @@ pub struct PropertiesMut<'a> {
 /// See [properties documentation](crate::doc::doc_04b_widget_properties) for details.
 #[derive(Default, Debug)]
 pub struct DefaultProperties {
-    /// Maps widget types to the default property set for that widget.
+    /// Maps widget types to the default property map for that widget.
     pub(crate) map: HashMap<TypeId, AnyMap>,
     pub(crate) dummy_map: AnyMap,
 }
@@ -89,7 +89,7 @@ impl Properties {
 // Don't return Option types anymore.
 
 impl PropertiesRef<'_> {
-    /// Returns `true` if the widget has a property of type `P`.
+    /// Returns `true` if the widget has a local property of type `P`.
     ///
     /// Does not check default properties.
     pub fn contains<P: Property>(&self) -> bool {
@@ -98,8 +98,8 @@ impl PropertiesRef<'_> {
 
     /// Get value of property `P`.
     ///
-    /// If the widget has an entry for `P`, returns that entry.
-    /// If the default property set has an entry for `P`, returns that entry.
+    /// If the widget has an entry for `P`, returns its value.
+    /// If the default property map has an entry for `P`, returns its value.
     /// Otherwise returns [`Property::static_default()`].
     pub fn get<P: Property>(&self) -> &P {
         if let Some(p) = self.map.get::<P>() {
@@ -113,7 +113,7 @@ impl PropertiesRef<'_> {
 }
 
 impl PropertiesMut<'_> {
-    /// Returns `true` if the widget has a property of type `P`.
+    /// Returns `true` if the widget has a local property of type `P`.
     ///
     /// Does not check default properties.
     pub fn contains<P: Property>(&self) -> bool {
@@ -122,8 +122,8 @@ impl PropertiesMut<'_> {
 
     /// Get value of property `P`.
     ///
-    /// If the widget has an entry for `P`, returns that entry.
-    /// If the default property set has an entry for `P`, returns that entry.
+    /// If the widget has an entry for `P`, returns its value.
+    /// If the default property map has an entry for `P`, returns its value.
     /// Otherwise returns [`Property::static_default()`].
     pub fn get<P: Property>(&self) -> &P {
         if let Some(p) = self.map.get::<P>() {
@@ -135,7 +135,7 @@ impl PropertiesMut<'_> {
         }
     }
 
-    /// Set property `P` to given value. Returns the previous value if `P` was already set.
+    /// Set local property `P` to given value. Returns the previous value if `P` was already set.
     ///
     /// Does not affect default properties.
     ///
@@ -146,7 +146,7 @@ impl PropertiesMut<'_> {
         self.map.insert(value)
     }
 
-    /// Remove property `P`. Returns the previous value if `P` was set.
+    /// Remove local property `P`. Returns the previous value if `P` was set.
     ///
     /// Does not affect default properties.
     ///
@@ -167,12 +167,12 @@ impl PropertiesMut<'_> {
 }
 
 impl DefaultProperties {
-    /// Create an empty set with no default values.
+    /// Create an empty property map with no default values.
     ///
-    /// A completely empty set is probably not what you want.
+    /// A completely empty property map is probably not what you want.
     /// It means buttons will be displayed without borders or backgrounds, textboxes won't
     /// have default padding, etc.
-    /// You should either add a thorough set of values to this, or start from an existing set.
+    /// You should either add a thorough set of values to this, or start from an existing map.
     pub fn new() -> Self {
         Self {
             map: HashMap::new(),

--- a/masonry/src/core/properties.rs
+++ b/masonry/src/core/properties.rs
@@ -7,7 +7,7 @@ use std::any::TypeId;
 use std::collections::HashMap;
 use std::default::Default;
 
-use super::Widget;
+use crate::core::Widget;
 
 /// A marker trait that indicates that a type is intended to be used as a widget's property.
 ///

--- a/masonry/src/core/properties.rs
+++ b/masonry/src/core/properties.rs
@@ -24,8 +24,14 @@ pub trait Property: Default + Send + Sync + 'static {
     ///
     /// Should be the same as [`Default::default()`].
     ///
-    /// **Note:** This is a hacky workaround until we find a better way to store default
-    /// values for properties.
+    /// The reason we have this method is that we want e.g. [`PropertiesRef::get()`] to
+    /// return a `&T`, not an `Option<&T>`.
+    ///
+    /// Therefore `Property` must provide a method that will return a `&'static T` that we
+    /// can use anywhere.
+    /// We do that is by creating a static inside each impl, and returning a reference to that static.
+    ///
+    /// Ideally, when const generics are stable, we'll want to use `const Default` directly in the default impl.
     fn static_default() -> &'static Self;
 }
 

--- a/masonry/src/core/properties.rs
+++ b/masonry/src/core/properties.rs
@@ -64,7 +64,8 @@ pub struct PropertiesMut<'a> {
     pub(crate) default_map: &'a AnyMap,
 }
 
-// TODO - Document default properties.
+// TODO - Better document local vs default properties.
+
 /// A collection of default properties for all widgets.
 ///
 /// Default property values can be added to this collection for
@@ -84,9 +85,6 @@ impl Properties {
         Self { map: AnyMap::new() }
     }
 }
-
-// TODO - If a property is not in the widget *or* the type, return `Default::default()`.
-// Don't return Option types anymore.
 
 impl PropertiesRef<'_> {
     /// Returns `true` if the widget has a local property of type `P`.

--- a/masonry/src/core/properties.rs
+++ b/masonry/src/core/properties.rs
@@ -71,7 +71,7 @@ pub struct PropertiesMut<'a> {
 /// every `(widget type, property type)` pair.
 ///
 /// See [properties documentation](crate::doc::doc_04b_widget_properties) for details.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct DefaultProperties {
     /// Maps widget types to the default property set for that widget.
     pub(crate) map: HashMap<TypeId, AnyMap>,

--- a/masonry/src/core/properties.rs
+++ b/masonry/src/core/properties.rs
@@ -3,6 +3,11 @@
 
 use crate::util::AnyMap;
 
+use std::any::TypeId;
+use std::collections::HashMap;
+
+use super::Widget;
+
 /// A marker trait that indicates that a type is intended to be used as a widget's property.
 ///
 /// See [properties documentation](crate::doc::doc_04b_widget_properties) for
@@ -48,6 +53,20 @@ pub struct PropertiesRef<'a> {
 pub struct PropertiesMut<'a> {
     pub(crate) map: &'a mut AnyMap,
     pub(crate) default_map: &'a AnyMap,
+}
+
+// TODO - Document default properties.
+/// A collection of default properties for all widgets.
+///
+/// Default property values can be added to this collection for
+/// every `(widget type, property type)` pair.
+///
+/// See [properties documentation](crate::doc::doc_04b_widget_properties) for details.
+#[derive(Default)]
+pub struct DefaultProperties {
+    /// Maps widget types to the default property set for that widget.
+    pub(crate) map: HashMap<TypeId, AnyMap>,
+    pub(crate) dummy_map: AnyMap,
 }
 
 impl Properties {
@@ -119,7 +138,33 @@ impl PropertiesMut<'_> {
     pub fn reborrow_mut(&mut self) -> PropertiesMut<'_> {
         PropertiesMut {
             map: &mut *self.map,
-            default_map: &*self.default_map,
+            default_map: self.default_map,
         }
+    }
+}
+
+impl DefaultProperties {
+    /// Create an empty set with no default values.
+    ///
+    /// A completely empty set is probably not what you want.
+    /// It means buttons will be displayed without borders or backgrounds, textboxes won't
+    /// have default padding, etc.
+    /// You should either add a thorough set of values to this, or start from an existing set.
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+            dummy_map: AnyMap::new(),
+        }
+    }
+
+    /// Set the default value of property `P` for widget `W`.
+    ///
+    /// Widgets for which the property `P` isn't set will get `value` instead.
+    pub fn insert<W: Widget, P: Property>(&mut self, value: P) -> Option<P> {
+        self.map.entry(TypeId::of::<W>()).or_default().insert(value)
+    }
+
+    pub(crate) fn for_widget(&self, id: TypeId) -> &AnyMap {
+        self.map.get(&id).unwrap_or(&self.dummy_map)
     }
 }

--- a/masonry/src/core/properties.rs
+++ b/masonry/src/core/properties.rs
@@ -5,6 +5,7 @@ use crate::util::AnyMap;
 
 use std::any::TypeId;
 use std::collections::HashMap;
+use std::default::Default;
 
 use super::Widget;
 
@@ -18,7 +19,15 @@ use super::Widget;
 /// as a property.
 /// That information is deliberately not encoded in the type system.
 /// We might change that in a future version.
-pub trait Property: Send + Sync + 'static {}
+pub trait Property: Default + Send + Sync + 'static {
+    /// A default value that can be stored in statics.
+    ///
+    /// Should be the same as [`Default::default()`].
+    ///
+    /// **Note:** This is a hacky workaround until we find a better way to store default
+    /// values for properties.
+    const DEFAULT: Self;
+}
 
 /// A collection of properties that a widget can be created with.
 ///

--- a/masonry/src/core/properties.rs
+++ b/masonry/src/core/properties.rs
@@ -20,13 +20,13 @@ use super::Widget;
 /// That information is deliberately not encoded in the type system.
 /// We might change that in a future version.
 pub trait Property: Default + Send + Sync + 'static {
-    /// A default value that can be stored in statics.
+    /// A static reference to a default value.
     ///
     /// Should be the same as [`Default::default()`].
     ///
     /// **Note:** This is a hacky workaround until we find a better way to store default
     /// values for properties.
-    const DEFAULT: Self;
+    fn static_default() -> &'static Self;
 }
 
 /// A collection of properties that a widget can be created with.
@@ -98,10 +98,17 @@ impl PropertiesRef<'_> {
 
     /// Get value of property `P`.
     ///
-    /// Returns Some if either the widget or the default property set has an entry for `P`.
-    /// Returns `None` otherwise.
-    pub fn get<P: Property>(&self) -> Option<&P> {
-        self.map.get::<P>().or_else(|| self.default_map.get::<P>())
+    /// If the widget has an entry for `P`, returns that entry.
+    /// If the default property set has an entry for `P`, returns that entry.
+    /// Otherwise returns [`Property::static_default()`].
+    pub fn get<P: Property>(&self) -> &P {
+        if let Some(p) = self.map.get::<P>() {
+            p
+        } else if let Some(p) = self.default_map.get::<P>() {
+            p
+        } else {
+            P::static_default()
+        }
     }
 }
 
@@ -115,10 +122,17 @@ impl PropertiesMut<'_> {
 
     /// Get value of property `P`.
     ///
-    /// Returns Some if either the widget or the default property set has an entry for `P`.
-    /// Returns `None` otherwise.
-    pub fn get<P: Property>(&self) -> Option<&P> {
-        self.map.get::<P>().or_else(|| self.default_map.get::<P>())
+    /// If the widget has an entry for `P`, returns that entry.
+    /// If the default property set has an entry for `P`, returns that entry.
+    /// Otherwise returns [`Property::static_default()`].
+    pub fn get<P: Property>(&self) -> &P {
+        if let Some(p) = self.map.get::<P>() {
+            p
+        } else if let Some(p) = self.default_map.get::<P>() {
+            p
+        } else {
+            P::static_default()
+        }
     }
 
     /// Set property `P` to given value. Returns the previous value if `P` was already set.

--- a/masonry/src/core/widget.rs
+++ b/masonry/src/core/widget.rs
@@ -356,13 +356,11 @@ pub trait Widget: AsDynWidget + Any {
     fn find_widget_under_pointer<'c>(
         &'c self,
         ctx: QueryCtx<'c>,
-        props: PropertiesRef<'c>,
         pos: Point,
     ) -> Option<WidgetRef<'c, dyn Widget>> {
         find_widget_under_pointer(
             &WidgetRef {
                 widget: self.as_dyn(),
-                properties: props,
                 ctx,
             },
             pos,
@@ -416,10 +414,9 @@ pub fn find_widget_under_pointer<'c>(
     // of overlapping children.
     for child_id in widget.children_ids().iter().rev() {
         let child_ref = ctx.get(*child_id);
-        if let Some(child) =
-            child_ref
-                .widget
-                .find_widget_under_pointer(child_ref.ctx, child_ref.properties, pos)
+        if let Some(child) = child_ref
+            .widget
+            .find_widget_under_pointer(child_ref.ctx, pos)
         {
             return Some(child);
         }

--- a/masonry/src/core/widget_mut.rs
+++ b/masonry/src/core/widget_mut.rs
@@ -52,23 +52,25 @@ impl<W: Widget + ?Sized> WidgetMut<'_, W> {
     }
 
     /// Returns `true` if the widget has a property of type `T`.
-    pub fn get_prop<T: Property>(&self) -> Option<&T> {
-        self.ctx.properties.get::<T>()
-    }
-
-    /// Get value of property `T`, or `None` if the widget has no `T` property.
+    ///
+    /// Does not check default properties.
     pub fn contains_prop<T: Property>(&self) -> bool {
         self.ctx.properties.contains::<T>()
     }
 
-    /// Get value of property `T`, or `None` if the widget has no `T` property.
-    pub fn get_prop_mut<T: Property>(&mut self) -> Option<&mut T> {
-        self.widget
-            .property_changed(&mut self.ctx.update_mut(), TypeId::of::<T>());
-        self.ctx.properties.get_mut::<T>()
+    /// Get value of property `T`.
+    ///
+    /// Returns Some if either the widget or the default property set has an entry for `T`.
+    /// Returns `None` otherwise.
+    pub fn get_prop<T: Property>(&self) -> Option<&T> {
+        self.ctx.properties.get::<T>()
     }
 
     /// Set property `T` to given value. Returns the previous value if `T` was already set.
+    ///
+    /// Does not affect default properties.
+    ///
+    /// This also calls [`Widget::property_changed`] with the matching type id.
     pub fn insert_prop<T: Property>(&mut self, value: T) -> Option<T> {
         self.widget
             .property_changed(&mut self.ctx.update_mut(), TypeId::of::<T>());
@@ -76,6 +78,10 @@ impl<W: Widget + ?Sized> WidgetMut<'_, W> {
     }
 
     /// Remove property `T`. Returns the previous value if `T` was set.
+    ///
+    /// Does not affect default properties.
+    ///
+    /// This also calls [`Widget::property_changed`] with the matching type id.
     pub fn remove_prop<T: Property>(&mut self) -> Option<T> {
         self.widget
             .property_changed(&mut self.ctx.update_mut(), TypeId::of::<T>());

--- a/masonry/src/core/widget_mut.rs
+++ b/masonry/src/core/widget_mut.rs
@@ -67,26 +67,28 @@ impl<W: Widget + ?Sized> WidgetMut<'_, W> {
         self.ctx.properties.get::<T>()
     }
 
-    /// Set property `T` to given value. Returns the previous value if `T` was already set.
+    /// Set property `T` to given value. Returns the previous value if `T` was already set locally.
     ///
     /// Does not affect default properties.
     ///
     /// This also calls [`Widget::property_changed`] with the matching type id.
     pub fn insert_prop<T: Property>(&mut self, value: T) -> Option<T> {
+        let value = self.ctx.properties.insert(value);
         self.widget
             .property_changed(&mut self.ctx.update_mut(), TypeId::of::<T>());
-        self.ctx.properties.insert(value)
+        value
     }
 
-    /// Remove property `T`. Returns the previous value if `T` was set.
+    /// Remove property `T`. Returns the previous value if `T` was set locally.
     ///
     /// Does not affect default properties.
     ///
     /// This also calls [`Widget::property_changed`] with the matching type id.
     pub fn remove_prop<T: Property>(&mut self) -> Option<T> {
+        let value = self.ctx.properties.remove::<T>();
         self.widget
             .property_changed(&mut self.ctx.update_mut(), TypeId::of::<T>());
-        self.ctx.properties.remove::<T>()
+        value
     }
 
     /// Set the local transform of this widget.

--- a/masonry/src/core/widget_mut.rs
+++ b/masonry/src/core/widget_mut.rs
@@ -51,7 +51,7 @@ impl<W: Widget + ?Sized> WidgetMut<'_, W> {
         }
     }
 
-    /// Returns `true` if the widget has a property of type `T`.
+    /// Returns `true` if the widget has a local property of type `T`.
     ///
     /// Does not check default properties.
     pub fn contains_prop<T: Property>(&self) -> bool {

--- a/masonry/src/core/widget_mut.rs
+++ b/masonry/src/core/widget_mut.rs
@@ -60,9 +60,10 @@ impl<W: Widget + ?Sized> WidgetMut<'_, W> {
 
     /// Get value of property `T`.
     ///
-    /// Returns Some if either the widget or the default property set has an entry for `T`.
-    /// Returns `None` otherwise.
-    pub fn get_prop<T: Property>(&self) -> Option<&T> {
+    /// If the widget has an entry for `P`, returns that entry.
+    /// If the default property set has an entry for `P`, returns that entry.
+    /// Otherwise returns [`Property::static_default()`].
+    pub fn get_prop<T: Property>(&self) -> &T {
         self.ctx.properties.get::<T>()
     }
 

--- a/masonry/src/core/widget_ref.rs
+++ b/masonry/src/core/widget_ref.rs
@@ -86,7 +86,9 @@ impl<'w, W: Widget + ?Sized> WidgetRef<'w, W> {
         self.ctx.widget_state.id
     }
 
-    /// Returns `true` if the widget has a property of type `T`.
+    /// Returns `true` if the widget has a local property of type `T`.
+    ///
+    /// Does not check default properties.
     pub fn contains_prop<T: Property>(&self) -> bool {
         self.ctx.properties.contains::<T>()
     }

--- a/masonry/src/core/widget_ref.rs
+++ b/masonry/src/core/widget_ref.rs
@@ -87,13 +87,17 @@ impl<'w, W: Widget + ?Sized> WidgetRef<'w, W> {
     }
 
     /// Returns `true` if the widget has a property of type `T`.
-    pub fn get_prop<T: Property>(&self) -> Option<&T> {
-        self.ctx.properties.get::<T>()
-    }
-
-    /// Get value of property `T`, or `None` if the widget has no `T` property.
     pub fn contains_prop<T: Property>(&self) -> bool {
         self.ctx.properties.contains::<T>()
+    }
+
+    /// Get value of property `P`.
+    ///
+    /// If the widget has an entry for `P`, returns that entry.
+    /// If the default property set has an entry for `P`, returns that entry.
+    /// Otherwise returns [`Property::static_default()`].
+    pub fn get_prop<T: Property>(&self) -> &T {
+        self.ctx.properties.get::<T>()
     }
 
     /// Attempt to downcast to `WidgetRef` of concrete Widget type.

--- a/masonry/src/passes/accessibility.rs
+++ b/masonry/src/passes/accessibility.rs
@@ -7,14 +7,14 @@ use tree_arena::ArenaMut;
 use vello::kurbo::Rect;
 
 use crate::app::{RenderRoot, RenderRootState};
-use crate::core::{AccessCtx, PropertiesRef, Widget, WidgetState};
+use crate::core::{AccessCtx, DefaultProperties, PropertiesRef, Widget, WidgetState};
 use crate::passes::{enter_span_if, recurse_on_children};
 use crate::util::AnyMap;
 
 // --- MARK: BUILD TREE ---
 fn build_accessibility_tree(
     global_state: &mut RenderRootState,
-    default_properties: &AnyMap,
+    default_properties: &DefaultProperties,
     tree_update: &mut TreeUpdate,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
@@ -57,7 +57,7 @@ fn build_accessibility_tree(
         let mut node = build_access_node(&mut **widget.item, &mut ctx, scale_factor);
         let props = PropertiesRef {
             map: properties.item,
-            default_map: default_properties,
+            default_map: default_properties.for_widget(widget.item.type_id()),
         };
         widget.item.accessibility(&mut ctx, &props, &mut node);
 

--- a/masonry/src/passes/accessibility.rs
+++ b/masonry/src/passes/accessibility.rs
@@ -14,6 +14,7 @@ use crate::util::AnyMap;
 // --- MARK: BUILD TREE ---
 fn build_accessibility_tree(
     global_state: &mut RenderRootState,
+    default_properties: &AnyMap,
     tree_update: &mut TreeUpdate,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
@@ -24,6 +25,7 @@ fn build_accessibility_tree(
     let _span = enter_span_if(
         global_state.trace.access,
         global_state,
+        default_properties,
         widget.reborrow(),
         state.reborrow(),
         properties.reborrow(),
@@ -55,6 +57,7 @@ fn build_accessibility_tree(
         let mut node = build_access_node(&mut **widget.item, &mut ctx, scale_factor);
         let props = PropertiesRef {
             map: properties.item,
+            default_map: default_properties,
         };
         widget.item.accessibility(&mut ctx, &props, &mut node);
 
@@ -80,6 +83,7 @@ fn build_accessibility_tree(
             // is error-prone. We may want to revisit that decision.
             build_accessibility_tree(
                 global_state,
+                default_properties,
                 tree_update,
                 widget,
                 state.reborrow_mut(),
@@ -187,6 +191,7 @@ pub(crate) fn run_accessibility_pass(root: &mut RenderRoot, scale_factor: f64) -
     }
     build_accessibility_tree(
         &mut root.global_state,
+        &root.default_properties,
         &mut tree_update,
         root_widget,
         root_state,

--- a/masonry/src/passes/anim.rs
+++ b/masonry/src/passes/anim.rs
@@ -12,6 +12,7 @@ use crate::util::AnyMap;
 // --- MARK: UPDATE ANIM ---
 fn update_anim_for_widget(
     global_state: &mut RenderRootState,
+    default_properties: &AnyMap,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
@@ -20,6 +21,7 @@ fn update_anim_for_widget(
     let _span = enter_span_if(
         global_state.trace.anim,
         global_state,
+        default_properties,
         widget.reborrow(),
         state.reborrow(),
         properties.reborrow(),
@@ -43,6 +45,7 @@ fn update_anim_for_widget(
         };
         let mut props = PropertiesMut {
             map: properties.item,
+            default_map: default_properties,
         };
         widget.item.on_anim_frame(&mut ctx, &mut props, elapsed_ns);
     }
@@ -57,6 +60,7 @@ fn update_anim_for_widget(
         |widget, mut state, properties| {
             update_anim_for_widget(
                 global_state,
+                default_properties,
                 widget,
                 state.reborrow_mut(),
                 properties,
@@ -81,6 +85,7 @@ pub(crate) fn run_update_anim_pass(root: &mut RenderRoot, elapsed_ns: u64) {
         root.widget_arena.get_all_mut(root.root.id());
     update_anim_for_widget(
         &mut root.global_state,
+        &root.default_properties,
         root_widget,
         root_state.reborrow_mut(),
         root_properties,

--- a/masonry/src/passes/anim.rs
+++ b/masonry/src/passes/anim.rs
@@ -5,14 +5,14 @@ use tracing::info_span;
 use tree_arena::ArenaMut;
 
 use crate::app::{RenderRoot, RenderRootState};
-use crate::core::{PropertiesMut, UpdateCtx, Widget, WidgetState};
+use crate::core::{DefaultProperties, PropertiesMut, UpdateCtx, Widget, WidgetState};
 use crate::passes::{enter_span_if, recurse_on_children};
 use crate::util::AnyMap;
 
 // --- MARK: UPDATE ANIM ---
 fn update_anim_for_widget(
     global_state: &mut RenderRootState,
-    default_properties: &AnyMap,
+    default_properties: &DefaultProperties,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
@@ -45,7 +45,7 @@ fn update_anim_for_widget(
         };
         let mut props = PropertiesMut {
             map: properties.item,
-            default_map: default_properties,
+            default_map: default_properties.for_widget(widget.item.type_id()),
         };
         widget.item.on_anim_frame(&mut ctx, &mut props, elapsed_ns);
     }

--- a/masonry/src/passes/compose.rs
+++ b/masonry/src/passes/compose.rs
@@ -6,14 +6,14 @@ use tree_arena::ArenaMut;
 use vello::kurbo::Affine;
 
 use crate::app::{RenderRoot, RenderRootState};
-use crate::core::{ComposeCtx, Widget, WidgetState};
+use crate::core::{ComposeCtx, DefaultProperties, Widget, WidgetState};
 use crate::passes::{enter_span_if, recurse_on_children};
 use crate::util::AnyMap;
 
 // --- MARK: RECURSE ---
 fn compose_widget(
     global_state: &mut RenderRootState,
-    default_properties: &AnyMap,
+    default_properties: &DefaultProperties,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,

--- a/masonry/src/passes/compose.rs
+++ b/masonry/src/passes/compose.rs
@@ -13,6 +13,7 @@ use crate::util::AnyMap;
 // --- MARK: RECURSE ---
 fn compose_widget(
     global_state: &mut RenderRootState,
+    default_properties: &AnyMap,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
@@ -22,6 +23,7 @@ fn compose_widget(
     let _span = enter_span_if(
         global_state.trace.compose,
         global_state,
+        default_properties,
         widget.reborrow(),
         state.reborrow(),
         properties.reborrow(),
@@ -72,6 +74,7 @@ fn compose_widget(
         |widget, mut state, properties| {
             compose_widget(
                 global_state,
+                default_properties,
                 widget,
                 state.reborrow_mut(),
                 properties,
@@ -103,6 +106,7 @@ pub(crate) fn run_compose_pass(root: &mut RenderRoot) {
     let (root_widget, root_state, root_properties) = root.widget_arena.get_all_mut(root.root.id());
     compose_widget(
         &mut root.global_state,
+        &root.default_properties,
         root_widget,
         root_state,
         root_properties,

--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -111,7 +111,7 @@ fn run_event_pass<E>(
 
             let mut props = PropertiesMut {
                 map: properties_mut.item,
-                default_map: &root.default_properties,
+                default_map: root.default_properties.for_widget(widget.type_id()),
             };
             pass_fn(&mut **widget, &mut ctx, &mut props, event);
             is_handled = ctx.is_handled;

--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -85,6 +85,7 @@ fn run_event_pass<E>(
         if !is_handled {
             let _span = enter_span(
                 &root.global_state,
+                &root.default_properties,
                 widget_mut.reborrow(),
                 state_mut.reborrow(),
                 properties_mut.reborrow(),
@@ -110,6 +111,7 @@ fn run_event_pass<E>(
 
             let mut props = PropertiesMut {
                 map: properties_mut.item,
+                default_map: &root.default_properties,
             };
             pass_fn(&mut **widget, &mut ctx, &mut props, event);
             is_handled = ctx.is_handled;

--- a/masonry/src/passes/layout.rs
+++ b/masonry/src/passes/layout.rs
@@ -113,7 +113,9 @@ pub(crate) fn run_layout_on<W: Widget + ?Sized>(
         inner_ctx.widget_state.request_layout = false;
         let mut props = PropertiesMut {
             map: properties.item,
-            default_map: parent_ctx.default_properties,
+            default_map: parent_ctx
+                .default_properties
+                .for_widget(widget.item.type_id()),
         };
         widget.item.layout(&mut inner_ctx, &mut props, bc)
     };

--- a/masonry/src/passes/layout.rs
+++ b/masonry/src/passes/layout.rs
@@ -31,6 +31,7 @@ pub(crate) fn run_layout_on<W: Widget + ?Sized>(
     let _span = enter_span_if(
         trace,
         parent_ctx.global_state,
+        parent_ctx.default_properties,
         widget.reborrow(),
         state.reborrow(),
         properties.reborrow(),
@@ -103,6 +104,7 @@ pub(crate) fn run_layout_on<W: Widget + ?Sized>(
             widget_state_children: state.children.reborrow_mut(),
             widget_children: widget.children,
             properties_children: properties.children.reborrow_mut(),
+            default_properties: parent_ctx.default_properties,
             global_state: parent_ctx.global_state,
         };
 
@@ -111,6 +113,7 @@ pub(crate) fn run_layout_on<W: Widget + ?Sized>(
         inner_ctx.widget_state.request_layout = false;
         let mut props = PropertiesMut {
             map: properties.item,
+            default_map: parent_ctx.default_properties,
         };
         widget.item.layout(&mut inner_ctx, &mut props, bc)
     };
@@ -219,6 +222,7 @@ pub(crate) fn run_layout_pass(root: &mut RenderRoot) {
         widget_state_children: root_state_token,
         widget_children: root_widget_token,
         properties_children: root_properties_token,
+        default_properties: &root.default_properties,
     };
 
     let size = run_layout_on(&mut ctx, &mut root.root, &bc);

--- a/masonry/src/passes/mod.rs
+++ b/masonry/src/passes/mod.rs
@@ -11,7 +11,9 @@ use tracing::span::EnteredSpan;
 use tree_arena::{ArenaMut, ArenaMutList, ArenaRef};
 
 use crate::app::RenderRootState;
-use crate::core::{PropertiesRef, QueryCtx, Widget, WidgetArena, WidgetId, WidgetState};
+use crate::core::{
+    DefaultProperties, PropertiesRef, QueryCtx, Widget, WidgetArena, WidgetId, WidgetState,
+};
 use crate::util::AnyMap;
 
 pub(crate) mod accessibility;
@@ -27,7 +29,7 @@ pub(crate) mod update;
 pub(crate) fn enter_span_if(
     enabled: bool,
     global_state: &RenderRootState,
-    default_properties: &AnyMap,
+    default_properties: &DefaultProperties,
     widget: ArenaRef<'_, Box<dyn Widget>>,
     state: ArenaRef<'_, WidgetState>,
     properties: ArenaRef<'_, AnyMap>,
@@ -48,7 +50,7 @@ pub(crate) fn enter_span_if(
 #[must_use = "Span will be immediately closed if dropped"]
 pub(crate) fn enter_span(
     global_state: &RenderRootState,
-    default_properties: &AnyMap,
+    default_properties: &DefaultProperties,
     widget: ArenaRef<'_, Box<dyn Widget>>,
     state: ArenaRef<'_, WidgetState>,
     properties: ArenaRef<'_, AnyMap>,
@@ -60,7 +62,7 @@ pub(crate) fn enter_span(
         widget_children: widget.children,
         properties: PropertiesRef {
             map: properties.item,
-            default_map: default_properties,
+            default_map: default_properties.for_widget(widget.item.type_id()),
         },
         properties_children: properties.children,
     };

--- a/masonry/src/passes/mod.rs
+++ b/masonry/src/passes/mod.rs
@@ -11,7 +11,7 @@ use tracing::span::EnteredSpan;
 use tree_arena::{ArenaMut, ArenaMutList, ArenaRef};
 
 use crate::app::RenderRootState;
-use crate::core::{QueryCtx, Widget, WidgetArena, WidgetId, WidgetState};
+use crate::core::{PropertiesRef, QueryCtx, Widget, WidgetArena, WidgetId, WidgetState};
 use crate::util::AnyMap;
 
 pub(crate) mod accessibility;
@@ -27,12 +27,19 @@ pub(crate) mod update;
 pub(crate) fn enter_span_if(
     enabled: bool,
     global_state: &RenderRootState,
+    default_properties: &AnyMap,
     widget: ArenaRef<'_, Box<dyn Widget>>,
     state: ArenaRef<'_, WidgetState>,
     properties: ArenaRef<'_, AnyMap>,
 ) -> Option<EnteredSpan> {
     if enabled {
-        Some(enter_span(global_state, widget, state, properties))
+        Some(enter_span(
+            global_state,
+            default_properties,
+            widget,
+            state,
+            properties,
+        ))
     } else {
         None
     }
@@ -41,6 +48,7 @@ pub(crate) fn enter_span_if(
 #[must_use = "Span will be immediately closed if dropped"]
 pub(crate) fn enter_span(
     global_state: &RenderRootState,
+    default_properties: &AnyMap,
     widget: ArenaRef<'_, Box<dyn Widget>>,
     state: ArenaRef<'_, WidgetState>,
     properties: ArenaRef<'_, AnyMap>,
@@ -50,8 +58,14 @@ pub(crate) fn enter_span(
         widget_state: state.item,
         widget_state_children: state.children,
         widget_children: widget.children,
+        properties: PropertiesRef {
+            map: properties.item,
+            default_map: default_properties,
+        },
         properties_children: properties.children,
     };
+    // TODO - Should `make_trace_span` take QueryCtx?
+    // Building it adds a lot of boilerplate to this function.
     widget.item.make_trace_span(&ctx).entered()
 }
 

--- a/masonry/src/passes/mutate.rs
+++ b/masonry/src/passes/mutate.rs
@@ -26,6 +26,7 @@ pub(crate) fn mutate_widget<R>(
             widget_children: widget_mut.children,
             properties: PropertiesMut {
                 map: properties_mut.item,
+                default_map: &root.default_properties,
             },
             properties_children: properties_mut.children,
         },

--- a/masonry/src/passes/mutate.rs
+++ b/masonry/src/passes/mutate.rs
@@ -26,7 +26,9 @@ pub(crate) fn mutate_widget<R>(
             widget_children: widget_mut.children,
             properties: PropertiesMut {
                 map: properties_mut.item,
-                default_map: &root.default_properties,
+                default_map: root
+                    .default_properties
+                    .for_widget(widget_mut.item.type_id()),
             },
             properties_children: properties_mut.children,
         },

--- a/masonry/src/passes/paint.rs
+++ b/masonry/src/passes/paint.rs
@@ -19,6 +19,7 @@ use crate::util::{AnyMap, stroke};
 // --- MARK: PAINT WIDGET ---
 fn paint_widget(
     global_state: &mut RenderRootState,
+    default_properties: &AnyMap,
     complete_scene: &mut Scene,
     scenes: &mut HashMap<WidgetId, Scene>,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
@@ -30,6 +31,7 @@ fn paint_widget(
     let _span = enter_span_if(
         trace,
         global_state,
+        default_properties,
         widget.reborrow(),
         state.reborrow(),
         properties.reborrow(),
@@ -57,6 +59,7 @@ fn paint_widget(
         scene.reset();
         let props = PropertiesRef {
             map: properties.item,
+            default_map: default_properties,
         };
         widget.item.paint(&mut ctx, &props, scene);
     }
@@ -95,6 +98,7 @@ fn paint_widget(
             // - Once we implement compositor layers, we may want to paint outside of the clip path anyway in anticipation of user scrolling.
             paint_widget(
                 global_state,
+                default_properties,
                 complete_scene,
                 scenes,
                 widget,
@@ -154,6 +158,7 @@ pub(crate) fn run_paint_pass(root: &mut RenderRoot) -> Scene {
 
     paint_widget(
         &mut root.global_state,
+        &root.default_properties,
         &mut complete_scene,
         &mut scenes,
         root_widget,

--- a/masonry/src/passes/paint.rs
+++ b/masonry/src/passes/paint.rs
@@ -10,7 +10,7 @@ use vello::kurbo::Affine;
 use vello::peniko::{Color, Fill, Mix};
 
 use crate::app::{RenderRoot, RenderRootState};
-use crate::core::{PaintCtx, PropertiesRef, Widget, WidgetId, WidgetState};
+use crate::core::{DefaultProperties, PaintCtx, PropertiesRef, Widget, WidgetId, WidgetState};
 use crate::kurbo::Rect;
 use crate::passes::{enter_span_if, recurse_on_children};
 use crate::theme::get_debug_color;
@@ -19,7 +19,7 @@ use crate::util::{AnyMap, stroke};
 // --- MARK: PAINT WIDGET ---
 fn paint_widget(
     global_state: &mut RenderRootState,
-    default_properties: &AnyMap,
+    default_properties: &DefaultProperties,
     complete_scene: &mut Scene,
     scenes: &mut HashMap<WidgetId, Scene>,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
@@ -59,7 +59,7 @@ fn paint_widget(
         scene.reset();
         let props = PropertiesRef {
             map: properties.item,
-            default_map: default_properties,
+            default_map: default_properties.for_widget(widget.item.type_id()),
         };
         widget.item.paint(&mut ctx, &props, scene);
     }

--- a/masonry/src/passes/update.rs
+++ b/masonry/src/passes/update.rs
@@ -9,8 +9,8 @@ use tree_arena::ArenaMut;
 
 use crate::app::{RenderRoot, RenderRootSignal, RenderRootState};
 use crate::core::{
-    Ime, PointerEvent, PointerInfo, PropertiesMut, QueryCtx, RegisterCtx, TextEvent, Update,
-    UpdateCtx, Widget, WidgetId, WidgetState,
+    Ime, PointerEvent, PointerInfo, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent,
+    Update, UpdateCtx, Widget, WidgetId, WidgetState,
 };
 use crate::passes::event::{run_on_pointer_event_pass, run_on_text_event_pass};
 use crate::passes::{enter_span, enter_span_if, merge_state_up, recurse_on_children};
@@ -61,6 +61,7 @@ fn run_targeted_update_pass(
         };
         let mut props = PropertiesMut {
             map: properties_mut.item,
+            default_map: &root.default_properties,
         };
         pass_fn(&mut **widget_mut.item, &mut ctx, &mut props);
 
@@ -92,6 +93,7 @@ fn run_single_update_pass(
     };
     let mut props = PropertiesMut {
         map: properties_mut.item,
+        default_map: &root.default_properties,
     };
     pass_fn(&mut **widget_mut.item, &mut ctx, &mut props);
 
@@ -105,6 +107,7 @@ fn run_single_update_pass(
 // --- MARK: TREE ---
 fn update_widget_tree(
     global_state: &mut RenderRootState,
+    default_properties: &AnyMap,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
@@ -113,6 +116,7 @@ fn update_widget_tree(
     let _span = enter_span_if(
         trace,
         global_state,
+        default_properties,
         widget.reborrow(),
         state.reborrow(),
         properties.reborrow(),
@@ -177,6 +181,7 @@ fn update_widget_tree(
         };
         let mut props = PropertiesMut {
             map: properties.item,
+            default_map: default_properties,
         };
         widget
             .item
@@ -202,7 +207,13 @@ fn update_widget_tree(
         state.children,
         properties.children,
         |widget, mut state, properties| {
-            update_widget_tree(global_state, widget, state.reborrow_mut(), properties);
+            update_widget_tree(
+                global_state,
+                default_properties,
+                widget,
+                state.reborrow_mut(),
+                properties,
+            );
             parent_state.merge_up(state.item);
         },
     );
@@ -227,6 +238,7 @@ pub(crate) fn run_update_widget_tree_pass(root: &mut RenderRoot) {
         root.widget_arena.get_all_mut(root.root.id());
     update_widget_tree(
         &mut root.global_state,
+        &root.default_properties,
         root_widget,
         root_state.reborrow_mut(),
         root_properties,
@@ -240,6 +252,7 @@ pub(crate) fn run_update_widget_tree_pass(root: &mut RenderRoot) {
 /// See the [disabled status documentation](../doc/06_masonry_concepts.md#disabled).
 fn update_disabled_for_widget(
     global_state: &mut RenderRootState,
+    default_properties: &AnyMap,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
@@ -247,6 +260,7 @@ fn update_disabled_for_widget(
 ) {
     let _span = enter_span(
         global_state,
+        default_properties,
         widget.reborrow(),
         state.reborrow(),
         properties.reborrow(),
@@ -268,6 +282,7 @@ fn update_disabled_for_widget(
         };
         let mut props = PropertiesMut {
             map: properties.item,
+            default_map: default_properties,
         };
         widget
             .item
@@ -289,6 +304,7 @@ fn update_disabled_for_widget(
         |widget, mut state, properties| {
             update_disabled_for_widget(
                 global_state,
+                default_properties,
                 widget,
                 state.reborrow_mut(),
                 properties,
@@ -310,6 +326,7 @@ pub(crate) fn run_update_disabled_pass(root: &mut RenderRoot) {
     let (root_widget, root_state, root_properties) = root.widget_arena.get_all_mut(root.root.id());
     update_disabled_for_widget(
         &mut root.global_state,
+        &root.default_properties,
         root_widget,
         root_state,
         root_properties,
@@ -327,6 +344,7 @@ pub(crate) fn run_update_disabled_pass(root: &mut RenderRoot) {
 /// See the [stashed status documentation](../doc/06_masonry_concepts.md#stashed).
 fn update_stashed_for_widget(
     global_state: &mut RenderRootState,
+    default_properties: &AnyMap,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
@@ -334,6 +352,7 @@ fn update_stashed_for_widget(
 ) {
     let _span = enter_span(
         global_state,
+        default_properties,
         widget.reborrow(),
         state.reborrow(),
         properties.reborrow(),
@@ -355,6 +374,7 @@ fn update_stashed_for_widget(
         };
         let mut props = PropertiesMut {
             map: properties.item,
+            default_map: default_properties,
         };
         widget
             .item
@@ -385,6 +405,7 @@ fn update_stashed_for_widget(
         |widget, mut state, properties| {
             update_stashed_for_widget(
                 global_state,
+                default_properties,
                 widget,
                 state.reborrow_mut(),
                 properties,
@@ -401,6 +422,7 @@ pub(crate) fn run_update_stashed_pass(root: &mut RenderRoot) {
     let (root_widget, root_state, root_properties) = root.widget_arena.get_all_mut(root.root.id());
     update_stashed_for_widget(
         &mut root.global_state,
+        &root.default_properties,
         root_widget,
         root_state,
         root_properties,
@@ -421,6 +443,7 @@ pub(crate) fn run_update_stashed_pass(root: &mut RenderRoot) {
 /// See the [passes documentation](../doc/05_pass_system.md#update-passes).
 fn update_focus_chain_for_widget(
     global_state: &mut RenderRootState,
+    default_properties: &AnyMap,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
@@ -428,6 +451,7 @@ fn update_focus_chain_for_widget(
 ) {
     let _span = enter_span(
         global_state,
+        default_properties,
         widget.reborrow(),
         state.reborrow(),
         properties.reborrow(),
@@ -457,6 +481,7 @@ fn update_focus_chain_for_widget(
         |widget, mut state, properties| {
             update_focus_chain_for_widget(
                 global_state,
+                default_properties,
                 widget,
                 state.reborrow_mut(),
                 properties,
@@ -487,6 +512,7 @@ pub(crate) fn run_update_focus_chain_pass(root: &mut RenderRoot) {
     let (root_widget, root_state, root_properties) = root.widget_arena.get_all_mut(root.root.id());
     update_focus_chain_for_widget(
         &mut root.global_state,
+        &root.default_properties,
         root_widget,
         root_state,
         root_properties,
@@ -808,6 +834,10 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
             widget_state_children: state.children,
             widget_children: widget.children,
             widget_state: state.item,
+            properties: PropertiesRef {
+                map: properties.item,
+                default_map: &root.default_properties,
+            },
             properties_children: properties.children,
         };
 

--- a/masonry/src/properties/background.rs
+++ b/masonry/src/properties/background.rs
@@ -20,13 +20,16 @@ pub enum Background {
 }
 
 impl Property for Background {
-    // This matches the CSS default.
-    const DEFAULT: Self = Self::Color(AlphaColor::TRANSPARENT);
+    fn static_default() -> &'static Self {
+        // This matches the CSS default.
+        const DEFAULT: Background = Background::Color(AlphaColor::TRANSPARENT);
+        &DEFAULT
+    }
 }
 
 impl Default for Background {
     fn default() -> Self {
-        Self::DEFAULT
+        Self::static_default().clone()
     }
 }
 

--- a/masonry/src/properties/background.rs
+++ b/masonry/src/properties/background.rs
@@ -19,12 +19,14 @@ pub enum Background {
     Gradient(Gradient),
 }
 
-impl Property for Background {}
+impl Property for Background {
+    // This matches the CSS default.
+    const DEFAULT: Self = Self::Color(AlphaColor::TRANSPARENT);
+}
 
-// This matches the CSS default.
 impl Default for Background {
     fn default() -> Self {
-        Self::Color(AlphaColor::from_rgba8(0, 0, 0, 0))
+        Self::DEFAULT
     }
 }
 

--- a/masonry/src/properties/background.rs
+++ b/masonry/src/properties/background.rs
@@ -22,7 +22,7 @@ pub enum Background {
 impl Property for Background {
     fn static_default() -> &'static Self {
         // This matches the CSS default.
-        const DEFAULT: Background = Background::Color(AlphaColor::TRANSPARENT);
+        static DEFAULT: Background = Background::Color(AlphaColor::TRANSPARENT);
         &DEFAULT
     }
 }

--- a/masonry/src/properties/border_color.rs
+++ b/masonry/src/properties/border_color.rs
@@ -14,9 +14,12 @@ pub struct BorderColor {
 }
 
 impl Property for BorderColor {
-    const DEFAULT: Self = Self {
-        color: AlphaColor::TRANSPARENT,
-    };
+    fn static_default() -> &'static Self {
+        static DEFAULT: BorderColor = BorderColor {
+            color: AlphaColor::TRANSPARENT,
+        };
+        &DEFAULT
+    }
 }
 
 // TODO - The default border color in CSS is `currentcolor`,
@@ -25,7 +28,7 @@ impl Property for BorderColor {
 
 impl Default for BorderColor {
     fn default() -> Self {
-        Self::DEFAULT
+        *Self::static_default()
     }
 }
 

--- a/masonry/src/properties/border_color.rs
+++ b/masonry/src/properties/border_color.rs
@@ -13,7 +13,11 @@ pub struct BorderColor {
     pub color: AlphaColor<Srgb>,
 }
 
-impl Property for BorderColor {}
+impl Property for BorderColor {
+    const DEFAULT: Self = Self {
+        color: AlphaColor::TRANSPARENT,
+    };
+}
 
 // TODO - The default border color in CSS is `currentcolor`,
 // the color text is displayed in.
@@ -21,9 +25,7 @@ impl Property for BorderColor {}
 
 impl Default for BorderColor {
     fn default() -> Self {
-        Self {
-            color: AlphaColor::from_rgba8(0, 0, 0, 0),
-        }
+        Self::DEFAULT
     }
 }
 

--- a/masonry/src/properties/border_width.rs
+++ b/masonry/src/properties/border_width.rs
@@ -17,7 +17,9 @@ pub struct BorderWidth {
 // TODO - To match CSS, we should use a non-zero default width
 // and a "border style" of "None".
 
-impl Property for BorderWidth {}
+impl Property for BorderWidth {
+    const DEFAULT: Self = Self { width: 0. };
+}
 
 impl BorderWidth {
     /// Helper function to be called in [`Widget::property_changed`](crate::core::Widget::property_changed).

--- a/masonry/src/properties/border_width.rs
+++ b/masonry/src/properties/border_width.rs
@@ -18,7 +18,10 @@ pub struct BorderWidth {
 // and a "border style" of "None".
 
 impl Property for BorderWidth {
-    const DEFAULT: Self = Self { width: 0. };
+    fn static_default() -> &'static Self {
+        static DEFAULT: BorderWidth = BorderWidth { width: 0. };
+        &DEFAULT
+    }
 }
 
 impl BorderWidth {

--- a/masonry/src/properties/box_shadow.rs
+++ b/masonry/src/properties/box_shadow.rs
@@ -82,7 +82,7 @@ impl BoxShadow {
         ctx.request_layout();
     }
 
-    /// Returns false if the shadow can be safely treated as non-existent.
+    /// Returns `false` if the shadow can be safely treated as non-existent.
     ///
     /// May have false positives.
     pub fn is_visible(&self) -> bool {

--- a/masonry/src/properties/box_shadow.rs
+++ b/masonry/src/properties/box_shadow.rs
@@ -38,15 +38,17 @@ pub struct BoxShadow {
     pub blur_radius: f64,
 }
 
-impl Property for BoxShadow {}
+impl Property for BoxShadow {
+    const DEFAULT: Self = Self {
+        color: AlphaColor::TRANSPARENT,
+        offset: Point::ZERO,
+        blur_radius: 0.,
+    };
+}
 
 impl Default for BoxShadow {
     fn default() -> Self {
-        Self {
-            color: AlphaColor::TRANSPARENT,
-            offset: Point::ZERO,
-            blur_radius: 0.,
-        }
+        Self::DEFAULT
     }
 }
 

--- a/masonry/src/properties/box_shadow.rs
+++ b/masonry/src/properties/box_shadow.rs
@@ -39,16 +39,19 @@ pub struct BoxShadow {
 }
 
 impl Property for BoxShadow {
-    const DEFAULT: Self = Self {
-        color: AlphaColor::TRANSPARENT,
-        offset: Point::ZERO,
-        blur_radius: 0.,
-    };
+    fn static_default() -> &'static Self {
+        static DEFAULT: BoxShadow = BoxShadow {
+            color: AlphaColor::TRANSPARENT,
+            offset: Point::ZERO,
+            blur_radius: 0.,
+        };
+        &DEFAULT
+    }
 }
 
 impl Default for BoxShadow {
     fn default() -> Self {
-        Self::DEFAULT
+        *Self::static_default()
     }
 }
 
@@ -79,8 +82,20 @@ impl BoxShadow {
         ctx.request_layout();
     }
 
+    /// Returns false if the shadow can be safely treated as non-existent.
+    ///
+    /// May have false positives.
+    pub fn is_visible(&self) -> bool {
+        let alpha = self.color.components[3];
+        alpha != 0.0
+    }
+
     /// Helper function to paint the shadow into a scene.
     pub fn paint(&self, scene: &mut Scene, transform: Affine, rect: RoundedRect) {
+        if !self.is_visible() {
+            return;
+        }
+
         let transform = transform.pre_translate(self.offset.to_vec2());
         let blur_radius = self.blur_radius.max(0.);
 

--- a/masonry/src/properties/corner_radius.rs
+++ b/masonry/src/properties/corner_radius.rs
@@ -12,7 +12,9 @@ pub struct CornerRadius {
     pub radius: f64,
 }
 
-impl Property for CornerRadius {}
+impl Property for CornerRadius {
+    const DEFAULT: Self = Self { radius: 0. };
+}
 
 impl CornerRadius {
     pub(crate) fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {

--- a/masonry/src/properties/corner_radius.rs
+++ b/masonry/src/properties/corner_radius.rs
@@ -13,7 +13,10 @@ pub struct CornerRadius {
 }
 
 impl Property for CornerRadius {
-    const DEFAULT: Self = Self { radius: 0. };
+    fn static_default() -> &'static Self {
+        static DEFAULT: CornerRadius = CornerRadius { radius: 0. };
+        &DEFAULT
+    }
 }
 
 impl CornerRadius {

--- a/masonry/src/properties/padding.rs
+++ b/masonry/src/properties/padding.rs
@@ -20,7 +20,10 @@ pub struct Padding {
 }
 
 impl Property for Padding {
-    const DEFAULT: Self = Self::ZERO;
+    fn static_default() -> &'static Self {
+        static DEFAULT: Padding = Padding::ZERO;
+        &DEFAULT
+    }
 }
 
 impl From<f64> for Padding {

--- a/masonry/src/properties/padding.rs
+++ b/masonry/src/properties/padding.rs
@@ -6,11 +6,8 @@ use std::any::TypeId;
 use crate::core::{BoxConstraints, Property, UpdateCtx};
 use crate::kurbo::{Point, Size, Vec2};
 
-/// The amount of space between a widget's border and its contents.
-///
-/// Padding can be constructed using [`from(value: f64)`][Self::from]
-/// as well as from a `(f64, f64)` tuple, or `(f64, f64, f64, f64)` tuple, following the CSS padding conventions.
-#[derive(Debug, Clone, Copy, PartialEq)]
+/// The width of padding between a widget's border and its contents.
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
 pub struct Padding {
     /// The amount of padding in logical pixels for the left edge.
     pub left: f64,
@@ -22,7 +19,9 @@ pub struct Padding {
     pub bottom: f64,
 }
 
-impl Property for Padding {}
+impl Property for Padding {
+    const DEFAULT: Self = Self::ZERO;
+}
 
 impl From<f64> for Padding {
     /// Converts the value to a `Padding` object with that amount of padding on all edges.

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -34,6 +34,7 @@ use crate::kurbo::{Point, Size, Vec2};
 use crate::passes::anim::run_update_anim_pass;
 use crate::peniko::{Blob, Color};
 use crate::testing::screenshots::get_image_diff;
+use crate::theme::default_property_set;
 
 /// A [`PointerInfo`] for a primary mouse, for testing.
 pub const PRIMARY_MOUSE: PointerInfo = PointerInfo {
@@ -243,6 +244,7 @@ impl TestHarness {
             render_root: RenderRoot::new(
                 root_widget,
                 RenderRootOptions {
+                    default_properties: default_property_set(),
                     use_system_fonts: false,
                     size_policy: WindowSizePolicy::User,
                     scale_factor: params.scale_factor,

--- a/masonry/src/testing/helper_widgets.rs
+++ b/masonry/src/testing/helper_widgets.rs
@@ -456,17 +456,9 @@ impl<S: 'static> Widget for ModularWidget<S> {
     fn find_widget_under_pointer<'c>(
         &'c self,
         ctx: QueryCtx<'c>,
-        props: PropertiesRef<'c>,
         pos: Point,
     ) -> Option<WidgetRef<'c, dyn Widget>> {
-        find_widget_under_pointer(
-            &WidgetRef {
-                widget: self,
-                properties: props,
-                ctx,
-            },
-            pos,
-        )
+        find_widget_under_pointer(&WidgetRef { widget: self, ctx }, pos)
     }
 
     fn type_name(&self) -> &'static str {
@@ -712,10 +704,9 @@ impl<W: Widget> Widget for Recorder<W> {
     fn find_widget_under_pointer<'c>(
         &'c self,
         ctx: QueryCtx<'c>,
-        props: PropertiesRef<'c>,
         pos: Point,
     ) -> Option<WidgetRef<'c, dyn Widget>> {
-        self.child.find_widget_under_pointer(ctx, props, pos)
+        self.child.find_widget_under_pointer(ctx, pos)
     }
 
     fn type_name(&self) -> &'static str {

--- a/masonry/src/theme.rs
+++ b/masonry/src/theme.rs
@@ -108,5 +108,7 @@ pub fn default_property_set() -> DefaultProperties {
         Gradient::new_linear(0.0).with_stops([BUTTON_LIGHT, BUTTON_DARK]),
     ));
 
+    // TODO - Add default Padding to RootWidget?
+
     properties
 }

--- a/masonry/src/theme.rs
+++ b/masonry/src/theme.rs
@@ -5,8 +5,11 @@
 
 #![allow(missing_docs, reason = "Names are self-explanatory.")]
 
+use crate::core::DefaultProperties;
 use crate::kurbo::Insets;
 use crate::peniko::Color;
+use crate::properties::{BorderColor, BorderWidth, CornerRadius, Padding};
+use crate::widgets::Button;
 
 // Colors are from https://sashat.me/2017/01/11/list-of-20-simple-distinct-colors/
 // They're picked for visual distinction and accessibility (99 percent)
@@ -85,4 +88,21 @@ static DEBUG_COLOR: &[Color] = &[
 pub fn get_debug_color(id: u64) -> Color {
     let color_num = id as usize % DEBUG_COLOR.len();
     DEBUG_COLOR[color_num]
+}
+
+pub fn default_property_set() -> DefaultProperties {
+    let mut properties = DefaultProperties::new();
+
+    properties.insert::<Button, _>(BorderColor { color: BORDER_DARK });
+    properties.insert::<Button, _>(BorderWidth {
+        width: BUTTON_BORDER_WIDTH,
+    });
+    properties.insert::<Button, _>(CornerRadius {
+        radius: BUTTON_BORDER_RADIUS,
+    });
+    // NOTE: these padding values are chosen to match the existing look of TextBox;
+    // they should be reevaluated at some point.
+    properties.insert::<Button, _>(Padding::from_vh(2., 8.));
+
+    properties
 }

--- a/masonry/src/theme.rs
+++ b/masonry/src/theme.rs
@@ -102,7 +102,7 @@ pub fn default_property_set() -> DefaultProperties {
     });
     // NOTE: these padding values are chosen to match the existing look of TextBox;
     // they should be reevaluated at some point.
-    properties.insert::<Button, _>(Padding::from_vh(2., 8.));
+    properties.insert::<Button, _>(Padding { x: 8., y: 2. });
 
     properties
 }

--- a/masonry/src/theme.rs
+++ b/masonry/src/theme.rs
@@ -8,7 +8,8 @@
 use crate::core::DefaultProperties;
 use crate::kurbo::Insets;
 use crate::peniko::Color;
-use crate::properties::{BorderColor, BorderWidth, CornerRadius, Padding};
+use crate::properties::types::Gradient;
+use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use crate::widgets::Button;
 
 // Colors are from https://sashat.me/2017/01/11/list-of-20-simple-distinct-colors/
@@ -102,7 +103,10 @@ pub fn default_property_set() -> DefaultProperties {
     });
     // NOTE: these padding values are chosen to match the existing look of TextBox;
     // they should be reevaluated at some point.
-    properties.insert::<Button, _>(Padding { x: 8., y: 2. });
+    properties.insert::<Button, _>(Padding::from_vh(2., 8.));
+    properties.insert::<Button, _>(Background::Gradient(
+        Gradient::new_linear(0.0).with_stops([BUTTON_LIGHT, BUTTON_DARK]),
+    ));
 
     properties
 }

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -13,8 +13,8 @@ use vello::kurbo::Affine;
 
 use crate::core::{
     AccessCtx, AccessEvent, Action, ArcStr, BoxConstraints, EventCtx, LayoutCtx, PaintCtx,
-    PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, TextEvent, Update, UpdateCtx, Widget,
-    WidgetId, WidgetMut, WidgetPod,
+    PointerEvent, PropertiesMut, PropertiesRef, Property, QueryCtx, TextEvent, Update, UpdateCtx,
+    Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::kurbo::Size;
 use crate::properties::types::Gradient;
@@ -22,21 +22,6 @@ use crate::properties::*;
 use crate::theme;
 use crate::util::{fill, stroke};
 use crate::widgets::Label;
-
-// --- MARK: CONSTANTS ---
-const DEFAULT_BORDER_COLOR: BorderColor = BorderColor {
-    color: theme::BORDER_DARK,
-};
-const DEFAULT_BORDER_WIDTH: BorderWidth = BorderWidth {
-    width: theme::BUTTON_BORDER_WIDTH,
-};
-const DEFAULT_BORDER_RADII: CornerRadius = CornerRadius {
-    radius: theme::BUTTON_BORDER_RADIUS,
-};
-
-// NOTE: these values are chosen to match the existing look of TextBox; these
-// should be reevaluated at some point.
-const DEFAULT_PADDING: Padding = Padding::from_vh(2., 8.);
 
 /// A button with a text label.
 ///
@@ -167,6 +152,7 @@ impl Widget for Button {
     }
 
     fn property_changed(&mut self, ctx: &mut UpdateCtx, property_type: TypeId) {
+        Background::prop_changed(ctx, property_type);
         BorderColor::prop_changed(ctx, property_type);
         BorderWidth::prop_changed(ctx, property_type);
         CornerRadius::prop_changed(ctx, property_type);
@@ -180,8 +166,8 @@ impl Widget for Button {
         props: &mut PropertiesMut<'_>,
         bc: &BoxConstraints,
     ) -> Size {
-        let border = props.get::<BorderWidth>().unwrap_or(&DEFAULT_BORDER_WIDTH);
-        let padding = props.get::<Padding>().unwrap_or(&DEFAULT_PADDING);
+        let border = props.get::<BorderWidth>().unwrap_or(&Property::DEFAULT);
+        let padding = props.get::<Padding>().unwrap_or(&Property::DEFAULT);
         let shadow = props.get::<BoxShadow>();
 
         let initial_bc = bc;
@@ -223,9 +209,9 @@ impl Widget for Button {
         let is_hovered = ctx.is_hovered();
         let size = ctx.size();
 
-        let border_color = props.get::<BorderColor>().unwrap_or(&DEFAULT_BORDER_COLOR);
-        let border_width = props.get::<BorderWidth>().unwrap_or(&DEFAULT_BORDER_WIDTH);
-        let border_radius = props.get::<CornerRadius>().unwrap_or(&DEFAULT_BORDER_RADII);
+        let border_color = props.get::<BorderColor>().unwrap_or(&Property::DEFAULT);
+        let border_width = props.get::<BorderWidth>().unwrap_or(&Property::DEFAULT);
+        let border_radius = props.get::<CornerRadius>().unwrap_or(&Property::DEFAULT);
         let shadow = props.get::<BoxShadow>();
 
         // TODO - Add DEFAULT_BACKGROUND_GRADIENT constant.

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -13,8 +13,8 @@ use vello::kurbo::Affine;
 
 use crate::core::{
     AccessCtx, AccessEvent, Action, ArcStr, BoxConstraints, EventCtx, LayoutCtx, PaintCtx,
-    PointerEvent, PropertiesMut, PropertiesRef, Property, QueryCtx, TextEvent, Update, UpdateCtx,
-    Widget, WidgetId, WidgetMut, WidgetPod,
+    PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, TextEvent, Update, UpdateCtx, Widget,
+    WidgetId, WidgetMut, WidgetPod,
 };
 use crate::kurbo::Size;
 use crate::properties::types::Gradient;
@@ -166,8 +166,8 @@ impl Widget for Button {
         props: &mut PropertiesMut<'_>,
         bc: &BoxConstraints,
     ) -> Size {
-        let border = props.get::<BorderWidth>().unwrap_or(&Property::DEFAULT);
-        let padding = props.get::<Padding>().unwrap_or(&Property::DEFAULT);
+        let border = props.get::<BorderWidth>();
+        let padding = props.get::<Padding>();
         let shadow = props.get::<BoxShadow>();
 
         let initial_bc = bc;
@@ -196,7 +196,7 @@ impl Widget for Button {
 
         // TODO - pos = (size - label_size) / 2
 
-        if let Some(shadow) = shadow {
+        if shadow.is_visible() {
             ctx.set_paint_insets(shadow.get_insets());
         }
 
@@ -209,17 +209,12 @@ impl Widget for Button {
         let is_hovered = ctx.is_hovered();
         let size = ctx.size();
 
-        let border_color = props.get::<BorderColor>().unwrap_or(&Property::DEFAULT);
-        let border_width = props.get::<BorderWidth>().unwrap_or(&Property::DEFAULT);
-        let border_radius = props.get::<CornerRadius>().unwrap_or(&Property::DEFAULT);
+        let border_color = props.get::<BorderColor>();
+        let border_width = props.get::<BorderWidth>();
+        let border_radius = props.get::<CornerRadius>();
         let shadow = props.get::<BoxShadow>();
 
-        // TODO - Add DEFAULT_BACKGROUND_GRADIENT constant.
-        // Right now we can't because `.with_stops` isn't const-compatible.
-        let bg_gradient =
-            Gradient::new_linear(0.0).with_stops([theme::BUTTON_LIGHT, theme::BUTTON_DARK]);
-        let bg_gradient = Background::Gradient(bg_gradient);
-        let bg_gradient = props.get::<Background>().unwrap_or(&bg_gradient);
+        let bg_gradient = props.get::<Background>();
 
         let bg_rect = border_width.bg_rect(size, border_radius);
         let border_rect = border_width.border_rect(size, border_radius);
@@ -247,9 +242,7 @@ impl Widget for Button {
             *border_color
         };
 
-        if let Some(shadow) = shadow {
-            shadow.paint(scene, Affine::IDENTITY, bg_rect);
-        }
+        shadow.paint(scene, Affine::IDENTITY, bg_rect);
 
         let brush = bg_gradient.get_peniko_brush_for_rect(bg_rect.rect());
         fill(scene, &bg_rect, &brush);

--- a/masonry/src/widgets/root_widget.rs
+++ b/masonry/src/widgets/root_widget.rs
@@ -11,8 +11,8 @@ use vello::kurbo::Point;
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
-    PropertiesMut, PropertiesRef, Property, QueryCtx, RegisterCtx, TextEvent, UpdateCtx, Widget,
-    WidgetId, WidgetMut, WidgetPod,
+    PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, UpdateCtx, Widget, WidgetId,
+    WidgetMut, WidgetPod,
 };
 use crate::kurbo::Size;
 use crate::properties::{Background, Padding};
@@ -88,7 +88,7 @@ impl Widget for RootWidget {
         props: &mut PropertiesMut<'_>,
         bc: &BoxConstraints,
     ) -> Size {
-        let padding = props.get::<Padding>().unwrap_or(&Property::DEFAULT);
+        let padding = props.get::<Padding>();
 
         let bc = padding.layout_down(*bc);
         let size = ctx.run_layout(&mut self.pod, &bc);
@@ -100,12 +100,11 @@ impl Widget for RootWidget {
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx, props: &PropertiesRef<'_>, scene: &mut Scene) {
-        if let Some(bg) = props.get::<Background>() {
-            let bg_rect = ctx.size().to_rect();
-            let bg_brush = bg.get_peniko_brush_for_rect(bg_rect);
+        let bg = props.get::<Background>();
+        let bg_rect = ctx.size().to_rect();
+        let bg_brush = bg.get_peniko_brush_for_rect(bg_rect);
 
-            fill(scene, &bg_rect, &bg_brush);
-        }
+        fill(scene, &bg_rect, &bg_brush);
     }
 
     fn accessibility_role(&self) -> Role {

--- a/masonry/src/widgets/root_widget.rs
+++ b/masonry/src/widgets/root_widget.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::any::TypeId;
+
 use accesskit::{Node, Role};
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
@@ -9,12 +11,20 @@ use vello::kurbo::Point;
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
-    PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut,
-    WidgetPod,
+    PropertiesMut, PropertiesRef, Property, QueryCtx, RegisterCtx, TextEvent, UpdateCtx, Widget,
+    WidgetId, WidgetMut, WidgetPod,
 };
 use crate::kurbo::Size;
+use crate::properties::{Background, Padding};
+use crate::util::fill;
 
 /// A wrapper Widget which app drivers can wrap around the rest of the widget tree.
+///
+/// This is useful for a few things:
+/// - Reporting a [`Role::Window`] to the accessibility API.
+/// - Setting a default [`Background`] and [`Padding`] for the entire app using [`DefaultProperties`].
+///
+/// [`DefaultProperties`]: crate::core::DefaultProperties
 pub struct RootWidget {
     pub(crate) pod: WidgetPod<dyn Widget>,
 }
@@ -67,18 +77,36 @@ impl Widget for RootWidget {
         ctx.register_child(&mut self.pod);
     }
 
+    fn property_changed(&mut self, ctx: &mut UpdateCtx, property_type: TypeId) {
+        Background::prop_changed(ctx, property_type);
+        Padding::prop_changed(ctx, property_type);
+    }
+
     fn layout(
         &mut self,
         ctx: &mut LayoutCtx,
-        _props: &mut PropertiesMut<'_>,
+        props: &mut PropertiesMut<'_>,
         bc: &BoxConstraints,
     ) -> Size {
-        let size = ctx.run_layout(&mut self.pod, bc);
-        ctx.place_child(&mut self.pod, Point::ORIGIN);
+        let padding = props.get::<Padding>().unwrap_or(&Property::DEFAULT);
+
+        let bc = padding.layout_down(*bc);
+        let size = ctx.run_layout(&mut self.pod, &bc);
+        let (size, _) = padding.layout_up(size, 0.);
+
+        let pos = padding.place_down(Point::ORIGIN);
+        ctx.place_child(&mut self.pod, pos);
         size
     }
 
-    fn paint(&mut self, _ctx: &mut PaintCtx, _props: &PropertiesRef<'_>, _scene: &mut Scene) {}
+    fn paint(&mut self, ctx: &mut PaintCtx, props: &PropertiesRef<'_>, scene: &mut Scene) {
+        if let Some(bg) = props.get::<Background>() {
+            let bg_rect = ctx.size().to_rect();
+            let bg_brush = bg.get_peniko_brush_for_rect(bg_rect);
+
+            fill(scene, &bg_rect, &bg_brush);
+        }
+    }
 
     fn accessibility_role(&self) -> Role {
         Role::Window

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -428,9 +428,8 @@ impl Widget for SizedBox {
         let background = self.background.clone().or_else(|| {
             // TODO - bg_rect should account for border width
             let bg_rect = ctx.size().to_rect();
-            props
-                .get::<Background>()
-                .map(|background| background.get_peniko_brush_for_rect(bg_rect))
+            // TODO - Remove `Some()`
+            Some(props.get::<Background>().get_peniko_brush_for_rect(bg_rect))
         });
 
         if let Some(background) = background {

--- a/masonry_winit/examples/calc_masonry.rs
+++ b/masonry_winit/examples/calc_masonry.rs
@@ -24,13 +24,13 @@ use masonry_winit::core::{
 use masonry_winit::dpi::LogicalSize;
 use masonry_winit::kurbo::{Point, Size};
 use masonry_winit::peniko::Color;
+use masonry_winit::peniko::color::AlphaColor;
 use masonry_winit::properties::{Background, Padding};
 use masonry_winit::theme::default_property_set;
 use masonry_winit::widgets::{Align, CrossAxisAlignment, Flex, Label, RootWidget, SizedBox};
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace, trace_span};
 use vello::Scene;
-use vello::peniko::color::AlphaColor;
 use winit::window::Window;
 
 #[derive(Clone)]

--- a/masonry_winit/examples/calc_masonry.rs
+++ b/masonry_winit/examples/calc_masonry.rs
@@ -12,6 +12,8 @@
 )]
 #![expect(elided_lifetimes_in_paths, reason = "Deferred: Noisy")]
 
+use std::str::FromStr;
+
 use accesskit::{Node, Role};
 use masonry_winit::app::{AppDriver, DriverCtx};
 use masonry_winit::core::{
@@ -22,10 +24,13 @@ use masonry_winit::core::{
 use masonry_winit::dpi::LogicalSize;
 use masonry_winit::kurbo::{Point, Size};
 use masonry_winit::peniko::Color;
+use masonry_winit::properties::{Background, Padding};
+use masonry_winit::theme::default_property_set;
 use masonry_winit::widgets::{Align, CrossAxisAlignment, Flex, Label, RootWidget, SizedBox};
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace, trace_span};
 use vello::Scene;
+use vello::peniko::color::AlphaColor;
 use winit::window::Window;
 
 #[derive(Clone)]
@@ -416,11 +421,22 @@ fn main() {
         in_num: false,
     };
 
-    masonry_winit::app::run(
-        masonry_winit::app::EventLoop::with_user_event(),
+    let mut default_properties = default_property_set();
+    default_properties.insert::<RootWidget<dyn Widget>, _>(Background::Color(
+        AlphaColor::from_str("#794869").unwrap(),
+    ));
+    default_properties.insert::<RootWidget<dyn Widget>, _>(Padding::all(2.0));
+
+    let event_loop = masonry_winit::app::EventLoop::with_user_event()
+        .build()
+        .unwrap();
+    masonry_winit::app::run_with(
+        event_loop,
         window_attributes,
-        RootWidget::new(build_calc()),
+        RootWidget::new_dyn(build_calc()),
         calc_state,
+        default_properties,
+        Color::BLACK,
     )
     .unwrap();
 }

--- a/masonry_winit/examples/calc_masonry.rs
+++ b/masonry_winit/examples/calc_masonry.rs
@@ -422,10 +422,9 @@ fn main() {
     };
 
     let mut default_properties = default_property_set();
-    default_properties.insert::<RootWidget<dyn Widget>, _>(Background::Color(
-        AlphaColor::from_str("#794869").unwrap(),
-    ));
-    default_properties.insert::<RootWidget<dyn Widget>, _>(Padding::all(2.0));
+    default_properties
+        .insert::<RootWidget, _>(Background::Color(AlphaColor::from_str("#794869").unwrap()));
+    default_properties.insert::<RootWidget, _>(Padding::all(2.0));
 
     let event_loop = masonry_winit::app::EventLoop::with_user_event()
         .build()
@@ -433,7 +432,7 @@ fn main() {
     masonry_winit::app::run_with(
         event_loop,
         window_attributes,
-        RootWidget::new_dyn(build_calc()),
+        RootWidget::new(build_calc()),
         calc_state,
         default_properties,
         Color::BLACK,

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -106,6 +106,7 @@ pub fn run(
         window_attributes,
         root_widget,
         app_driver,
+        default_property_set(),
         Color::BLACK,
     )
 }
@@ -115,6 +116,7 @@ pub fn run_with(
     window: WindowAttributes,
     root_widget: impl Widget,
     app_driver: impl AppDriver + 'static,
+    default_properties: DefaultProperties,
     background_color: Color,
 ) -> Result<(), EventLoopError> {
     // If there is no default tracing subscriber, we set our own. If one has
@@ -124,7 +126,13 @@ pub fn run_with(
     let _ = crate::app::try_init_tracing();
 
     let mut main_state = MainState {
-        masonry_state: MasonryState::new(window, &event_loop, root_widget, background_color),
+        masonry_state: MasonryState::new(
+            window,
+            &event_loop,
+            root_widget,
+            default_properties,
+            background_color,
+        ),
         app_driver: Box::new(app_driver),
     };
     main_state
@@ -207,6 +215,7 @@ impl MasonryState<'_> {
         window: WindowAttributes,
         event_loop: &EventLoop,
         root_widget: impl Widget,
+        default_properties: DefaultProperties,
         background_color: Color,
     ) -> Self {
         let render_cx = RenderContext::new();
@@ -218,6 +227,7 @@ impl MasonryState<'_> {
             render_root: RenderRoot::new(
                 root_widget,
                 RenderRootOptions {
+                    default_properties,
                     use_system_fonts: true,
                     size_policy: WindowSizePolicy::User,
                     scale_factor,

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -6,6 +6,8 @@
 use std::sync::Arc;
 
 use accesskit_winit::Adapter;
+use masonry_core::core::DefaultProperties;
+use masonry_core::theme::default_property_set;
 use tracing::{debug, error, info, info_span};
 use vello::kurbo::Affine;
 use vello::util::{RenderContext, RenderSurface};

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -6,8 +6,8 @@
 use std::sync::Arc;
 
 use accesskit_winit::Adapter;
-use masonry_core::core::DefaultProperties;
-use masonry_core::theme::default_property_set;
+use masonry::core::DefaultProperties;
+use masonry::theme::default_property_set;
 use tracing::{debug, error, info, info_span};
 use vello::kurbo::Affine;
 use vello::util::{RenderContext, RenderSurface};

--- a/xilem/examples/external_event_loop.rs
+++ b/xilem/examples/external_event_loop.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use masonry_winit::app::{AppDriver, MasonryUserEvent};
 use masonry_winit::peniko::Color;
+use masonry_winit::theme::default_property_set;
 use masonry_winit::widgets::{CrossAxisAlignment, MainAxisAlignment};
 use winit::application::ApplicationHandler;
 use winit::error::EventLoopError;
@@ -138,8 +139,13 @@ fn main() -> Result<(), EventLoopError> {
     let event_loop = EventLoop::with_user_event().build().unwrap();
     let proxy = MasonryProxy::new(event_loop.create_proxy());
     let (widget, driver) = xilem.into_driver(Arc::new(proxy));
-    let masonry_state =
-        masonry_winit::app::MasonryState::new(window_attributes, &event_loop, widget, Color::BLACK);
+    let masonry_state = masonry_winit::app::MasonryState::new(
+        window_attributes,
+        &event_loop,
+        widget,
+        default_property_set(),
+        Color::BLACK,
+    );
 
     let mut app = ExternalApp {
         masonry_state,

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -133,8 +133,11 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use masonry_winit::core::{FromDynWidget, Widget, WidgetId, WidgetMut, WidgetPod};
+use masonry_winit::core::{
+    DefaultProperties, FromDynWidget, Widget, WidgetId, WidgetMut, WidgetPod,
+};
 use masonry_winit::dpi::LogicalSize;
+use masonry_winit::theme::default_property_set;
 use masonry_winit::widgets::RootWidget;
 use view::{Transformed, transformed};
 use winit::error::EventLoopError;
@@ -172,6 +175,7 @@ pub struct Xilem<State, Logic> {
     state: State,
     logic: Logic,
     runtime: tokio::runtime::Runtime,
+    default_properties: Option<DefaultProperties>,
     background_color: Color,
     // Font data to include in loading.
     fonts: Vec<Blob<u8>>,
@@ -190,6 +194,7 @@ where
             state,
             logic,
             runtime,
+            default_properties: None,
             background_color: Color::BLACK,
             fonts: Vec::new(),
         }
@@ -206,6 +211,13 @@ where
     /// Sets main window background color.
     pub fn background_color(mut self, color: Color) -> Self {
         self.background_color = color;
+        self
+    }
+
+    // TODO: Find better ways to customize default property set.
+    /// Sets default properties of widget tree.
+    pub fn with_default_properties(mut self, default_properties: DefaultProperties) -> Self {
+        self.default_properties = Some(default_properties);
         self
     }
 
@@ -234,7 +246,7 @@ where
     // TODO: Make windows into a custom view
     /// Run app with custom window attributes.
     pub fn run_windowed_in(
-        self,
+        mut self,
         mut event_loop: EventLoopBuilder,
         window_attributes: WindowAttributes,
     ) -> Result<(), EventLoopError>
@@ -246,8 +258,19 @@ where
         let event_loop = event_loop.build()?;
         let proxy = event_loop.create_proxy();
         let bg_color = self.background_color;
+        let default_properties = self
+            .default_properties
+            .take()
+            .unwrap_or_else(default_property_set);
         let (root_widget, driver) = self.into_driver(Arc::new(MasonryProxy(proxy)));
-        masonry_winit::app::run_with(event_loop, window_attributes, root_widget, driver, bg_color)
+        masonry_winit::app::run_with(
+            event_loop,
+            window_attributes,
+            root_widget,
+            driver,
+            default_properties,
+            bg_color,
+        )
     }
 
     pub fn into_driver(


### PR DESCRIPTION
Add method in Property trait that returns a static reference to a default value.
Make property getters return non-optional values.

Create DefaultProperties type.
Create default set of properties in `theme` module.
Add options to override that set of properties by passing DefaultProperties at startup.
Add some properties to RootWidget.
Change background color in calc example.