### PR TITLE
[Draft] Refactor WidgetMut to remove parent_state reference

### DIFF
--- a/masonry/src/core/widget_mut.rs
+++ b/masonry/src/core/widget_mut.rs
@@ -31,16 +31,6 @@ pub struct WidgetMut<'a, W: Widget + ?Sized> {
     pub ctx: MutateCtx<'a>,
 }
 
-impl<W: Widget + ?Sized> Drop for WidgetMut<'_, W> {
-    fn drop(&mut self) {
-        // If this `WidgetMut` is a reborrow, a parent non-reborrow `WidgetMut`
-        // still exists which will do the merge-up in `Drop`.
-        if let Some(parent_widget_state) = self.ctx.parent_widget_state.take() {
-            parent_widget_state.merge_up(self.ctx.widget_state);
-        }
-    }
-}
-
 impl<W: Widget + ?Sized> WidgetMut<'_, W> {
     /// Get a `WidgetMut` for the same underlying widget with a shorter lifetime.
     pub fn reborrow_mut(&mut self) -> WidgetMut<'_, W> {

--- a/masonry/src/core/widget_state.rs
+++ b/masonry/src/core/widget_state.rs
@@ -114,6 +114,9 @@ pub(crate) struct WidgetState {
     /// A flag used to track and debug missing calls to `place_child`.
     pub(crate) is_expecting_place_child_call: bool,
 
+    /// This widget or a descendant needs its flags to be propagated up.
+    pub(crate) needs_update_flags: bool,
+
     /// This widget explicitly requested layout
     pub(crate) request_layout: bool,
     /// This widget or a descendant explicitly requested layout
@@ -214,6 +217,7 @@ impl WidgetState {
             is_new: true,
             has_hovered: false,
             is_hovered: false,
+            needs_update_flags: false,
             request_layout: true,
             needs_layout: true,
             request_compose: true,
@@ -279,6 +283,8 @@ impl WidgetState {
         self.children_changed |= child_state.children_changed;
         self.needs_update_focus_chain |= child_state.needs_update_focus_chain;
         self.needs_update_stashed |= child_state.needs_update_stashed;
+
+        // needs_update_flags doesn't need to propagate up.
     }
 
     /// The paint region for this widget.

--- a/masonry/src/passes/mutate.rs
+++ b/masonry/src/passes/mutate.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use tracing::info_span;
+use tree_arena::ArenaMut;
 
 use crate::app::RenderRoot;
-use crate::core::{MutateCtx, PropertiesMut, Widget, WidgetId, WidgetMut};
+use crate::core::{MutateCtx, PropertiesMut, Widget, WidgetId, WidgetMut, WidgetState};
 use crate::passes::merge_state_up;
 
 pub(crate) fn mutate_widget<R>(
@@ -12,30 +13,31 @@ pub(crate) fn mutate_widget<R>(
     id: WidgetId,
     mutate_fn: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R,
 ) -> R {
-    let (widget_mut, state_mut, properties_mut) = root.widget_arena.get_all_mut(id);
+    let (mut widget_mut, mut state_mut, mut properties_mut) = root.widget_arena.get_all_mut(id);
 
     let _span = info_span!("mutate_widget", name = widget_mut.item.short_type_name()).entered();
-    // NOTE - we can set parent_widget_state to None here, because the loop below will merge the
-    // states up to the root.
+
     let root_widget = WidgetMut {
         ctx: MutateCtx {
             global_state: &mut root.global_state,
-            parent_widget_state: None,
             widget_state: state_mut.item,
-            widget_state_children: state_mut.children,
-            widget_children: widget_mut.children,
+            widget_state_children: state_mut.children.reborrow_mut(),
+            widget_children: widget_mut.children.reborrow_mut(),
             properties: PropertiesMut {
                 map: properties_mut.item,
                 default_map: root
                     .default_properties
                     .for_widget(widget_mut.item.type_id()),
             },
-            properties_children: properties_mut.children,
+            properties_children: properties_mut.children.reborrow_mut(),
         },
         widget: &mut **widget_mut.item,
     };
+    root_widget.ctx.widget_state.needs_update_flags = true;
 
     let result = mutate_fn(root_widget);
+
+    update_flags(widget_mut, state_mut);
 
     // Merge all state changes up to the root.
     let mut current_id = Some(id);
@@ -46,6 +48,24 @@ pub(crate) fn mutate_widget<R>(
     }
 
     result
+}
+
+fn update_flags(mut widget: ArenaMut<'_, Box<dyn Widget>>, mut state: ArenaMut<'_, WidgetState>) {
+    if !state.item.needs_update_flags {
+        return;
+    }
+    state.item.needs_update_flags = false;
+
+    let parent_state = state.item;
+    for child_id in widget.item.children_ids() {
+        let widget = widget.children.item_mut(child_id);
+        let state = state.children.item_mut(child_id);
+
+        if let (Some(widget), Some(mut state)) = (widget, state) {
+            update_flags(widget, state.reborrow_mut());
+            parent_state.merge_up(state.item);
+        }
+    }
 }
 
 /// Apply any deferred mutations (created using [`...Ctx::mutate_later`]


### PR DESCRIPTION
This lets us remove the Drop impl for WidgetMut, which makes it easier to use without making the borrow checker mad.