### PR TITLE
Refactor some layout methods to only use public items

### DIFF
--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -726,6 +726,14 @@ impl LayoutCtx<'_> {
         self.widget_state.needs_accessibility = true;
         self.widget_state.needs_paint = true;
     }
+
+    #[doc(hidden)]
+    /// Return the widget's size at the beginning of the layout pass.
+    ///
+    /// **TODO** This method should be removed after the layout refactor.
+    pub fn old_size(&self) -> Size {
+        self.widget_state.size
+    }
 }
 
 impl ComposeCtx<'_> {
@@ -786,9 +794,9 @@ impl_context_method!(
             self.widget_state.size
         }
 
-        // TODO - Remove
-        #[allow(dead_code, reason = "Only used in tests")]
-        pub(crate) fn local_layout_rect(&self) -> Rect {
+        // TODO - Remove. Currently only used in tests.
+        #[doc(hidden)]
+        pub fn local_layout_rect(&self) -> Rect {
             self.widget_state.layout_rect()
         }
 

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -859,7 +859,7 @@ impl Iterator for Spacing {
             if self.n_children == 0 {
                 self.extra
             } else {
-                #[allow(clippy::match_bool)]
+                #[allow(clippy::match_bool, reason = "readability")]
                 match self.alignment {
                     MainAxisAlignment::Start => match self.index == self.n_children {
                         true => self.extra,
@@ -1029,7 +1029,7 @@ impl Widget for Flex {
                         let alignment = alignment.unwrap_or(self.cross_alignment);
                         any_use_baseline |= alignment == CrossAxisAlignment::Baseline;
 
-                        let old_size = ctx.widget_state.layout_rect().size();
+                        let old_size = ctx.old_size();
                         let child_size = ctx.run_layout(widget, &loosened_bc);
 
                         if child_size.width.is_infinite() {
@@ -1094,7 +1094,7 @@ impl Widget for Flex {
                         let actual_major = desired_major.round();
                         remainder = desired_major - actual_major;
 
-                        let old_size = ctx.widget_state.layout_rect().size();
+                        let old_size = ctx.old_size();
                         let child_bc = self.direction.constraints(&loosened_bc, 0.0, actual_major);
                         let child_size = ctx.run_layout(widget, &child_bc);
 
@@ -1147,7 +1147,6 @@ impl Widget for Flex {
         let extra_height = minor - minor_dim.min(minor);
 
         let mut major = spacing.next().unwrap_or(0.);
-        let mut child_paint_rect = Rect::ZERO;
 
         for child in &mut self.children {
             match child {
@@ -1172,7 +1171,7 @@ impl Widget for Flex {
                                 .direction
                                 .pack(self.direction.major(child_size), minor_dim)
                                 .into();
-                            if ctx.widget_state.layout_rect().size() != fill_size {
+                            if ctx.old_size() != fill_size {
                                 let child_bc = BoxConstraints::tight(fill_size);
                                 //TODO: this is the second call of layout on the same child, which
                                 // is bad, because it can lead to exponential increase in layout calls
@@ -1189,7 +1188,6 @@ impl Widget for Flex {
 
                     let child_pos: Point = self.direction.pack(major, child_minor_offset).into();
                     ctx.place_child(widget, child_pos);
-                    child_paint_rect = child_paint_rect.union(ctx.widget_state.paint_rect());
                     major += self.direction.major(child_size).expand();
                     major += spacing.next().unwrap_or(0.);
                     major += gap;
@@ -1221,10 +1219,6 @@ impl Widget for Flex {
         // In which case, the Flex widget will either overflow its parent
         // or be clipped (e.g. if its parent is a Portal).
         let my_size: Size = self.direction.pack(major, minor_dim).into();
-
-        let my_bounds = my_size.to_rect();
-        let insets = child_paint_rect - my_bounds;
-        ctx.set_paint_insets(insets);
 
         let baseline_offset = match self.direction {
             Axis::Horizontal => max_below_baseline,

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -219,13 +219,8 @@ impl<W: Widget + FromDynWidget + ?Sized> Portal<W> {
 
     #[expect(missing_docs, reason = "TODO")]
     pub fn set_viewport_pos(this: &mut WidgetMut<'_, Self>, position: Point) -> bool {
-        let portal_size = this.ctx.local_layout_rect().size();
-        let content_size = this
-            .ctx
-            .get_mut(&mut this.widget.child)
-            .ctx
-            .local_layout_rect()
-            .size();
+        let portal_size = this.ctx.size();
+        let content_size = this.ctx.get_mut(&mut this.widget.child).ctx.size();
 
         let pos_changed = this
             .widget
@@ -250,7 +245,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Portal<W> {
     #[expect(missing_docs, reason = "TODO")]
     // Note - Rect is in child coordinates
     pub fn pan_viewport_to(this: &mut WidgetMut<'_, Self>, target: Rect) -> bool {
-        let viewport = Rect::from_origin_size(this.widget.viewport_pos, this.ctx.widget_state.size);
+        let viewport = Rect::from_origin_size(this.widget.viewport_pos, this.ctx.size());
 
         let new_pos_x = compute_pan_range(
             viewport.min_x()..viewport.max_x(),
@@ -276,11 +271,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
         event: &PointerEvent,
     ) {
         let portal_size = ctx.size();
-        let content_size = ctx
-            .get_raw_ref(&mut self.child)
-            .ctx()
-            .local_layout_rect()
-            .size();
+        let content_size = ctx.get_raw_ref(&mut self.child).ctx().size();
 
         match *event {
             PointerEvent::Scroll { delta, .. } => {
@@ -373,11 +364,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
         match event {
             Update::RequestPanToChild(target) => {
                 let portal_size = ctx.size();
-                let content_size = ctx
-                    .get_raw_ref(&mut self.child)
-                    .ctx()
-                    .local_layout_rect()
-                    .size();
+                let content_size = ctx.get_raw_ref(&mut self.child).ctx().size();
 
                 self.pan_viewport_to_raw(portal_size, content_size, *target);
                 ctx.request_compose();


### PR DESCRIPTION
This also removes the call to `set_paint_insets` in `Flex::layout`, which was redundant since the layout pass already computes paint insets on its own.