### PR TITLE
Move WidgetRef test to dedicated file

### DIFF
--- a/masonry/src/core/widget_ref.rs
+++ b/masonry/src/core/widget_ref.rs
@@ -193,24 +193,3 @@ impl WidgetRef<'_, dyn Widget> {
         self.widget.find_widget_under_pointer(self.ctx, pos)
     }
 }
-
-// --- MARK: TESTS
-#[cfg(test)]
-mod tests {
-    use assert_matches::assert_matches;
-
-    use crate::testing::{TestHarness, TestWidgetExt as _, widget_ids};
-    use crate::theme::default_property_set;
-    use crate::widgets::{Button, Label};
-
-    #[test]
-    fn downcast_ref_in_harness() {
-        let [label_id] = widget_ids();
-        let label = Label::new("Hello").with_id(label_id);
-
-        let harness = TestHarness::create(default_property_set(), label);
-
-        assert_matches!(harness.get_widget(label_id).downcast::<Label>(), Some(_));
-        assert_matches!(harness.get_widget(label_id).downcast::<Button>(), None);
-    }
-}

--- a/masonry/src/widgets/tests/widget_ref.rs
+++ b/masonry/src/widgets/tests/widget_ref.rs
@@ -1,0 +1,19 @@
+// Copyright 2025 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use assert_matches::assert_matches;
+
+use crate::testing::{TestHarness, TestWidgetExt as _, widget_ids};
+use crate::theme::default_property_set;
+use crate::widgets::{Button, Label};
+
+#[test]
+fn downcast_ref_in_harness() {
+    let [label_id] = widget_ids();
+    let label = Label::new("Hello").with_id(label_id);
+
+    let harness = TestHarness::create(default_property_set(), label);
+
+    assert_matches!(harness.get_widget(label_id).downcast::<Label>(), Some(_));
+    assert_matches!(harness.get_widget(label_id).downcast::<Button>(), None);
+}


### PR DESCRIPTION
This is in preparation for the crate split, after which TestHarness won't be available from widget_ref.rs anymore.