### PR TITLE
Prepare to release 0.3.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "masonry"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "accesskit",
  "anymap3",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "masonry_winit"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -4918,7 +4918,7 @@ checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
 
 [[package]]
 name = "xilem"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -4937,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "xilem_core"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "kurbo",
  "tracing",
@@ -4945,7 +4945,7 @@ dependencies = [
 
 [[package]]
 name = "xilem_web"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "futures",
  "peniko",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,13 @@ members = [
 ]
 
 [workspace.package]
+# Xilem version, also used by other packages which want to mimic Xilem's version.
+# Right now those packages include: xilem_core, xilem_web, masonry, masonry_winit.
+#
+# NOTE: When bumping this, remember to also bump the aforementioned other packages'
+#       version in the dependencies section of this file.
+version = "0.3.0"
+
 edition = "2024"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files.
 rust-version = "1.86"
@@ -29,9 +36,9 @@ repository = "https://github.com/linebender/xilem"
 homepage = "https://xilem.dev/"
 
 [workspace.dependencies]
-masonry = { version = "0.2.0", path = "masonry" }
-masonry_winit = { version = "0.2.0", path = "masonry_winit" }
-xilem_core = { version = "0.1.0", path = "xilem_core" }
+masonry = { version = "0.3.0", path = "masonry" }
+masonry_winit = { version = "0.3.0", path = "masonry_winit" }
+xilem_core = { version = "0.3.0", path = "xilem_core" }
 tree_arena = { version = "0.1.0", path = "tree_arena" }
 vello = "0.5.0"
 wgpu = "24.0.3"

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masonry"
-version = "0.2.0"
+version.workspace = true # We mimic Xilem's version
 description = "Traits and types of the Masonry toolkit."
 keywords = ["gui", "ui", "toolkit"]
 categories = ["gui", "internationalization", "accessibility"]

--- a/masonry_winit/Cargo.toml
+++ b/masonry_winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masonry_winit"
-version = "0.2.0"
+version.workspace = true # We mimic Xilem's version
 description = "Data-oriented Rust UI design toolkit."
 keywords = ["gui", "ui", "toolkit"]
 categories = ["gui", "internationalization", "accessibility"]

--- a/tree_arena/Cargo.toml
+++ b/tree_arena/Cargo.toml
@@ -9,8 +9,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
-publish = false # Remove just before publishing
-
 [package.metadata.docs.rs]
 all-features = true # all features are enabled - this means that the generated docs are for the safe version
 # There are no platform specific docs.

--- a/xilem/Cargo.toml
+++ b/xilem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xilem"
-version = "0.1.0"
+version.workspace = true
 description = "A next-generation cross-platform Rust UI framework."
 keywords = ["gui", "ui", "native", "gpu", "performance"]
 categories = ["gui", "graphics", "internationalization", "accessibility"]

--- a/xilem_core/Cargo.toml
+++ b/xilem_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xilem_core"
-version = "0.1.0"
+version.workspace = true # We mimic Xilem's version
 description = "Common core of the Xilem Rust UI framework."
 keywords = ["xilem", "ui", "reactive", "performance"]
 categories = ["gui"]
@@ -9,8 +9,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-
-publish = false # We'll publish this alongside Xilem 0.2
 
 [package.metadata.docs.rs]
 all-features = true

--- a/xilem_web/Cargo.toml
+++ b/xilem_web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xilem_web"
-version = "0.1.0"
+version.workspace = true # We mimic Xilem's version
 description = "HTML DOM frontend for the Xilem Rust UI framework."
 keywords = ["xilem", "html", "svg", "dom", "web", "ui"]
 categories = ["gui", "web-programming"]


### PR DESCRIPTION
We skip Xilem 0.2.0 and go straight to 0.3.0 in order to synchronize the version with its companion packages that are expected to be updated in lock-step for now.

[The one exception is `tree_arena`](https://xi.zulipchat.com/#narrow/channel/419691-linebender/topic/Xilem.20version.20sync/with/517174026), which will retain its own version pacing, because it's likely to see fewer updates.