### PR TITLE
Implement reparenting in tree_arena

### DIFF
--- a/tree_arena/src/tree_arena_safe.rs
+++ b/tree_arena/src/tree_arena_safe.rs
@@ -140,6 +140,11 @@ impl<T> TreeArena<T> {
         }
     }
 
+    /// An iterator visiting all root ids in arbitrary order.
+    pub fn root_ids(&self) -> impl Iterator<Item = NodeId> {
+        self.roots.keys().copied()
+    }
+
     /// Returns a handle giving access to the roots of the tree.
     ///
     /// Using [`insert`](ArenaMutList::insert) on this handle
@@ -230,6 +235,11 @@ impl<T> ArenaRef<'_, T> {
         self.children
             .parent_id
             .expect("ArenaRefList always has a parent_id when it's a member of ArenaRef")
+    }
+
+    /// An iterator visiting all child ids in arbitrary order.
+    pub fn child_ids(&self) -> impl IntoIterator<Item = NodeId> {
+        self.children.children.keys().copied()
     }
 }
 

--- a/tree_arena/src/tree_arena_unsafe.rs
+++ b/tree_arena/src/tree_arena_unsafe.rs
@@ -121,13 +121,7 @@ impl<T> DataMap<T> {
         }
     }
 
-    /// Find an item in the tree.
-    ///
-    /// Returns a shared reference to the item if present.
-    ///
-    /// Time Complexity O(1)
-    fn find_inner(&self, id: NodeId) -> Option<ArenaRef<'_, T>> {
-        let parent_id = *self.parents.get(&id)?;
+    fn find_node(&self, id: NodeId) -> Option<&TreeNode<T>> {
         let node_cell = self.items.get(&id)?;
 
         // SAFETY
@@ -136,7 +130,18 @@ impl<T> DataMap<T> {
         // As we are taking &self, there can be no mutable access to the node
         // Thus this is safe
 
-        let TreeNode { item, .. } = unsafe { node_cell.get().as_ref()? };
+        Some(unsafe { node_cell.get().as_ref()? })
+    }
+
+    /// Find an item in the tree.
+    ///
+    /// Returns a shared reference to the item if present.
+    ///
+    /// Time Complexity O(1)
+    fn find_inner(&self, id: NodeId) -> Option<ArenaRef<'_, T>> {
+        let parent_id = *self.parents.get(&id)?;
+
+        let TreeNode { item, .. } = self.find_node(id)?;
 
         let children = ArenaRefList {
             parent_arena: self,
@@ -234,6 +239,11 @@ impl<T> TreeArena<T> {
         }
     }
 
+    /// An iterator visiting all root ids in arbitrary order.
+    pub fn root_ids(&self) -> impl Iterator<Item = NodeId> {
+        self.roots.iter().copied()
+    }
+
     /// Returns a handle whose children are the roots, if any, of the tree.
     ///
     /// Using [`insert_child`](ArenaMutList::insert_child) on this handle
@@ -290,6 +300,19 @@ impl<T> ArenaRef<'_, T> {
         self.children
             .parent_id
             .expect("ArenaRefList always has a parent_id when it's a member of ArenaRef")
+    }
+
+    /// An iterator visiting all child ids in arbitrary order.
+    // NOTE: We're implementing child_ids for ArenaRef instead of ArenaRefList
+    // because in an ArenaRefList the implementation for the root ids would be quite inefficient
+    // (since the roots are stored in the TreeArena to which the ArenaRefList doesn't have access).
+    pub fn child_ids(&self) -> impl IntoIterator<Item = NodeId> {
+        self.children
+            .parent_arena
+            .find_node(self.id())
+            .into_iter()
+            .flat_map(|c: &TreeNode<T>| &c.children)
+            .copied()
     }
 }
 

--- a/tree_arena/src/tree_arena_unsafe.rs
+++ b/tree_arena/src/tree_arena_unsafe.rs
@@ -286,6 +286,54 @@ impl<T> TreeArena<T> {
     pub fn get_id_path(&self, id: impl Into<NodeId>) -> Vec<NodeId> {
         self.data_map.get_id_path(id.into(), None)
     }
+
+    /// Moves the given child (along with all its children) to the new parent.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the parent is actually a child of the to-be-reparented node, or
+    /// if the to-be-reparented node is a root node, or
+    /// if either node id cannot be found, or
+    /// if both given ids are equal.
+    pub fn reparent(&mut self, child: impl Into<NodeId>, new_parent: impl Into<NodeId>) {
+        let child_id = child.into();
+        let new_parent_id = new_parent.into();
+
+        assert_ne!(
+            child_id, new_parent_id,
+            "expected child to be different from new_parent but both have id #{child_id}"
+        );
+        assert!(
+            !self.get_id_path(new_parent_id).contains(&child_id),
+            "cannot reparent because new_parent #{new_parent_id} is a child of the to-be-reparented node #{child_id}"
+        );
+        assert!(
+            !self.roots.contains(&child_id),
+            "reparenting of root nodes is currently not supported"
+        );
+
+        let old_parent_id = self
+            .data_map
+            .parents
+            .get(&child_id)
+            .unwrap_or_else(|| panic!("no node found for child id #{child_id}"))
+            .unwrap();
+
+        // Move child.
+        self.find_mut(old_parent_id)
+            .unwrap()
+            .children
+            .child_arr
+            .retain(|i| *i != child_id);
+        self.find_mut(new_parent_id)
+            .unwrap_or_else(|| panic!("no node found for new_parent id #{new_parent_id}"))
+            .children
+            .child_arr
+            .push(child_id);
+
+        // Update parent reference.
+        self.data_map.parents.insert(child_id, Some(new_parent_id));
+    }
 }
 
 impl<T> Default for TreeArena<T> {


### PR DESCRIPTION
This commit firstly implements root_ids and child_ids iterators so that the reparenting implementation can be properly tested.

Reparenting is then implemented in both the safe and the unsafe tree. For the unsafe tree no new unsafe code is introduced.

To make the tests more readable a new Node struct is introduced in the test code so that the tree after the reparenting can be compared with a single assert_eq!.