### PR TITLE
Rewrite marker comments across multiple lines.

### DIFF
--- a/masonry/ARCHITECTURE.md
+++ b/masonry/ARCHITECTURE.md
@@ -167,7 +167,7 @@ https://code.visualstudio.com/docs/getstarted/userinterface#_minimap
 These markers look like this:
 
 ```rust
-// --- MARK: MARKER NAME ---
+// --- MARK: MARKER NAME
 ```
 
 By convention, we write them in all caps with three dashes. Markers don't need to follow strict naming conventions, but their names should be a shorthand for the area of the code they're in. Names should be short enough not to overflow the VS Code minimap.

--- a/masonry/src/app/render_root.rs
+++ b/masonry/src/app/render_root.rs
@@ -47,7 +47,7 @@ use cursor_icon::CursorIcon;
 /// IME area as the `last_sent_ime_area`.
 const INVALID_IME_AREA: Rect = Rect::new(f64::NAN, f64::NAN, f64::NAN, f64::NAN);
 
-// --- MARK: STRUCTS ---
+// --- MARK: STRUCTS
 
 /// The composition root of Masonry.
 ///
@@ -343,7 +343,7 @@ impl RenderRoot {
             .item
     }
 
-    // --- MARK: WINDOW_EVENT ---
+    // --- MARK: WINDOW_EVENT
     /// Handle a window event.
     pub fn handle_window_event(&mut self, event: WindowEvent) -> Handled {
         match event {
@@ -387,7 +387,7 @@ impl RenderRoot {
         }
     }
 
-    // --- MARK: PUB FUNCTIONS ---
+    // --- MARK: PUB FUNCTIONS
     /// Handle a pointer event.
     pub fn handle_pointer_event(&mut self, event: PointerEvent) -> Handled {
         let _span = info_span!("pointer_event");
@@ -571,7 +571,7 @@ impl RenderRoot {
         kurbo::Size::new(size.width, size.height)
     }
 
-    // --- MARK: REWRITE PASSES ---
+    // --- MARK: REWRITE PASSES
     /// Run all rewrite passes on widget tree.
     ///
     /// Rewrite passes are passes which occur after external events, and

--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -139,7 +139,7 @@ pub struct AccessCtx<'a> {
     pub(crate) rebuild_all: bool,
 }
 
-// --- MARK: GETTERS ---
+// --- MARK: GETTERS
 // Methods for all context types
 impl_context_method!(
     MutateCtx<'_>,
@@ -220,7 +220,7 @@ impl_context_method!(
     }
 );
 
-// --- MARK: WIDGET_MUT ---
+// --- MARK: WIDGET_MUT
 // Methods to get a child WidgetMut from a parent.
 impl MutateCtx<'_> {
     /// Return a [`WidgetMut`] to a child widget.
@@ -293,7 +293,7 @@ impl MutateCtx<'_> {
     }
 }
 
-// --- MARK: WIDGET_REF ---
+// --- MARK: WIDGET_REF
 // Methods to get a child WidgetRef from a parent.
 impl<'w> QueryCtx<'w> {
     /// Return a [`WidgetRef`] to a child widget.
@@ -353,7 +353,7 @@ impl_context_method!(
     }
 );
 
-// --- MARK: EVENT HANDLING ---
+// --- MARK: EVENT HANDLING
 impl EventCtx<'_> {
     /// Capture the pointer in the current widget.
     ///
@@ -499,7 +499,7 @@ impl EventCtx<'_> {
     }
 }
 
-// --- MARK: UPDATE LAYOUT ---
+// --- MARK: UPDATE LAYOUT
 impl LayoutCtx<'_> {
     #[track_caller]
     fn assert_layout_done(&self, child: &WidgetPod<impl Widget + ?Sized>, method_name: &str) {
@@ -764,7 +764,7 @@ impl ComposeCtx<'_> {
     }
 }
 
-// --- MARK: GET LAYOUT ---
+// --- MARK: GET LAYOUT
 // Methods on all context types except LayoutCtx
 // These methods access layout info calculated during the layout pass.
 impl_context_method!(
@@ -975,7 +975,7 @@ impl_context_method!(
     }
 );
 
-// --- MARK: UPDATE FLAGS ---
+// --- MARK: UPDATE FLAGS
 // Methods on MutateCtx, EventCtx, and UpdateCtx
 impl_context_method!(MutateCtx<'_>, EventCtx<'_>, UpdateCtx<'_>, {
     /// Request a [`paint`](crate::core::Widget::paint) and an [`accessibility`](crate::core::Widget::accessibility) pass.
@@ -1101,7 +1101,7 @@ impl_context_method!(MutateCtx<'_>, EventCtx<'_>, UpdateCtx<'_>, {
     }
 });
 
