### PR TITLE
Refactor Masonry to prepare for crate split

### DIFF
--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -20,8 +20,7 @@ use crate::core::{
 use crate::kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
 use crate::passes::layout::run_layout_on;
 use crate::peniko::Color;
-use crate::theme::get_debug_color;
-use crate::util::AnyMap;
+use crate::util::{AnyMap, get_debug_color};
 
 // Note - Most methods defined in this file revolve around `WidgetState` fields.
 // Consider reading `WidgetState` documentation (especially the documented naming scheme)
@@ -499,6 +498,18 @@ impl EventCtx<'_> {
     }
 }
 
+// --- MARK: ACCESSIBILITY ---
+
+impl AccessCtx<'_> {
+    // TODO - We need access to the TreeUpdate to create sub-nodes for text runs,
+    // but this seems too powerful. We should figure out another API.
+    /// A mutable reference to the global [`TreeUpdate`] object in which all modified/new
+    /// accessibility nodes are stored.
+    pub fn tree_update(&mut self) -> &mut TreeUpdate {
+        self.tree_update
+    }
+}
+
 // --- MARK: UPDATE LAYOUT ---
 impl LayoutCtx<'_> {
     #[track_caller]
@@ -726,6 +737,14 @@ impl LayoutCtx<'_> {
         self.widget_state.needs_accessibility = true;
         self.widget_state.needs_paint = true;
     }
+
+    #[doc(hidden)]
+    /// Return the widget's size at the beginning of the layout pass.
+    ///
+    /// **TODO** This method should be removed after the layout refactor.
+    pub fn old_size(&self) -> Size {
+        self.widget_state.size
+    }
 }
 
 impl ComposeCtx<'_> {
@@ -786,9 +805,9 @@ impl_context_method!(
             self.widget_state.size
         }
 
-        // TODO - Remove
-        #[allow(dead_code, reason = "Only used in tests")]
-        pub(crate) fn local_layout_rect(&self) -> Rect {
+        // TODO - Remove. Currently only used in tests.
+        #[doc(hidden)]
+        pub fn local_layout_rect(&self) -> Rect {
             self.widget_state.layout_rect()
         }
 

--- a/masonry/src/core/events.rs
+++ b/masonry/src/core/events.rs
@@ -3,9 +3,11 @@
 
 //! Events.
 
-use super::KeyboardEvent;
 use crate::dpi::PhysicalSize;
 use crate::kurbo::Rect;
+use crate::util::Duration;
+
+use ui_events::keyboard::KeyboardEvent;
 
 // TODO - Occluded(bool) event
 // TODO - winit ActivationTokenDone thing
@@ -19,7 +21,7 @@ pub enum WindowEvent {
     /// The window was resized.
     Resize(PhysicalSize<u32>),
     /// The animation frame requested by this window must run.
-    AnimFrame,
+    AnimFrame(Duration),
     /// The accessibility tree must be rebuilt.
     RebuildAccessTree,
 }

--- a/masonry/src/core/mod.rs
+++ b/masonry/src/core/mod.rs
@@ -34,14 +34,12 @@ pub use widget_pod::WidgetPod;
 pub use widget_ref::WidgetRef;
 pub use widget_state::WidgetOptions;
 
-pub use ui_events::{ScrollDelta, keyboard, pointer};
-
-pub use keyboard::{KeyboardEvent, Modifiers};
 pub use pointer::{
     PointerButton, PointerEvent, PointerId, PointerInfo, PointerState, PointerType, PointerUpdate,
 };
+pub use ui_events::keyboard::{KeyboardEvent, Modifiers};
+pub use ui_events::{ScrollDelta, keyboard, pointer};
 
-pub(crate) use text::default_styles;
 pub(crate) use widget_arena::WidgetArena;
 pub(crate) use widget_pod::CreateWidget;
 pub(crate) use widget_state::WidgetState;

--- a/masonry/src/core/text.rs
+++ b/masonry/src/core/text.rs
@@ -10,8 +10,6 @@
 //!
 //! All of these have the same set of global styling options, and can contain rich text
 
-use parley::GenericFamily;
-
 /// A reference counted string slice.
 ///
 /// This is a data-friendly way to represent strings in Masonry. Unlike `String`
@@ -32,12 +30,6 @@ pub type StyleProperty = parley::StyleProperty<'static, BrushIndex>;
 
 /// A set of styles specialised for use within Masonry.
 pub type StyleSet = parley::StyleSet<BrushIndex>;
-
-/// Applies the default text styles for Masonry into `styles`.
-pub(crate) fn default_styles(styles: &mut StyleSet) {
-    styles.insert(StyleProperty::LineHeight(1.2));
-    styles.insert(GenericFamily::SystemUi.into());
-}
 
 use parley::{Layout, PositionedLayoutItem};
 use vello::Scene;

--- a/masonry/src/core/widget.rs
+++ b/masonry/src/core/widget.rs
@@ -358,13 +358,7 @@ pub trait Widget: AsDynWidget + Any {
         ctx: QueryCtx<'c>,
         pos: Point,
     ) -> Option<WidgetRef<'c, dyn Widget>> {
-        find_widget_under_pointer(
-            &WidgetRef {
-                widget: self.as_dyn(),
-                ctx,
-            },
-            pos,
-        )
+        find_widget_under_pointer(self.as_dyn(), ctx, pos)
     }
 
     /// Get the (verbose) type name of the widget for debugging purposes.
