### PR TITLE
Fix visiblity of a property function

### DIFF
--- a/masonry/src/properties/corner_radius.rs
+++ b/masonry/src/properties/corner_radius.rs
@@ -20,7 +20,8 @@ impl Property for CornerRadius {
 }
 
 impl CornerRadius {
-    pub(crate) fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
+    /// Helper function to be called in [`Widget::property_changed`](crate::core::Widget::property_changed).
+    pub fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
         if property_type != TypeId::of::<Self>() {
             return;
         }


### PR DESCRIPTION
The `prop_changed` function of the other properties are public, so I thought this was a mistake.