### PR TITLE
Put `Cargo.toml` sections into consistent order.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,30 @@ license = "Apache-2.0"
 repository = "https://github.com/linebender/xilem"
 homepage = "https://xilem.dev/"
 
+[workspace.dependencies]
+masonry = { version = "0.2.0", path = "masonry" }
+masonry_winit = { version = "0.2.0", path = "masonry_winit" }
+xilem_core = { version = "0.1.0", path = "xilem_core" }
+tree_arena = { version = "0.1.0", path = "tree_arena" }
+vello = "0.5.0"
+wgpu = "24.0.3"
+kurbo = "0.11.2"
+parley = { version = "0.4.0", features = ["accesskit"] }
+peniko = "0.4.0"
+winit = "0.30.10"
+tracing = { version = "0.1.41", default-features = false }
+ui-events = "0.1.0"
+ui-events-winit = "0.1.0"
+smallvec = "1.15.0"
+hashbrown = "0.15.3"
+dpi = "0.1.2"
+image = { version = "0.25.6", default-features = false }
+web-time = "1.1.0"
+bitflags = "2.9.0"
+accesskit = "0.19.0"
+accesskit_winit = "0.27.0"
+time = "0.3.41"
+
 [workspace.lints]
 # unsafe code is not allowed in Xilem or Masonry
 # We would like to set this to `forbid`, but we have to use `deny` because `android_activity`
@@ -83,30 +107,6 @@ clippy.negative_feature_names = "warn"
 clippy.redundant_feature_names = "warn"
 clippy.wildcard_dependencies = "warn"
 # END LINEBENDER LINT SET
-
-[workspace.dependencies]
-masonry = { version = "0.2.0", path = "masonry" }
-masonry_winit = { version = "0.2.0", path = "masonry_winit" }
-xilem_core = { version = "0.1.0", path = "xilem_core" }
-tree_arena = { version = "0.1.0", path = "tree_arena" }
-vello = "0.5.0"
-wgpu = "24.0.3"
-kurbo = "0.11.2"
-parley = { version = "0.4.0", features = ["accesskit"] }
-peniko = "0.4.0"
-winit = "0.30.10"
-tracing = { version = "0.1.41", default-features = false }
-ui-events = "0.1.0"
-ui-events-winit = "0.1.0"
-smallvec = "1.15.0"
-hashbrown = "0.15.3"
-dpi = "0.1.2"
-image = { version = "0.25.6", default-features = false }
-web-time = "1.1.0"
-bitflags = "2.9.0"
-accesskit = "0.19.0"
-accesskit_winit = "0.27.0"
-time = "0.3.41"
 
 [profile.ci]
 inherits = "dev"

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -2,32 +2,24 @@
 name = "masonry"
 version = "0.2.0"
 description = "Traits and types of the Masonry toolkit."
-
 keywords = ["gui", "ui", "toolkit"]
 categories = ["gui", "internationalization", "accessibility"]
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-homepage.workspace = true
-exclude = ["/doc/", ".gitignore"]
-rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
 # There are no platform specific docs.
 default-target = "x86_64-unknown-linux-gnu"
 targets = []
-# rustdoc-scrape-examples tracking issue https://github.com/rust-lang/rust/issues/88791
-cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [features]
 default = []
 # Enables tracing using tracy if the default Masonry tracing is used.
 # https://github.com/wolfpld/tracy can be connected to when this feature is enabled.
 tracy = ["dep:tracing-tracy", "tracing-tracy/enable", "vello/wgpu-profiler"]
-
-[lints]
-workspace = true
 
 [dependencies]
 vello.workspace = true
