### PR TITLE
Refactor text code

### DIFF
--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -499,6 +499,17 @@ impl EventCtx<'_> {
     }
 }
 
+// --- MARK: ACCESSIBILITY
+impl AccessCtx<'_> {
+    // TODO - We need access to the TreeUpdate to create sub-nodes for text runs,
+    // but this seems too powerful. We should figure out another API.
+    /// A mutable reference to the global [`TreeUpdate`] object in which all modified/new
+    /// accessibility nodes are stored.
+    pub fn tree_update(&mut self) -> &mut TreeUpdate {
+        self.tree_update
+    }
+}
+
 // --- MARK: UPDATE LAYOUT
 impl LayoutCtx<'_> {
     #[track_caller]

--- a/masonry/src/core/mod.rs
+++ b/masonry/src/core/mod.rs
@@ -41,7 +41,6 @@ pub use pointer::{
     PointerButton, PointerEvent, PointerId, PointerInfo, PointerState, PointerType, PointerUpdate,
 };
 
-pub(crate) use text::default_styles;
 pub(crate) use widget_arena::WidgetArena;
 pub(crate) use widget_pod::CreateWidget;
 pub(crate) use widget_state::WidgetState;

--- a/masonry/src/core/text.rs
+++ b/masonry/src/core/text.rs
@@ -10,8 +10,6 @@
 //!
 //! All of these have the same set of global styling options, and can contain rich text
 
-use parley::GenericFamily;
-
 /// A reference counted string slice.
 ///
 /// This is a data-friendly way to represent strings in Masonry. Unlike `String`
@@ -32,12 +30,6 @@ pub type StyleProperty = parley::StyleProperty<'static, BrushIndex>;
 
 /// A set of styles specialised for use within Masonry.
 pub type StyleSet = parley::StyleSet<BrushIndex>;
-
-/// Applies the default text styles for Masonry into `styles`.
-pub(crate) fn default_styles(styles: &mut StyleSet) {
-    styles.insert(StyleProperty::LineHeight(1.2));
-    styles.insert(GenericFamily::SystemUi.into());
-}
 
 use parley::{Layout, PositionedLayoutItem};
 use vello::Scene;

--- a/masonry/src/theme.rs
+++ b/masonry/src/theme.rs
@@ -5,7 +5,7 @@
 
 #![allow(missing_docs, reason = "Names are self-explanatory.")]
 
-use crate::core::DefaultProperties;
+use crate::core::{DefaultProperties, StyleProperty, StyleSet};
 use crate::kurbo::Insets;
 use crate::peniko::Color;
 use crate::properties::types::Gradient;
@@ -14,6 +14,8 @@ use crate::properties::{
     HoveredBorderColor, Padding,
 };
 use crate::widgets::Button;
+
+use parley::GenericFamily;
 
 // Colors are from https://sashat.me/2017/01/11/list-of-20-simple-distinct-colors/
 // They're picked for visual distinction and accessibility (99 percent)
@@ -123,4 +125,10 @@ pub fn default_property_set() -> DefaultProperties {
     // TODO - Add default Padding to RootWidget?
 
     properties
+}
+
+/// Applies the default text styles for Masonry into `styles`.
+pub fn default_text_styles(styles: &mut StyleSet) {
+    styles.insert(StyleProperty::LineHeight(1.2));
+    styles.insert(GenericFamily::SystemUi.into());
 }

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -17,9 +17,10 @@ use vello::peniko::{BlendMode, Brush};
 use crate::core::{
     AccessCtx, AccessEvent, ArcStr, BoxConstraints, BrushIndex, EventCtx, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, StyleProperty, StyleSet,
-    TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut, default_styles, render_text,
+    TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut, render_text,
 };
 use crate::theme;
+use crate::theme::default_text_styles;
 
 // TODO - Replace with Padding property.
 /// Added padding between each horizontal edge of the widget
@@ -89,7 +90,7 @@ impl Label {
     /// To change the font size, use `with_style`, setting [`StyleProperty::FontSize`](parley::StyleProperty::FontSize).
     pub fn new(text: impl Into<ArcStr>) -> Self {
         let mut styles = StyleSet::new(theme::TEXT_SIZE_NORMAL);
-        default_styles(&mut styles);
+        default_text_styles(&mut styles);
         Self {
             text_layout: Layout::new(),
             accessibility: LayoutAccessibility::default(),
@@ -459,7 +460,7 @@ impl Widget for Label {
         self.accessibility.build_nodes(
             self.text.as_ref(),
             &self.text_layout,
-            ctx.tree_update,
+            ctx.tree_update(),
             node,
             || NodeId::from(WidgetId::next()),
             LABEL_X_PADDING,


### PR DESCRIPTION
Makes text widgets not use private items.
Move default_text_styles to theme module.
Rewrite some imports to match usual coding style.