### PR TITLE
Tweak error case for event pass

### DIFF
--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use tracing::{debug, error, info_span, trace};
+use tracing::{debug, info_span, trace};
 
 use crate::Handled;
 use crate::app::{RenderRoot, RenderRootSignal};
@@ -74,17 +74,17 @@ fn run_event_pass<E>(
 ) -> Handled {
     let mut pass_fn = pass_fn;
 
+    if let Some(id) = target {
+        if !root.widget_arena.has(id) {
+            debug_panic!("Cannot send event to non-existent widget {id}.");
+            return Handled::No;
+        }
+    }
+
     let original_target = target;
     let mut target_widget_id = target;
     let mut is_handled = false;
     while let Some(widget_id) = target_widget_id {
-        if !root.widget_arena.has(widget_id) {
-            error!(
-                "Tried to access {widget_id} whilst processing event, but it wasn't in the tree. Discarding event"
-            );
-            break;
-        }
-
         let parent_id = root.widget_arena.parent_of(widget_id);
         let (mut widget_mut, mut state_mut, mut properties_mut) =
             root.widget_arena.get_all_mut(widget_id);


### PR DESCRIPTION
Replaces the error log with a debug_panic.
This also moves the check outside the loop, since it was only ever going to fail in the first iteration anyway.