### PR TITLE
Remove the package `homepage`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ edition = "2024"
 rust-version = "1.86"
 license = "Apache-2.0"
 repository = "https://github.com/linebender/xilem"
-homepage = "https://xilem.dev/"
 
 [workspace.dependencies]
 masonry = { version = "0.3.0", path = "masonry" }

--- a/xilem/Cargo.toml
+++ b/xilem/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-homepage.workspace = true
 exclude = [
     "/resources/fonts/roboto_flex/",
     "/resources/data/http_cats_status/",

--- a/xilem_core/Cargo.toml
+++ b/xilem_core/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-homepage.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/xilem_web/Cargo.toml
+++ b/xilem_web/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-homepage.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This was originally added to the Cargo.toml without sufficient review, and it's not currently meaningfully managed by Linebender (e.g. there's no repository or review process for content).

Fixes https://github.com/linebender/xilem/issues/990
Further discussion for that issue should move to [#linebender > xilem.dev](https://xi.zulipchat.com/#narrow/channel/419691-linebender/topic/xilem.2Edev/with/520087715).

According to [Cargo's docs](https://doc.rust-lang.org/cargo/reference/manifest.html#the-homepage-field), the homepage field should be set to a homepage specifically for the package (which https://linebender.org does not currently fulfil).
We should probably have some mention that this is a Linebender crate and link to linebender.org. The exact shape of that is left as follow-up.