-// --- MARK: OTHER METHODS ---
+// --- MARK: OTHER METHODS
 // Methods on mutable context types
 impl_context_method!(
     MutateCtx<'_>,
@@ -1270,7 +1270,7 @@ impl RegisterCtx<'_> {
     }
 }
 
-// --- MARK: DEBUG PAINT ---
+// --- MARK: DEBUG PAINT
 impl PaintCtx<'_> {
     /// Whether debug paint is enabled.
     ///
@@ -1294,7 +1294,7 @@ impl PaintCtx<'_> {
     }
 }
 
-// --- MARK: RAW WRAPPERS ---
+// --- MARK: RAW WRAPPERS
 macro_rules! impl_get_raw {
     ($SomeCtx:tt) => {
         impl<'s> $SomeCtx<'s> {

--- a/masonry/src/core/widget_ref.rs
+++ b/masonry/src/core/widget_ref.rs
@@ -26,7 +26,7 @@ pub struct WidgetRef<'w, W: Widget + ?Sized> {
     pub(crate) widget: &'w W,
 }
 
-// --- MARK: TRAIT IMPLS ---
+// --- MARK: TRAIT IMPLS
 
 #[allow(clippy::non_canonical_clone_impl)]
 impl<W: Widget + ?Sized> Clone for WidgetRef<'_, W> {
@@ -68,7 +68,7 @@ impl<W: Widget + ?Sized> Deref for WidgetRef<'_, W> {
     }
 }
 
