### PR TITLE
Normalize imports according to usual coding style

### DIFF
--- a/masonry/src/app/render_root.rs
+++ b/masonry/src/app/render_root.rs
@@ -4,6 +4,7 @@
 use std::collections::{HashMap, VecDeque};
 
 use accesskit::{ActionRequest, TreeUpdate};
+use cursor_icon::CursorIcon;
 use parley::fontique::{self, Blob, Collection, CollectionOptions, SourceCache};
 use parley::{FontContext, LayoutContext};
 use tracing::{info_span, warn};
@@ -36,7 +37,6 @@ use crate::passes::update::{
 };
 use crate::passes::{PassTracing, recurse_on_children};
 use crate::util::AnyMap;
-use cursor_icon::CursorIcon;
 
 /// We ensure that any valid initial IME area is sent to the platform by storing an invalid initial
 /// IME area as the `last_sent_ime_area`.

--- a/masonry/src/core/box_constraints.rs
+++ b/masonry/src/core/box_constraints.rs
@@ -1,6 +1,8 @@
 // Copyright 2019 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
+pub use crate::debug_panic;
+
 use vello::kurbo::Size;
 
 /// Constraints for layout.

--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -18,6 +18,7 @@ use crate::core::{
     FromDynWidget, PropertiesMut, PropertiesRef, ResizeDirection, Widget, WidgetId, WidgetMut,
     WidgetPod, WidgetRef, WidgetState,
 };
+use crate::debug_panic;
 use crate::passes::layout::run_layout_on;
 use crate::peniko::Color;
 use crate::util::{AnyMap, get_debug_color};

--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -10,6 +10,7 @@ use dpi::{LogicalPosition, PhysicalPosition};
 use parley::{FontContext, LayoutContext};
 use tracing::{trace, warn};
 use tree_arena::{ArenaMutList, ArenaRefList};
