### PR TITLE
Update `README.md` structures to the latest Linebender standard.

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,7 +24,7 @@ An evolution of the ideas implemented in xilem can be found in the following res
 - **High Performance.** Lightweight state management, retained widget layer, massively parallel rendering backend (Vello), fast startup time, small binary size
 - **Productive.** Offer an ergonomic API, code is concise (low Rust tax), idiomatic and UI components compose well
 - **Rich 2D graphics model.**
-- **Wide platform support.** Windows, MacOS, Linux (Wayland/X11), Android (Google funded), iOS
+- **Wide platform support.** Windows, macOS, Linux (Wayland/X11), Android (Google funded), iOS
 - **Batteries-included.** Advanced text layout, IME, Accessibility, Animation, Styling
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -4,23 +4,17 @@
 
 **An experimental Rust architecture for reactive UI**
 
-[![Xi Zulip](https://img.shields.io/badge/Xi%20Zulip-%23xilem-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/354396-xilem)
-[![dependency status](https://deps.rs/repo/github/linebender/xilem/status.svg)](https://deps.rs/repo/github/linebender/xilem)
-[![Apache 2.0](https://img.shields.io/badge/license-Apache-blue.svg)](#license)
-[![Build Status](https://github.com/linebender/xilem/actions/workflows/ci.yml/badge.svg)](https://github.com/linebender/xilem/actions)
-[![Crates.io](https://img.shields.io/crates/v/xilem.svg)](https://crates.io/crates/xilem)
-[![Docs](https://docs.rs/xilem/badge.svg)](https://docs.rs/xilem)
+[![Linebender Zulip chat.](https://img.shields.io/badge/Xi%20Zulip-%23xilem-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/354396-xilem)
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/xilem/ci.yml?logo=github&label=CI)](https://github.com/linebender/xilem/actions)
+[![Dependency staleness status.](https://deps.rs/repo/github/linebender/xilem/status.svg)](https://deps.rs/repo/github/linebender/xilem)
+[![Apache 2.0 license.](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
 
 </div>
 
-This repo contains an experimental architecture, implemented with a toy UI. At a very high level, it combines ideas from Flutter, SwiftUI, and Elm. Like all of these, it uses lightweight view objects, diffing them to provide minimal updates to a retained UI. Like SwiftUI, it is strongly typed.
-
-## Community
-
-[![Xi Zulip](https://img.shields.io/badge/Xi%20Zulip-%23xilem-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/354396-xilem)
-
-Discussion of Xilem development happens in the [Xi Zulip](https://xi.zulipchat.com/), specifically the [#xilem channel](https://xi.zulipchat.com/#narrow/stream/354396-xilem). 
-All public content can be read without logging in
+This repo contains an experimental architecture, implemented with a toy UI.
+At a very high level, it combines ideas from Flutter, SwiftUI, and Elm.
+Like all of these, it uses lightweight view objects, diffing them to provide minimal updates to a retained UI.
+Like SwiftUI, it is strongly typed.
 
 ## Project structure
 
@@ -50,9 +44,12 @@ This section should not be in the main README. -->
 >
 > This README is a bit out of date. To understand more of what's going on, please read the blog post, [Xilem: an architecture for UI in Rust].
 
-Like Elm, the app logic contains *centralized state.* On each cycle (meaning, roughly, on each high-level UI interaction such as a button click), the framework calls a closure, giving it mutable access to the app state, and the return value is a *view tree.* This view tree is fairly short-lived; it is used to render the UI, possibly dispatch some events, and be used as a reference for *diffing* by the next cycle, at which point it is dropped.
+Like Elm, the app logic contains *centralized state.*
+On each cycle (meaning, roughly, on each high-level UI interaction such as a button click), the framework calls a closure, giving it mutable access to the app state, and the return value is a *view tree.*
+This view tree is fairly short-lived; it is used to render the UI, possibly dispatch some events, and be used as a reference for *diffing* by the next cycle, at which point it is dropped.
 
-We'll use the standard counter example. Here the state is a single integer, and the view tree is a column containing two buttons.
+We'll use the standard counter example.
+Here the state is a single integer, and the view tree is a column containing two buttons.
 
 ```rust
 fn app_logic(data: &mut u32) -> impl View<u32, (), Element = impl Widget> {
@@ -63,9 +60,15 @@ fn app_logic(data: &mut u32) -> impl View<u32, (), Element = impl Widget> {
 }
 ```
 
-These are all just vanilla data structures. The next step is diffing or reconciling against a previous version, now a standard technique. The result is an *element tree.* Each node type in the view tree has a corresponding element as an associated type. The `build` method on a view node creates the element, and the `rebuild` method diffs against the previous version (for example, if the string changes) and updates the element. There's also an associated state tree, not actually needed in this simple example, but would be used for memoization.
+These are all just vanilla data structures.
+The next step is diffing or reconciling against a previous version, now a standard technique.
+The result is an *element tree.*
+Each node type in the view tree has a corresponding element as an associated type.
+The `build` method on a view node creates the element, and the `rebuild` method diffs against the previous version (for example, if the string changes) and updates the element.
+There's also an associated state tree, not actually needed in this simple example, but would be used for memoization.
 
-The closures are the interesting part. When they're run, they take a mutable reference to the app data.
+The closures are the interesting part.
+When they're run, they take a mutable reference to the app data.
 
 ### Components
 
@@ -86,13 +89,16 @@ fn app_logic(data: &mut AppData) -> impl View<AppData, (), Element = impl Widget
 }
 ```
 
-This adapt node is very similar to a lens (quite familiar to existing Druid users), and is also very similar to the [Html.map] node in Elm. Note that in this case the data presented to the child component to render, and the mutable app state available in callbacks is the same, but that is not necessarily the case.
+This adapt node is very similar to a lens (quite familiar to existing Druid users), and is also very similar to the [Html.map] node in Elm.
+Note that in this case the data presented to the child component to render, and the mutable app state available in callbacks is the same, but that is not necessarily the case.
 
 ### Memoization
 
 In the simplest case, the app builds the entire view tree, which is diffed against the previous tree, only to find that most of it hasn't changed.
 
-When a subtree is a pure function of some data, as is the case for the button above, it makes sense to *memoize.* The data is compared to the previous version, and only when it's changed is the view tree build. The signature of the memoize node is nearly identical to [Html.lazy] in Elm:
+When a subtree is a pure function of some data, as is the case for the button above, it makes sense to *memoize.*
+The data is compared to the previous version, and only when it's changed is the view tree build.
+The signature of the memoize node is nearly identical to [Html.lazy] in Elm:
 
 ```rust
 fn app_logic(data: &mut AppData) -> impl View<AppData, (), Element = impl Widget> {
@@ -106,22 +112,29 @@ fn app_logic(data: &mut AppData) -> impl View<AppData, (), Element = impl Widget
 
 The current code uses a `PartialEq` bound, but in practice I think it might be much more useful to use pointer equality on `Rc` and `Arc`.
 
-The combination of memoization with pointer equality and an adapt node that calls [Rc::make_mut] on the parent type is actually a powerful form of change tracking, similar in scope to Adapton, self-adjusting computation, or the types of binding objects used in SwiftUI. If a piece of data is rendered in two different places, it automatically propagates the change to both of those, without having to do any explicit management of the dependency graph.
+The combination of memoization with pointer equality and an adapt node that calls [Rc::make_mut] on the parent type is actually a powerful form of change tracking, similar in scope to Adapton, self-adjusting computation, or the types of binding objects used in SwiftUI.
+If a piece of data is rendered in two different places, it automatically propagates the change to both of those, without having to do any explicit management of the dependency graph.
 
 I anticipate it will also be possible to do dirty tracking manually - the app logic can set a dirty flag when a subtree needs re-rendering.
 
 ### Optional type erasure
 
-By default, view nodes are strongly typed. The type of a container includes the types of its children (through the `ViewTuple` trait), so for a large tree the type can become quite large. In addition, such types don't make for easy dynamic reconfiguration of the UI. SwiftUI has exactly this issue, and provides [AnyView] as the solution. Ours is more or less identical.
+By default, view nodes are strongly typed.
+The type of a container includes the types of its children (through the `ViewTuple` trait), so for a large tree the type can become quite large.
+In addition, such types don't make for easy dynamic reconfiguration of the UI.
+SwiftUI has exactly this issue, and provides [AnyView] as the solution.
+Ours is more or less identical.
 
-The type erasure of View nodes is not an easy trick, as the trait has two associated types and the `rebuild` method takes the previous view as a `&Self` typed parameter. Nonetheless, it is possible. (As far as I know, Olivier Faure was the first to demonstrate this technique, in [Panoramix], but I'm happy to be further enlightened)
+The type erasure of View nodes is not an easy trick, as the trait has two associated types and the `rebuild` method takes the previous view as a `&Self` typed parameter.
+Nonetheless, it is possible.
+(As far as I know, Olivier Faure was the first to demonstrate this technique, in [Panoramix], but I'm happy to be further enlightened)
 
 ## Prerequisites
 
 ### Linux and BSD
 
-You need to have installed `pkg-config`, `clang`, and the development packages of `wayland`,
-`libxkbcommon`, `libxcb`, and `vulkan-loader`. Most distributions have `pkg-config` installed by default.
+You need to have installed `pkg-config`, `clang`, and the development packages of `wayland`, `libxkbcommon`, `libxcb`, and `vulkan-loader`.
+Most distributions have `pkg-config` installed by default.
 
 To install the remaining packages on Fedora, run:
 
@@ -133,6 +146,20 @@ To install the remaining packages on Debian or Ubuntu, run:
 
 ```sh
 sudo apt-get install clang libwayland-dev libxkbcommon-x11-dev libvulkan-dev
+```
+
+## Recommended Cargo Config
+
+The Xilem repository includes a lot of projects and examples, most of them pulling a lot of dependencies.
+
+If you contribute to Xilem on Linux or MacOS, we recommend using [`split-debuginfo`](https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo) in your [`.cargo/config.toml`](https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure) file to reduce the size of the `target/` folder:
+
+```toml
+[profile.dev]
+# One debuginfo file per dependency, to reduce file size of tests/examples.
+# Note that this value is not supported on Windows.
+# See https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo
+split-debuginfo="unpacked"
 ```
 
 ## Minimum supported Rust Version (MSRV)
@@ -152,42 +179,27 @@ If you encounter a compilation issue due to a dependency and don't want to upgra
 # Use the problematic dependency's name and version
 cargo update -p package_name --precise 0.1.1
 ```
-
 </details>
 
-## Recommended Cargo Config
+## Community
 
-The Xilem repository includes a lot of projects and examples, most of them pulling a lot of dependencies.
+Discussion of Xilem development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#xilem channel](https://xi.zulipchat.com/#narrow/stream/354396-xilem).
+All public content can be read without logging in.
 
-If you contribute to Xilem on Linux or MacOS, we recommend using [`split-debuginfo`](https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo) in your
-[`.cargo/config.toml`](https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure) file to reduce the size of the `target/` folder:
+Contributions are welcome by pull request.
+The [Rust code of conduct] applies.
 
-```toml
-[profile.dev]
-# One debuginfo file per dependency, to reduce file size of tests/examples.
-# Note that this value is not supported on Windows.
-# See https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo
-split-debuginfo="unpacked"
-```
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache 2.0 license, shall be licensed as noted in the [License](#license) section, without any additional terms or conditions.
 
 ## License
 
-Licensed under the Apache License, Version 2.0
-([LICENSE](LICENSE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+Licensed under the Apache License, Version 2.0 ([LICENSE](LICENSE) or <http://www.apache.org/licenses/LICENSE-2.0>)
 
 Some files used for examples are under different licenses:
 
 - The font file (`RobotoFlex-Subset.ttf`) in `xilem/resources/fonts/roboto_flex/` is licensed solely as documented in that folder (and is not licensed under the Apache License, Version 2.0).
 - The data file (`status.csv`) in `xilem/resources/data/http_cats_status/` is licensed solely as documented in that folder (and is not licensed under the Apache License, Version 2.0).
 - The data file (`emoji.csv`) in `xilem/resources/data/emoji_names/` is licensed solely as documented in that folder (and is not licensed under the Apache License, Version 2.0).
-
-## Contribution
-
-Contributions are welcome by pull request. The [Rust code of conduct] applies.
-
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
-licensed as above, without any additional terms or conditions.
 
 [Html.lazy]: https://guide.elm-lang.org/optimization/lazy.html
 [Html map]: https://package.elm-lang.org/packages/elm/html/latest/Html#map
@@ -196,4 +208,4 @@ licensed as above, without any additional terms or conditions.
 [Panoramix]: https://github.com/PoignardAzur/panoramix
 [Xilem: an architecture for UI in Rust]: https://raphlinus.github.io/rust/gui/2022/05/07/ui-architecture.html
 [xkbcommon]: https://github.com/xkbcommon/libxkbcommon
-[rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 </div>
 
-This repo contains an experimental architecture, implemented with a toy UI.
+This repo contains an experimental architecture, implemented with Masonry.
 At a very high level, it combines ideas from Flutter, SwiftUI, and Elm.
 Like all of these, it uses lightweight view objects, diffing them to provide minimal updates to a retained UI.
 Like SwiftUI, it is strongly typed.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ sudo apt-get install clang libwayland-dev libxkbcommon-x11-dev libvulkan-dev
 
 The Xilem repository includes a lot of projects and examples, most of them pulling a lot of dependencies.
 
-If you contribute to Xilem on Linux or MacOS, we recommend using [`split-debuginfo`](https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo) in your [`.cargo/config.toml`](https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure) file to reduce the size of the `target/` folder:
+If you contribute to Xilem on Linux or macOS, we recommend using [`split-debuginfo`](https://doc.rust-lang.org/cargo/reference/profiles.html#split-debuginfo) in your [`.cargo/config.toml`](https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure) file to reduce the size of the `target/` folder:
 
 ```toml
 [profile.dev]

--- a/masonry/README.md
+++ b/masonry/README.md
@@ -1,4 +1,65 @@
-# `masonry`
+<div align="center">
+
+# Masonry
+
+**A foundational framework for Rust GUI libraries**
+
+[![Latest published version.](https://img.shields.io/crates/v/masonry.svg)](https://crates.io/crates/masonry)
+[![Documentation build status.](https://img.shields.io/docsrs/masonry.svg)](https://docs.rs/masonry)
+[![Apache 2.0 license.](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
+\
+[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23masonry-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/317477-masonry)
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/xilem/ci.yml?logo=github&label=CI)](https://github.com/linebender/xilem/actions)
+[![Dependency staleness status.](https://deps.rs/crate/masonry/latest/status.svg)](https://deps.rs/crate/masonry)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=masonry --heading-base-level=0
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs should be evaluated here.
+See https://linebender.org/blog/doc-include/ for related discussion. -->
+
+<!-- cargo-rdme start -->
 
 Traits and types of the Masonry toolkit.
-See Masonry documentation for more details, examples and resources.
+See [Masonry Winit's documentation] for more details, examples and resources.
+
+[Masonry Winit's documentation]: https://docs.rs/masonry_winit/latest/
+
+<!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This version of Masonry has been verified to compile with **Rust 1.86** and later.
+
+Future versions of Masonry might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some of Masonry's dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+</details>
+
+## Community
+
+Discussion of Masonry development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#masonry channel](https://xi.zulipchat.com/#narrow/stream/317477-masonry).
+All public content can be read without logging in.
+
+Contributions are welcome by pull request.
+The [Rust code of conduct] applies.
+
+## License
+
+Licensed under the Apache License, Version 2.0 ([LICENSE](LICENSE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+
+[Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Traits and types of the Masonry toolkit.
-//! See Masonry documentation for more details, examples and resources.
+//! See [Masonry Winit's documentation] for more details, examples and resources.
+//!
+//! [Masonry Winit's documentation]: https://docs.rs/masonry_winit/latest/
 
 // LINEBENDER LINT SET - lib.rs - v3
 // See https://linebender.org/wiki/canonical-lints/

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -18,7 +18,7 @@ use crate::util::{fill_color, stroke};
 use crate::widgets::Axis;
 
 // TODO
-// - Fade scrollbars? Find out how Linux/MacOS/Windows do it
+// - Fade scrollbars? Find out how Linux/macOS/Windows do it
 // - Rename cursor to oval/rect/bar/grabber/grabbybar
 // - Rename progress to something more descriptive
 // - Document names

--- a/masonry_winit/README.md
+++ b/masonry_winit/README.md
@@ -1,13 +1,13 @@
 <div align="center">
 
-# Masonry
+# Masonry Winit
 
-**A foundational framework for Rust GUI libraries.**
+**A foundational framework for Rust GUI libraries**
 
 [![Latest published version.](https://img.shields.io/crates/v/masonry_winit.svg)](https://crates.io/crates/masonry_winit)
 [![Documentation build status.](https://img.shields.io/docsrs/masonry_winit.svg)](https://docs.rs/masonry_winit)
 [![Apache 2.0 license.](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
-
+\
 [![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23masonry-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/317477-masonry)
 [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/xilem/ci.yml?logo=github&label=CI)](https://github.com/linebender/xilem/actions)
 [![Dependency staleness status.](https://deps.rs/crate/masonry_winit/latest/status.svg)](https://deps.rs/crate/masonry_winit)
@@ -16,7 +16,7 @@
 
 <!-- We use cargo-rdme to update the README with the contents of lib.rs.
 To edit the following section, update it in lib.rs, then run:
-cargo rdme --workspace-project=color --heading-base-level=0
+cargo rdme --workspace-project=masonry_winit --heading-base-level=0
 Full documentation at https://github.com/orium/cargo-rdme -->
 
 <!-- Intra-doc links used in lib.rs should be evaluated here.
@@ -125,32 +125,30 @@ Masonry apps currently ship with two debugging features built in:
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Masonry has been verified to compile with **Rust 1.86** and later.
+This version of Masonry Winit has been verified to compile with **Rust 1.86** and later.
 
-Future versions of Masonry might increase the Rust version requirement.
+Future versions of Masonry Winit might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
 
 <details>
 <summary>Click here if compiling fails.</summary>
 
-As time has passed, some of Masonry's dependencies could have released versions with a higher Rust requirement.
+As time has passed, some of Masonry Winit's dependencies could have released versions with a higher Rust requirement.
 If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
 
 ```sh
 # Use the problematic dependency's name and version
 cargo update -p package_name --precise 0.1.1
 ```
-
 </details>
 
 ## Community
 
-Discussion of Masonry development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#masonry channel](https://xi.zulipchat.com/#narrow/stream/317477-masonry).
+Discussion of Masonry Winit development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#masonry channel](https://xi.zulipchat.com/#narrow/stream/317477-masonry).
 All public content can be read without logging in.
 
-Contributions are welcome by pull request. The [Rust code of conduct] applies.
-
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache 2.0 license, shall be licensed as noted in the [License](#license) section, without any additional terms or conditions.
+Contributions are welcome by pull request.
+The [Rust code of conduct] applies.
 
 ## License
 

--- a/tree_arena/README.md
+++ b/tree_arena/README.md
@@ -1,13 +1,26 @@
+<div align="center">
+
 # Tree Arena
 
+**A tree implementation for Masonry**
+
+[![Latest published version.](https://img.shields.io/crates/v/tree_arena.svg)](https://crates.io/crates/tree_arena)
+[![Documentation build status.](https://img.shields.io/docsrs/tree_arena.svg)](https://docs.rs/tree_arena)
 [![Apache 2.0 license.](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
+\
 [![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23masonry-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/317477-masonry)
 [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/xilem/ci.yml?logo=github&label=CI)](https://github.com/linebender/xilem/actions)
+[![Dependency staleness status.](https://deps.rs/crate/tree_arena/latest/status.svg)](https://deps.rs/crate/tree_arena)
+
+</div>
 
 <!-- We use cargo-rdme to update the README with the contents of lib.rs.
 To edit the following section, update it in lib.rs, then run:
-cargo rdme --workspace-project=color --heading-base-level=0
+cargo rdme --workspace-project=tree_arena --heading-base-level=0
 Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs should be evaluated here.
+See https://linebender.org/blog/doc-include/ for related discussion. -->
 
 <!-- cargo-rdme start -->
 
@@ -76,3 +89,36 @@ This invariant is not checked by the compiler and thus relies on the logic to de
 [Masonry]: https://crates.io/crates/masonry
 
 <!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This version of Tree Arena has been verified to compile with **Rust 1.86** and later.
+
+Future versions of Tree Arena might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some of Tree Arena's dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+</details>
+
+## Community
+
+Discussion of Tree Arena development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#masonry channel](https://xi.zulipchat.com/#narrow/stream/317477-masonry).
+All public content can be read without logging in.
+
+Contributions are welcome by pull request.
+The [Rust code of conduct] applies.
+
+## License
+
+Licensed under the Apache License, Version 2.0 ([LICENSE](LICENSE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+
+[Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct

--- a/xilem/README.md
+++ b/xilem/README.md
@@ -7,7 +7,7 @@
 [![Latest published version.](https://img.shields.io/crates/v/xilem.svg)](https://crates.io/crates/xilem)
 [![Documentation build status.](https://img.shields.io/docsrs/xilem.svg)](https://docs.rs/xilem)
 [![Apache 2.0 license.](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
-
+\
 [![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23xilem-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/354396-xilem)
 [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/xilem/ci.yml?logo=github&label=CI)](https://github.com/linebender/xilem/actions)
 [![Dependency staleness status.](https://deps.rs/crate/xilem/latest/status.svg)](https://deps.rs/crate/xilem)
@@ -16,7 +16,7 @@
 
 <!-- We use cargo-rdme to update the README with the contents of lib.rs.
 To edit the following section, update it in lib.rs, then run:
-cargo rdme --workspace-project=color --heading-base-level=0
+cargo rdme --workspace-project=xilem --heading-base-level=0
 Full documentation at https://github.com/orium/cargo-rdme -->
 
 <!-- Intra-doc links used in lib.rs should be evaluated here.
@@ -33,6 +33,7 @@ See https://linebender.org/blog/doc-include/ for related discussion. -->
 [crate::view::progress_bar]: https://docs.rs/xilem/latest/xilem/view/fn.progress_bar.html
 [crate::view::prose]: https://docs.rs/xilem/latest/xilem/view/fn.prose.html
 [crate::view::sized_box]: https://docs.rs/xilem/latest/xilem/view/fn.sized_box.html
+[crate::view::split]: https://docs.rs/xilem/latest/xilem/view/fn.split.html
 [crate::view::task]: https://docs.rs/xilem/latest/xilem/view/fn.task.html
 [crate::view::textbox]: https://docs.rs/xilem/latest/xilem/view/fn.textbox.html
 [crate::view::zstack]: https://docs.rs/xilem/latest/xilem/view/fn.zstack.html
@@ -165,7 +166,6 @@ If you encounter a compilation issue due to a dependency and don't want to upgra
 # Use the problematic dependency's name and version
 cargo update -p package_name --precise 0.1.1
 ```
-
 </details>
 
 ## Community
@@ -173,9 +173,8 @@ cargo update -p package_name --precise 0.1.1
 Discussion of Xilem development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#xilem channel](https://xi.zulipchat.com/#narrow/stream/354396-xilem).
 All public content can be read without logging in.
 
-Contributions are welcome by pull request. The [Rust code of conduct] applies.
-
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache 2.0 license, shall be licensed as noted in the [License](#license) section, without any additional terms or conditions.
+Contributions are welcome by pull request.
+The [Rust code of conduct] applies.
 
 ## License
 

--- a/xilem_core/README.md
+++ b/xilem_core/README.md
@@ -76,7 +76,7 @@ The [Rust code of conduct] applies.
 
 ## License
 
-Licensed under the Apache License, Version 2.0 ([LICENSE](LICENSE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+Licensed under the Apache License, Version 2.0 ([LICENSE] or <http://www.apache.org/licenses/LICENSE-2.0>)
 
 </div>
 
@@ -87,3 +87,6 @@ Licensed under the Apache License, Version 2.0 ([LICENSE](LICENSE) or <http://ww
 [`alloc`]: https://doc.rust-lang.org/stable/alloc/
 [`memoize`]: https://docs.rs/xilem_core/latest/xilem_core/views/memoize/fn.memoize.html
 [`View`]: https://docs.rs/xilem_core/latest/xilem_core/view/trait.View.html
+
+<!-- Needs to be defined here for rustdoc's benefit -->
+[LICENSE]: LICENSE

--- a/xilem_core/README.md
+++ b/xilem_core/README.md
@@ -1,4 +1,3 @@
-
 <div align="center" class="rustdoc-hidden">
 
 # Xilem Core
@@ -12,7 +11,7 @@
 [![Latest published version.](https://img.shields.io/crates/v/xilem_core.svg)](https://crates.io/crates/xilem_core)
 [![Documentation build status.](https://img.shields.io/docsrs/xilem_core.svg)](https://docs.rs/xilem_core)
 [![Apache 2.0 license.](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
-
+\
 [![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23xilem-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/354396-xilem)
 [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/xilem/ci.yml?logo=github&label=CI)](https://github.com/linebender/xilem/actions)
 [![Dependency staleness status.](https://deps.rs/crate/xilem_core/latest/status.svg)](https://deps.rs/crate/xilem_core)
@@ -38,7 +37,7 @@ The current proposal would split the application into two processes:
 
 ## Quickstart
 
-## no_std support
+## `no_std` support
 
 Xilem Core supports running with `#![no_std]`, but does use [`alloc`][] to be available.
 
@@ -62,7 +61,6 @@ If you encounter a compilation issue due to a dependency and don't want to upgra
 # Use the problematic dependency's name and version
 cargo update -p package_name --precise 0.1.1
 ```
-
 </details>
 
 <!-- We hide these elements when viewing in Rustdoc, because they're not expected to be present in crate level docs -->
@@ -73,18 +71,16 @@ cargo update -p package_name --precise 0.1.1
 Discussion of Xilem Core development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#xilem channel](https://xi.zulipchat.com/#narrow/stream/354396-xilem).
 All public content can be read without logging in.
 
-Contributions are welcome by pull request. The [Rust code of conduct][] applies.
+Contributions are welcome by pull request.
+The [Rust code of conduct] applies.
 
 ## License
 
-- Licensed under the Apache License, Version 2.0
-  ([LICENSE] or <http://www.apache.org/licenses/LICENSE-2.0>)
+Licensed under the Apache License, Version 2.0 ([LICENSE](LICENSE) or <http://www.apache.org/licenses/LICENSE-2.0>)
 
 </div>
 
-[rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
-
-[LICENSE]: LICENSE
+[Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
 [Xilem]: https://crates.io/crates/xilem
 [Xilem Web]: https://crates.io/crates/xilem_web
 [xilem docs]: https://docs.rs/xilem/latest/xilem/

--- a/xilem_web/README.md
+++ b/xilem_web/README.md
@@ -82,10 +82,13 @@ The [Rust code of conduct] applies.
 
 ## License
 
-Licensed under the Apache License, Version 2.0 ([LICENSE](LICENSE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+Licensed under the Apache License, Version 2.0 ([LICENSE] or <http://www.apache.org/licenses/LICENSE-2.0>)
 
 </div>
 
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
 [Trunk]: https://trunkrs.dev/
 [Xilem Core]: https://crates.io/crates/xilem_core
+
+<!-- Needs to be defined here for rustdoc's benefit -->
+[LICENSE]: LICENSE

--- a/xilem_web/README.md
+++ b/xilem_web/README.md
@@ -67,27 +67,25 @@ If you encounter a compilation issue due to a dependency and don't want to upgra
 # Use the problematic dependency's name and version
 cargo update -p package_name --precise 0.1.1
 ```
-
 </details>
 
+<!-- We hide these elements when viewing in Rustdoc, because they're not expected to be present in crate level docs -->
 <div class="rustdoc-hidden">
 
 ## Community
 
-Discussion of Xilem Web development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically in
-[#xilem](https://xi.zulipchat.com/#narrow/stream/354396-xilem).
+Discussion of Xilem Web development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#xilem channel](https://xi.zulipchat.com/#narrow/stream/354396-xilem).
 All public content can be read without logging in.
 
-Contributions are welcome by pull request. The [Rust code of conduct][] applies.
+Contributions are welcome by pull request.
+The [Rust code of conduct] applies.
 
 ## License
 
-- Licensed under the Apache License, Version 2.0
-  ([LICENSE] or <http://www.apache.org/licenses/LICENSE-2.0>)
+Licensed under the Apache License, Version 2.0 ([LICENSE](LICENSE) or <http://www.apache.org/licenses/LICENSE-2.0>)
 
 </div>
 
-[rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
 [Trunk]: https://trunkrs.dev/
-[LICENSE]: LICENSE
 [Xilem Core]: https://crates.io/crates/xilem_core


### PR DESCRIPTION
Despite the line diff number, there are almost no content changes in this PR.

* [One line per sentence.](https://linebender.org/wiki/formatting-scheme/)
* Updated badges. Of note is that the repo level badges are not finalized, but I updated to the latest checkpoint. After further discussion has happened in [Zulip](https://xi.zulipchat.com/#narrow/channel/419691-linebender/topic/Bikeshedding.20badges/with/452312397) we can once again update them.
* Reordered some sections to be in consistent order between crates.
* Gave `masonry` an actual `README.md`.
* Updated some references to `Masonry` with `Masonry Winit` to reflect the new state of things.
* A few miscellaneous tidy-ups.