@@ -390,11 +384,10 @@ pub trait Widget: AsDynWidget + Any {
 
 /// See [`Widget::find_widget_under_pointer`] for more details.
 pub fn find_widget_under_pointer<'c>(
-    widget: &WidgetRef<'c, dyn Widget>,
+    widget: &'c dyn Widget,
+    ctx: QueryCtx<'c>,
     pos: Point,
 ) -> Option<WidgetRef<'c, dyn Widget>> {
-    let ctx = widget.ctx();
-
     if !ctx.bounding_rect().contains(pos) {
         return None;
     }
@@ -424,7 +417,7 @@ pub fn find_widget_under_pointer<'c>(
 
     // If no child is under pointer, test the current widget.
     if ctx.accepts_pointer_interaction() && ctx.size().to_rect().contains(local_pos) {
-        Some(*widget)
+        Some(WidgetRef { widget, ctx })
     } else {
         None
     }

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 the Xilem Authors and the Druid Authors
+// Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Traits and types of the Masonry toolkit.
@@ -36,7 +36,6 @@
     unnameable_types,
     reason = "Requires lint_reasons rustc feature for exceptions"
 )]
-#![expect(clippy::todo, reason = "We have a lot of 'real' todos")]
 #![expect(clippy::single_match, reason = "General policy not decided")]
 
 // TODO - Add logo

--- a/masonry/src/passes/paint.rs
+++ b/masonry/src/passes/paint.rs
@@ -13,8 +13,7 @@ use crate::app::{RenderRoot, RenderRootState};
 use crate::core::{DefaultProperties, PaintCtx, PropertiesRef, Widget, WidgetId, WidgetState};
 use crate::kurbo::Rect;
 use crate::passes::{enter_span_if, recurse_on_children};
