### PR TITLE
Reorganize imports

### DIFF
--- a/masonry/src/core/mod.rs
+++ b/masonry/src/core/mod.rs
@@ -34,12 +34,11 @@ pub use widget_pod::WidgetPod;
 pub use widget_ref::WidgetRef;
 pub use widget_state::WidgetOptions;
 
-pub use ui_events::{ScrollDelta, keyboard, pointer};
-
-pub use keyboard::{KeyboardEvent, Modifiers};
-pub use pointer::{
+pub use ui_events::keyboard::{KeyboardEvent, Modifiers};
+pub use ui_events::pointer::{
     PointerButton, PointerEvent, PointerId, PointerInfo, PointerState, PointerType, PointerUpdate,
 };
+pub use ui_events::{ScrollDelta, keyboard, pointer};
 
 pub(crate) use text::default_styles;
 pub(crate) use widget_arena::WidgetArena;

--- a/masonry/src/testing/mod.rs
+++ b/masonry/src/testing/mod.rs
@@ -7,6 +7,9 @@ mod harness;
 mod helper_widgets;
 mod screenshots;
 
+pub use crate::assert_failing_render_snapshot;
+pub use crate::assert_render_snapshot;
+
 pub use harness::{PRIMARY_MOUSE, TestHarness, TestHarnessParams};
 pub use helper_widgets::{ModularWidget, Record, Recorder, Recording, ReplaceChild, TestWidgetExt};
 

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -13,8 +13,8 @@ use vello::kurbo::Affine;
 
 use crate::core::{
     AccessCtx, AccessEvent, Action, ArcStr, BoxConstraints, EventCtx, LayoutCtx, PaintCtx,
-    PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, TextEvent, Update, UpdateCtx, Widget,
-    WidgetId, WidgetMut, WidgetPod,
+    PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
+    UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::kurbo::Size;
 use crate::properties::*;
@@ -146,7 +146,7 @@ impl Widget for Button {
         }
     }
 
-    fn register_children(&mut self, ctx: &mut crate::core::RegisterCtx) {
+    fn register_children(&mut self, ctx: &mut RegisterCtx) {
         ctx.register_child(&mut self.label);
     }
 

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -12,7 +12,8 @@ use vello::kurbo::{Affine, Line, Stroke, Vec2};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
-    PropertiesMut, PropertiesRef, QueryCtx, TextEvent, Widget, WidgetId, WidgetMut, WidgetPod,
+    PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut,
+    WidgetPod,
 };
 use crate::kurbo::{Point, Rect, Size};
 
@@ -984,7 +985,7 @@ impl Widget for Flex {
     ) {
     }
 
-    fn register_children(&mut self, ctx: &mut crate::core::RegisterCtx) {
+    fn register_children(&mut self, ctx: &mut RegisterCtx) {
         for child in self.children.iter_mut().filter_map(|x| x.widget_mut()) {
             ctx.register_child(child);
         }

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -9,7 +9,8 @@ use vello::kurbo::{Affine, Line, Stroke};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
-    PropertiesMut, PropertiesRef, QueryCtx, TextEvent, Widget, WidgetId, WidgetMut, WidgetPod,
+    PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut,
+    WidgetPod,
 };
 use crate::kurbo::{Point, Size};
 
@@ -306,7 +307,7 @@ impl Widget for Grid {
     ) {
     }
 
-    fn register_children(&mut self, ctx: &mut crate::core::RegisterCtx) {
+    fn register_children(&mut self, ctx: &mut RegisterCtx) {
         for child in self.children.iter_mut() {
             ctx.register_child(&mut child.widget);
         }

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -489,9 +489,9 @@ mod tests {
     use vello::peniko::Gradient;
 
     use super::*;
-    use crate::testing::TestHarness;
+    use crate::palette;
+    use crate::testing::{TestHarness, assert_failing_render_snapshot, assert_render_snapshot};
     use crate::widgets::Label;
-    use crate::{assert_failing_render_snapshot, assert_render_snapshot, palette};
 
     // TODO - Add WidgetMut tests
 

--- a/masonry/src/widgets/spinner.rs
+++ b/masonry/src/widgets/spinner.rs
@@ -189,8 +189,8 @@ impl Widget for Spinner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::TestHarness;
-    use crate::{assert_render_snapshot, palette};
+    use crate::palette;
+    use crate::testing::{TestHarness, assert_render_snapshot};
 
     #[test]
     fn simple_spinner() {


### PR DESCRIPTION
Replace some qualified symbols with imports.
Re-export test macros from test module.