### PR TITLE
masonry: fix panic on event when widget is not in the tree

### DIFF
--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use tracing::{debug, info_span, trace};
+use tracing::{debug, error, info_span, trace};
 
 use crate::Handled;
 use crate::app::{RenderRoot, RenderRootSignal};
@@ -79,6 +79,9 @@ fn run_event_pass<E>(
     let mut is_handled = false;
     while let Some(widget_id) = target_widget_id {
         if !root.widget_arena.has(widget_id) {
+            error!(
+                "Tried to access {widget_id} whilst processing event, but it wasn't in the tree. Discarding event"
+            );
             break;
         }
 

--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -78,6 +78,10 @@ fn run_event_pass<E>(
     let mut target_widget_id = target;
     let mut is_handled = false;
     while let Some(widget_id) = target_widget_id {
+        if !root.widget_arena.has(widget_id) {
+            break;
+        }
+
         let parent_id = root.widget_arena.parent_of(widget_id);
         let (mut widget_mut, mut state_mut, mut properties_mut) =
             root.widget_arena.get_all_mut(widget_id);


### PR DESCRIPTION
If a widget is removed from the tree in response to an event it can cause a panic in the `on_event` function. I have seen this in a Xilem app when a `text_box(..).on_enter(..)` handler causes the text_box and its parent to be removed from the view. I have also seen it when a button responds to an accessibility click event causing it to be removed. I'm not certain if it is a subsequent event (like "key up") being delivered to the removed widget that tiggers the panic or if it is traversing the ancestor list for the same event when the ancestor has been removed.