+use vello::kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
 
 use crate::app::{MutateCallback, RenderRootSignal, RenderRootState};
 use crate::core::{
@@ -20,7 +21,6 @@ use crate::core::{
 use crate::passes::layout::run_layout_on;
 use crate::peniko::Color;
 use crate::util::{AnyMap, get_debug_color};
-use vello::kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
 
 // Note - Most methods defined in this file revolve around `WidgetState` fields.
 // Consider reading `WidgetState` documentation (especially the documented naming scheme)

--- a/masonry/src/core/contexts.rs
+++ b/masonry/src/core/contexts.rs
@@ -17,10 +17,10 @@ use crate::core::{
     FromDynWidget, PropertiesMut, PropertiesRef, ResizeDirection, Widget, WidgetId, WidgetMut,
     WidgetPod, WidgetRef, WidgetState,
 };
-use crate::kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
 use crate::passes::layout::run_layout_on;
 use crate::peniko::Color;
 use crate::util::{AnyMap, get_debug_color};
+use vello::kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
 
 // Note - Most methods defined in this file revolve around `WidgetState` fields.
 // Consider reading `WidgetState` documentation (especially the documented naming scheme)

--- a/masonry/src/core/events.rs
+++ b/masonry/src/core/events.rs
@@ -3,11 +3,11 @@
 
 //! Events.
 
-use crate::dpi::PhysicalSize;
-use crate::util::Duration;
+use ui_events::keyboard::KeyboardEvent;
 use vello::kurbo::Rect;
 
-use ui_events::keyboard::KeyboardEvent;
+use crate::dpi::PhysicalSize;
+use crate::util::Duration;
 
 // TODO - Occluded(bool) event
 // TODO - winit ActivationTokenDone thing

--- a/masonry/src/core/events.rs
+++ b/masonry/src/core/events.rs
@@ -4,8 +4,8 @@
 //! Events.
 
 use crate::dpi::PhysicalSize;
-use crate::kurbo::Rect;
 use crate::util::Duration;
+use vello::kurbo::Rect;
 
 use ui_events::keyboard::KeyboardEvent;
 

--- a/masonry/src/core/object_fit.rs
+++ b/masonry/src/core/object_fit.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::kurbo::{Affine, Size};
+use vello::kurbo::{Affine, Size};
 
 // These are based on https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit
 /// Strategies for inscribing a rectangle inside another rectangle.

--- a/masonry/src/core/properties.rs
+++ b/masonry/src/core/properties.rs
@@ -1,13 +1,12 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::util::AnyMap;
-
 use std::any::TypeId;
 use std::collections::HashMap;
 use std::default::Default;
 
 use crate::core::Widget;
+use crate::util::AnyMap;
 
 /// A marker trait that indicates that a type is intended to be used as a widget's property.
 ///

--- a/masonry/src/core/text.rs
+++ b/masonry/src/core/text.rs
@@ -21,7 +21,7 @@ pub type ArcStr = std::sync::Arc<str>;
 /// This enables updating of brush details without performing relayouts;
 /// the inner values are indexes into the `brushes` argument to [`render_text()`].
 ///
-/// [`Brush`]: crate::parley::Brush
+/// [`Brush`]: parley::Brush
 #[derive(Clone, PartialEq, Default, Debug)]
 pub struct BrushIndex(pub usize);
 

--- a/masonry/src/core/widget.rs
+++ b/masonry/src/core/widget.rs
@@ -12,13 +12,13 @@ use smallvec::SmallVec;
 use tracing::field::DisplayValue;
 use tracing::{Span, trace_span};
 use vello::Scene;
+use vello::kurbo::{Point, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
     UpdateCtx, WidgetRef,
 };
-use vello::kurbo::{Point, Size};
 
 /// A unique identifier for a single [`Widget`].
 ///

--- a/masonry/src/core/widget.rs
+++ b/masonry/src/core/widget.rs
@@ -18,7 +18,7 @@ use crate::core::{
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
     UpdateCtx, WidgetRef,
 };
-use crate::kurbo::{Point, Size};
+use vello::kurbo::{Point, Size};
 
 /// A unique identifier for a single [`Widget`].
 ///

--- a/masonry/src/core/widget_mut.rs
+++ b/masonry/src/core/widget_mut.rs
@@ -3,8 +3,9 @@
 
 use std::any::TypeId;
 
-use crate::core::{FromDynWidget, MutateCtx, Property, Widget};
 use vello::kurbo::Affine;
+
+use crate::core::{FromDynWidget, MutateCtx, Property, Widget};
 
 /// A rich mutable reference to a [`Widget`].
 ///

--- a/masonry/src/core/widget_mut.rs
+++ b/masonry/src/core/widget_mut.rs
@@ -4,7 +4,7 @@
 use std::any::TypeId;
 
 use crate::core::{FromDynWidget, MutateCtx, Property, Widget};
-use crate::kurbo::Affine;
+use vello::kurbo::Affine;
 
 /// A rich mutable reference to a [`Widget`].
 ///

--- a/masonry/src/doc/02_implementing_widget.md
+++ b/masonry/src/doc/02_implementing_widget.md
@@ -441,7 +441,7 @@ The next one is about creating a container widgets, and the complications it add
 [`PaintCtx::size()`]: crate::core::PaintCtx::size
 [`UpdateCtx::request_paint_only()`]: crate::core::UpdateCtx::request_paint_only
 [`ButtonPressed`]: crate::core::Action::ButtonPressed
-[`vello::Scene`]: crate::vello::Scene
+[`vello::Scene`]: vello::Scene
 [`Role::Button`]: accesskit::Role::Button
 [`RenderRoot::edit_root_widget()`]: crate::app::RenderRoot::edit_root_widget
 [`Label::set_text()`]: crate::widgets::Label::set_text

--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -5,10 +5,10 @@ use tracing::{debug, info_span, trace};
 
 use crate::Handled;
 use crate::app::{RenderRoot, RenderRootSignal};
+use crate::core::keyboard::{Key, KeyState, NamedKey};
 use crate::core::{
     AccessEvent, EventCtx, PointerEvent, PointerInfo, PointerUpdate, PropertiesMut, TextEvent,
     Widget, WidgetId,
-    keyboard::{Key, KeyState, NamedKey},
 };
 use crate::dpi::{LogicalPosition, PhysicalPosition};
 use crate::passes::{enter_span, merge_state_up};

--- a/masonry/src/passes/event.rs
+++ b/masonry/src/passes/event.rs
@@ -10,6 +10,7 @@ use crate::core::{
     AccessEvent, EventCtx, PointerEvent, PointerInfo, PointerUpdate, PropertiesMut, TextEvent,
     Widget, WidgetId,
 };
+use crate::debug_panic;
 use crate::dpi::{LogicalPosition, PhysicalPosition};
 use crate::passes::{enter_span, merge_state_up};
 

--- a/masonry/src/passes/layout.rs
+++ b/masonry/src/passes/layout.rs
@@ -12,6 +12,7 @@ use vello::kurbo::{Point, Rect, Size};
 
 use crate::app::{RenderRoot, RenderRootSignal, WindowSizePolicy};
 use crate::core::{BoxConstraints, LayoutCtx, PropertiesMut, Widget, WidgetPod, WidgetState};
+use crate::debug_panic;
 use crate::passes::{enter_span_if, recurse_on_children};
 
 // --- MARK: RUN LAYOUT

--- a/masonry/src/passes/paint.rs
+++ b/masonry/src/passes/paint.rs
@@ -11,9 +11,9 @@ use vello::peniko::{Color, Fill, Mix};
 
 use crate::app::{RenderRoot, RenderRootState};
 use crate::core::{DefaultProperties, PaintCtx, PropertiesRef, Widget, WidgetId, WidgetState};
-use crate::kurbo::Rect;
 use crate::passes::{enter_span_if, recurse_on_children};
 use crate::util::{AnyMap, get_debug_color, stroke};
+use vello::kurbo::Rect;
 
 // --- MARK: PAINT WIDGET
 fn paint_widget(

--- a/masonry/src/passes/paint.rs
+++ b/masonry/src/passes/paint.rs
@@ -6,8 +6,7 @@ use std::collections::HashMap;
 use tracing::{info_span, trace};
 use tree_arena::ArenaMut;
 use vello::Scene;
-use vello::kurbo::Affine;
-use vello::kurbo::Rect;
+use vello::kurbo::{Affine, Rect};
 use vello::peniko::{Color, Fill, Mix};
 
 use crate::app::{RenderRoot, RenderRootState};

--- a/masonry/src/passes/paint.rs
+++ b/masonry/src/passes/paint.rs
@@ -7,13 +7,13 @@ use tracing::{info_span, trace};
 use tree_arena::ArenaMut;
 use vello::Scene;
 use vello::kurbo::Affine;
+use vello::kurbo::Rect;
 use vello::peniko::{Color, Fill, Mix};
 
 use crate::app::{RenderRoot, RenderRootState};
 use crate::core::{DefaultProperties, PaintCtx, PropertiesRef, Widget, WidgetId, WidgetState};
 use crate::passes::{enter_span_if, recurse_on_children};
 use crate::util::{AnyMap, get_debug_color, stroke};
-use vello::kurbo::Rect;
 
 // --- MARK: PAINT WIDGET
 fn paint_widget(

--- a/masonry/src/properties/background.rs
+++ b/masonry/src/properties/background.rs
@@ -3,10 +3,11 @@
 
 use std::any::TypeId;
 
+use vello::kurbo::Rect;
+
 use crate::core::{Property, UpdateCtx};
 use crate::peniko::color::{AlphaColor, Srgb};
 use crate::properties::types::Gradient;
-use vello::kurbo::Rect;
 
 // TODO - Replace "Background" with "BackgroundColor" and move the gradient case
 // to BackgroundImage to match CSS spec.

--- a/masonry/src/properties/background.rs
+++ b/masonry/src/properties/background.rs
@@ -4,9 +4,9 @@
 use std::any::TypeId;
 
 use crate::core::{Property, UpdateCtx};
-use crate::kurbo::Rect;
 use crate::peniko::color::{AlphaColor, Srgb};
 use crate::properties::types::Gradient;
+use vello::kurbo::Rect;
 
 // TODO - Replace "Background" with "BackgroundColor" and move the gradient case
 // to BackgroundImage to match CSS spec.

--- a/masonry/src/properties/border_width.rs
+++ b/masonry/src/properties/border_width.rs
@@ -3,9 +3,10 @@
 
 use std::any::TypeId;
 
+use vello::kurbo::{Point, RoundedRect, Size, Vec2};
+
 use crate::core::{BoxConstraints, Property, UpdateCtx};
 use crate::properties::CornerRadius;
-use vello::kurbo::{Point, RoundedRect, Size, Vec2};
 
 /// The width of a widget's border, in logical pixels.
 #[expect(missing_docs, reason = "obvious")]

--- a/masonry/src/properties/border_width.rs
+++ b/masonry/src/properties/border_width.rs
@@ -4,8 +4,8 @@
 use std::any::TypeId;
 
 use crate::core::{BoxConstraints, Property, UpdateCtx};
-use crate::kurbo::{Point, RoundedRect, Size, Vec2};
 use crate::properties::CornerRadius;
+use vello::kurbo::{Point, RoundedRect, Size, Vec2};
 
 /// The width of a widget's border, in logical pixels.
 #[expect(missing_docs, reason = "obvious")]

--- a/masonry/src/properties/padding.rs
+++ b/masonry/src/properties/padding.rs
@@ -4,7 +4,7 @@
 use std::any::TypeId;
 
 use crate::core::{BoxConstraints, Property, UpdateCtx};
-use crate::kurbo::{Point, Size, Vec2};
+use vello::kurbo::{Point, Size, Vec2};
 
 /// The width of padding between a widget's border and its contents.
 #[derive(Default, Clone, Copy, Debug, PartialEq)]

--- a/masonry/src/properties/padding.rs
+++ b/masonry/src/properties/padding.rs
@@ -3,8 +3,9 @@
 
 use std::any::TypeId;
 
-use crate::core::{BoxConstraints, Property, UpdateCtx};
 use vello::kurbo::{Point, Size, Vec2};
+
+use crate::core::{BoxConstraints, Property, UpdateCtx};
 
 /// The width of padding between a widget's border and its contents.
 #[derive(Default, Clone, Copy, Debug, PartialEq)]

--- a/masonry/src/properties/types/gradient.rs
+++ b/masonry/src/properties/types/gradient.rs
@@ -1,9 +1,10 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+use vello::kurbo::{Point, Rect};
+
 use crate::peniko::color::{ColorSpaceTag, HueDirection};
 use crate::peniko::{ColorStops, ColorStopsSource, Extend};
-use vello::kurbo::{Point, Rect};
 
 /// Properties for the supported [`Gradient`] types.
 ///

--- a/masonry/src/properties/types/gradient.rs
+++ b/masonry/src/properties/types/gradient.rs
@@ -1,9 +1,9 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::kurbo::{Point, Rect};
 use crate::peniko::color::{ColorSpaceTag, HueDirection};
 use crate::peniko::{ColorStops, ColorStopsSource, Extend};
+use vello::kurbo::{Point, Rect};
 
 /// Properties for the supported [`Gradient`] types.
 ///

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -31,10 +31,10 @@ use crate::core::{
     WidgetRef, WindowEvent,
 };
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
-use crate::kurbo::{Point, Size, Vec2};
 use crate::peniko::{Blob, Color};
 use crate::testing::screenshots::get_image_diff;
 use crate::util::Duration;
+use vello::kurbo::{Point, Size, Vec2};
 
 /// A [`PointerInfo`] for a primary mouse, for testing.
 pub const PRIMARY_MOUSE: PointerInfo = PointerInfo {

--- a/masonry/src/testing/harness.rs
+++ b/masonry/src/testing/harness.rs
@@ -15,6 +15,7 @@ use image::{DynamicImage, ImageFormat, ImageReader, Rgba, RgbaImage};
 use oxipng::{Options, optimize_from_memory};
 use tracing::debug;
 use vello::RendererOptions;
+use vello::kurbo::{Point, Size, Vec2};
 use vello::util::{RenderContext, block_on_wgpu};
 use wgpu::{
     BufferDescriptor, BufferUsages, CommandEncoderDescriptor, Extent3d, TexelCopyBufferInfo,
@@ -34,7 +35,6 @@ use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::peniko::{Blob, Color};
 use crate::testing::screenshots::get_image_diff;
 use crate::util::Duration;
-use vello::kurbo::{Point, Size, Vec2};
 
 /// A [`PointerInfo`] for a primary mouse, for testing.
 pub const PRIMARY_MOUSE: PointerInfo = PointerInfo {

--- a/masonry/src/testing/mod.rs
+++ b/masonry/src/testing/mod.rs
@@ -9,8 +9,7 @@ mod recorder_widget;
 mod screenshots;
 mod wrapper_widget;
 
-pub use crate::assert_failing_render_snapshot;
-pub use crate::assert_render_snapshot;
+pub use crate::{assert_failing_render_snapshot, assert_render_snapshot};
 
 pub use harness::{PRIMARY_MOUSE, TestHarness, TestHarnessParams};
 pub use modular_widget::ModularWidget;

--- a/masonry/src/testing/modular_widget.rs
+++ b/masonry/src/testing/modular_widget.rs
@@ -14,7 +14,7 @@ use crate::core::{
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetRef, find_widget_under_pointer,
 };
-use crate::kurbo::{Point, Size};
+use vello::kurbo::{Point, Size};
 
 pub type PointerEventFn<S> =
     dyn FnMut(&mut S, &mut EventCtx, &mut PropertiesMut<'_>, &PointerEvent);

--- a/masonry/src/testing/modular_widget.rs
+++ b/masonry/src/testing/modular_widget.rs
@@ -8,13 +8,13 @@ use cursor_icon::CursorIcon;
 use smallvec::SmallVec;
 use tracing::trace_span;
 use vello::Scene;
+use vello::kurbo::{Point, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetRef, find_widget_under_pointer,
 };
-use vello::kurbo::{Point, Size};
 
 pub type PointerEventFn<S> =
     dyn FnMut(&mut S, &mut EventCtx, &mut PropertiesMut<'_>, &PointerEvent);

--- a/masonry/src/testing/recorder_widget.rs
+++ b/masonry/src/testing/recorder_widget.rs
@@ -17,13 +17,13 @@ use accesskit::{Node, Role};
 use cursor_icon::CursorIcon;
 use smallvec::SmallVec;
 use vello::Scene;
+use vello::kurbo::{Point, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetRef,
 };
-use vello::kurbo::{Point, Size};
 
 /// A wrapper widget that records each time one of its methods is called.
 ///

--- a/masonry/src/testing/recorder_widget.rs
+++ b/masonry/src/testing/recorder_widget.rs
@@ -23,7 +23,7 @@ use crate::core::{
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetRef,
 };
-use crate::kurbo::{Point, Size};
+use vello::kurbo::{Point, Size};
 
 /// A wrapper widget that records each time one of its methods is called.
 ///

--- a/masonry/src/testing/wrapper_widget.rs
+++ b/masonry/src/testing/wrapper_widget.rs
@@ -12,7 +12,7 @@ use crate::core::{
     PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update, UpdateCtx, Widget,
     WidgetId, WidgetMut, WidgetPod,
 };
-use crate::kurbo::{Point, Size};
+use vello::kurbo::{Point, Size};
 
 /// A basic wrapper widget that can replace its child.
 pub struct WrapperWidget {

--- a/masonry/src/testing/wrapper_widget.rs
+++ b/masonry/src/testing/wrapper_widget.rs
@@ -6,13 +6,13 @@ use std::any::TypeId;
 use accesskit::{Node, Role};
 use smallvec::{SmallVec, smallvec};
 use vello::Scene;
+use vello::kurbo::{Point, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update, UpdateCtx, Widget,
     WidgetId, WidgetMut, WidgetPod,
 };
-use vello::kurbo::{Point, Size};
 
 /// A basic wrapper widget that can replace its child.
 pub struct WrapperWidget {

--- a/masonry/src/theme.rs
+++ b/masonry/src/theme.rs
@@ -5,6 +5,9 @@
 
 #![allow(missing_docs, reason = "Names are self-explanatory.")]
 
+use parley::GenericFamily;
+use vello::kurbo::Insets;
+
 use crate::core::{DefaultProperties, StyleProperty, StyleSet};
 use crate::peniko::Color;
 use crate::properties::types::Gradient;
@@ -13,9 +16,6 @@ use crate::properties::{
     HoveredBorderColor, Padding,
 };
 use crate::widgets::Button;
-use vello::kurbo::Insets;
-
-use parley::GenericFamily;
 
 // Colors are from https://sashat.me/2017/01/11/list-of-20-simple-distinct-colors/
 // They're picked for visual distinction and accessibility (99 percent)

--- a/masonry/src/theme.rs
+++ b/masonry/src/theme.rs
@@ -6,7 +6,6 @@
 #![allow(missing_docs, reason = "Names are self-explanatory.")]
 
 use crate::core::{DefaultProperties, StyleProperty, StyleSet};
-use crate::kurbo::Insets;
 use crate::peniko::Color;
 use crate::properties::types::Gradient;
 use crate::properties::{
@@ -14,6 +13,7 @@ use crate::properties::{
     HoveredBorderColor, Padding,
 };
 use crate::widgets::Button;
+use vello::kurbo::Insets;
 
 use parley::GenericFamily;
 

--- a/masonry/src/util.rs
+++ b/masonry/src/util.rs
@@ -164,14 +164,10 @@ pub fn fill_color(scene: &mut Scene, path: &impl Shape, color: Color) {
 // ---
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use std::time::Instant;
-#[cfg(target_arch = "wasm32")]
-pub use web_time::Instant;
+pub use std::time::{Duration, Instant};
 
-#[cfg(not(target_arch = "wasm32"))]
-pub use std::time::Duration;
 #[cfg(target_arch = "wasm32")]
-pub use web_time::Duration;
+pub use web_time::{Duration, Instant};
 
 // ---
 

--- a/masonry/src/util.rs
+++ b/masonry/src/util.rs
@@ -7,10 +7,7 @@ use std::any::Any;
 use std::hash::Hash;
 
 use vello::Scene;
-use vello::kurbo::Join;
-use vello::kurbo::{
-    Affine, Rect, Shape, Stroke, {self},
-};
+use vello::kurbo::{Affine, Join, Point, Rect, Shape, Stroke};
 use vello::peniko::{BrushRef, Color, ColorStopsSource, Fill, Gradient};
 
 /// Panic in debug and `tracing::error` in release mode.
@@ -126,8 +123,8 @@ impl UnitPoint {
     }
 
     /// Given a rectangle, resolve the point within the rectangle.
-    pub fn resolve(self, rect: Rect) -> kurbo::Point {
-        kurbo::Point::new(
+    pub fn resolve(self, rect: Rect) -> Point {
+        Point::new(
             rect.x0 + self.u * (rect.x1 - rect.x0),
             rect.y0 + self.v * (rect.y1 - rect.y0),
         )

--- a/masonry/src/widgets/align.rs
+++ b/masonry/src/widgets/align.rs
@@ -12,13 +12,13 @@ use accesskit::{Node, Role};
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
 use vello::Scene;
+use vello::kurbo::{Rect, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetPod,
 };
 use crate::util::UnitPoint;
-use vello::kurbo::{Rect, Size};
 
 // TODO - Have child widget type as generic argument
 

--- a/masonry/src/widgets/align.rs
+++ b/masonry/src/widgets/align.rs
@@ -17,8 +17,8 @@ use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetPod,
 };
-use crate::kurbo::{Rect, Size};
 use crate::util::UnitPoint;
+use vello::kurbo::{Rect, Size};
 
 // TODO - Have child widget type as generic argument
 

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -10,6 +10,7 @@ use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace, trace_span};
 use vello::Scene;
 use vello::kurbo::Affine;
+use vello::kurbo::Size;
 
 use crate::core::{
     AccessCtx, AccessEvent, Action, ArcStr, BoxConstraints, EventCtx, LayoutCtx, PaintCtx,
@@ -20,7 +21,6 @@ use crate::properties::*;
 use crate::theme;
 use crate::util::{fill, stroke};
 use crate::widgets::Label;
-use vello::kurbo::Size;
 
 /// A button with a text label.
 ///

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -9,8 +9,7 @@ use accesskit::{Node, Role};
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace, trace_span};
 use vello::Scene;
-use vello::kurbo::Affine;
-use vello::kurbo::Size;
+use vello::kurbo::{Affine, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, Action, ArcStr, BoxConstraints, EventCtx, LayoutCtx, PaintCtx,

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -16,11 +16,11 @@ use crate::core::{
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
-use crate::kurbo::Size;
 use crate::properties::*;
 use crate::theme;
 use crate::util::{fill, stroke};
 use crate::widgets::Label;
+use vello::kurbo::Size;
 
 /// A button with a text label.
 ///

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -9,13 +9,13 @@ use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::common::FloatExt;
 use vello::kurbo::{Affine, Line, Stroke, Vec2};
+use vello::kurbo::{Point, Rect, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut,
     WidgetPod,
 };
-use vello::kurbo::{Point, Rect, Size};
 
 /// A container with either horizontal or vertical layout.
 ///

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -8,8 +8,7 @@ use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::common::FloatExt;
-use vello::kurbo::{Affine, Line, Stroke, Vec2};
-use vello::kurbo::{Point, Rect, Size};
+use vello::kurbo::{Affine, Line, Point, Rect, Size, Stroke, Vec2};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -15,6 +15,7 @@ use crate::core::{
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut,
     WidgetPod,
 };
+use crate::debug_panic;
 
 /// A container with either horizontal or vertical layout.
 ///

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -15,7 +15,7 @@ use crate::core::{
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut,
     WidgetPod,
 };
-use crate::kurbo::{Point, Rect, Size};
+use vello::kurbo::{Point, Rect, Size};
 
 /// A container with either horizontal or vertical layout.
 ///

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -12,7 +12,7 @@ use crate::core::{
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut,
     WidgetPod,
 };
-use crate::kurbo::{Point, Size};
+use vello::kurbo::{Point, Size};
 
 /// A widget that arranges its children in a grid.
 ///

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -5,8 +5,7 @@ use accesskit::{Node, Role};
 use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Affine, Line, Stroke};
-use vello::kurbo::{Point, Size};
+use vello::kurbo::{Affine, Line, Point, Size, Stroke};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -6,13 +6,13 @@ use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Affine, Line, Stroke};
+use vello::kurbo::{Point, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut,
     WidgetPod,
 };
-use vello::kurbo::{Point, Size};
 
 /// A widget that arranges its children in a grid.
 ///

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -12,6 +12,7 @@ use crate::core::{
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut,
     WidgetPod,
 };
+use crate::debug_panic;
 
 /// A widget that arranges its children in a grid.
 ///

--- a/masonry/src/widgets/image.rs
+++ b/masonry/src/widgets/image.rs
@@ -16,7 +16,7 @@ use crate::core::{
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget,
     WidgetId, WidgetMut,
 };
-use crate::kurbo::Size;
+use vello::kurbo::Size;
 
 // TODO - Resolve name collision between masonry_winit::Image and peniko::Image
 

--- a/masonry/src/widgets/image.rs
+++ b/masonry/src/widgets/image.rs
@@ -9,6 +9,7 @@ use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::Affine;
+use vello::kurbo::Size;
 use vello::peniko::{BlendMode, Image as ImageBuf};
 
 use crate::core::{
@@ -16,7 +17,6 @@ use crate::core::{
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget,
     WidgetId, WidgetMut,
 };
-use vello::kurbo::Size;
 
 // TODO - Resolve name collision between masonry_winit::Image and peniko::Image
 

--- a/masonry/src/widgets/image.rs
+++ b/masonry/src/widgets/image.rs
@@ -8,8 +8,7 @@ use accesskit::{Node, Role};
 use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::Affine;
-use vello::kurbo::Size;
+use vello::kurbo::{Affine, Size};
 use vello::peniko::{BlendMode, Image as ImageBuf};
 
 use crate::core::{

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -19,6 +19,7 @@ use crate::core::{
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, StyleProperty, StyleSet,
     TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut, render_text,
 };
+use crate::debug_panic;
 use crate::theme;
 use crate::theme::default_text_styles;
 

--- a/masonry/src/widgets/progress_bar.rs
+++ b/masonry/src/widgets/progress_bar.rs
@@ -7,6 +7,7 @@ use accesskit::{Node, Role};
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
 use vello::Scene;
+use vello::kurbo::{Point, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, ArcStr, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
@@ -16,7 +17,6 @@ use crate::core::{
 use crate::theme;
 use crate::util::{UnitPoint, fill_lin_gradient, stroke};
 use crate::widgets::{Label, LineBreaking};
-use vello::kurbo::{Point, Size};
 
 // TODO - NaN probably shouldn't be a meaningful value in our API.
 

--- a/masonry/src/widgets/progress_bar.rs
+++ b/masonry/src/widgets/progress_bar.rs
@@ -13,10 +13,10 @@ use crate::core::{
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget,
     WidgetId, WidgetMut, WidgetPod,
 };
-use crate::kurbo::{Point, Size};
 use crate::theme;
 use crate::util::{UnitPoint, fill_lin_gradient, stroke};
 use crate::widgets::{Label, LineBreaking};
+use vello::kurbo::{Point, Size};
 
 // TODO - NaN probably shouldn't be a meaningful value in our API.
 

--- a/masonry/src/widgets/root_widget.rs
+++ b/masonry/src/widgets/root_widget.rs
@@ -7,8 +7,7 @@ use accesskit::{Node, Role};
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::Point;
-use vello::kurbo::Size;
+use vello::kurbo::{Point, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,

--- a/masonry/src/widgets/root_widget.rs
+++ b/masonry/src/widgets/root_widget.rs
@@ -14,9 +14,9 @@ use crate::core::{
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, UpdateCtx, Widget, WidgetId,
     WidgetMut, WidgetPod,
 };
-use crate::kurbo::Size;
 use crate::properties::{Background, Padding};
 use crate::util::fill;
+use vello::kurbo::Size;
 
 /// A wrapper Widget which app drivers can wrap around the rest of the widget tree.
 ///

--- a/masonry/src/widgets/root_widget.rs
+++ b/masonry/src/widgets/root_widget.rs
@@ -8,6 +8,7 @@ use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::Point;
+use vello::kurbo::Size;
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
@@ -16,7 +17,6 @@ use crate::core::{
 };
 use crate::properties::{Background, Padding};
 use crate::util::fill;
-use vello::kurbo::Size;
 
 /// A wrapper Widget which app drivers can wrap around the rest of the widget tree.
 ///

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -5,8 +5,7 @@ use accesskit::{Node, Role};
 use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::Rect;
-use vello::kurbo::{Point, Size};
+use vello::kurbo::{Point, Rect, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, AllowRawMut, BoxConstraints, EventCtx, LayoutCtx, PaintCtx,

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -12,10 +12,10 @@ use crate::core::{
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetMut,
 };
-use crate::kurbo::{Point, Size};
 use crate::theme;
 use crate::util::{fill_color, stroke};
 use crate::widgets::Axis;
+use vello::kurbo::{Point, Size};
 
 // TODO
 // - Fade scrollbars? Find out how Linux/macOS/Windows do it

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -6,6 +6,7 @@ use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::Rect;
+use vello::kurbo::{Point, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, AllowRawMut, BoxConstraints, EventCtx, LayoutCtx, PaintCtx,
@@ -15,7 +16,6 @@ use crate::core::{
 use crate::theme;
 use crate::util::{fill_color, stroke};
 use crate::widgets::Axis;
-use vello::kurbo::{Point, Size};
 
 // TODO
 // - Fade scrollbars? Find out how Linux/macOS/Windows do it

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -10,6 +10,7 @@ use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span, warn};
 use vello::Scene;
 use vello::kurbo::{Affine, RoundedRectRadii};
+use vello::kurbo::{Point, Size};
 use vello::peniko::{Brush, Fill};
 
 use crate::core::{
@@ -19,7 +20,6 @@ use crate::core::{
 };
 use crate::properties::{Background, Padding};
 use crate::util::stroke;
-use vello::kurbo::{Point, Size};
 
 // FIXME - Improve all doc in this module ASAP.
 

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -9,8 +9,7 @@ use accesskit::{Node, Role};
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span, warn};
 use vello::Scene;
-use vello::kurbo::{Affine, RoundedRectRadii};
-use vello::kurbo::{Point, Size};
+use vello::kurbo::{Affine, Point, RoundedRectRadii, Size};
 use vello::peniko::{Brush, Fill};
 
 use crate::core::{

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -17,9 +17,9 @@ use crate::core::{
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, UpdateCtx, Widget, WidgetId,
     WidgetMut, WidgetPod,
 };
-use crate::kurbo::{Point, Size};
 use crate::properties::{Background, Padding};
 use crate::util::stroke;
+use vello::kurbo::{Point, Size};
 
 // FIXME - Improve all doc in this module ASAP.
 

--- a/masonry/src/widgets/spinner.rs
+++ b/masonry/src/widgets/spinner.rs
@@ -16,9 +16,9 @@ use crate::core::{
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget,
     WidgetId, WidgetMut,
 };
-use crate::kurbo::{Point, Size, Vec2};
 use crate::peniko::Color;
 use crate::theme;
+use vello::kurbo::{Point, Size, Vec2};
 
 /// An animated spinner widget for showing a loading state.
 ///

--- a/masonry/src/widgets/spinner.rs
+++ b/masonry/src/widgets/spinner.rs
@@ -9,8 +9,7 @@ use accesskit::{Node, Role};
 use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Affine, Cap, Line, Stroke};
-use vello::kurbo::{Point, Size, Vec2};
+use vello::kurbo::{Affine, Cap, Line, Point, Size, Stroke, Vec2};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,

--- a/masonry/src/widgets/spinner.rs
+++ b/masonry/src/widgets/spinner.rs
@@ -10,6 +10,7 @@ use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Affine, Cap, Line, Stroke};
+use vello::kurbo::{Point, Size, Vec2};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
@@ -18,7 +19,6 @@ use crate::core::{
 };
 use crate::peniko::Color;
 use crate::theme;
-use vello::kurbo::{Point, Size, Vec2};
 
 /// An animated spinner widget for showing a loading state.
 ///

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -4,9 +4,11 @@
 //! A widget which splits an area in two, with a settable ratio, and optional draggable resizing.
 
 use accesskit::{Node, Role};
+use cursor_icon::CursorIcon;
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span, warn};
 use vello::Scene;
+use vello::kurbo::{Line, Point, Rect, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, FromDynWidget, LayoutCtx, PaintCtx,
@@ -17,8 +19,6 @@ use crate::peniko::Color;
 use crate::theme;
 use crate::util::{fill_color, stroke};
 use crate::widgets::flex::Axis;
-use cursor_icon::CursorIcon;
-use vello::kurbo::{Line, Point, Rect, Size};
 
 /// A container containing two other widgets, splitting the area either horizontally or vertically.
 ///

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -13,12 +13,12 @@ use crate::core::{
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId,
     WidgetMut, WidgetPod,
 };
-use crate::kurbo::{Line, Point, Rect, Size};
 use crate::peniko::Color;
 use crate::theme;
 use crate::util::{fill_color, stroke};
 use crate::widgets::flex::Axis;
 use cursor_icon::CursorIcon;
+use vello::kurbo::{Line, Point, Rect, Size};
 
 /// A container containing two other widgets, splitting the area either horizontally or vertically.
 ///

--- a/masonry/src/widgets/tests/safety_rails.rs
+++ b/masonry/src/widgets/tests/safety_rails.rs
@@ -4,10 +4,10 @@
 use smallvec::smallvec;
 
 use crate::core::{PointerButton, Update, Widget, WidgetId, WidgetPod};
-use crate::kurbo::{Point, Size};
 use crate::testing::{ModularWidget, TestHarness, TestWidgetExt};
 use crate::theme::default_property_set;
 use crate::widgets::Flex;
+use vello::kurbo::{Point, Size};
 
 fn make_parent_widget<W: Widget>(child: W) -> ModularWidget<WidgetPod<W>> {
     let child = WidgetPod::new(child);

--- a/masonry/src/widgets/tests/safety_rails.rs
+++ b/masonry/src/widgets/tests/safety_rails.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use smallvec::smallvec;
+use vello::kurbo::{Point, Size};
 
 use crate::core::{PointerButton, Update, Widget, WidgetId, WidgetPod};
 use crate::testing::{ModularWidget, TestHarness, TestWidgetExt};
 use crate::theme::default_property_set;
 use crate::widgets::Flex;
-use vello::kurbo::{Point, Size};
 
 fn make_parent_widget<W: Widget>(child: W) -> ModularWidget<WidgetPod<W>> {
     let child = WidgetPod::new(child);

--- a/masonry/src/widgets/tests/status_change.rs
+++ b/masonry/src/widgets/tests/status_change.rs
@@ -4,12 +4,12 @@
 use assert_matches::assert_matches;
 
 use crate::core::{PointerButton, PointerEvent, Update, WidgetId};
-use crate::kurbo::Vec2;
 use crate::testing::{
     PRIMARY_MOUSE, Record, Recording, TestHarness, TestWidgetExt as _, widget_ids,
 };
 use crate::theme::default_property_set;
 use crate::widgets::{Button, Flex, SizedBox};
+use vello::kurbo::Vec2;
 
 fn next_pointer_event(recording: &Recording) -> Option<PointerEvent> {
     while let Some(event) = recording.next() {

--- a/masonry/src/widgets/tests/status_change.rs
+++ b/masonry/src/widgets/tests/status_change.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use assert_matches::assert_matches;
+use vello::kurbo::Vec2;
 
 use crate::core::{PointerButton, PointerEvent, Update, WidgetId};
 use crate::testing::{
@@ -9,7 +10,6 @@ use crate::testing::{
 };
 use crate::theme::default_property_set;
 use crate::widgets::{Button, Flex, SizedBox};
-use vello::kurbo::Vec2;
 
 fn next_pointer_event(recording: &Recording) -> Option<PointerEvent> {
     while let Some(event) = recording.next() {

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -21,6 +21,7 @@ use crate::core::{
     PointerButton, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx,
     StyleProperty, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut, render_text,
 };
+use crate::debug_panic;
 use crate::theme::default_text_styles;
 use crate::{palette, theme};
 

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -5,6 +5,7 @@ use std::mem::Discriminant;
 use std::time::Instant;
 
 use accesskit::{Node, NodeId, Role};
+use cursor_icon::CursorIcon;
 use parley::PlainEditor;
 use parley::editor::{Generation, SplitString};
 use parley::layout::Alignment;
@@ -22,7 +23,6 @@ use crate::core::{
 };
 use crate::theme::default_text_styles;
 use crate::{palette, theme};
-use cursor_icon::CursorIcon;
 
 /// `TextArea` implements the core of interactive text.
 ///

--- a/masonry/src/widgets/variable_label.rs
+++ b/masonry/src/widgets/variable_label.rs
@@ -6,6 +6,7 @@
 use std::cmp::Ordering;
 
 use accesskit::{Node, Role};
+use parley::style::FontWeight;
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
 use vello::Scene;
@@ -16,7 +17,6 @@ use crate::core::{
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, StyleProperty, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
-use crate::parley::style::FontWeight;
 use crate::widgets::Label;
 
 /// An `f32` value which can move towards a target value at a linear rate over time.

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -3,7 +3,8 @@
 
 #![warn(missing_docs)]
 
-use std::{collections::HashMap, ops::Range};
+use std::collections::HashMap;
+use std::ops::Range;
 
 use vello::kurbo::{Point, Size, Vec2};
 

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -14,6 +14,7 @@ use crate::core::{
     PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, ScrollDelta, TextEvent,
     Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
+use crate::debug_panic;
 
 /// The action type sent by the [`VirtualScroll`] widget.
 ///

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -4,13 +4,13 @@
 use accesskit::{Node, Role};
 use smallvec::SmallVec;
 use tracing::trace_span;
+use vello::Scene;
 use vello::kurbo::{Point, Size};
 
 use crate::core::{
     AccessCtx, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef, QueryCtx,
     RegisterCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
-use crate::vello::Scene;
 
 struct Child {
     widget: WidgetPod<dyn Widget>,

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -9,8 +9,8 @@ use crate::core::{
     AccessCtx, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef, QueryCtx,
     RegisterCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
-use crate::kurbo::{Point, Size};
 use crate::vello::Scene;
+use vello::kurbo::{Point, Size};
 
 struct Child {
     widget: WidgetPod<dyn Widget>,

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -4,13 +4,13 @@
 use accesskit::{Node, Role};
 use smallvec::SmallVec;
 use tracing::trace_span;
+use vello::kurbo::{Point, Size};
 
 use crate::core::{
     AccessCtx, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef, QueryCtx,
     RegisterCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::vello::Scene;
-use vello::kurbo::{Point, Size};
 
 struct Child {
     widget: WidgetPod<dyn Widget>,

--- a/masonry_winit/examples/virtual_fizzbuzz.rs
+++ b/masonry_winit/examples/virtual_fizzbuzz.rs
@@ -13,7 +13,6 @@ use masonry_winit::app::{AppDriver, DriverCtx};
 use masonry_winit::core::{Action, ArcStr, StyleProperty, WidgetId, WidgetPod};
 use masonry_winit::dpi::LogicalSize;
 use masonry_winit::widgets::{Label, RootWidget, VirtualScroll, VirtualScrollAction};
-
 use winit::window::Window;
 
 /// The widget kind contained in the scroll area. This is a type parameter (`W`) of [`VirtualScroll`],

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -10,6 +10,7 @@ use masonry::core::DefaultProperties;
 use masonry::theme::default_property_set;
 use masonry::util::Instant;
 use tracing::{debug, error, info, info_span};
+use ui_events_winit::{WindowEventReducer, WindowEventTranslation};
 use vello::kurbo::Affine;
 use vello::util::{RenderContext, RenderSurface};
 use vello::{AaSupport, RenderParams, Renderer, RendererOptions, Scene};
@@ -26,7 +27,6 @@ use crate::app::{
 };
 use crate::core::{TextEvent, Widget, WidgetId, WindowEvent};
 use crate::peniko::Color;
-use ui_events_winit::{WindowEventReducer, WindowEventTranslation};
 
 #[derive(Debug)]
 pub enum MasonryUserEvent {

--- a/xilem/src/view/virtual_scroll.rs
+++ b/xilem/src/view/virtual_scroll.rs
@@ -3,10 +3,8 @@
 
 use std::{collections::HashMap, marker::PhantomData, ops::Range};
 
-use masonry_winit::{
-    core::{FromDynWidget, Widget, WidgetPod},
-    widgets::{self, VirtualScrollAction},
-};
+use masonry_winit::core::{FromDynWidget, Widget, WidgetPod};
+use masonry_winit::widgets::{self, VirtualScrollAction};
 use private::VirtualScrollState;
 use xilem_core::{AsyncCtx, DynMessage, MessageResult, View, ViewId, ViewMarker, ViewPathTracker};
 


### PR DESCRIPTION
Replace `crate::vello/kurbo/parley` with `vello/kurbo/parley`.
Group imports with the usual std-imports-crate grouping.
Import `debug_panic` manually in each file instead of using syntactic macro lookup.

These changes will make the crate split easier.