### PR TITLE
refactor: stop using RawProxy for driver constructor

### DIFF
--- a/xilem/examples/external_event_loop.rs
+++ b/xilem/examples/external_event_loop.rs
@@ -6,8 +6,6 @@
 //! accessing raw events from winit.
 //! Support for more custom embeddings would be welcome, but needs more design work
 
-use std::sync::Arc;
-
 use masonry_winit::app::{AppDriver, MasonryUserEvent};
 use masonry_winit::peniko::Color;
 use masonry_winit::theme::default_property_set;
@@ -17,7 +15,7 @@ use winit::error::EventLoopError;
 use winit::event::ElementState;
 use winit::keyboard::{KeyCode, PhysicalKey};
 use xilem::view::{Axis, Label, button, flex, label, sized_box};
-use xilem::{EventLoop, MasonryProxy, WidgetView, Xilem};
+use xilem::{EventLoop, WidgetView, Xilem};
 
 /// A component to make a bigger than usual button
 fn big_button(
@@ -136,8 +134,9 @@ fn main() -> Result<(), EventLoopError> {
     let xilem = Xilem::new(0, app_logic);
 
     let event_loop = EventLoop::with_user_event().build().unwrap();
-    let proxy = MasonryProxy::new(event_loop.create_proxy());
-    let (widget, driver) = xilem.into_driver(Arc::new(proxy));
+    let proxy = event_loop.create_proxy();
+    let (widget, driver) =
+        xilem.into_driver(move |event| proxy.send_event(event).map_err(|err| err.0));
     let masonry_state = masonry_winit::app::MasonryState::new(
         window_attributes,
         &event_loop,


### PR DESCRIPTION
MasonryUserEvent will gain a WindowId but RawProxy::send_event won't.

Note that we're not using EventLoopProxy instead because we want the driver to be constructible without an event loop for testing (currently not feasible with winit 0.30 but will be with 0.31 which introduces traits for ActiveEventLoop and Window).