-use crate::theme::get_debug_color;
-use crate::util::{AnyMap, stroke};
+use crate::util::{AnyMap, get_debug_color, stroke};
 
 // --- MARK: PAINT WIDGET ---
 fn paint_widget(

--- a/masonry/src/properties/background.rs
+++ b/masonry/src/properties/background.rs
@@ -6,6 +6,7 @@ use std::any::TypeId;
 use crate::core::{Property, UpdateCtx};
 use crate::kurbo::Rect;
 use crate::peniko::color::{AlphaColor, Srgb};
+
 use crate::properties::types::Gradient;
 
 // TODO - Replace "Background" with "BackgroundColor" and move the gradient case
@@ -49,7 +50,7 @@ impl Background {
     /// CSS spec.
     ///
     /// (See [`Gradient::get_peniko_gradient_for_rect`])
-    pub fn get_peniko_brush_for_rect(&self, rect: Rect) -> crate::peniko::Brush {
+    pub fn get_peniko_brush_for_rect(&self, rect: Rect) -> vello::peniko::Brush {
         match self {
             Self::Color(color) => (*color).into(),
             Self::Gradient(gradient) => gradient.get_peniko_gradient_for_rect(rect).into(),

--- a/masonry/src/properties/types/gradient.rs
+++ b/masonry/src/properties/types/gradient.rs
@@ -7,7 +7,7 @@ use crate::peniko::{ColorStops, ColorStopsSource, Extend};
 
 /// Properties for the supported [`Gradient`] types.
 ///
-/// This mirrors [`peniko::GradientKind`](crate::peniko::GradientKind),
+/// This mirrors [`peniko::GradientKind`](vello::peniko::GradientKind),
 /// but uses a layout-invariant representation: instead of saying
 /// "The gradient goes from point A to point B", we declare things like
 /// "The gradient has angle X", and A and B are computed dynamically from widget layout.
@@ -27,7 +27,7 @@ pub enum GradientShape {
 
 /// Definition of a gradient that transitions between two or more colors.
 ///
-/// This mirrors [`peniko::Gradient`](crate::peniko::Gradient),
+/// This mirrors [`peniko::Gradient`](vello::peniko::Gradient),
 /// but uses a layout-invariant representation: instead of saying
 /// "The gradient goes from point A to point B", we declare things like
 /// "The gradient has angle X", and A and B and computed dynamically from widget layout.
@@ -82,8 +82,8 @@ impl Gradient {
     /// Returns gradient brush covering the given Rect.
     ///
     /// This matches the CSS spec for [`linear-gradient()`](https://drafts.csswg.org/css-images-3/#linear-gradient-syntax).
-    pub fn get_peniko_gradient_for_rect(&self, rect: Rect) -> crate::peniko::Gradient {
-        crate::peniko::Gradient {
+    pub fn get_peniko_gradient_for_rect(&self, rect: Rect) -> vello::peniko::Gradient {
+        vello::peniko::Gradient {
             kind: self.shape.get_peniko_kind_for_rect(rect),
             extend: self.extend,
             interpolation_cs: self.interpolation_cs,
@@ -97,13 +97,13 @@ impl GradientShape {
     /// Returns gradient coordinates for a gradient covering the given Rect.
     ///
     /// This matches the CSS spec for [`linear-gradient()`](https://drafts.csswg.org/css-images-3/#linear-gradient-syntax).
-    pub fn get_peniko_kind_for_rect(&self, rect: Rect) -> crate::peniko::GradientKind {
+    pub fn get_peniko_kind_for_rect(&self, rect: Rect) -> vello::peniko::GradientKind {
         match self {
             Self::Linear { angle } => Self::get_peniko_linear_for_rect(*angle, rect),
         }
     }
 
-    fn get_peniko_linear_for_rect(angle: f64, rect: Rect) -> crate::peniko::GradientKind {
+    fn get_peniko_linear_for_rect(angle: f64, rect: Rect) -> vello::peniko::GradientKind {
         // The CSS spec gives this formula for the gradient line length:
         // `abs(W * sin(A)) + abs(H * cos(A))`
         // https://drafts.csswg.org/css-images-3/#linear-gradient-syntax
@@ -120,6 +120,6 @@ impl GradientShape {
         let start = Point::new(center.x - x, center.y - y);
         let end = Point::new(center.x + x, center.y + y);
 
-        crate::peniko::GradientKind::Linear { start, end }
+        vello::peniko::GradientKind::Linear { start, end }
     }
 }

--- a/masonry/src/testing/mod.rs
+++ b/masonry/src/testing/mod.rs
@@ -7,6 +7,9 @@ mod harness;
 mod helper_widgets;
 mod screenshots;
 
+pub use crate::assert_failing_render_snapshot;
+pub use crate::assert_render_snapshot;
+
 pub use harness::{PRIMARY_MOUSE, TestHarness, TestHarnessParams};
 pub use helper_widgets::{ModularWidget, Record, Recorder, Recording, ReplaceChild, TestWidgetExt};
 

--- a/masonry/src/testing/screenshots.rs
+++ b/masonry/src/testing/screenshots.rs
@@ -5,52 +5,6 @@
 
 use image::{GenericImageView as _, Pixel as _, Rgb, RgbImage};
 
-// FIXME - We're essentially completely disabling screenshots, period.
-// Hopefully we'll be able to re-enable them soon.
-// See https://github.com/linebender/xilem/issues/851
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! include_screenshot {
-    ($path:literal $(, $caption:literal)? $(,)?) => {
-        // On docsrs we just remove the screenshot links for now.
-        " "
-    };
-}
-
-// TODO - Re-enable this once we find a way to load screenshots that doesn't go against our
-// storage quotas.
-#[cfg(FALSE)]
-#[cfg(docsrs)]
-#[doc(hidden)]
-#[macro_export]
-macro_rules! include_screenshot {
-    ($path:literal $(, $caption:literal)? $(,)?) => {
-        concat!(
-            "![", $($caption,)? "]",
-            "(", "https://media.githubusercontent.com/media/linebender/xilem/",
-            "masonry-v", env!("CARGO_PKG_VERSION"), "/masonry/screenshots/", $path,
-            ")",
-        )
-    };
-}
-
-#[cfg(FALSE)]
-#[cfg(not(docsrs))]
-#[doc(hidden)]
-#[macro_export]
-/// Macro used to create markdown img tag, with a different URL when uploading to docs.rs.
-macro_rules! include_screenshot {
-    ($path:literal $(, $caption:literal)? $(,)?) => {
-        // This space at the start avoids triggering https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_doc_comments
-        // when using this macro in a `doc` attribute
-        concat!(
-            " ![", $($caption,)? "]",
-            "(", env!("CARGO_MANIFEST_DIR"), "/screenshots/", $path, ")",
-        )
-    };
-}
-
 // Copy-pasted from kompari
 fn pixel_min_max_distance(left: Rgb<u8>, right: Rgb<u8>) -> (u8, u8) {
     left.channels()

--- a/masonry/src/theme.rs
+++ b/masonry/src/theme.rs
@@ -5,12 +5,14 @@
 
 #![allow(missing_docs, reason = "Names are self-explanatory.")]
 
-use crate::core::DefaultProperties;
+use crate::core::{DefaultProperties, StyleProperty, StyleSet};
 use crate::kurbo::Insets;
 use crate::peniko::Color;
 use crate::properties::types::Gradient;
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use crate::widgets::Button;
+
+use parley::GenericFamily;
 
 // Colors are from https://sashat.me/2017/01/11/list-of-20-simple-distinct-colors/
 // They're picked for visual distinction and accessibility (99 percent)
@@ -61,36 +63,6 @@ pub const WIDGET_PADDING_VERTICAL: f64 = 10.0;
 pub const WIDGET_PADDING_HORIZONTAL: f64 = 8.0;
 pub const WIDGET_CONTROL_COMPONENT_PADDING: f64 = 4.0;
 
-static DEBUG_COLOR: &[Color] = &[
-    Color::from_rgb8(230, 25, 75),
-    Color::from_rgb8(60, 180, 75),
-    Color::from_rgb8(255, 225, 25),
-    Color::from_rgb8(0, 130, 200),
-    Color::from_rgb8(245, 130, 48),
-    Color::from_rgb8(70, 240, 240),
-    Color::from_rgb8(240, 50, 230),
-    Color::from_rgb8(250, 190, 190),
-    Color::from_rgb8(0, 128, 128),
-    Color::from_rgb8(230, 190, 255),
-    Color::from_rgb8(170, 110, 40),
-    Color::from_rgb8(255, 250, 200),
-    Color::from_rgb8(128, 0, 0),
-    Color::from_rgb8(170, 255, 195),
-    Color::from_rgb8(0, 0, 128),
-    Color::from_rgb8(128, 128, 128),
-    Color::from_rgb8(255, 255, 255),
-    Color::from_rgb8(0, 0, 0),
-];
-
-/// A color used for debug painting.
-///
-/// The same color is always returned given the same id, usually the id of a widget.
-/// When painting a widget, [`PaintCtx::debug_color`][crate::core::PaintCtx::debug_color] is typically used instead.
-pub fn get_debug_color(id: u64) -> Color {
-    let color_num = id as usize % DEBUG_COLOR.len();
-    DEBUG_COLOR[color_num]
-}
-
 pub fn default_property_set() -> DefaultProperties {
     let mut properties = DefaultProperties::new();
 
@@ -111,4 +83,10 @@ pub fn default_property_set() -> DefaultProperties {
     // TODO - Add default Padding to RootWidget?
 
     properties
+}
+
+/// Applies the default text styles for Masonry into `styles`.
+pub fn default_text_styles(styles: &mut StyleSet) {
+    styles.insert(StyleProperty::LineHeight(1.2));
+    styles.insert(GenericFamily::SystemUi.into());
 }

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -13,8 +13,8 @@ use vello::kurbo::Affine;
 
 use crate::core::{
     AccessCtx, AccessEvent, Action, ArcStr, BoxConstraints, EventCtx, LayoutCtx, PaintCtx,
-    PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, TextEvent, Update, UpdateCtx, Widget,
-    WidgetId, WidgetMut, WidgetPod,
+    PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
+    UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::kurbo::Size;
 use crate::properties::types::Gradient;
@@ -147,7 +147,7 @@ impl Widget for Button {
         }
     }
 
-    fn register_children(&mut self, ctx: &mut crate::core::RegisterCtx) {
+    fn register_children(&mut self, ctx: &mut RegisterCtx) {
         ctx.register_child(&mut self.label);
     }
 

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -9,7 +9,8 @@ use vello::kurbo::{Affine, Line, Stroke};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
-    PropertiesMut, PropertiesRef, QueryCtx, TextEvent, Widget, WidgetId, WidgetMut, WidgetPod,
+    PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut,
+    WidgetPod,
 };
 use crate::kurbo::{Point, Size};
 
@@ -306,7 +307,7 @@ impl Widget for Grid {
     ) {
     }
 
-    fn register_children(&mut self, ctx: &mut crate::core::RegisterCtx) {
+    fn register_children(&mut self, ctx: &mut RegisterCtx) {
         for child in self.children.iter_mut() {
             ctx.register_child(&mut child.widget);
         }

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -17,9 +17,10 @@ use vello::peniko::{BlendMode, Brush};
 use crate::core::{
     AccessCtx, AccessEvent, ArcStr, BoxConstraints, BrushIndex, EventCtx, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, StyleProperty, StyleSet,
-    TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut, default_styles, render_text,
+    TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut, render_text,
 };
 use crate::theme;
+use crate::theme::default_text_styles;
 
 // TODO - Replace with Padding property.
 /// Added padding between each horizontal edge of the widget
@@ -89,7 +90,7 @@ impl Label {
     /// To change the font size, use `with_style`, setting [`StyleProperty::FontSize`](parley::StyleProperty::FontSize).
     pub fn new(text: impl Into<ArcStr>) -> Self {
         let mut styles = StyleSet::new(theme::TEXT_SIZE_NORMAL);
-        default_styles(&mut styles);
+        default_text_styles(&mut styles);
         Self {
             text_layout: Layout::new(),
             accessibility: LayoutAccessibility::default(),
@@ -459,7 +460,7 @@ impl Widget for Label {
         self.accessibility.build_nodes(
             self.text.as_ref(),
             &self.text_layout,
-            ctx.tree_update,
+            ctx.tree_update(),
             node,
             || NodeId::from(WidgetId::next()),
             LABEL_X_PADDING,

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -219,13 +219,8 @@ impl<W: Widget + FromDynWidget + ?Sized> Portal<W> {
 
     #[expect(missing_docs, reason = "TODO")]
     pub fn set_viewport_pos(this: &mut WidgetMut<'_, Self>, position: Point) -> bool {
-        let portal_size = this.ctx.local_layout_rect().size();
-        let content_size = this
-            .ctx
-            .get_mut(&mut this.widget.child)
-            .ctx
-            .local_layout_rect()
-            .size();
+        let portal_size = this.ctx.size();
+        let content_size = this.ctx.get_mut(&mut this.widget.child).ctx.size();
 
         let pos_changed = this
             .widget
@@ -250,7 +245,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Portal<W> {
     #[expect(missing_docs, reason = "TODO")]
     // Note - Rect is in child coordinates
     pub fn pan_viewport_to(this: &mut WidgetMut<'_, Self>, target: Rect) -> bool {
-        let viewport = Rect::from_origin_size(this.widget.viewport_pos, this.ctx.widget_state.size);
+        let viewport = Rect::from_origin_size(this.widget.viewport_pos, this.ctx.size());
 
         let new_pos_x = compute_pan_range(
             viewport.min_x()..viewport.max_x(),
@@ -276,11 +271,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
         event: &PointerEvent,
     ) {
         let portal_size = ctx.size();
-        let content_size = ctx
-            .get_raw_ref(&mut self.child)
-            .ctx()
-            .local_layout_rect()
-            .size();
+        let content_size = ctx.get_raw_ref(&mut self.child).ctx().size();
 
         match *event {
             PointerEvent::Scroll { delta, .. } => {
@@ -373,11 +364,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
         match event {
             Update::RequestPanToChild(target) => {
                 let portal_size = ctx.size();
-                let content_size = ctx
-                    .get_raw_ref(&mut self.child)
-                    .ctx()
-                    .local_layout_rect()
-                    .size();
+                let content_size = ctx.get_raw_ref(&mut self.child).ctx().size();
 
                 self.pan_viewport_to_raw(portal_size, content_size, *target);
                 ctx.request_compose();

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -158,7 +158,7 @@ impl SizedBox {
     /// notably, it can be any [`Color`], any gradient, or an [`Image`].
     ///
     /// [`Image`]: vello::peniko::Image
-    /// [`Color`]: crate::peniko::Color
+    /// [`Color`]: vello::peniko::Color
     pub fn background(mut self, brush: impl Into<Brush>) -> Self {
         self.background = Some(brush.into());
         self
@@ -251,7 +251,7 @@ impl SizedBox {
     /// notably, it can be any [`Color`], any gradient, or an [`Image`].
     ///
     /// [`Image`]: vello::peniko::Image
-    /// [`Color`]: crate::peniko::Color
+    /// [`Color`]: vello::peniko::Color
     pub fn set_background(this: &mut WidgetMut<'_, Self>, brush: impl Into<Brush>) {
         this.widget.background = Some(brush.into());
         this.ctx.request_paint_only();
@@ -489,9 +489,9 @@ mod tests {
     use vello::peniko::Gradient;
 
     use super::*;
-    use crate::testing::TestHarness;
+    use crate::palette;
+    use crate::testing::{TestHarness, assert_failing_render_snapshot, assert_render_snapshot};
     use crate::widgets::Label;
-    use crate::{assert_failing_render_snapshot, assert_render_snapshot, palette};
 
     // TODO - Add WidgetMut tests
 

--- a/masonry/src/widgets/spinner.rs
+++ b/masonry/src/widgets/spinner.rs
@@ -189,8 +189,9 @@ impl Widget for Spinner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::TestHarness;
-    use crate::{assert_render_snapshot, palette};
+    use crate::palette;
+
+    use crate::testing::{TestHarness, assert_render_snapshot};
 
     #[test]
     fn simple_spinner() {

--- a/masonry/src/widgets/tests/ime_focused.rs
+++ b/masonry/src/widgets/tests/ime_focused.rs
@@ -1,11 +1,9 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    core::WidgetPod,
-    testing::{TestHarness, widget_ids},
-    widgets::{Flex, TextArea, Textbox},
-};
+use crate::core::{Ime, TextEvent, WidgetPod};
+use crate::testing::{TestHarness, widget_ids};
+use crate::widgets::{Flex, TextArea, Textbox};
 
 /// Tests that IME's interactions with focus are sensible.
 
@@ -19,15 +17,13 @@ fn ime_on_remove() {
 
     let mut harness = TestHarness::create(widget);
     harness.focus_on(Some(text_area));
-    harness.process_text_event(crate::core::TextEvent::Ime(crate::core::Ime::Commit(
-        "New Text".to_string(),
-    )));
+    harness.process_text_event(TextEvent::Ime(Ime::Commit("New Text".to_string())));
     let text_area = harness
         .get_widget(text_area)
         .downcast::<TextArea<true>>()
         .unwrap();
     // TODO: Ideally the cursor would start at the logical end of the text.
-    assert_eq!(text_area.widget.text(), "New TextSimple input test");
+    assert_eq!(text_area.text(), "New TextSimple input test");
     let ime_area_size = harness.ime_rect().1;
     assert!(ime_area_size.width > 0. && ime_area_size.height > 0.);
     harness.edit_root_widget(|mut widget| {


### PR DESCRIPTION
Among other things, this means making the widget implementations and the testing code rely much less on private items. This also includes some minor formatting changes which should make renaming some modules/crates much easier.

This commit includes a fair amount of todo content, among which:
- It replaces SizedBox with ReplaceChild as the wrapper to pre-assign a widget's id. Doing so without blowing up the PR diff requires some minor hacks, which shoul get fixed as soon as the PR is merged.
- Some doc(hidden) methods are added, which should ideally be phased out.

The main remaining work before we can split the crate is injecting default_properties in TestHarness.