### PR TITLE
feat: introduce WidgetMut::find_mut

### DIFF
--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -257,6 +257,41 @@ impl MutateCtx<'_> {
         }
     }
 
+    /// Return a [`WidgetMut`] to a child widget by its id.
+    pub fn find_mut(&mut self, child_id: WidgetId) -> WidgetMut<'_, dyn Widget> {
+        let child_state_mut = self
+            .widget_state_children
+            .reborrow_mut()
+            .find_mut(child_id)
+            .expect("find_mut: child not found");
+        let child_mut = self
+            .widget_children
+            .reborrow_mut()
+            .find_mut(child_id)
+            .expect("find_mut: child not found");
+        let child_properties = self
+            .properties_children
+            .reborrow_mut()
+            .find_mut(child_id)
+            .expect("find_mut: child not found");
+        let child_ctx = MutateCtx {
+            global_state: self.global_state,
+            parent_widget_state: Some(&mut self.widget_state),
+            widget_state: child_state_mut.item,
+            widget_state_children: child_state_mut.children,
+            widget_children: child_mut.children,
+            properties: PropertiesMut {
+                map: child_properties.item,
+                default_map: self.properties.default_map,
+            },
+            properties_children: child_properties.children,
+        };
+        WidgetMut {
+            ctx: child_ctx,
+            widget: child_mut.item.as_mut_dyn(),
+        }
+    }
+
     pub(crate) fn reborrow_mut(&mut self) -> MutateCtx<'_> {
         MutateCtx {
             global_state: self.global_state,

--- a/masonry/src/core/widget.rs
+++ b/masonry/src/core/widget.rs
@@ -50,6 +50,12 @@ impl WidgetId {
     }
 }
 
+impl Default for WidgetId {
+    fn default() -> Self {
+        Self::next()
+    }
+}
+
 /// A trait to access a `Widget` as trait object. It is implemented for all types that implement `Widget`.
 pub trait AsDynWidget {
     fn as_box_dyn(self: Box<Self>) -> Box<dyn Widget>;


### PR DESCRIPTION
Finding widgets by their id in the RenderRoot::edit_root_widget callback makes the code more maintainable because you can rearrange the widgets without having to update the callback. And with the unsafe tree arena find_mut from the root is O(1).

To make this pattern convenient this commit also introduces a Default impl for WidgetId that just returns WidgetId::next().