### PR TITLE
xilem: support disabling inputs

### DIFF
--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -1248,7 +1248,7 @@ impl RegisterCtx<'_> {
     pub fn register_child(&mut self, child: &mut WidgetPod<impl Widget + ?Sized>) {
         let Some(CreateWidget {
             widget,
-            transform,
+            options,
             properties,
         }) = child.take_inner()
         else {
@@ -1261,7 +1261,7 @@ impl RegisterCtx<'_> {
         }
 
         let id = child.id();
-        let state = WidgetState::new(child.id(), widget.short_type_name(), transform);
+        let state = WidgetState::new(child.id(), widget.short_type_name(), options);
 
         self.widget_children.insert(id, widget.as_box_dyn());
         self.widget_state_children.insert(id, state);

--- a/masonry/src/core/mod.rs
+++ b/masonry/src/core/mod.rs
@@ -32,6 +32,7 @@ pub use widget::{AllowRawMut, FromDynWidget, Widget, WidgetId};
 pub use widget_mut::WidgetMut;
 pub use widget_pod::WidgetPod;
 pub use widget_ref::WidgetRef;
+pub use widget_state::WidgetOptions;
 
 pub use ui_events::{ScrollDelta, keyboard, pointer};
 

--- a/masonry/src/core/widget_pod.rs
+++ b/masonry/src/core/widget_pod.rs
@@ -1,8 +1,7 @@
 // Copyright 2018 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::core::{Properties, Widget, WidgetId};
-use crate::kurbo::Affine;
+use crate::core::{Properties, Widget, WidgetId, WidgetOptions};
 
 /// A container for one widget in the hierarchy.
 ///
@@ -24,7 +23,7 @@ pub struct WidgetPod<W: ?Sized> {
 
 pub(crate) struct CreateWidget<W: ?Sized> {
     pub(crate) widget: Box<W>,
-    pub(crate) transform: Affine,
+    pub(crate) options: WidgetOptions,
     pub(crate) properties: Properties,
 }
 
@@ -45,36 +44,40 @@ impl<W: Widget> WidgetPod<W> {
 
     /// Create a new widget pod with fixed id.
     pub fn new_with_id(inner: W, id: WidgetId) -> Self {
-        Self::new_with_id_and_transform(Box::new(inner), id, Affine::IDENTITY)
+        Self::new_with_id_and_options(Box::new(inner), id, WidgetOptions::default())
     }
 }
 
 impl<W: Widget + ?Sized> WidgetPod<W> {
-    /// Create a new widget pod with a custom transform.
-    pub fn new_with_transform(inner: Box<W>, transform: Affine) -> Self {
-        Self::new_with_id_and_transform(inner, WidgetId::next(), transform)
+    /// Create a new widget pod with custom options.
+    pub fn new_with_options(inner: Box<W>, options: WidgetOptions) -> Self {
+        Self::new_with_id_and_options(inner, WidgetId::next(), options)
     }
 
-    /// Create a new widget pod with a custom transform and a pre-set [`WidgetId`].
-    pub fn new_with_id_and_transform(inner: Box<W>, id: WidgetId, transform: Affine) -> Self {
+    /// Create a new widget pod with custom options and a pre-set [`WidgetId`].
+    pub fn new_with_id_and_options(inner: Box<W>, id: WidgetId, options: WidgetOptions) -> Self {
         Self {
             id,
             inner: WidgetPodInner::Create(CreateWidget {
                 widget: inner,
-                transform,
+                options,
                 properties: Properties::new(),
             }),
         }
     }
 
-    // TODO - Remove transform, have it as a special-case property instead.
-    /// Create a new widget pod with a custom transform and custom [`Properties`].
-    pub fn new_with(inner: Box<W>, id: WidgetId, transform: Affine, props: Properties) -> Self {
+    /// Create a new widget pod with custom options and custom [`Properties`].
+    pub fn new_with(
+        inner: Box<W>,
+        id: WidgetId,
+        options: WidgetOptions,
+        props: Properties,
+    ) -> Self {
         Self {
             id,
             inner: WidgetPodInner::Create(CreateWidget {
                 widget: inner,
-                transform,
+                options,
                 properties: props,
             }),
         }
@@ -110,7 +113,7 @@ impl<W: Widget + ?Sized> WidgetPod<W> {
             id: self.id,
             inner: WidgetPodInner::Create(CreateWidget {
                 widget: inner.widget.as_box_dyn(),
-                transform: inner.transform,
+                options: inner.options,
                 properties: inner.properties,
             }),
         }

--- a/masonry/src/core/widget_state.rs
+++ b/masonry/src/core/widget_state.rs
@@ -185,6 +185,8 @@ pub(crate) struct WidgetState {
 pub struct WidgetOptions {
     /// The transform the widget will be created with.
     pub transform: Affine,
+    /// The disabled state the widget will be created with.
+    pub disabled: bool,
 }
 
 impl WidgetState {
@@ -203,7 +205,7 @@ impl WidgetState {
             clip_path: Option::default(),
             scroll_translation: Vec2::ZERO,
             transform_changed: false,
-            is_explicitly_disabled: false,
+            is_explicitly_disabled: options.disabled,
             is_explicitly_stashed: false,
             is_disabled: false,
             is_stashed: false,

--- a/masonry/src/core/widget_state.rs
+++ b/masonry/src/core/widget_state.rs
@@ -180,8 +180,15 @@ pub(crate) struct WidgetState {
     pub(crate) widget_name: &'static str,
 }
 
+/// The options the widget will be created with.
+#[derive(Default, Debug)]
+pub struct WidgetOptions {
+    /// The transform the widget will be created with.
+    pub transform: Affine,
+}
+
 impl WidgetState {
-    pub(crate) fn new(id: WidgetId, widget_name: &'static str, transform: Affine) -> Self {
+    pub(crate) fn new(id: WidgetId, widget_name: &'static str, options: WidgetOptions) -> Self {
         Self {
             id,
             origin: Point::ORIGIN,
@@ -224,7 +231,7 @@ impl WidgetState {
             widget_name,
             window_transform: Affine::IDENTITY,
             bounding_rect: Rect::ZERO,
-            transform,
+            transform: options.transform,
         }
     }
 
@@ -248,7 +255,7 @@ impl WidgetState {
             needs_update_stashed: false,
             children_changed: false,
             needs_update_focus_chain: false,
-            ..Self::new(id, "<root>", Affine::IDENTITY)
+            ..Self::new(id, "<root>", WidgetOptions::default())
         }
     }
 

--- a/masonry/src/widgets/tests/transforms.rs
+++ b/masonry/src/widgets/tests/transforms.rs
@@ -9,7 +9,7 @@ use vello::kurbo::{Affine, Vec2};
 use vello::peniko::color::palette;
 
 use crate::assert_render_snapshot;
-use crate::core::{PointerButton, Widget, WidgetPod};
+use crate::core::{PointerButton, Widget, WidgetOptions, WidgetPod};
 use crate::testing::TestHarness;
 use crate::widgets::{Alignment, Button, ChildAlignment, Label, SizedBox, ZStack};
 
@@ -26,13 +26,15 @@ fn blue_box(inner: impl Widget) -> Box<SizedBox> {
 #[test]
 fn transforms_translation_rotation() {
     let translation = Vec2::new(100.0, 50.0);
-    let transformed_widget = WidgetPod::new_with_transform(
+    let transformed_widget = WidgetPod::new_with_options(
         blue_box(Label::new("Background")),
         // Currently there's no support for changing the transform-origin, which is currently at the top left.
         // This rotates around the center of the widget
-        Affine::translate(-translation)
-            .then_rotate(PI * 0.25)
-            .then_translate(translation),
+        WidgetOptions {
+            transform: Affine::translate(-translation)
+                .then_rotate(PI * 0.25)
+                .then_translate(translation),
+        },
     )
     .erased();
     let widget = ZStack::new().with_child_pod(transformed_widget, ChildAlignment::ParentAligned);
@@ -43,11 +45,13 @@ fn transforms_translation_rotation() {
 
 #[test]
 fn transforms_pointer_events() {
-    let transformed_widget = WidgetPod::new_with_transform(
+    let transformed_widget = WidgetPod::new_with_options(
         blue_box(
             ZStack::new().with_child(Button::new("Should be pressed"), Alignment::BottomRight),
         ),
-        Affine::rotate(PI * 0.125).then_translate(Vec2::new(100.0, 50.0)),
+        WidgetOptions {
+            transform: Affine::rotate(PI * 0.125).then_translate(Vec2::new(100.0, 50.0)),
+        },
     )
     .erased();
     let widget = ZStack::new().with_child_pod(transformed_widget, ChildAlignment::ParentAligned);

--- a/masonry/src/widgets/tests/transforms.rs
+++ b/masonry/src/widgets/tests/transforms.rs
@@ -34,6 +34,7 @@ fn transforms_translation_rotation() {
             transform: Affine::translate(-translation)
                 .then_rotate(PI * 0.25)
                 .then_translate(translation),
+            ..Default::default()
         },
     )
     .erased();
@@ -51,6 +52,7 @@ fn transforms_pointer_events() {
         ),
         WidgetOptions {
             transform: Affine::rotate(PI * 0.125).then_translate(Vec2::new(100.0, 50.0)),
+            ..Default::default()
         },
     )
     .erased();

--- a/xilem/examples/emoji_picker.rs
+++ b/xilem/examples/emoji_picker.rs
@@ -103,20 +103,18 @@ fn paginate(
 
     flex((
         // TODO: Expose that this is a previous page button to accessibility
-        (current_start != 0).then(|| {
-            button(label("⬅️").text_size(24.0), move |data| {
-                *data = current_start.saturating_sub(count_per_page);
-            })
-        }),
+        button(label("⬅️").text_size(24.0), move |data| {
+            *data = current_start.saturating_sub(count_per_page);
+        })
+        .disabled(current_start == 0),
         label(format!("{percentage_start}% - {percentage_end}%")),
-        (current_end < max_count).then(|| {
-            button(label("➡️").text_size(24.0), move |data| {
-                let new_idx = current_start + count_per_page;
-                if new_idx < max_count {
-                    *data = new_idx;
-                }
-            })
-        }),
+        button(label("➡️").text_size(24.0), move |data| {
+            let new_idx = current_start + count_per_page;
+            if new_idx < max_count {
+                *data = new_idx;
+            }
+        })
+        .disabled(current_end == max_count),
     ))
     .direction(Axis::Horizontal)
 }

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -134,7 +134,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use masonry_winit::core::{
-    DefaultProperties, FromDynWidget, Widget, WidgetId, WidgetMut, WidgetPod,
+    DefaultProperties, FromDynWidget, Widget, WidgetId, WidgetMut, WidgetOptions, WidgetPod,
 };
 use masonry_winit::dpi::LogicalSize;
 use masonry_winit::theme::default_property_set;
@@ -316,13 +316,13 @@ where
 pub struct Pod<W: Widget + FromDynWidget + ?Sized> {
     pub widget: Box<W>,
     pub id: WidgetId,
-    /// The transform the widget will be created with.
+    /// The options the widget will be created with.
     ///
     /// If changing transforms of widgets, prefer to use [`transformed`]
     /// (or [`WidgetView::transform`]).
     /// This has a protocol to ensure that multiple views changing the
     /// transform interoperate successfully.
-    pub transform: Affine,
+    pub options: WidgetOptions,
 }
 
 impl<W: Widget + FromDynWidget> Pod<W> {
@@ -334,7 +334,7 @@ impl<W: Widget + FromDynWidget> Pod<W> {
         Self {
             widget: Box::new(widget),
             id: WidgetId::next(),
-            transform: Affine::default(),
+            options: WidgetOptions::default(),
         }
     }
 }
@@ -348,7 +348,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Pod<W> {
         Pod {
             widget: self.widget.as_box_dyn(),
             id: self.id,
-            transform: self.transform,
+            options: self.options,
         }
     }
     /// Finalise this `Pod`, converting into a [`WidgetPod`].
@@ -361,7 +361,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Pod<W> {
     /// which can contain heterogenous widgets, you will probably
     /// prefer to use [`Self::erased_widget_pod`].
     pub fn into_widget_pod(self) -> WidgetPod<W> {
-        WidgetPod::new_with_id_and_transform(self.widget, self.id, self.transform)
+        WidgetPod::new_with_id_and_options(self.widget, self.id, self.options)
     }
     /// Finalise this `Pod` into a type-erased [`WidgetPod`].
     ///
@@ -369,7 +369,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Pod<W> {
     /// widget which supports heterogenous widgets.
     /// For example, [`Flex`](masonry_winit::widgets::Flex) accepts type-erased widget pods.
     pub fn erased_widget_pod(self) -> WidgetPod<dyn Widget> {
-        WidgetPod::new_with_id_and_transform(self.widget, self.id, self.transform).erased()
+        WidgetPod::new_with_id_and_options(self.widget, self.id, self.options).erased()
     }
 }
 

--- a/xilem/src/view/checkbox.rs
+++ b/xilem/src/view/checkbox.rs
@@ -37,6 +37,7 @@ where
         label: label.into(),
         callback,
         checked,
+        disabled: false,
     }
 }
 
@@ -48,6 +49,15 @@ pub struct Checkbox<F> {
     label: ArcStr,
     checked: bool,
     callback: F,
+    disabled: bool,
+}
+
+impl<F> Checkbox<F> {
+    /// Set the disabled state of the widget.
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
 }
 
 impl<F> ViewMarker for Checkbox<F> {}
@@ -60,7 +70,9 @@ where
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         ctx.with_leaf_action_widget(|ctx| {
-            ctx.new_pod(widgets::Checkbox::new(self.checked, self.label.clone()))
+            let mut pod = ctx.new_pod(widgets::Checkbox::new(self.checked, self.label.clone()));
+            pod.options.disabled = self.disabled;
+            pod
         })
     }
 
@@ -71,6 +83,9 @@ where
         _ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
     ) {
+        if element.ctx.is_disabled() != self.disabled {
+            element.ctx.set_disabled(self.disabled);
+        }
         if prev.label != self.label {
             widgets::Checkbox::set_text(&mut element, self.label.clone());
         }

--- a/xilem/src/view/transform.rs
+++ b/xilem/src/view/transform.rs
@@ -100,9 +100,9 @@ where
         let (mut child_pod, child_state) = self.child.build(ctx);
         let state = private::TransformedState {
             child: child_state,
-            previous_transform: child_pod.transform,
+            previous_transform: child_pod.options.transform,
         };
-        child_pod.transform = self.transform * state.previous_transform;
+        child_pod.options.transform = self.transform * state.previous_transform;
         (child_pod, state)
     }
 


### PR DESCRIPTION
This commit firstly introduces a breaking change by changing the WidgetPod constructors from taking an Affine to taking a WidgetOptions containing an Affine so that then the disabled boolean can be added to the WidgetOptions struct, allowing widgets to be created in disabled state. The Xilem views for the 3 currently existing input widgets then also gain a `disabled` method in order to change the disabled state.