### PR TITLE
Remove tests and docgen from the xilem examples

### DIFF
--- a/xilem_web/web_examples/counter/Cargo.toml
+++ b/xilem_web/web_examples/counter/Cargo.toml
@@ -6,6 +6,13 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[[bin]]
+name = "counter"
+test = false
+doctest = false
+bench = false
+doc = false
+
 [lints]
 workspace = true
 

--- a/xilem_web/web_examples/counter_custom_element/Cargo.toml
+++ b/xilem_web/web_examples/counter_custom_element/Cargo.toml
@@ -6,6 +6,13 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[[bin]]
+name = "counter_custom_element"
+test = false
+doctest = false
+bench = false
+doc = false
+
 [lints]
 workspace = true
 

--- a/xilem_web/web_examples/elm/Cargo.toml
+++ b/xilem_web/web_examples/elm/Cargo.toml
@@ -6,6 +6,13 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[[bin]]
+name = "elm"
+test = false
+doctest = false
+bench = false
+doc = false
+
 [lints]
 workspace = true
 

--- a/xilem_web/web_examples/fetch/Cargo.toml
+++ b/xilem_web/web_examples/fetch/Cargo.toml
@@ -6,6 +6,13 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[[bin]]
+name = "fetch"
+test = false
+doctest = false
+bench = false
+doc = false
+
 [lints]
 workspace = true
 

--- a/xilem_web/web_examples/mathml_svg/Cargo.toml
+++ b/xilem_web/web_examples/mathml_svg/Cargo.toml
@@ -6,6 +6,13 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[[bin]]
+name = "mathml_svg"
+test = false
+doctest = false
+bench = false
+doc = false
+
 [lints]
 workspace = true
 

--- a/xilem_web/web_examples/raw_dom_access/Cargo.toml
+++ b/xilem_web/web_examples/raw_dom_access/Cargo.toml
@@ -6,6 +6,13 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[[bin]]
+name = "raw_dom_access"
+test = false
+doctest = false
+bench = false
+doc = false
+
 [dependencies]
 console_error_panic_hook = "0.1"
 console_log = "1.0.0"

--- a/xilem_web/web_examples/spawn_tasks/Cargo.toml
+++ b/xilem_web/web_examples/spawn_tasks/Cargo.toml
@@ -6,6 +6,13 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[[bin]]
+name = "spawn_tasks"
+test = false
+doctest = false
+bench = false
+doc = false
+
 [lints]
 workspace = true
 

--- a/xilem_web/web_examples/svgdraw/Cargo.toml
+++ b/xilem_web/web_examples/svgdraw/Cargo.toml
@@ -6,6 +6,13 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[[bin]]
+name = "svgdraw"
+test = false
+doctest = false
+bench = false
+doc = false
+
 [lints]
 workspace = true
 

--- a/xilem_web/web_examples/svgtoy/Cargo.toml
+++ b/xilem_web/web_examples/svgtoy/Cargo.toml
@@ -6,6 +6,13 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[[bin]]
+name = "svgtoy"
+test = false
+doctest = false
+bench = false
+doc = false
+
 [lints]
 workspace = true
 

--- a/xilem_web/web_examples/todomvc/Cargo.toml
+++ b/xilem_web/web_examples/todomvc/Cargo.toml
@@ -6,6 +6,13 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[[bin]]
+name = "todomvc"
+test = false
+doctest = false
+bench = false
+doc = false
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
None of them have any tests and the doc is just a title, but the test runner still took the time to visit them.