### PR TITLE
Rewrite TestHarness constructors to take default properties as a param.

### DIFF
--- a/masonry/src/core/widget_ref.rs
+++ b/masonry/src/core/widget_ref.rs
@@ -200,6 +200,7 @@ mod tests {
     use assert_matches::assert_matches;
 
     use crate::testing::{TestHarness, TestWidgetExt as _, widget_ids};
+    use crate::theme::default_property_set;
     use crate::widgets::{Button, Label};
 
     #[test]
@@ -207,7 +208,7 @@ mod tests {
         let [label_id] = widget_ids();
         let label = Label::new("Hello").with_id(label_id);
 
-        let harness = TestHarness::create(label);
+        let harness = TestHarness::create(default_property_set(), label);
 
         assert_matches!(harness.get_widget(label_id).downcast::<Label>(), Some(_));
         assert_matches!(harness.get_widget(label_id).downcast::<Button>(), None);

--- a/masonry/src/doc/04_testing_widget.md
+++ b/masonry/src/doc/04_testing_widget.md
@@ -32,6 +32,7 @@ First, let's write a test module with a first unit test:
 mod tests {
     use insta::assert_debug_snapshot;
     use masonry_winit::testing::{widget_ids, TestHarness, TestWidgetExt};
+    use masonry_winit::theme::default_property_set;
 
     use super::*;
 
@@ -40,7 +41,7 @@ mod tests {
         let [rect_id] = widget_ids();
         let widget = ColorRectangle::new(Size::new(20.0, 20.0), Color::BLUE).with_id(rect_id);
 
-        let harness = TestHarness::create(widget);
+        let harness = TestHarness::create(default_property_set(), widget);
 
         assert_debug_snapshot!(harness.root_widget());
 

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -26,8 +26,9 @@ use crate::app::{
     RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy, try_init_test_tracing,
 };
 use crate::core::{
-    Action, Ime, PointerButton, PointerEvent, PointerId, PointerInfo, PointerState, PointerType,
-    PointerUpdate, ScrollDelta, TextEvent, Widget, WidgetId, WidgetMut, WidgetRef, WindowEvent,
+    Action, DefaultProperties, Ime, PointerButton, PointerEvent, PointerId, PointerInfo,
+    PointerState, PointerType, PointerUpdate, ScrollDelta, TextEvent, Widget, WidgetId, WidgetMut,
+    WidgetRef, WindowEvent,
 };
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::kurbo::{Point, Size, Vec2};
@@ -88,7 +89,7 @@ pub const PRIMARY_MOUSE: PointerInfo = PointerInfo {
 /// use masonry::testing::TestHarness;
 /// use masonry::testing::TestWidgetExt;
 /// use masonry::theme::PRIMARY_LIGHT;
-///
+/// use masonry::theme::default_property_set;
 /// # /*
 /// #[test]
 /// # */
@@ -96,7 +97,7 @@ pub const PRIMARY_MOUSE: PointerInfo = PointerInfo {
 ///     let [button_id] = widget_ids();
 ///     let widget = Button::new("Hello").with_id(button_id);
 ///
-///     let mut harness = TestHarness::create(widget);
+///     let mut harness = TestHarness::create(default_property_set(), widget);
 ///
 ///     # if false {
 ///     assert_debug_snapshot!(harness.root_widget());
@@ -203,13 +204,18 @@ impl TestHarness {
     ///
     /// Window size will be [`TestHarnessParams::DEFAULT_SIZE`].
     /// Background color will be [`TestHarnessParams::DEFAULT_BACKGROUND_COLOR`].
-    pub fn create(root_widget: impl Widget) -> Self {
-        Self::create_with(root_widget, TestHarnessParams::default())
+    pub fn create(default_props: DefaultProperties, root_widget: impl Widget) -> Self {
+        Self::create_with(default_props, root_widget, TestHarnessParams::default())
     }
 
     /// Builds harness with given root widget and window size.
-    pub fn create_with_size(root_widget: impl Widget, window_size: Size) -> Self {
+    pub fn create_with_size(
+        default_props: DefaultProperties,
+        root_widget: impl Widget,
+        window_size: Size,
+    ) -> Self {
         Self::create_with(
+            default_props,
             root_widget,
             TestHarnessParams {
                 window_size,
@@ -219,7 +225,11 @@ impl TestHarness {
     }
 
     /// Builds harness with given root widget and additional parameters.
-    pub fn create_with(root_widget: impl Widget, params: TestHarnessParams) -> Self {
+    pub fn create_with(
+        default_props: DefaultProperties,
+        root_widget: impl Widget,
+        params: TestHarnessParams,
+    ) -> Self {
         let mouse_state = PointerState::default();
         let window_size = PhysicalSize::new(
             params.window_size.width as _,
@@ -244,7 +254,7 @@ impl TestHarness {
                 root_widget,
                 RenderRootOptions {
                     // TODO - Pass the default property set as an input instead.
-                    default_properties: crate::theme::default_property_set(),
+                    default_properties: default_props,
                     use_system_fonts: false,
                     size_policy: WindowSizePolicy::User,
                     scale_factor: params.scale_factor,

--- a/masonry/src/testing/recorder_widget.rs
+++ b/masonry/src/testing/recorder_widget.rs
@@ -40,7 +40,7 @@ use crate::kurbo::{Point, Size};
 /// let recording = Recording::default();
 /// let widget = Label::new("Hello").record(&recording);
 ///
-/// TestHarness::create(widget);
+/// TestHarness::create(Default::default(), widget);
 /// assert_matches!(recording.next().unwrap(), Record::RC);
 /// assert_matches!(recording.next().unwrap(), Record::U(Update::WidgetAdded));
 /// ```

--- a/masonry/src/widgets/align.rs
+++ b/masonry/src/widgets/align.rs
@@ -201,6 +201,7 @@ mod tests {
     use super::*;
     use crate::assert_render_snapshot;
     use crate::testing::TestHarness;
+    use crate::theme::default_property_set;
     use crate::widgets::Label;
 
     // TODO - Add more unit tests
@@ -209,7 +210,7 @@ mod tests {
     fn centered() {
         let widget = Align::centered(Label::new("hello"));
 
-        let mut harness = TestHarness::create(widget);
+        let mut harness = TestHarness::create(default_property_set(), widget);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "align_centered");
@@ -219,7 +220,7 @@ mod tests {
     fn right() {
         let widget = Align::right(Label::new("hello"));
 
-        let mut harness = TestHarness::create(widget);
+        let mut harness = TestHarness::create(default_property_set(), widget);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "align_right");
@@ -229,7 +230,7 @@ mod tests {
     fn left() {
         let widget = Align::left(Label::new("hello"));
 
-        let mut harness = TestHarness::create(widget);
+        let mut harness = TestHarness::create(default_property_set(), widget);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "align_left");

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -274,6 +274,7 @@ mod tests {
     use crate::core::{PointerButton, StyleProperty};
     use crate::testing::{TestHarness, TestWidgetExt, widget_ids};
     use crate::theme::PRIMARY_LIGHT;
+    use crate::theme::default_property_set;
     use crate::widgets::{Grid, GridParams, SizedBox};
 
     #[test]
@@ -282,7 +283,8 @@ mod tests {
         let widget = Button::new("Hello").with_id(button_id);
 
         let window_size = Size::new(100.0, 40.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "button_hello");
@@ -307,7 +309,11 @@ mod tests {
                 .with_style(StyleProperty::FontSize(20.0));
             let button = Button::from_label(label);
 
-            let mut harness = TestHarness::create_with_size(button, Size::new(50.0, 50.0));
+            let mut harness = TestHarness::create_with_size(
+                default_property_set(),
+                button,
+                Size::new(50.0, 50.0),
+            );
 
             harness.render()
         };
@@ -315,7 +321,11 @@ mod tests {
         let image_2 = {
             let button = Button::new("Hello world");
 
-            let mut harness = TestHarness::create_with_size(button, Size::new(50.0, 50.0));
+            let mut harness = TestHarness::create_with_size(
+                default_property_set(),
+                button,
+                Size::new(50.0, 50.0),
+            );
 
             harness.edit_root_widget(|mut button| {
                 let mut button = button.downcast::<Button>();
@@ -339,7 +349,8 @@ mod tests {
         let button = Button::new("Some random text");
 
         let window_size = Size::new(200.0, 80.0);
-        let mut harness = TestHarness::create_with_size(button, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), button, window_size);
 
         harness.edit_root_widget(|mut button| {
             let mut button = button.downcast::<Button>();
@@ -369,7 +380,8 @@ mod tests {
         let root_widget = SizedBox::new(grid).padding(20.);
 
         let window_size = Size::new(300.0, 300.0);
-        let mut harness = TestHarness::create_with_size(root_widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), root_widget, window_size);
 
         harness.edit_root_widget(|mut root| {
             let mut root = root.downcast::<SizedBox>();

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -273,8 +273,7 @@ mod tests {
     use crate::assert_render_snapshot;
     use crate::core::{PointerButton, StyleProperty};
     use crate::testing::{TestHarness, TestWidgetExt, widget_ids};
-    use crate::theme::PRIMARY_LIGHT;
-    use crate::theme::default_property_set;
+    use crate::theme::{PRIMARY_LIGHT, default_property_set};
     use crate::widgets::{Grid, GridParams, SizedBox};
 
     #[test]

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -260,6 +260,7 @@ mod tests {
     use crate::core::StyleProperty;
     use crate::testing::{TestHarness, TestWidgetExt, widget_ids};
     use crate::theme::PRIMARY_LIGHT;
+    use crate::theme::default_property_set;
 
     #[test]
     fn simple_checkbox() {
@@ -267,7 +268,8 @@ mod tests {
         let widget = Checkbox::new(false, "Hello").with_id(checkbox_id);
 
         let window_size = Size::new(100.0, 40.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "checkbox_hello_unchecked");
@@ -300,7 +302,11 @@ mod tests {
                     .with_style(StyleProperty::FontSize(20.0)),
             );
 
-            let mut harness = TestHarness::create_with_size(checkbox, Size::new(50.0, 50.0));
+            let mut harness = TestHarness::create_with_size(
+                default_property_set(),
+                checkbox,
+                Size::new(50.0, 50.0),
+            );
 
             harness.render()
         };
@@ -308,7 +314,11 @@ mod tests {
         let image_2 = {
             let checkbox = Checkbox::new(false, "Hello world");
 
-            let mut harness = TestHarness::create_with_size(checkbox, Size::new(50.0, 50.0));
+            let mut harness = TestHarness::create_with_size(
+                default_property_set(),
+                checkbox,
+                Size::new(50.0, 50.0),
+            );
 
             harness.edit_root_widget(|mut checkbox| {
                 let mut checkbox = checkbox.downcast::<Checkbox>();

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -259,8 +259,7 @@ mod tests {
     use crate::assert_render_snapshot;
     use crate::core::StyleProperty;
     use crate::testing::{TestHarness, TestWidgetExt, widget_ids};
-    use crate::theme::PRIMARY_LIGHT;
-    use crate::theme::default_property_set;
+    use crate::theme::{PRIMARY_LIGHT, default_property_set};
 
     #[test]
     fn simple_checkbox() {

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -1287,6 +1287,7 @@ mod tests {
     use super::*;
     use crate::assert_render_snapshot;
     use crate::testing::TestHarness;
+    use crate::theme::default_property_set;
     use crate::widgets::Label;
 
     #[test]
@@ -1387,7 +1388,8 @@ mod tests {
             );
 
         let window_size = Size::new(200.0, 150.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
@@ -1432,7 +1434,8 @@ mod tests {
             );
 
         let window_size = Size::new(200.0, 150.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         // MAIN AXIS ALIGNMENT
 
@@ -1494,7 +1497,8 @@ mod tests {
             );
 
         let window_size = Size::new(200.0, 150.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
@@ -1539,7 +1543,8 @@ mod tests {
             );
 
         let window_size = Size::new(200.0, 150.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         // MAIN AXIS ALIGNMENT
 
@@ -1600,7 +1605,8 @@ mod tests {
             // -> abcd
 
             let window_size = Size::new(200.0, 150.0);
-            let mut harness = TestHarness::create_with_size(widget, window_size);
+            let mut harness =
+                TestHarness::create_with_size(default_property_set(), widget, window_size);
 
             harness.edit_root_widget(|mut flex| {
                 let mut flex = flex.downcast::<Flex>();
@@ -1648,7 +1654,8 @@ mod tests {
                 .with_flex_spacer(1.0);
 
             let window_size = Size::new(200.0, 150.0);
-            let mut harness = TestHarness::create_with_size(widget, window_size);
+            let mut harness =
+                TestHarness::create_with_size(default_property_set(), widget, window_size);
             harness.render()
         };
 
@@ -1664,7 +1671,8 @@ mod tests {
             .with_spacer(1.0);
 
         let window_size = Size::new(200.0, 150.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
         harness.edit_root_widget(|mut flex| {
             let mut flex = flex.downcast::<Flex>();
 
@@ -1692,7 +1700,8 @@ mod tests {
 
         // Running layout should not panic when the flex sum is zero.
         let window_size = Size::new(200.0, 150.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
         harness.render();
     }
 }

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -385,6 +385,7 @@ mod tests {
     use super::*;
     use crate::assert_render_snapshot;
     use crate::testing::TestHarness;
+    use crate::theme::default_property_set;
     use crate::widgets::button;
 
     #[test]
@@ -393,7 +394,8 @@ mod tests {
         let widget = Grid::with_dimensions(1, 1)
             .with_child(button::Button::new("A"), GridParams::new(0, 0, 1, 1));
         let window_size = Size::new(200.0, 200.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
         // Snapshot with the single widget.
         assert_render_snapshot!(harness, "grid_initial_1x1");
 
@@ -463,7 +465,8 @@ mod tests {
         let widget = Grid::with_dimensions(2, 2)
             .with_child(button::Button::new("A"), GridParams::new(0, 0, 1, 1));
         let window_size = Size::new(200.0, 200.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
         // Snapshot with the single widget.
         assert_render_snapshot!(harness, "grid_initial_2x2");
 
@@ -505,7 +508,8 @@ mod tests {
         let widget = Grid::with_dimensions(2, 2)
             .with_child(button::Button::new("A"), GridParams::new(0, 0, 1, 1));
         let window_size = Size::new(200.0, 200.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
         // Snapshot with the single widget.
         assert_render_snapshot!(harness, "grid_initial_2x2");
 

--- a/masonry/src/widgets/image.rs
+++ b/masonry/src/widgets/image.rs
@@ -178,6 +178,7 @@ mod tests {
     use super::*;
     use crate::assert_render_snapshot;
     use crate::testing::TestHarness;
+    use crate::theme::default_property_set;
 
     /// Painting an empty image shouldn't crash.
     #[test]
@@ -186,7 +187,7 @@ mod tests {
         let image_data = ImageBuf::new(Vec::new().into(), ImageFormat::Rgba8, 0, 0);
 
         let image_widget = Image::new(image_data);
-        let mut harness = TestHarness::create(image_widget);
+        let mut harness = TestHarness::create(default_property_set(), image_widget);
         let _ = harness.render();
     }
 
@@ -212,7 +213,11 @@ mod tests {
         );
         let image_widget = Image::new(image_data);
 
-        let mut harness = TestHarness::create_with_size(image_widget, Size::new(40., 60.));
+        let mut harness = TestHarness::create_with_size(
+            default_property_set(),
+            image_widget,
+            Size::new(40., 60.),
+        );
         assert_render_snapshot!(harness, "image_tall_paint");
     }
 
@@ -223,7 +228,11 @@ mod tests {
         let render_1 = {
             let image_widget = Image::new(image_data.clone());
 
-            let mut harness = TestHarness::create_with_size(image_widget, Size::new(40.0, 60.0));
+            let mut harness = TestHarness::create_with_size(
+                default_property_set(),
+                image_widget,
+                Size::new(40.0, 60.0),
+            );
 
             harness.render()
         };
@@ -233,7 +242,11 @@ mod tests {
                 ImageBuf::new(vec![10; 4 * 8 * 8].into(), ImageFormat::Rgba8, 8, 8);
             let image_widget = Image::new(other_image_data);
 
-            let mut harness = TestHarness::create_with_size(image_widget, Size::new(40.0, 60.0));
+            let mut harness = TestHarness::create_with_size(
+                default_property_set(),
+                image_widget,
+                Size::new(40.0, 60.0),
+            );
 
             harness.edit_root_widget(|mut image| {
                 let mut image = image.downcast::<Image>();
@@ -255,37 +268,44 @@ mod tests {
 
         // Contain.
         let image_widget = Image::new(image_data.clone()).fit_mode(ObjectFit::Contain);
-        let mut harness = TestHarness::create_with_size(image_widget, harness_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), image_widget, harness_size);
         assert_render_snapshot!(harness, "image_layout_contain");
 
         // Cover.
         let image_widget = Image::new(image_data.clone()).fit_mode(ObjectFit::Cover);
-        let mut harness = TestHarness::create_with_size(image_widget, harness_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), image_widget, harness_size);
         assert_render_snapshot!(harness, "image_layout_cover");
 
         // Fill.
         let image_widget = Image::new(image_data.clone()).fit_mode(ObjectFit::Fill);
-        let mut harness = TestHarness::create_with_size(image_widget, harness_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), image_widget, harness_size);
         assert_render_snapshot!(harness, "image_layout_fill");
 
         // FitHeight.
         let image_widget = Image::new(image_data.clone()).fit_mode(ObjectFit::FitHeight);
-        let mut harness = TestHarness::create_with_size(image_widget, harness_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), image_widget, harness_size);
         assert_render_snapshot!(harness, "image_layout_fitheight");
 
         // FitWidth.
         let image_widget = Image::new(image_data.clone()).fit_mode(ObjectFit::FitWidth);
-        let mut harness = TestHarness::create_with_size(image_widget, harness_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), image_widget, harness_size);
         assert_render_snapshot!(harness, "image_layout_fitwidth");
 
         // None.
         let image_widget = Image::new(image_data.clone()).fit_mode(ObjectFit::None);
-        let mut harness = TestHarness::create_with_size(image_widget, harness_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), image_widget, harness_size);
         assert_render_snapshot!(harness, "image_layout_none");
 
         // ScaleDown.
         let image_widget = Image::new(image_data.clone()).fit_mode(ObjectFit::ScaleDown);
-        let mut harness = TestHarness::create_with_size(image_widget, harness_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), image_widget, harness_size);
         assert_render_snapshot!(harness, "image_layout_scaledown");
     }
 }

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -491,8 +491,7 @@ mod tests {
     use super::*;
     use crate::assert_render_snapshot;
     use crate::testing::TestHarness;
-    use crate::theme::default_property_set;
-    use crate::theme::{PRIMARY_DARK, PRIMARY_LIGHT};
+    use crate::theme::{PRIMARY_DARK, PRIMARY_LIGHT, default_property_set};
     use crate::widgets::{CrossAxisAlignment, Flex, SizedBox};
 
     #[test]

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -491,6 +491,7 @@ mod tests {
     use super::*;
     use crate::assert_render_snapshot;
     use crate::testing::TestHarness;
+    use crate::theme::default_property_set;
     use crate::theme::{PRIMARY_DARK, PRIMARY_LIGHT};
     use crate::widgets::{CrossAxisAlignment, Flex, SizedBox};
 
@@ -499,7 +500,7 @@ mod tests {
         let label = Label::new("Hello");
 
         let window_size = Size::new(100.0, 40.0);
-        let mut harness = TestHarness::create_with_size(label, window_size);
+        let mut harness = TestHarness::create_with_size(default_property_set(), label, window_size);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "label_hello");
@@ -514,7 +515,8 @@ mod tests {
             .with_line_break_mode(LineBreaking::WordWrap)
             .with_alignment(Alignment::Middle);
 
-        let mut harness = TestHarness::create_with_size(label, Size::new(200.0, 200.0));
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), label, Size::new(200.0, 200.0));
 
         assert_render_snapshot!(harness, "label_styled_label");
     }
@@ -526,7 +528,7 @@ mod tests {
             .with_style(StyleProperty::Underline(true));
 
         let window_size = Size::new(100.0, 40.0);
-        let mut harness = TestHarness::create_with_size(label, window_size);
+        let mut harness = TestHarness::create_with_size(default_property_set(), label, window_size);
 
         assert_render_snapshot!(harness, "label_underline_label");
     }
@@ -538,7 +540,7 @@ mod tests {
             .with_style(StyleProperty::StrikethroughSize(Some(4.)));
 
         let window_size = Size::new(100.0, 40.0);
-        let mut harness = TestHarness::create_with_size(label, window_size);
+        let mut harness = TestHarness::create_with_size(default_property_set(), label, window_size);
 
         assert_render_snapshot!(harness, "label_strikethrough_label");
     }
@@ -568,7 +570,8 @@ mod tests {
             .with_flex_child(label6, CrossAxisAlignment::Center)
             .gap(0.0);
 
-        let mut harness = TestHarness::create_with_size(flex, Size::new(200.0, 200.0));
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), flex, Size::new(200.0, 200.0));
 
         assert_render_snapshot!(harness, "label_label_alignment_flex");
     }
@@ -602,7 +605,8 @@ mod tests {
             )
             .with_flex_spacer(1.0);
 
-        let mut harness = TestHarness::create_with_size(widget, Size::new(200.0, 200.0));
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, Size::new(200.0, 200.0));
 
         assert_render_snapshot!(harness, "label_line_break_modes");
     }
@@ -617,7 +621,8 @@ mod tests {
                 .with_line_break_mode(LineBreaking::WordWrap)
                 .with_alignment(Alignment::Middle);
 
-            let mut harness = TestHarness::create_with_size(label, Size::new(50.0, 50.0));
+            let mut harness =
+                TestHarness::create_with_size(default_property_set(), label, Size::new(50.0, 50.0));
 
             harness.render()
         };
@@ -627,7 +632,8 @@ mod tests {
                 .with_brush(PRIMARY_DARK)
                 .with_style(StyleProperty::FontSize(40.0));
 
-            let mut harness = TestHarness::create_with_size(label, Size::new(50.0, 50.0));
+            let mut harness =
+                TestHarness::create_with_size(default_property_set(), label, Size::new(50.0, 50.0));
 
             harness.edit_root_widget(|mut label| {
                 let mut label = label.downcast::<Label>();

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -516,6 +516,7 @@ mod tests {
     use super::*;
     use crate::assert_render_snapshot;
     use crate::testing::{TestHarness, widget_ids};
+    use crate::theme::default_property_set;
     use crate::widgets::{Button, Flex, SizedBox};
 
     fn button(text: &'static str) -> impl Widget {
@@ -560,7 +561,8 @@ mod tests {
                 .with_spacer(10.0),
         );
 
-        let mut harness = TestHarness::create_with_size(widget, Size::new(400., 400.));
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, Size::new(400., 400.));
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "portal_button_list_no_scroll");

--- a/masonry/src/widgets/progress_bar.rs
+++ b/masonry/src/widgets/progress_bar.rs
@@ -224,6 +224,7 @@ mod tests {
     use super::*;
     use crate::assert_render_snapshot;
     use crate::testing::{TestHarness, TestWidgetExt, widget_ids};
+    use crate::theme::default_property_set;
 
     #[test]
     fn indeterminate_progressbar() {
@@ -231,7 +232,8 @@ mod tests {
         let widget = ProgressBar::new(None).with_id(progressbar_id);
 
         let window_size = Size::new(150.0, 60.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "progress_bar_indeterminate_progressbar");
@@ -243,7 +245,8 @@ mod tests {
 
         let widget = ProgressBar::new(Some(0.)).with_id(_0percent);
         let window_size = Size::new(150.0, 60.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "progress_bar_0_percent_progressbar");
     }
@@ -254,7 +257,8 @@ mod tests {
 
         let widget = ProgressBar::new(Some(0.25)).with_id(_25percent);
         let window_size = Size::new(150.0, 60.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "progress_bar_25_percent_progressbar");
     }
@@ -265,7 +269,8 @@ mod tests {
 
         let widget = ProgressBar::new(Some(0.5)).with_id(_50percent);
         let window_size = Size::new(150.0, 60.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "progress_bar_50_percent_progressbar");
     }
@@ -276,7 +281,8 @@ mod tests {
 
         let widget = ProgressBar::new(Some(0.75)).with_id(_75percent);
         let window_size = Size::new(150.0, 60.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "progress_bar_75_percent_progressbar");
     }
@@ -287,7 +293,8 @@ mod tests {
 
         let widget = ProgressBar::new(Some(1.)).with_id(_100percent);
         let window_size = Size::new(150.0, 60.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "progress_bar_100_percent_progressbar");
     }
@@ -297,7 +304,8 @@ mod tests {
         let image_1 = {
             let bar = ProgressBar::new(Some(0.5));
 
-            let mut harness = TestHarness::create_with_size(bar, Size::new(60.0, 20.0));
+            let mut harness =
+                TestHarness::create_with_size(default_property_set(), bar, Size::new(60.0, 20.0));
 
             harness.render()
         };
@@ -305,7 +313,8 @@ mod tests {
         let image_2 = {
             let bar = ProgressBar::new(None);
 
-            let mut harness = TestHarness::create_with_size(bar, Size::new(60.0, 20.0));
+            let mut harness =
+                TestHarness::create_with_size(default_property_set(), bar, Size::new(60.0, 20.0));
 
             harness.edit_root_widget(|mut label| {
                 let mut bar = label.downcast::<ProgressBar>();

--- a/masonry/src/widgets/prose.rs
+++ b/masonry/src/widgets/prose.rs
@@ -185,6 +185,7 @@ mod tests {
     use super::*;
     use crate::assert_render_snapshot;
     use crate::testing::TestHarness;
+    use crate::theme::default_property_set;
     use crate::widgets::{CrossAxisAlignment, Flex, SizedBox, TextArea};
 
     #[test]
@@ -200,7 +201,11 @@ mod tests {
 
         let root_widget = Flex::row().with_child(SizedBox::new(prose).width(60.));
 
-        let mut harness = TestHarness::create_with_size(root_widget, Size::new(200.0, 40.0));
+        let mut harness = TestHarness::create_with_size(
+            default_property_set(),
+            root_widget,
+            Size::new(200.0, 40.0),
+        );
 
         assert_render_snapshot!(harness, "prose_clipping");
     }
@@ -233,7 +238,8 @@ mod tests {
             .with_flex_child(prose6, CrossAxisAlignment::Center)
             .gap(0.0);
 
-        let mut harness = TestHarness::create_with_size(flex, Size::new(200.0, 120.0));
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), flex, Size::new(200.0, 120.0));
 
         assert_render_snapshot!(harness, "prose_alignment_flex");
     }

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -263,13 +263,15 @@ mod tests {
     use crate::assert_render_snapshot;
     use crate::core::PointerButton;
     use crate::testing::{TestHarness, TestWidgetExt, widget_ids};
+    use crate::theme::default_property_set;
 
     #[test]
     fn simple_scrollbar() {
         let [scrollbar_id] = widget_ids();
         let widget = ScrollBar::new(Axis::Vertical, 200.0, 600.0).with_id(scrollbar_id);
 
-        let mut harness = TestHarness::create_with_size(widget, Size::new(50.0, 200.0));
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, Size::new(50.0, 200.0));
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "scrollbar_default");
@@ -296,7 +298,8 @@ mod tests {
         let [scrollbar_id] = widget_ids();
         let widget = ScrollBar::new(Axis::Horizontal, 200.0, 600.0).with_id(scrollbar_id);
 
-        let mut harness = TestHarness::create_with_size(widget, Size::new(200.0, 50.0));
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, Size::new(200.0, 50.0));
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "scrollbar_horizontal");

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -491,6 +491,7 @@ mod tests {
     use super::*;
     use crate::palette;
     use crate::testing::{TestHarness, assert_failing_render_snapshot, assert_render_snapshot};
+    use crate::theme::default_property_set;
     use crate::widgets::Label;
 
     // TODO - Add WidgetMut tests
@@ -521,7 +522,8 @@ mod tests {
             .rounded(5.0);
 
         let window_size = Size::new(100.0, 100.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "sized_box_empty_box");
@@ -534,7 +536,8 @@ mod tests {
             .rounded(5.0);
 
         let window_size = Size::new(100.0, 100.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "sized_box_label_box_no_size");
@@ -549,7 +552,8 @@ mod tests {
             .rounded(5.0);
 
         let window_size = Size::new(100.0, 100.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "sized_box_label_box_with_size");
@@ -563,7 +567,8 @@ mod tests {
             .padding(Padding::from_vh(15., 10.));
 
         let window_size = Size::new(100.0, 100.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "sized_box_label_box_with_padding");
@@ -577,7 +582,8 @@ mod tests {
             .background(palette::css::PLUM);
 
         let window_size = Size::new(100.0, 100.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "sized_box_label_box_with_solid_background");
@@ -601,7 +607,8 @@ mod tests {
             );
 
         let window_size = Size::new(100.0, 100.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "sized_box_empty_box_with_gradient_background");
@@ -617,7 +624,8 @@ mod tests {
             .padding(25.);
 
         let window_size = Size::new(100.0, 100.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "sized_box_label_box_with_background_and_padding");
@@ -635,7 +643,8 @@ mod tests {
         .padding(25.);
 
         let window_size = Size::new(100.0, 100.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "sized_box_label_box_with_outer_padding");
@@ -650,7 +659,8 @@ mod tests {
         let widget = SizedBox::empty().width(20.).height(20.).rounded(10.);
 
         let window_size = Size::new(100.0, 100.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         harness.edit_root_widget(|mut sized_box| {
             let brush = Background::Color(palette::css::RED);
@@ -689,7 +699,8 @@ mod tests {
         let widget = widget.border(palette::css::BLUE, 5.2);
 
         let window_size = Size::new(100.0, 100.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_failing_render_snapshot!(harness, "sized_box_empty_box");
     }
@@ -707,7 +718,8 @@ mod tests {
         let widget = widget.padding(0.2);
 
         let window_size = Size::new(100.0, 100.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_failing_render_snapshot!(harness, "sized_box_label_box_with_size");
     }

--- a/masonry/src/widgets/spinner.rs
+++ b/masonry/src/widgets/spinner.rs
@@ -191,13 +191,15 @@ mod tests {
     use super::*;
     use crate::palette;
     use crate::testing::{TestHarness, assert_render_snapshot};
+    use crate::theme::default_property_set;
 
     #[test]
     fn simple_spinner() {
         let spinner = Spinner::new();
 
         let window_size = Size::new(100.0, 100.0);
-        let mut harness = TestHarness::create_with_size(spinner, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), spinner, window_size);
         assert_render_snapshot!(harness, "spinner_init");
 
         harness.animate_ms(700);
@@ -212,14 +214,22 @@ mod tests {
         let image_1 = {
             let spinner = Spinner::new().with_color(palette::css::PURPLE);
 
-            let mut harness = TestHarness::create_with_size(spinner, Size::new(30.0, 30.0));
+            let mut harness = TestHarness::create_with_size(
+                default_property_set(),
+                spinner,
+                Size::new(30.0, 30.0),
+            );
             harness.render()
         };
 
         let image_2 = {
             let spinner = Spinner::new();
 
-            let mut harness = TestHarness::create_with_size(spinner, Size::new(30.0, 30.0));
+            let mut harness = TestHarness::create_with_size(
+                default_property_set(),
+                spinner,
+                Size::new(30.0, 30.0),
+            );
 
             harness.edit_root_widget(|mut spinner| {
                 let mut spinner = spinner.downcast::<Spinner>();

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -616,6 +616,7 @@ mod tests {
     use super::*;
     use crate::assert_render_snapshot;
     use crate::testing::TestHarness;
+    use crate::theme::default_property_set;
     use crate::widgets::Label;
 
     #[test]
@@ -627,7 +628,8 @@ mod tests {
         ).split_axis(Axis::Horizontal).draggable(false);
 
         let window_size = Size::new(150.0, 150.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "split_columns");
@@ -642,7 +644,8 @@ mod tests {
         ).split_axis(Axis::Vertical).draggable(false);
 
         let window_size = Size::new(150.0, 150.0);
-        let mut harness = TestHarness::create_with_size(widget, window_size);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         assert_debug_snapshot!(harness.root_widget());
         assert_render_snapshot!(harness, "split_rows");
@@ -661,7 +664,11 @@ mod tests {
                 .draggable(true)
                 .solid_bar(true);
 
-            let mut harness = TestHarness::create_with_size(widget, Size::new(100.0, 100.0));
+            let mut harness = TestHarness::create_with_size(
+                default_property_set(),
+                widget,
+                Size::new(100.0, 100.0),
+            );
 
             harness.render()
         };
@@ -669,7 +676,11 @@ mod tests {
         let image_2 = {
             let widget = Split::new(Label::new("Hello"), Label::new("World"));
 
-            let mut harness = TestHarness::create_with_size(widget, Size::new(100.0, 100.0));
+            let mut harness = TestHarness::create_with_size(
+                default_property_set(),
+                widget,
+                Size::new(100.0, 100.0),
+            );
 
             harness.edit_root_widget(|mut splitter| {
                 let mut splitter = splitter.downcast::<Split<Label, Label>>();

--- a/masonry/src/widgets/tests/ime_focused.rs
+++ b/masonry/src/widgets/tests/ime_focused.rs
@@ -3,6 +3,7 @@
 
 use crate::core::{Ime, TextEvent, WidgetPod};
 use crate::testing::{TestHarness, widget_ids};
+use crate::theme::default_property_set;
 use crate::widgets::{Flex, TextArea, Textbox};
 
 /// Tests that IME's interactions with focus are sensible.
@@ -15,7 +16,7 @@ fn ime_on_remove() {
         text_area,
     )));
 
-    let mut harness = TestHarness::create(widget);
+    let mut harness = TestHarness::create(default_property_set(), widget);
     harness.focus_on(Some(text_area));
     harness.process_text_event(TextEvent::Ime(Ime::Commit("New Text".to_string())));
     let text_area = harness

--- a/masonry/src/widgets/tests/layout.rs
+++ b/masonry/src/widgets/tests/layout.rs
@@ -6,6 +6,7 @@
 use vello::kurbo::{Insets, Size};
 
 use crate::testing::{ModularWidget, TestHarness, TestWidgetExt, widget_ids};
+use crate::theme::default_property_set;
 use crate::widgets::{Flex, SizedBox};
 
 #[test]
@@ -23,7 +24,7 @@ fn layout_simple() {
         )
         .with_flex_spacer(1.0);
 
-    let harness = TestHarness::create(widget);
+    let harness = TestHarness::create(default_property_set(), widget);
 
     let first_box_rect = harness.get_widget(id_1).ctx().local_layout_rect();
     let first_box_paint_rect = harness.get_widget(id_1).ctx().paint_rect();
@@ -53,7 +54,7 @@ fn layout_insets() {
 
     let parent_widget = SizedBox::new_with_id(child_widget, child_id).with_id(parent_id);
 
-    let harness = TestHarness::create(parent_widget);
+    let harness = TestHarness::create(default_property_set(), parent_widget);
 
     let child_paint_rect = harness.get_widget(child_id).ctx().paint_rect();
     let parent_paint_rect = harness.get_widget(parent_id).ctx().paint_rect();

--- a/masonry/src/widgets/tests/lifecycle_basic.rs
+++ b/masonry/src/widgets/tests/lifecycle_basic.rs
@@ -8,6 +8,7 @@ use insta::assert_debug_snapshot;
 use crate::testing::{
     Record, Recording, TestHarness, TestWidgetExt as _, WrapperWidget, widget_ids,
 };
+use crate::theme::default_property_set;
 use crate::widgets::{Flex, Label, SizedBox};
 use crate::*;
 
@@ -16,7 +17,7 @@ fn app_creation() {
     let record = Recording::default();
     let widget = SizedBox::empty().record(&record);
 
-    let _harness = TestHarness::create(widget);
+    let _harness = TestHarness::create(default_property_set(), widget);
 
     let record = record.drain();
     assert_debug_snapshot!(record);

--- a/masonry/src/widgets/tests/safety_rails.rs
+++ b/masonry/src/widgets/tests/safety_rails.rs
@@ -6,6 +6,7 @@ use smallvec::smallvec;
 use crate::core::{PointerButton, Update, Widget, WidgetId, WidgetPod};
 use crate::kurbo::{Point, Size};
 use crate::testing::{ModularWidget, TestHarness, TestWidgetExt};
+use crate::theme::default_property_set;
 use crate::widgets::Flex;
 
 fn make_parent_widget<W: Widget>(child: W) -> ModularWidget<WidgetPod<W>> {
@@ -76,7 +77,7 @@ fn check_forget_register_child() {
         // We forget to call ctx.register_child();
     });
 
-    let _harness = TestHarness::create(widget);
+    let _harness = TestHarness::create(default_property_set(), widget);
 }
 
 #[should_panic(expected = "in the list returned by children_ids")]
@@ -91,7 +92,7 @@ fn check_register_invalid_child() {
         ctx.register_child(&mut WidgetPod::new(Flex::row()));
     });
 
-    let _harness = TestHarness::create(widget);
+    let _harness = TestHarness::create(default_property_set(), widget);
 }
 
 #[should_panic(expected = "event does not allow pointer capture")]
@@ -105,7 +106,7 @@ fn check_pointer_capture_outside_pointer_down() {
         ctx.capture_pointer();
     });
 
-    let mut harness = TestHarness::create(widget);
+    let mut harness = TestHarness::create(default_property_set(), widget);
     harness.mouse_move((10.0, 10.0));
     harness.mouse_button_release(PointerButton::Primary);
 }
@@ -125,7 +126,7 @@ fn check_pointer_capture_text_event() {
         })
         .with_id(id);
 
-    let mut harness = TestHarness::create(widget);
+    let mut harness = TestHarness::create(default_property_set(), widget);
     harness.focus_on(Some(id));
     harness.keyboard_type_chars("a");
 }
@@ -142,7 +143,7 @@ fn check_forget_to_recurse_layout() {
         Size::ZERO
     });
 
-    let _harness = TestHarness::create(widget);
+    let _harness = TestHarness::create(default_property_set(), widget);
 }
 
 #[should_panic(expected = "LayoutCtx::place_child() was not called")]
@@ -157,7 +158,7 @@ fn check_forget_to_call_place_child() {
         ctx.run_layout(child, bc)
     });
 
-    let _harness = TestHarness::create(widget);
+    let _harness = TestHarness::create(default_property_set(), widget);
 }
 
 // ---
@@ -339,7 +340,7 @@ fn check_layout_stashed() {
             size
         });
 
-    let mut harness = TestHarness::create(widget);
+    let mut harness = TestHarness::create(default_property_set(), widget);
     harness.mouse_move(Point::ZERO);
 }
 

--- a/masonry/src/widgets/tests/status_change.rs
+++ b/masonry/src/widgets/tests/status_change.rs
@@ -8,6 +8,7 @@ use crate::kurbo::Vec2;
 use crate::testing::{
     PRIMARY_MOUSE, Record, Recording, TestHarness, TestWidgetExt as _, widget_ids,
 };
+use crate::theme::default_property_set;
 use crate::widgets::{Button, Flex, SizedBox};
 
 fn next_pointer_event(recording: &Recording) -> Option<PointerEvent> {
@@ -62,7 +63,7 @@ fn propagate_hovered() {
         .record(&root_rec)
         .with_id(root);
 
-    let mut harness = TestHarness::create(widget);
+    let mut harness = TestHarness::create(default_property_set(), widget);
 
     // we don't care about setup events, so discard them now.
     root_rec.clear();
@@ -156,7 +157,7 @@ fn update_hovered_on_mouse_leave() {
 
     let widget = Button::new("hello").record(&button_rec).with_id(button_id);
 
-    let mut harness = TestHarness::create(widget);
+    let mut harness = TestHarness::create(default_property_set(), widget);
 
     harness.mouse_move_to(button_id);
     assert!(is_hovered(&harness, button_id));
@@ -233,7 +234,7 @@ fn get_pointer_events_while_active() {
         .with_child_id(Button::new("hello").record(&button_rec), button)
         .with_id(root);
 
-    let mut harness = TestHarness::create(widget);
+    let mut harness = TestHarness::create(default_property_set(), widget);
 
     // First we check that the default state is clear: nothing active, no event recorded
     assert_eq!(harness.pointer_capture_target_id(), None);
@@ -307,7 +308,7 @@ fn automatically_lose_pointer_on_pointer_lost() {
         .with_child_id(Button::new("hello").record(&button_rec), button)
         .with_id(root);
 
-    let mut harness = TestHarness::create(widget);
+    let mut harness = TestHarness::create(default_property_set(), widget);
 
     // The default state is that nothing has captured the pointer.
     assert_eq!(harness.pointer_capture_target_id(), None);

--- a/masonry/src/widgets/tests/transforms.rs
+++ b/masonry/src/widgets/tests/transforms.rs
@@ -11,6 +11,7 @@ use vello::peniko::color::palette;
 use crate::assert_render_snapshot;
 use crate::core::{PointerButton, Widget, WidgetOptions, WidgetPod};
 use crate::testing::TestHarness;
+use crate::theme::default_property_set;
 use crate::widgets::{Alignment, Button, ChildAlignment, Label, SizedBox, ZStack};
 
 fn blue_box(inner: impl Widget) -> Box<SizedBox> {
@@ -40,7 +41,7 @@ fn transforms_translation_rotation() {
     .erased();
     let widget = ZStack::new().with_child_pod(transformed_widget, ChildAlignment::ParentAligned);
 
-    let mut harness = TestHarness::create(widget);
+    let mut harness = TestHarness::create(default_property_set(), widget);
     assert_render_snapshot!(harness, "transforms_translation_rotation");
 }
 
@@ -58,7 +59,7 @@ fn transforms_pointer_events() {
     .erased();
     let widget = ZStack::new().with_child_pod(transformed_widget, ChildAlignment::ParentAligned);
 
-    let mut harness = TestHarness::create(widget);
+    let mut harness = TestHarness::create(default_property_set(), widget);
     harness.mouse_move((335.0, 350.0)); // Should hit the last "d" of the button text
     harness.mouse_button_press(PointerButton::Primary);
     assert_render_snapshot!(harness, "transforms_pointer_events");

--- a/masonry/src/widgets/tests/widget_tree.rs
+++ b/masonry/src/widgets/tests/widget_tree.rs
@@ -4,6 +4,7 @@
 use insta::assert_debug_snapshot;
 
 use crate::testing::{TestHarness, widget_ids};
+use crate::theme::default_property_set;
 use crate::widgets::{Flex, Label};
 
 #[test]
@@ -16,7 +17,7 @@ fn access_grandchild_widget() {
         )
         .with_flex_spacer(1.0);
 
-    let mut harness = TestHarness::create(widget);
+    let mut harness = TestHarness::create(default_property_set(), widget);
 
     dbg!(harness.root_widget());
     harness.edit_widget(id_label, |mut label| {

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -996,6 +996,7 @@ mod tests {
     use super::*;
     use crate::core::{Action, KeyboardEvent, Modifiers};
     use crate::testing::{TestHarness, TestWidgetExt, widget_ids};
+    use crate::theme::default_property_set;
     // Tests of alignment happen in Prose.
 
     #[test]
@@ -1003,7 +1004,8 @@ mod tests {
         let base_with_wrapping = {
             let area = TextArea::new_immutable("String which will wrap").with_word_wrap(true);
 
-            let mut harness = TestHarness::create_with_size(area, Size::new(60.0, 40.0));
+            let mut harness =
+                TestHarness::create_with_size(default_property_set(), area, Size::new(60.0, 40.0));
 
             harness.render()
         };
@@ -1011,7 +1013,8 @@ mod tests {
         {
             let area = TextArea::new_immutable("String which will wrap").with_word_wrap(false);
 
-            let mut harness = TestHarness::create_with_size(area, Size::new(60.0, 40.0));
+            let mut harness =
+                TestHarness::create_with_size(default_property_set(), area, Size::new(60.0, 40.0));
 
             let without_wrapping = harness.render();
 
@@ -1046,7 +1049,8 @@ mod tests {
         let base_target = {
             let area = TextArea::new_immutable("Test string").with_brush(palette::css::AZURE);
 
-            let mut harness = TestHarness::create_with_size(area, Size::new(200.0, 20.0));
+            let mut harness =
+                TestHarness::create_with_size(default_property_set(), area, Size::new(200.0, 20.0));
 
             harness.render()
         };
@@ -1054,7 +1058,8 @@ mod tests {
         {
             let area = TextArea::new_immutable("Different string").with_brush(palette::css::AZURE);
 
-            let mut harness = TestHarness::create_with_size(area, Size::new(200.0, 20.0));
+            let mut harness =
+                TestHarness::create_with_size(default_property_set(), area, Size::new(200.0, 20.0));
 
             harness.edit_root_widget(|mut root| {
                 let mut area = root.downcast::<TextArea<false>>();
@@ -1135,7 +1140,7 @@ mod tests {
                 .with_insert_newline(scenario.insert_newline)
                 .with_id(text_id);
 
-            let mut harness = TestHarness::create(area);
+            let mut harness = TestHarness::create(default_property_set(), area);
 
             harness.focus_on(Some(text_id));
             harness.process_text_event(TextEvent::Keyboard(KeyboardEvent {

--- a/masonry/src/widgets/textbox.rs
+++ b/masonry/src/widgets/textbox.rs
@@ -212,6 +212,7 @@ mod tests {
     use crate::assert_render_snapshot;
     use crate::core::StyleProperty;
     use crate::testing::TestHarness;
+    use crate::theme::default_property_set;
     use crate::widgets::TextArea;
 
     #[test]
@@ -219,7 +220,8 @@ mod tests {
         let textbox = Textbox::from_text_area(
             TextArea::new_editable("Textbox contents").with_style(StyleProperty::FontSize(14.0)),
         );
-        let mut harness = TestHarness::create_with_size(textbox, Size::new(150.0, 40.0));
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), textbox, Size::new(150.0, 40.0));
 
         assert_render_snapshot!(harness, "textbox_outline");
 

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -919,6 +919,7 @@ mod tests {
         WidgetMut, WidgetPod,
     };
     use crate::testing::{PRIMARY_MOUSE, TestHarness, assert_render_snapshot};
+    use crate::theme::default_property_set;
     use crate::widgets::{Label, VirtualScroll, VirtualScrollAction};
 
     use super::opt_iter_difference;
@@ -964,7 +965,8 @@ mod tests {
 
         let widget = VirtualScroll::<ScrollContents>::new(0);
 
-        let mut harness = TestHarness::create_with_size(widget, Size::new(100., 200.));
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, Size::new(100., 200.));
         let virtual_scroll_id = harness.root_widget().id();
         fn driver(action: VirtualScrollAction, mut scroll: WidgetMut<'_, VirtualScroll<Label>>) {
             VirtualScroll::will_handle_action(&mut scroll, &action);
@@ -1012,7 +1014,8 @@ mod tests {
 
         let widget = VirtualScroll::<ScrollContents>::new(0);
 
-        let mut harness = TestHarness::create_with_size(widget, Size::new(100., 200.));
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, Size::new(100., 200.));
         let virtual_scroll_id = harness.root_widget().id();
         fn driver(action: VirtualScrollAction, mut scroll: WidgetMut<'_, VirtualScroll<Label>>) {
             VirtualScroll::will_handle_action(&mut scroll, &action);
@@ -1057,7 +1060,8 @@ mod tests {
 
         let widget = VirtualScroll::<ScrollContents>::new(0);
 
-        let mut harness = TestHarness::create_with_size(widget, Size::new(100., 200.));
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, Size::new(100., 200.));
         let virtual_scroll_id = harness.root_widget().id();
         fn driver(action: VirtualScrollAction, mut scroll: WidgetMut<'_, VirtualScroll<Label>>) {
             VirtualScroll::will_handle_action(&mut scroll, &action);
@@ -1102,7 +1106,8 @@ mod tests {
 
         let widget = VirtualScroll::<ScrollContents>::new(0);
 
-        let mut harness = TestHarness::create_with_size(widget, Size::new(100., 200.));
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, Size::new(100., 200.));
         let virtual_scroll_id = harness.root_widget().id();
         fn driver(action: VirtualScrollAction, mut scroll: WidgetMut<'_, VirtualScroll<Label>>) {
             VirtualScroll::will_handle_action(&mut scroll, &action);
@@ -1147,7 +1152,8 @@ mod tests {
         const MIN: i64 = 10;
         let widget = VirtualScroll::<ScrollContents>::new(0).with_valid_range(MIN..i64::MAX);
 
-        let mut harness = TestHarness::create_with_size(widget, Size::new(100., 200.));
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, Size::new(100., 200.));
         let virtual_scroll_id = harness.root_widget().id();
         fn driver(action: VirtualScrollAction, mut scroll: WidgetMut<'_, VirtualScroll<Label>>) {
             VirtualScroll::will_handle_action(&mut scroll, &action);
@@ -1229,7 +1235,8 @@ mod tests {
         const MAX: i64 = 10;
         let widget = VirtualScroll::<ScrollContents>::new(100).with_valid_range(i64::MIN..MAX);
 
-        let mut harness = TestHarness::create_with_size(widget, Size::new(100., 200.));
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, Size::new(100., 200.));
         let virtual_scroll_id = harness.root_widget().id();
         fn driver(action: VirtualScrollAction, mut scroll: WidgetMut<'_, VirtualScroll<Label>>) {
             VirtualScroll::will_handle_action(&mut scroll, &action);

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -383,6 +383,7 @@ mod tests {
     use super::*;
     use crate::assert_render_snapshot;
     use crate::testing::TestHarness;
+    use crate::theme::default_property_set;
     use crate::widgets::{Label, SizedBox};
 
     #[test]
@@ -403,7 +404,7 @@ mod tests {
                 ChildAlignment::ParentAligned,
             );
 
-        let mut harness = TestHarness::create(widget);
+        let mut harness = TestHarness::create(default_property_set(), widget);
         assert_render_snapshot!(harness, "zstack_alignment_default");
 
         let vertical_cases = [
@@ -444,7 +445,7 @@ mod tests {
             .with_child(Label::new("BottomLeft"), Alignment::BottomLeft)
             .with_child(Label::new("BottomRight"), Alignment::BottomRight);
 
-        let mut harness = TestHarness::create(widget);
+        let mut harness = TestHarness::create(default_property_set(), widget);
         assert_render_snapshot!(harness, "zstack_alignments_self_aligned");
     }
 }

--- a/masonry_winit/examples/calc_masonry.rs
+++ b/masonry_winit/examples/calc_masonry.rs
@@ -445,12 +445,13 @@ fn main() {
 mod tests {
     use masonry_winit::assert_render_snapshot;
     use masonry_winit::testing::TestHarness;
+    use masonry_winit::theme::default_property_set;
 
     use super::*;
 
     #[test]
     fn screenshot_test() {
-        let mut harness = TestHarness::create(build_calc());
+        let mut harness = TestHarness::create(default_property_set(), build_calc());
         assert_render_snapshot!(harness, "example_calc_masonry_initial");
 
         // TODO - Test clicking buttons

--- a/masonry_winit/examples/custom_widget.rs
+++ b/masonry_winit/examples/custom_widget.rs
@@ -207,6 +207,7 @@ fn make_image_data(width: usize, height: usize) -> Vec<u8> {
 mod tests {
     use masonry_winit::assert_render_snapshot;
     use masonry_winit::testing::TestHarness;
+    use masonry_winit::theme::default_property_set;
 
     use super::*;
 
@@ -214,7 +215,7 @@ mod tests {
     fn screenshot_test() {
         let my_string = "Masonry + Vello".to_string();
 
-        let mut harness = TestHarness::create(CustomWidget(my_string));
+        let mut harness = TestHarness::create(default_property_set(), CustomWidget(my_string));
         assert_render_snapshot!(harness, "example_custom_widget_initial");
     }
 }

--- a/masonry_winit/examples/grid_masonry.rs
+++ b/masonry_winit/examples/grid_masonry.rs
@@ -131,12 +131,13 @@ fn main() {
 mod tests {
     use masonry_winit::assert_render_snapshot;
     use masonry_winit::testing::TestHarness;
+    use masonry_winit::theme::default_property_set;
 
     use super::*;
 
     #[test]
     fn screenshot_test() {
-        let mut harness = TestHarness::create(make_grid(1.0));
+        let mut harness = TestHarness::create(default_property_set(), make_grid(1.0));
         assert_render_snapshot!(harness, "example_grid_masonry_initial");
 
         // TODO - Test clicking buttons

--- a/masonry_winit/examples/simple_image.rs
+++ b/masonry_winit/examples/simple_image.rs
@@ -56,12 +56,13 @@ fn main() {
 mod tests {
     use masonry_winit::assert_render_snapshot;
     use masonry_winit::testing::TestHarness;
+    use masonry_winit::theme::default_property_set;
 
     use super::*;
 
     #[test]
     fn screenshot_test() {
-        let mut harness = TestHarness::create(make_image());
+        let mut harness = TestHarness::create(default_property_set(), make_image());
         assert_render_snapshot!(harness, "example_simple_image_initial");
     }
 }

--- a/masonry_winit/examples/to_do_list.rs
+++ b/masonry_winit/examples/to_do_list.rs
@@ -82,12 +82,13 @@ fn main() {
 mod tests {
     use masonry_winit::assert_render_snapshot;
     use masonry_winit::testing::TestHarness;
+    use masonry_winit::theme::default_property_set;
 
     use super::*;
 
     #[test]
     fn screenshot_test() {
-        let mut harness = TestHarness::create(make_widget_tree());
+        let mut harness = TestHarness::create(default_property_set(), make_widget_tree());
         assert_render_snapshot!(harness, "example_to_do_list_initial");
 
         // TODO - Test clicking buttons


### PR DESCRIPTION
This will be necessary once testing and theming are split into two crates.