### PR TITLE
add lfs-to-blobs.sh

### DIFF
--- a/docs/lfs-to-blobs.sh
+++ b/docs/lfs-to-blobs.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Embedding screenshots from Git LFS in our documentation via
+# https://media.githubusercontent.com/ depletes our GitHub LFS quota
+# so we instead convert our LFS objects into regular Git blobs
+# in the branch configured below on release so that we can embed them
+# via https://raw.githubusercontent.com/ which has no quota.
+
+BLOB_BRANCH=screenshots
+TAG=$1
+
+set -e
+
+if [ -z "$TAG" ]; then
+    echo "usage: $0 <tag>"
+    exit 1
+fi
+
+
+if git show-ref --tags --quiet --verify refs/tags/$TAG; then
+    git switch --detach $TAG
+else
+    echo "error: $TAG is not a tag."
+    exit 1
+fi
+
+LFS_FILES=$(git lfs ls-files --name-only)
+if [ -z "$LFS_FILES" ]; then
+    echo "error: no LFS files found"
+    git switch -
+    exit 1
+fi
+
+
+WORKTREE_PATH=$(git rev-parse --show-toplevel)/.git/lfs-to-blob-worktree
+NEW_BRANCH="$BLOB_BRANCH-$TAG"
+
+git worktree add "$WORKTREE_PATH" "$BLOB_BRANCH" -b "$NEW_BRANCH"
+mkdir "$WORKTREE_PATH/$TAG"
+echo "$LFS_FILES" | xargs -I {} cp --parents "{}" "$WORKTREE_PATH/$TAG"
+git -C "$WORKTREE_PATH" add "$TAG"
+git -C "$WORKTREE_PATH" commit -m "add $TAG"
+git worktree remove "$WORKTREE_PATH"
+git switch -
+echo "created branch $NEW_BRANCH"


### PR DESCRIPTION
This is an idea to work around or LFS quota problem (#851) that prevents us from embedding our screenshots in our docs.

The idea is to have a `screenshots` branch (starting from scratch, not based on our existing branches) and for every release we run the script introduced in this PR to update that branch, converting all Git LFS objects into regular Git blobs.

To try this out:
```
git switch --orphan screenshots
git commit --allow-empty -m init
git switch -
./docs/lfs-to-blobs.sh v0.3.0
```

This creates a new screenshots-v0.3.0 branch based on the screenshots branch, with a new commit adding all LFS objects of the given git tag into a directory named after the tag.