### PR TITLE
Use more precise fn types for task/worker

### DIFF
--- a/xilem/src/view/task.rs
+++ b/xilem/src/view/task.rs
@@ -5,7 +5,7 @@
 
 use std::future::Future;
 use std::marker::PhantomData;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use tokio::task::JoinHandle;
 
@@ -26,22 +26,17 @@ use crate::core::{
 /// cannot capture.
 // TODO: More thorough documentation.
 /// See [`run_once`](crate::core::run_once) for details.
-pub fn task<M, F, H, State, Action, Fut>(init_future: F, on_event: H) -> Task<F, H, M>
+pub fn task<M, H, State, Action, Fut>(
+    init_future: fn(MessageProxy<M>) -> Fut,
+    on_event: H,
+) -> Task<fn(MessageProxy<M>) -> Fut, H, M>
 where
-    F: Fn(MessageProxy<M>) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
     M: AnyMessage + 'static,
 {
-    const {
-        assert!(
-            size_of::<F>() == 0,
-            "`task` will not be ran again when its captured variables are updated.\n\
-            To ignore this warning, use `task_raw`."
-        );
-    };
     Task {
-        init_future,
+        init_future: Mutex::new(Some(init_future)),
         on_event,
         message: PhantomData,
     }
@@ -53,20 +48,20 @@ where
 /// See `task` for full documentation.
 pub fn task_raw<M, F, H, State, Action, Fut>(init_future: F, on_event: H) -> Task<F, H, M>
 where
-    F: Fn(MessageProxy<M>) -> Fut,
+    F: FnOnce(MessageProxy<M>) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
     M: AnyMessage + 'static,
 {
     Task {
-        init_future,
+        init_future: Mutex::new(Some(init_future)),
         on_event,
         message: PhantomData,
     }
 }
 
 pub struct Task<F, H, M> {
-    init_future: F,
+    init_future: Mutex<Option<F>>,
     on_event: H,
     message: PhantomData<fn() -> M>,
 }
@@ -74,7 +69,7 @@ pub struct Task<F, H, M> {
 impl<F, H, M> ViewMarker for Task<F, H, M> {}
 impl<State, Action, F, H, M, Fut> View<State, Action, ViewCtx> for Task<F, H, M>
 where
-    F: Fn(MessageProxy<M>) -> Fut + 'static,
+    F: FnOnce(MessageProxy<M>) -> Fut + 'static,
     Fut: Future<Output = ()> + Send + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
     M: AnyMessage + 'static,
@@ -84,12 +79,14 @@ where
     type ViewState = JoinHandle<()>;
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+        let init_future = self.init_future.lock().unwrap().take();
+        let init_future = init_future.unwrap();
         let path: Arc<[ViewId]> = ctx.view_path().into();
 
         let proxy = ctx.proxy.clone();
         let handle = ctx
             .runtime()
-            .spawn((self.init_future)(MessageProxy::new(proxy, path)));
+            .spawn(init_future(MessageProxy::new(proxy, path)));
         (NoElement, handle)
     }
 

--- a/xilem/src/view/worker.rs
+++ b/xilem/src/view/worker.rs
@@ -5,7 +5,7 @@
 
 use std::future::Future;
 use std::marker::PhantomData;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
@@ -28,27 +28,19 @@ use crate::core::{
 /// cannot capture.
 // TODO: More thorough documentation.
 /// See [`run_once`](crate::core::run_once) for details.
-pub fn worker<M, V, F, H, State, Action, Fut>(
+pub fn worker<M, V, H, State, Action, Fut>(
     value: V,
-    init_future: F,
+    init_future: fn(MessageProxy<M>, UnboundedReceiver<V>) -> Fut,
     on_response: H,
-) -> Worker<F, H, M, V>
+) -> Worker<fn(MessageProxy<M>, UnboundedReceiver<V>) -> Fut, H, M, V>
 where
-    F: Fn(MessageProxy<M>, UnboundedReceiver<V>) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
     M: AnyMessage + 'static,
 {
-    const {
-        assert!(
-            size_of::<F>() == 0,
-            "`worker` will not be ran again when its captured variables are updated.\n\
-            To ignore this warning, use `worker_raw`."
-        );
-    };
     Worker {
         value,
-        init_future,
+        init_future: Mutex::new(Some(init_future)),
         on_response,
         message: PhantomData,
     }
@@ -64,21 +56,21 @@ pub fn worker_raw<M, V, F, H, State, Action, Fut>(
     on_response: H,
 ) -> Worker<F, H, M, V>
 where
-    F: Fn(MessageProxy<M>, UnboundedReceiver<V>) -> Fut,
+    F: FnOnce(MessageProxy<M>, UnboundedReceiver<V>) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
     M: AnyMessage + 'static,
 {
     Worker {
         value,
-        init_future,
+        init_future: Mutex::new(Some(init_future)),
         on_response,
         message: PhantomData,
     }
 }
 
 pub struct Worker<F, H, M, V> {
-    init_future: F,
+    init_future: Mutex<Option<F>>,
     value: V,
     on_response: H,
     message: PhantomData<fn() -> M>,
@@ -94,7 +86,7 @@ impl<F, H, M, V> ViewMarker for Worker<F, H, M, V> {}
 
 impl<State, Action, V, F, H, M, Fut> View<State, Action, ViewCtx> for Worker<F, H, M, V>
 where
-    F: Fn(MessageProxy<M>, UnboundedReceiver<V>) -> Fut + 'static,
+    F: FnOnce(MessageProxy<M>, UnboundedReceiver<V>) -> Fut + 'static,
     V: Send + PartialEq + Clone + 'static,
     Fut: Future<Output = ()> + Send + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
@@ -105,6 +97,8 @@ where
     type ViewState = WorkerState<V>;
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+        let init_future = self.init_future.lock().unwrap().take();
+        let init_future = init_future.unwrap();
         let path: Arc<[ViewId]> = ctx.view_path().into();
 
         let proxy = ctx.proxy.clone();
@@ -113,7 +107,7 @@ where
         tx.send(self.value.clone()).unwrap();
         let handle = ctx
             .runtime()
-            .spawn((self.init_future)(MessageProxy::new(proxy, path), rx));
+            .spawn(init_future(MessageProxy::new(proxy, path), rx));
         (NoElement, WorkerState { handle, sender: tx })
     }
 


### PR DESCRIPTION
Changes the bounds on the `init_future` function in `Task` and `Worker` to be `FnOnce` instead of `Fn`. This ensures that the function can only be called once at the type system level, and allows the closure to move out of captured values which can avoid unneeded clones.

The bounds on the `task()` and `worker()` functions are changed to take `fn()` types instead of generic `FnOnce` to allow the compiler to enforce that they do not capture any values from their scope. If you would prefer to keep the const assert instead, they can be changed to take `FnOnce` types like `task_raw()` and `worker_raw()`.

This does require introducing a `Mutex` into the `Task` and `Worker` types to allow the `init_future` value to be moved out in `build()`, since `build()` takes a shared reference to self. This will increase the memory footprint of the view types slightly, but should have minimal performance impact since the mutex should never have any contention.

This approach does not work for `xilem_core::RunOnce` because `Mutex` is only available in `std`.