### PR TITLE
Improve accessibility of ProgressBar and Spinner

### DIFF
--- a/masonry/src/widgets/progress_bar.rs
+++ b/masonry/src/widgets/progress_bar.rs
@@ -196,9 +196,10 @@ impl Widget for ProgressBar {
     }
 
     fn accessibility(&mut self, _ctx: &mut AccessCtx, _props: &PropertiesRef<'_>, node: &mut Node) {
-        node.set_value(self.value_accessibility());
+        node.set_min_numeric_value(0.0);
+        node.set_max_numeric_value(1.0);
         if let Some(value) = self.progress {
-            node.set_numeric_value(value * 100.0);
+            node.set_numeric_value(value);
         }
     }
 

--- a/masonry/src/widgets/spinner.rs
+++ b/masonry/src/widgets/spinner.rs
@@ -165,9 +165,7 @@ impl Widget for Spinner {
     }
 
     fn accessibility_role(&self) -> Role {
-        // Don't like to use that role, but I'm not seeing
-        // anything that matches in accesskit::Role
-        Role::Unknown
+        Role::ProgressIndicator
     }
 
     fn accessibility(


### PR DESCRIPTION
- It is better to explicitly set min and max values rather than relying on defaults.
- We can then directly set the numeric value without doing any calculation.
- Setting text value on progress bar is not recommended unless there is strong reason to do so, the indeterminate case lacks translation anyway.
- A spinner can be considered as a progress indicator with indeterminate value.