@@ -63,3 +55,6 @@ profiling = { version = "1.0.16", features = ["profile-with-tracing"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 tracing_android_trace = "0.1.1"
+
+[lints]
+workspace = true

--- a/masonry_winit/Cargo.toml
+++ b/masonry_winit/Cargo.toml
@@ -5,11 +5,9 @@ description = "Data-oriented Rust UI design toolkit."
 keywords = ["gui", "ui", "toolkit"]
 categories = ["gui", "internationalization", "accessibility"]
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-homepage.workspace = true
-exclude = ["/doc/", ".gitignore"]
-rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
@@ -24,9 +22,6 @@ default = []
 # Enables tracing using tracy if the default Masonry tracing is used.
 # https://github.com/wolfpld/tracy can be connected to when this feature is enabled.
 tracy = ["dep:tracing-tracy", "dep:wgpu-profiler", "wgpu-profiler/tracy", "masonry/tracy"]
-
-[lints]
-workspace = true
 
 [dependencies]
 masonry.workspace = true
@@ -54,3 +49,12 @@ accesskit.workspace = true
 
 # Make wgpu use tracing for its spans.
 profiling = { version = "1.0.16", features = ["profile-with-tracing"] }
+
+[lints]
+workspace = true
+
+[[example]]
+name = "calc_masonry"
+# This actually enables scraping for all examples, not just this one.
+# However it is possible to set doc-scrape-examples to false for other specific examples.
+doc-scrape-examples = true

--- a/tree_arena/Cargo.toml
+++ b/tree_arena/Cargo.toml
@@ -5,10 +5,9 @@ description = "An arena allocated tree."
 keywords = ["arena", "tree"]
 categories = ["algorithms", "data-structures"]
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-homepage.workspace = true
-rust-version.workspace = true
 
 publish = false # Remove just before publishing
 
@@ -26,8 +25,8 @@ targets = []
 default = ["safe_tree"]
 safe_tree = []
 
-[lints]
-workspace = true
-
 [dependencies]
 hashbrown.workspace = true
+
+[lints]
+workspace = true

--- a/xilem/Cargo.toml
+++ b/xilem/Cargo.toml
@@ -5,10 +5,10 @@ description = "A next-generation cross-platform Rust UI framework."
 keywords = ["gui", "ui", "native", "gpu", "performance"]
 categories = ["gui", "graphics", "internationalization", "accessibility"]
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-rust-version.workspace = true
 exclude = [
     "/resources/fonts/roboto_flex/",
     "/resources/data/http_cats_status/",
@@ -22,6 +22,47 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 # rustdoc-scrape-examples tracking issue https://github.com/rust-lang/rust/issues/88791
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+
+# This makes the examples discoverable to (e.g.) Android GPU inspector without needing to provide the full name manually.
+# Do not use when releasing a production app.
+[package.metadata.android.application]
+debuggable = true
+
+[[package.metadata.android.uses_permission]]
+# Needed for http_cats
+name = "android.permission.INTERNET"
+
+[dependencies]
+xilem_core.workspace = true
+masonry_winit.workspace = true
+winit.workspace = true
+tracing.workspace = true
+vello.workspace = true
+smallvec.workspace = true
+accesskit.workspace = true
+tokio = { version = "1.45.0", features = ["rt", "rt-multi-thread", "time", "sync"] }
+
+[dev-dependencies]
+# Used for `variable_clock`
+time = { workspace = true, features = ["local-offset"] }
+
+# Used for http_cats
+reqwest = { version = "0.12.15", default-features = false, features = [
+    # We use rustls as Android doesn't ship with openssl
+    # and this is likely to be easiest to get working.
+    "rustls-tls",
+] }
+image = { workspace = true, features = ["jpeg"] }
+
+# Make wgpu use tracing for its spans.
+profiling = { version = "1.0.16", features = ["profile-with-tracing"] }
+anyhow = "1.0.98"
+
+[target.'cfg(target_os = "android")'.dev-dependencies]
+winit = { features = ["android-native-activity"], workspace = true }
+
+[lints]
+workspace = true
 
 [[example]]
 name = "mason"
@@ -90,44 +131,3 @@ name = "emoji_picker_android"
 path = "examples/emoji_picker.rs"
 # cdylib is required for cargo-apk
 crate-type = ["cdylib"]
-
-[lints]
-workspace = true
-
-[dependencies]
-xilem_core.workspace = true
-masonry_winit.workspace = true
-winit.workspace = true
-tracing.workspace = true
-vello.workspace = true
-smallvec.workspace = true
-accesskit.workspace = true
-tokio = { version = "1.45.0", features = ["rt", "rt-multi-thread", "time", "sync"] }
-
-[dev-dependencies]
-# Used for `variable_clock`
-time = { workspace = true, features = ["local-offset"] }
-
-# Used for http_cats
-reqwest = { version = "0.12.15", default-features = false, features = [
-    # We use rustls as Android doesn't ship with openssl
-    # and this is likely to be easiest to get working.
-    "rustls-tls",
-] }
-image = { workspace = true, features = ["jpeg"] }
-
-# Make wgpu use tracing for its spans.
-profiling = { version = "1.0.16", features = ["profile-with-tracing"] }
-anyhow = "1.0.98"
-
-[target.'cfg(target_os = "android")'.dev-dependencies]
-winit = { features = ["android-native-activity"], workspace = true }
-
-# This makes the examples discoverable to (e.g.) Android GPU inspector without needing to provide the full name manually.
-# Do not use when releasing a production app.
-[package.metadata.android.application]
-debuggable = true
-
-[[package.metadata.android.uses_permission]]
-# Needed for http_cats
-name = "android.permission.INTERNET"

--- a/xilem_core/Cargo.toml
+++ b/xilem_core/Cargo.toml
@@ -5,9 +5,10 @@ description = "Common core of the Xilem Rust UI framework."
 keywords = ["xilem", "ui", "reactive", "performance"]
 categories = ["gui"]
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version.workspace = true
+homepage.workspace = true
 
 publish = false # We'll publish this alongside Xilem 0.2
 

--- a/xilem_web/Cargo.toml
+++ b/xilem_web/Cargo.toml
@@ -6,10 +6,10 @@ keywords = ["xilem", "html", "svg", "dom", "web", "ui"]
 categories = ["gui", "web-programming"]
 publish = false # Until it's ready
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
@@ -17,8 +17,10 @@ all-features = true
 default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
-[lints]
-workspace = true
+[features]
+default = []
+# This interns some often used strings, such as element tags ("div" etc.), which slightly improves performance when creating elements at the cost of a bigger wasm binary
+intern_strings = ["wasm-bindgen/enable-interning"]
 
 [dependencies]
 futures = "0.3.31"
@@ -178,7 +180,5 @@ features = [
     "HtmlVideoElement",
 ]
 
-[features]
-default = []
-# This interns some often used strings, such as element tags ("div" etc.), which slightly improves performance when creating elements at the cost of a bigger wasm binary
-intern_strings = ["wasm-bindgen/enable-interning"]
+[lints]
+workspace = true


### PR DESCRIPTION
* Ordering of sections: `package`, `features`, `dependencies`, `lints`, `profile`, `example`.
* Ordering of `package` fields: `name`, `version`, `description`, `keywords`, `categories`, `edition`, `rust-version`, `license`, `repository`, `homepage`, `exclude`.

I also removed the `homepage` field from non-Xilem crates, some stale exclusions, and the example scraping from `masonry` as it doesn't have examples.