### PR TITLE
masonry: Allow `get_scale_factor()` in more contexts.

### DIFF
--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -843,13 +843,11 @@ impl_context_method!(
     }
 );
 
-impl_context_method!(PaintCtx<'_>, AccessCtx<'_>, {
+impl_context_method!(AccessCtx<'_>, EventCtx<'_>, LayoutCtx<'_>, PaintCtx<'_>, {
     /// Get DPI scaling factor.
     ///
     /// This is not required for most widgets, and should be used only for precise
     /// rendering, such as rendering single pixel lines or selecting image variants.
-    /// This is currently only provided in the render stages, as these are the only passes which
-    /// are re-run when the scale factor changes.
     ///
     /// Note that accessibility nodes and paint results will automatically be scaled by Masonry.
     /// This also doesn't account for the widget's current transform, which cannot currently be

--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -843,7 +843,7 @@ impl_context_method!(
     }
 );
 
-impl_context_method!(AccessCtx<'_>, EventCtx<'_>, LayoutCtx<'_>, PaintCtx<'_>, {
+impl_context_method!(AccessCtx<'_>, EventCtx<'_>, PaintCtx<'_>, {
     /// Get DPI scaling factor.
     ///
     /// This is not required for most widgets, and should be used only for precise

--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -848,6 +848,9 @@ impl_context_method!(AccessCtx<'_>, EventCtx<'_>, PaintCtx<'_>, {
     ///
     /// This is not required for most widgets, and should be used only for precise
     /// rendering, such as rendering single pixel lines or selecting image variants.
+    /// This is currently only provided in the render stages, as these are the only passes which
+    /// are re-run when the scale factor changes, except [`EventCtx`] where it is necessary to
+    /// translate pointer events which are currently in physical coordinates.
     ///
     /// Note that accessibility nodes and paint results will automatically be scaled by Masonry.
     /// This also doesn't account for the widget's current transform, which cannot currently be

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -293,7 +293,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
                         } * 120.0
                     }
                     _ => Vec2::ZERO,
-                } * ctx.global_state.scale_factor;
+                } * ctx.get_scale_factor();
                 self.set_viewport_pos_raw(portal_size, content_size, self.viewport_pos + delta);
                 ctx.request_compose();
 

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -478,12 +478,8 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for VirtualScroll<W> {
         match event {
             PointerEvent::Scroll { delta, .. } => {
                 let delta = match delta {
-                    ScrollDelta::PixelDelta(p) => {
-                        -p.to_logical::<f64>(ctx.global_state.scale_factor).y
-                    }
-                    ScrollDelta::LineDelta(_, y) => {
-                        -y as f64 * ctx.global_state.scale_factor * 120.
-                    }
+                    ScrollDelta::PixelDelta(p) => -p.to_logical::<f64>(ctx.get_scale_factor()).y,
+                    ScrollDelta::LineDelta(_, y) => -y as f64 * ctx.get_scale_factor() * 120.,
                     _ => 0.0,
                 };
                 self.scroll_offset_from_anchor += delta;


### PR DESCRIPTION
The original rationale for which contexts to include this on doesn't really make sense;
there are legitimate reasons to use the scale factor in any context that deals with sizes or positions.