-// --- MARK: IMPLS ---
+// --- MARK: IMPLS
 
 impl<'w, W: Widget + ?Sized> WidgetRef<'w, W> {
     /// Get a [`QueryCtx`] with information about the current widget.
@@ -194,7 +194,7 @@ impl WidgetRef<'_, dyn Widget> {
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;

--- a/masonry/src/passes/accessibility.rs
+++ b/masonry/src/passes/accessibility.rs
@@ -11,7 +11,7 @@ use crate::core::{AccessCtx, DefaultProperties, PropertiesRef, Widget, WidgetSta
 use crate::passes::{enter_span_if, recurse_on_children};
 use crate::util::AnyMap;
 
-// --- MARK: BUILD TREE ---
+// --- MARK: BUILD TREE
 fn build_accessibility_tree(
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
@@ -96,7 +96,7 @@ fn build_accessibility_tree(
     );
 }
 
-// --- MARK: BUILD NODE ---
+// --- MARK: BUILD NODE
 fn build_access_node(
     widget: &mut dyn Widget,
     ctx: &mut AccessCtx,
@@ -147,7 +147,7 @@ fn to_accesskit_rect(r: Rect) -> accesskit::Rect {
     accesskit::Rect::new(r.x0, r.y0, r.x1, r.y1)
 }
 
-// --- MARK: ROOT ---
+// --- MARK: ROOT
 /// See the [passes documentation](../doc/05_pass_system.md#render-passes).
 pub(crate) fn run_accessibility_pass(root: &mut RenderRoot, scale_factor: f64) -> TreeUpdate {
     let _span = info_span!("accessibility").entered();

--- a/masonry/src/passes/anim.rs
+++ b/masonry/src/passes/anim.rs
@@ -9,7 +9,7 @@ use crate::core::{DefaultProperties, PropertiesMut, UpdateCtx, Widget, WidgetSta
 use crate::passes::{enter_span_if, recurse_on_children};
 use crate::util::AnyMap;
 
-// --- MARK: UPDATE ANIM ---
+// --- MARK: UPDATE ANIM
 fn update_anim_for_widget(
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,

--- a/masonry/src/passes/compose.rs
+++ b/masonry/src/passes/compose.rs
@@ -10,7 +10,7 @@ use crate::core::{ComposeCtx, DefaultProperties, Widget, WidgetState};
 use crate::passes::{enter_span_if, recurse_on_children};
 use crate::util::AnyMap;
 
-// --- MARK: RECURSE ---
+// --- MARK: RECURSE
 fn compose_widget(
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
@@ -92,7 +92,7 @@ fn compose_widget(
     );
 }
 
-// --- MARK: ROOT ---
+// --- MARK: ROOT
 /// See the [passes documentation](../doc/05_pass_system.md#compose-pass).
 pub(crate) fn run_compose_pass(root: &mut RenderRoot) {
     let _span = info_span!("compose").entered();

--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -13,7 +13,7 @@ use crate::core::{
 use crate::dpi::{LogicalPosition, PhysicalPosition};
 use crate::passes::{enter_span, merge_state_up};
 
-// --- MARK: HELPERS ---
+// --- MARK: HELPERS
 fn get_pointer_target(
     root: &RenderRoot,
     pointer_pos: Option<LogicalPosition<f64>>,
@@ -131,7 +131,7 @@ fn run_event_pass<E>(
     Handled::from(is_handled)
 }
 
-// --- MARK: POINTER_EVENT ---
+// --- MARK: POINTER_EVENT
 /// See the [passes documentation](../doc/05_pass_system.md#event-passes).
 pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEvent) -> Handled {
     let _span = info_span!("dispatch_pointer_event").entered();
@@ -235,7 +235,7 @@ pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEv
     handled
 }
 
-// --- MARK: TEXT EVENT ---
+// --- MARK: TEXT EVENT
 /// See the [passes documentation](../doc/05_pass_system.md#event-passes).
 pub(crate) fn run_on_text_event_pass(root: &mut RenderRoot, event: &TextEvent) -> Handled {
     if matches!(event, TextEvent::WindowFocusChange(false)) {
@@ -322,7 +322,7 @@ pub(crate) fn run_on_text_event_pass(root: &mut RenderRoot, event: &TextEvent) -
     handled
 }
 
-// --- MARK: ACCESS EVENT ---
+// --- MARK: ACCESS EVENT
 /// See the [passes documentation](../doc/05_pass_system.md#event-passes).
 pub(crate) fn run_on_access_event_pass(
     root: &mut RenderRoot,

--- a/masonry/src/passes/layout.rs
+++ b/masonry/src/passes/layout.rs
@@ -14,7 +14,7 @@ use crate::app::{RenderRoot, RenderRootSignal, WindowSizePolicy};
 use crate::core::{BoxConstraints, LayoutCtx, PropertiesMut, Widget, WidgetPod, WidgetState};
 use crate::passes::{enter_span_if, recurse_on_children};
 
-// --- MARK: RUN LAYOUT ---
+// --- MARK: RUN LAYOUT
 /// Run [`Widget::layout`] method on the widget contained in `pod`.
 /// This will be called by [`LayoutCtx::run_layout`], which is itself called in the parent widget's `layout`.
 pub(crate) fn run_layout_on<W: Widget + ?Sized>(
@@ -197,7 +197,7 @@ pub(crate) fn run_layout_on<W: Widget + ?Sized>(
     new_size
 }
 
-// --- MARK: ROOT ---
+// --- MARK: ROOT
 /// See the [passes documentation](../doc/05_pass_system.md#layout-pass).
 pub(crate) fn run_layout_pass(root: &mut RenderRoot) {
     if !root.root_state().needs_layout {

--- a/masonry/src/passes/paint.rs
+++ b/masonry/src/passes/paint.rs
@@ -16,7 +16,7 @@ use crate::passes::{enter_span_if, recurse_on_children};
 use crate::theme::get_debug_color;
 use crate::util::{AnyMap, stroke};
 
-// --- MARK: PAINT WIDGET ---
+// --- MARK: PAINT WIDGET
 fn paint_widget(
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
@@ -123,7 +123,7 @@ fn paint_widget(
     }
 }
 
-// --- MARK: ROOT ---
+// --- MARK: ROOT
 /// See the [passes documentation](../doc/05_pass_system.md#render-passes).
 pub(crate) fn run_paint_pass(root: &mut RenderRoot) -> Scene {
     let _span = info_span!("paint").entered();

--- a/masonry/src/passes/update.rs
+++ b/masonry/src/passes/update.rs
@@ -16,7 +16,7 @@ use crate::passes::event::{run_on_pointer_event_pass, run_on_text_event_pass};
 use crate::passes::{enter_span, enter_span_if, merge_state_up, recurse_on_children};
 use crate::util::AnyMap;
 
-// --- MARK: HELPERS ---
+// --- MARK: HELPERS
 /// Returns the id path starting from the given widget id and ending at the root.
 ///
 /// If `widget_id` is `None`, returns an empty `Vec`.
@@ -107,7 +107,7 @@ fn run_single_update_pass(
     }
 }
 
-// --- MARK: TREE ---
+// --- MARK: TREE
 fn update_widget_tree(
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
@@ -250,7 +250,7 @@ pub(crate) fn run_update_widget_tree_pass(root: &mut RenderRoot) {
 
 // ----------------
 
-// --- MARK: UPDATE DISABLED ---
+// --- MARK: UPDATE DISABLED
 /// See the [passes documentation](../doc/05_pass_system.md#update-passes).
 /// See the [disabled status documentation](../doc/06_masonry_concepts.md#disabled).
 fn update_disabled_for_widget(
@@ -342,7 +342,7 @@ pub(crate) fn run_update_disabled_pass(root: &mut RenderRoot) {
 // *Stashed* is for widgets that are no longer "part of the graph". So they can't get keyboard events, don't get painted, etc, but should keep some state.
 // Scrolled-out widgets are *not* stashed.
 
-// --- MARK: UPDATE STASHED ---
+// --- MARK: UPDATE STASHED
 /// See the [passes documentation](../doc/05_pass_system.md#update-passes).
 /// See the [stashed status documentation](../doc/06_masonry_concepts.md#stashed).
 fn update_stashed_for_widget(
@@ -435,7 +435,7 @@ pub(crate) fn run_update_stashed_pass(root: &mut RenderRoot) {
 
 // ----------------
 
-// --- MARK: FOCUS CHAIN ---
+// --- MARK: FOCUS CHAIN
 
 // TODO https://github.com/linebender/xilem/issues/376 - Some implicit invariants:
 // - A widget only receives BuildFocusChain if none of its parents are hidden.
@@ -525,7 +525,7 @@ pub(crate) fn run_update_focus_chain_pass(root: &mut RenderRoot) {
 
 // ----------------
 
-// --- MARK: UPDATE FOCUS ---
+// --- MARK: UPDATE FOCUS
 /// See the [passes documentation](../doc/05_pass_system.md#update-passes).
 /// See the [focus status documentation](../doc/06_masonry_concepts.md#text-focus).
 pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
@@ -683,7 +683,7 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
 
 // ----------------
 
-// --- MARK: SCROLL ---
+// --- MARK: SCROLL
 // This pass will update scroll positions in cases where a widget has requested to be
 // scrolled into view (usually a textbox getting text events).
 // Each parent that implements scrolling will update its scroll position to ensure the
@@ -714,7 +714,7 @@ pub(crate) fn run_update_scroll_pass(root: &mut RenderRoot) {
 
 // ----------------
 
-// --- MARK: UPDATE POINTER ---
+// --- MARK: UPDATE POINTER
 /// See the [passes documentation](../doc/05_pass_system.md#update-passes).
 pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
     if !root.global_state.needs_pointer_pass {

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -264,7 +264,7 @@ impl TestHarness {
         harness
     }
 
-    // --- MARK: PROCESS EVENTS ---
+    // --- MARK: PROCESS EVENTS
 
     /// Send a [`WindowEvent`] to the simulated window.
     ///
@@ -332,7 +332,7 @@ impl TestHarness {
         }
     }
 
-    // --- MARK: RENDER ---
+    // --- MARK: RENDER
     // TODO - We add way too many dependencies in this code
     // TODO - Should be async?
     /// Create a bitmap (an array of pixels), paint the window and return the bitmap as an 8-bits-per-channel RGB image.
@@ -432,7 +432,7 @@ impl TestHarness {
         RgbaImage::from_vec(width, height, result_unpadded).expect("failed to create image")
     }
 
-    // --- MARK: EVENT HELPERS ---
+    // --- MARK: EVENT HELPERS
 
     /// Move an internal mouse state, and send a [`Move`](PointerEvent::Move) event to the window.
     pub fn mouse_move(&mut self, pos: impl Into<Point>) {
@@ -572,7 +572,7 @@ impl TestHarness {
         self.process_signals();
     }
 
-    // --- MARK: GETTERS ---
+    // --- MARK: GETTERS
 
     /// Return a [`WidgetRef`] to the root widget.
     pub fn root_widget(&self) -> WidgetRef<'_, dyn Widget> {
@@ -688,7 +688,7 @@ impl TestHarness {
         self.title.clone()
     }
 
-    // --- MARK: SNAPSHOT ---
+    // --- MARK: SNAPSHOT
 
     /// Method used by [`assert_render_snapshot`] and [`assert_failing_render_snapshot`]. Use these macros, not this method.
     ///

--- a/masonry/src/util.rs
+++ b/masonry/src/util.rs
@@ -65,7 +65,7 @@ impl From<bool> for Handled {
     }
 }
 
-// --- MARK: PAINT HELPERS ---
+// --- MARK: PAINT HELPERS
 
 #[derive(Debug, Clone, Copy)]
 /// A point with coordinates in the range [0.0, 1.0].

--- a/masonry/src/widgets/align.rs
+++ b/masonry/src/widgets/align.rs
@@ -32,7 +32,7 @@ pub struct Align {
     height_factor: Option<f64>,
 }
 
-// --- MARK: BUILDERS ---
+// --- MARK: BUILDERS
 impl Align {
     /// Create widget with alignment.
     ///
@@ -84,7 +84,7 @@ impl Align {
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl Widget for Align {
     fn on_pointer_event(
         &mut self,
@@ -193,7 +193,7 @@ fn log_size_warnings(size: Size) {
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -32,7 +32,7 @@ pub struct Button {
     label: WidgetPod<Label>,
 }
 
-// --- MARK: BUILDERS ---
+// --- MARK: BUILDERS
 impl Button {
     /// Create a new button with a text label.
     ///
@@ -72,7 +72,7 @@ impl Button {
     }
 }
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl Button {
     /// Set the text.
     pub fn set_text(this: &mut WidgetMut<'_, Self>, new_text: impl Into<ArcStr>) {
@@ -85,7 +85,7 @@ impl Button {
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl Widget for Button {
     fn on_pointer_event(
         &mut self,
@@ -274,7 +274,7 @@ impl Widget for Button {
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -44,7 +44,7 @@ impl Checkbox {
     }
 }
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl Checkbox {
     /// Check or uncheck the box.
     pub fn set_checked(this: &mut WidgetMut<'_, Self>, checked: bool) {
@@ -66,7 +66,7 @@ impl Checkbox {
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl Widget for Checkbox {
     fn on_pointer_event(
         &mut self,
@@ -250,7 +250,7 @@ impl Widget for Checkbox {
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -117,7 +117,7 @@ enum Child {
     FlexedSpacer(f64, f64),
 }
 
-// --- MARK: IMPL FLEX ---
+// --- MARK: IMPL FLEX
 impl Flex {
     /// Create a new Flex oriented along the provided axis.
     pub fn for_axis(axis: Axis) -> Self {
@@ -1286,7 +1286,7 @@ impl Widget for Flex {
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -44,7 +44,7 @@ pub struct GridParams {
     pub height: i32,
 }
 
-// --- MARK: IMPL GRID ---
+// --- MARK: IMPL GRID
 impl Grid {
     /// Create a new grid with the given number of columns and rows.
     pub fn with_dimensions(width: i32, height: i32) -> Self {
@@ -86,7 +86,7 @@ impl Grid {
     }
 }
 
-// --- MARK: IMPL CHILD ---
+// --- MARK: IMPL CHILD
 impl Child {
     fn update_params(&mut self, params: GridParams) {
         self.x = params.x;
@@ -106,7 +106,7 @@ fn new_grid_child(params: GridParams, widget: WidgetPod<dyn Widget>) -> Child {
     }
 }
 
-// --- MARK: IMPL GRIDPARAMS ---
+// --- MARK: IMPL GRIDPARAMS
 impl GridParams {
     /// Create grid parameters with the given values.
     ///
@@ -378,7 +378,7 @@ impl Widget for Grid {
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/masonry/src/widgets/image.rs
+++ b/masonry/src/widgets/image.rs
@@ -32,7 +32,7 @@ pub struct Image {
     object_fit: ObjectFit,
 }
 
-// --- MARK: BUILDERS ---
+// --- MARK: BUILDERS
 impl Image {
     /// Create an image drawing widget from an image buffer.
     ///
@@ -53,7 +53,7 @@ impl Image {
     }
 }
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl Image {
     /// Modify the widget's object fit.
     #[inline]
@@ -70,7 +70,7 @@ impl Image {
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl Widget for Image {
     fn on_pointer_event(
         &mut self,
@@ -170,7 +170,7 @@ impl Widget for Image {
 
 // FIXME - remove cfg?
 #[cfg(not(target_arch = "wasm32"))]
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use vello::peniko::ImageFormat;

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -81,7 +81,7 @@ pub struct Label {
     hint: bool,
 }
 
-// --- MARK: BUILDERS ---
+// --- MARK: BUILDERS
 impl Label {
     /// Create a new label with the given text.
     ///
@@ -207,7 +207,7 @@ impl Label {
     }
 }
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl Label {
     // Note: These docs are lazy, but also have a decreased likelihood of going out of date.
     /// The runtime requivalent of [`with_style`](Self::with_style).
@@ -311,7 +311,7 @@ impl Label {
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl Widget for Label {
     fn on_pointer_event(
         &mut self,
@@ -480,7 +480,7 @@ impl Widget for Label {
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -40,7 +40,7 @@ pub struct Portal<W: Widget + ?Sized> {
     scrollbar_vertical_visible: bool,
 }
 
-// --- MARK: BUILDERS ---
+// --- MARK: BUILDERS
 impl<W: Widget> Portal<W> {
     #[expect(missing_docs, reason = "TODO")]
     pub fn new(child: W) -> Self {
@@ -172,7 +172,7 @@ impl<W: Widget + ?Sized> Portal<W> {
     }
 }
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl<W: Widget + FromDynWidget + ?Sized> Portal<W> {
     #[expect(missing_docs, reason = "TODO")]
     pub fn child_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, W> {
@@ -267,7 +267,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Portal<W> {
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
     fn on_pointer_event(
         &mut self,
@@ -521,7 +521,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widgets/progress_bar.rs
+++ b/masonry/src/widgets/progress_bar.rs
@@ -63,7 +63,7 @@ impl ProgressBar {
     }
 }
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl ProgressBar {
     /// Set the progress displayed by the bar.
     ///
@@ -95,7 +95,7 @@ fn clamp_progress(progress: Option<f64>) -> Option<f64> {
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl Widget for ProgressBar {
     fn on_pointer_event(
         &mut self,
@@ -216,7 +216,7 @@ impl Widget for ProgressBar {
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widgets/prose.rs
+++ b/masonry/src/widgets/prose.rs
@@ -76,7 +76,7 @@ impl Prose {
     }
 }
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl Prose {
     /// Edit the underlying text area.
     ///
@@ -97,7 +97,7 @@ impl Prose {
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl Widget for Prose {
     fn on_pointer_event(
         &mut self,

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -36,7 +36,7 @@ pub struct ScrollBar {
     grab_anchor: Option<f64>,
 }
 
-// --- MARK: BUILDERS ---
+// --- MARK: BUILDERS
 impl ScrollBar {
     #[expect(missing_docs, reason = "TODO")]
     pub fn new(axis: Axis, portal_size: f64, content_size: f64) -> Self {
@@ -102,7 +102,7 @@ impl ScrollBar {
     }
 }
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl ScrollBar {
     // TODO - Remove?
     #[expect(missing_docs, reason = "TODO")]
@@ -121,7 +121,7 @@ impl ScrollBar {
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl Widget for ScrollBar {
     fn on_pointer_event(
         &mut self,
@@ -254,7 +254,7 @@ impl Widget for ScrollBar {
 
 impl AllowRawMut for ScrollBar {}
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -52,7 +52,7 @@ pub struct SizedBox {
     padding: Padding,
 }
 
-// --- MARK: BUILDERS ---
+// --- MARK: BUILDERS
 impl SizedBox {
     /// Construct container with child, and both width and height not set.
     pub fn new(child: impl Widget) -> Self {
@@ -198,7 +198,7 @@ impl SizedBox {
     }
 }
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl SizedBox {
     /// Give this container a child widget.
     ///
@@ -306,7 +306,7 @@ impl SizedBox {
     }
 }
 
-// --- MARK: INTERNALS ---
+// --- MARK: INTERNALS
 impl SizedBox {
     fn child_constraints(&self, bc: &BoxConstraints) -> BoxConstraints {
         // if we don't have a width/height, we don't change that axis.
@@ -334,7 +334,7 @@ impl SizedBox {
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl Widget for SizedBox {
     fn on_pointer_event(
         &mut self,
@@ -482,7 +482,7 @@ impl Widget for SizedBox {
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;
@@ -643,7 +643,7 @@ mod tests {
 
     // TODO - add screenshot tests for different brush types
 
-    // --- MARK: PROP TESTS ---
+    // --- MARK: PROP TESTS
 
     #[test]
     fn background_brush_property() {

--- a/masonry/src/widgets/spinner.rs
+++ b/masonry/src/widgets/spinner.rs
@@ -33,7 +33,7 @@ pub struct Spinner {
     color: Color,
 }
 
-// --- MARK: BUILDERS ---
+// --- MARK: BUILDERS
 impl Spinner {
     /// Create a spinner widget
     pub fn new() -> Self {
@@ -58,7 +58,7 @@ impl Default for Spinner {
     }
 }
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl Spinner {
     /// Set the spinner's color.
     pub fn set_color(this: &mut WidgetMut<'_, Self>, color: impl Into<Color>) {
@@ -72,7 +72,7 @@ impl Spinner {
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl Widget for Spinner {
     fn on_pointer_event(
         &mut self,
@@ -185,7 +185,7 @@ impl Widget for Spinner {
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -44,7 +44,7 @@ where
     child2: WidgetPod<ChildB>,
 }
 
-// --- MARK: BUILDERS ---
+// --- MARK: BUILDERS
 impl<ChildA: Widget, ChildB: Widget> Split<ChildA, ChildB> {
     /// Create a new split panel.
     pub fn new(child1: ChildA, child2: ChildB) -> Self {
@@ -149,7 +149,7 @@ impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
     }
 }
 
-// --- MARK: INTERNALS ---
+// --- MARK: INTERNALS
 impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
     /// Returns the size of the splitter bar area.
     #[inline]
@@ -298,7 +298,7 @@ impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
 
 // FIXME - Add unit tests for WidgetMut<Split>
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl<ChildA, ChildB> Split<ChildA, ChildB>
 where
     ChildA: Widget + FromDynWidget + ?Sized,
@@ -391,7 +391,7 @@ where
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl<ChildA, ChildB> Widget for Split<ChildA, ChildB>
 where
     ChildA: Widget + ?Sized,
@@ -608,7 +608,7 @@ where
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -100,7 +100,7 @@ pub struct TextArea<const USER_EDITABLE: bool> {
     insert_newline: InsertNewline,
 }
 
-// --- MARK: BUILDERS ---
+// --- MARK: BUILDERS
 impl TextArea<true> {
     /// Create a new `TextArea` which can be edited.
     ///
@@ -278,7 +278,7 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
     }
 }
 
-// --- MARK: HELPERS ---
+// --- MARK: HELPERS
 impl<const EDITABLE: bool> TextArea<EDITABLE> {
     /// Get the IME area from the editor, accounting for padding.
     ///
@@ -292,7 +292,7 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
     }
 }
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl<const EDITABLE: bool> TextArea<EDITABLE> {
     /// Set font styling for an active text area.
     ///
@@ -474,7 +474,7 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
     fn on_pointer_event(
         &mut self,

--- a/masonry/src/widgets/textbox.rs
+++ b/masonry/src/widgets/textbox.rs
@@ -88,7 +88,7 @@ impl Textbox {
     }
 }
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl Textbox {
     /// Edit the underlying text area.
     ///
@@ -109,7 +109,7 @@ impl Textbox {
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl Widget for Textbox {
     fn on_pointer_event(
         &mut self,

--- a/masonry/src/widgets/variable_label.rs
+++ b/masonry/src/widgets/variable_label.rs
@@ -126,7 +126,7 @@ pub struct VariableLabel {
     weight: AnimatedF32,
 }
 
-// --- MARK: BUILDERS ---
+// --- MARK: BUILDERS
 impl VariableLabel {
     /// Create a new variable label from the given text.
     pub fn new(text: impl Into<ArcStr>) -> Self {
@@ -157,7 +157,7 @@ impl VariableLabel {
     }
 }
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl VariableLabel {
     /// Get the underlying label for this widget.
     pub fn label_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, Label> {
@@ -177,7 +177,7 @@ impl VariableLabel {
     }
 }
 
-// --- MARK: IMPL WIDGET ---
+// --- MARK: IMPL WIDGET
 impl Widget for VariableLabel {
     fn on_pointer_event(
         &mut self,
@@ -275,7 +275,7 @@ impl Widget for VariableLabel {
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     // TODO - Add tests

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -297,7 +297,7 @@ impl<W: Widget + FromDynWidget + ?Sized> VirtualScroll<W> {
     }
 }
 
-// --- MARK: WIDGETMUT ---
+// --- MARK: WIDGETMUT
 impl<W: Widget + FromDynWidget + ?Sized> VirtualScroll<W> {
     /// Indicates that `action` is about to be handled by the driver (which is calling this method).
     ///

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -90,7 +90,7 @@ pub enum HorizontalAlignment {
     Right,
 }
 
-// --- MARK: IMPL ALIGNMENTS ---
+// --- MARK: IMPL ALIGNMENTS
 
 impl Alignment {
     /// Constructs a new Alignment from a [vertical][VerticalAlignment] and [horizontal][HorizontalAlignment] alignment.
@@ -173,7 +173,7 @@ impl Child {
     }
 }
 
-// --- MARK: IMPL ZSTACK ---
+// --- MARK: IMPL ZSTACK
 impl ZStack {
     /// Constructs a new empty `ZStack` widget.
     pub fn new() -> Self {
@@ -375,7 +375,7 @@ impl Widget for ZStack {
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use vello::peniko::color::palette;

--- a/masonry_winit/examples/calc_masonry.rs
+++ b/masonry_winit/examples/calc_masonry.rs
@@ -440,7 +440,7 @@ fn main() {
     .unwrap();
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use masonry_winit::assert_render_snapshot;

--- a/masonry_winit/examples/custom_widget.rs
+++ b/masonry_winit/examples/custom_widget.rs
@@ -202,7 +202,7 @@ fn make_image_data(width: usize, height: usize) -> Vec<u8> {
     result
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use masonry_winit::assert_render_snapshot;

--- a/masonry_winit/examples/grid_masonry.rs
+++ b/masonry_winit/examples/grid_masonry.rs
@@ -126,7 +126,7 @@ fn main() {
     .unwrap();
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use masonry_winit::assert_render_snapshot;

--- a/masonry_winit/examples/simple_image.rs
+++ b/masonry_winit/examples/simple_image.rs
@@ -51,7 +51,7 @@ fn main() {
     .unwrap();
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use masonry_winit::assert_render_snapshot;

--- a/masonry_winit/examples/to_do_list.rs
+++ b/masonry_winit/examples/to_do_list.rs
@@ -77,7 +77,7 @@ fn main() {
     .unwrap();
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use masonry_winit::assert_render_snapshot;

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -91,7 +91,7 @@ pub type EventLoopBuilder = winit::event_loop::EventLoopBuilder<MasonryUserEvent
 /// A proxy used to send events to the event loop
 pub type EventLoopProxy = winit::event_loop::EventLoopProxy<MasonryUserEvent>;
 
-// --- MARK: RUN ---
+// --- MARK: RUN
 pub fn run(
     // Clearly, this API needs to be refactored, so we don't mind forcing this to be passed in here directly
     // This is passed in mostly to allow configuring the Android app
@@ -247,7 +247,7 @@ impl MasonryState<'_> {
         }
     }
 
-    // --- MARK: RESUMED ---
+    // --- MARK: RESUMED
     pub fn handle_resumed(&mut self, event_loop: &ActiveEventLoop, app_driver: &mut dyn AppDriver) {
         match std::mem::replace(
             &mut self.window,
@@ -328,7 +328,7 @@ impl MasonryState<'_> {
         }
     }
 
-    // --- MARK: SUSPENDED ---
+    // --- MARK: SUSPENDED
     pub fn handle_suspended(&mut self, _event_loop: &ActiveEventLoop) {
         match std::mem::replace(
             &mut self.window,
@@ -352,7 +352,7 @@ impl MasonryState<'_> {
         }
     }
 
-    // --- MARK: RENDER ---
+    // --- MARK: RENDER
     fn render(&mut self, scene: Scene) {
         let WindowState::Rendering {
             window, surface, ..
@@ -456,7 +456,7 @@ impl MasonryState<'_> {
         drop(self.frame.take());
     }
 
-    // --- MARK: WINDOW_EVENT ---
+    // --- MARK: WINDOW_EVENT
     pub fn handle_window_event(
         &mut self,
         event_loop: &ActiveEventLoop,
@@ -545,7 +545,7 @@ impl MasonryState<'_> {
         self.handle_signals(event_loop, app_driver);
     }
 
-    // --- MARK: DEVICE_EVENT ---
+    // --- MARK: DEVICE_EVENT
     pub fn handle_device_event(
         &mut self,
         _: &ActiveEventLoop,
@@ -555,7 +555,7 @@ impl MasonryState<'_> {
     ) {
     }
 
-    // --- MARK: USER_EVENT ---
+    // --- MARK: USER_EVENT
     pub fn handle_user_event(
         &mut self,
         event_loop: &ActiveEventLoop,
@@ -586,7 +586,7 @@ impl MasonryState<'_> {
         self.handle_signals(event_loop, app_driver);
     }
 
-    // --- MARK: EMPTY WINIT HANDLERS ---
+    // --- MARK: EMPTY WINIT HANDLERS
     pub fn handle_about_to_wait(&mut self, _: &ActiveEventLoop) {}
 
     pub fn handle_new_events(&mut self, _: &ActiveEventLoop, _: winit::event::StartCause) {}
@@ -595,7 +595,7 @@ impl MasonryState<'_> {
 
     pub fn handle_memory_warning(&mut self, _: &ActiveEventLoop) {}
 
-    // --- MARK: SIGNALS ---
+    // --- MARK: SIGNALS
     fn handle_signals(&mut self, event_loop: &ActiveEventLoop, app_driver: &mut dyn AppDriver) {
         let WindowState::Rendering { window, .. } = &mut self.window else {
             tracing::warn!("Tried to handle a signal whilst suspended or before window created");

--- a/xilem/src/view/zstack.rs
+++ b/xilem/src/view/zstack.rs
@@ -119,7 +119,7 @@ where
     }
 }
 
-// --- MARK: ZStackExt ---
+// --- MARK: ZStackExt
 
 /// A trait that extends a [`WidgetView`] with methods to provide parameters for a parent [`ZStack`].
 pub trait ZStackExt<State, Action>: WidgetView<State, Action> {
@@ -225,7 +225,7 @@ where
     }
 }
 
-// --- MARK: ZStackElement ---
+// --- MARK: ZStackElement
 
 /// A struct implementing [`ViewElement`] for a `ZStack`.
 pub struct ZStackElement {

--- a/xilem_core/tests/arc.rs
+++ b/xilem_core/tests/arc.rs
@@ -107,7 +107,7 @@ fn arc_passthrough_message() {
     assert_action(result, 0);
 }
 
-// --- MARK: Box tests ---
+// --- MARK: Box tests
 #[test]
 /// The Box view shouldn't impact the view path
 fn box_no_path() {


### PR DESCRIPTION
This is because VSCode now interprets dashes as part of the marker title, which makes markers more likely to overflow the minimap width.

Supersedes #947.