### PR TITLE
Remove 6th keyword from `xilem_web`.

### DIFF
--- a/xilem_web/Cargo.toml
+++ b/xilem_web/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xilem_web"
 version.workspace = true # We mimic Xilem's version
 description = "HTML DOM frontend for the Xilem Rust UI framework."
-keywords = ["xilem", "html", "svg", "dom", "web", "ui"]
+keywords = ["xilem", "html", "svg", "web", "ui"]
 categories = ["gui", "web-programming"]
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
Apparently 5 is the maximum.

```
error: failed to publish to registry at https://crates.io

Caused by:
  the remote server responded with an error (status 400 Bad Request): expected at most 5 keywords per crate
```