### PR TITLE
`masonry_winit`: Stop exporting `masonry`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4934,6 +4934,7 @@ dependencies = [
  "accesskit",
  "anyhow",
  "image",
+ "masonry",
  "masonry_winit",
  "profiling",
  "reqwest",

--- a/masonry/src/doc/01_creating_app.md
+++ b/masonry/src/doc/01_creating_app.md
@@ -45,7 +45,7 @@ Let's start with the `main()` function.
 fn main() {
     const VERTICAL_WIDGET_SPACING: f64 = 20.0;
 
-    use masonry_winit::widgets::{Button, Flex, Portal, RootWidget, Textbox};
+    use masonry::widgets::{Button, Flex, Portal, RootWidget, Textbox};
 
     let main_widget = Portal::new(
         Flex::column()
@@ -96,10 +96,10 @@ That method gives our app a `DriverCtx` context, which we can use to access the 
 We create a `Driver` struct to store a very simple app's state, and we implement the `AppDriver` trait for it:
 
 ```rust,ignore
+use masonry::core::{Action, WidgetId};
+use masonry::widgets::Label;
+# use masonry::widgets::{Button, Flex, Portal, RootWidget, Textbox};
 use masonry_winit::app::{AppDriver, DriverCtx};
-use masonry_winit::core::{Action, WidgetId};
-use masonry_winit::widgets::Label;
-# use masonry_winit::widgets::{Button, Flex, Portal, RootWidget, Textbox};
 
 struct Driver {
     next_task: String,
@@ -171,7 +171,7 @@ In our main function, we create a `Driver` and pass it to `event_loop_runner::ru
 The last step is to create our Winit window and start our main loop.
 
 ```rust,ignore
-    use masonry_winit::dpi::LogicalSize;
+    use masonry::dpi::LogicalSize;
     use winit::window::Window;
 
     let window_attributes = Window::default_attributes()
@@ -194,7 +194,7 @@ Our complete program therefore looks like this:
 fn main() {
     const VERTICAL_WIDGET_SPACING: f64 = 20.0;
 
-    use masonry_winit::widgets::{Button, Flex, Portal, RootWidget, Textbox};
+    use masonry::widgets::{Button, Flex, Portal, RootWidget, Textbox};
 
     let main_widget = Portal::new(
         Flex::column()
@@ -207,9 +207,9 @@ fn main() {
     );
     let main_widget = RootWidget::new(main_widget);
 
+    use masonry::core::{Action, WidgetId};
+    use masonry::widgets::Label;
     use masonry_winit::app::{AppDriver, DriverCtx};
-    use masonry_winit::core::{Action, WidgetId};
-    use masonry_winit::widgets::Label;
 
     struct Driver {
         next_task: String,
@@ -239,7 +239,7 @@ fn main() {
         next_task: String::new(),
     };
 
-    use masonry_winit::dpi::LogicalSize;
+    use masonry::dpi::LogicalSize;
     use winit::window::Window;
 
     let window_attributes = Window::default_attributes()

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -944,7 +944,7 @@ fn new_flex_child(params: FlexParams, widget: WidgetPod<dyn Widget>) -> Child {
             }
         } else {
             tracing::warn!(
-                "Flex value should be > 0.0 (was {flex}). See the docs for masonry_winit::widgets::Flex for more information"
+                "Flex value should be > 0.0 (was {flex}). See the docs for masonry::widgets::Flex for more information"
             );
             Child::Fixed {
                 widget,

--- a/masonry/src/widgets/image.rs
+++ b/masonry/src/widgets/image.rs
@@ -17,7 +17,7 @@ use crate::core::{
     WidgetId, WidgetMut,
 };
 
-// TODO - Resolve name collision between masonry_winit::Image and peniko::Image
+// TODO - Resolve name collision between masonry::Image and peniko::Image
 
 /// A widget that renders a bitmap Image.
 ///

--- a/masonry_winit/README.md
+++ b/masonry_winit/README.md
@@ -41,9 +41,9 @@ The to-do-list example looks like this:
 
 ```rust
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use masonry_winit::core::{Action, Widget, WidgetId};
-use masonry_winit::dpi::LogicalSize;
-use masonry_winit::widgets::{Button, Flex, Label, Portal, RootWidget, Textbox};
+use masonry::core::{Action, Widget, WidgetId};
+use masonry::dpi::LogicalSize;
+use masonry::widgets::{Button, Flex, Label, Portal, RootWidget, Textbox};
 use winit::window::Window;
 
 struct Driver {

--- a/masonry_winit/examples/calc_masonry.rs
+++ b/masonry_winit/examples/calc_masonry.rs
@@ -15,20 +15,20 @@
 use std::str::FromStr;
 
 use masonry::accesskit::{Node, Role};
-use masonry::smallvec::{SmallVec, smallvec};
-use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use masonry_winit::core::{
+use masonry::core::{
     AccessCtx, AccessEvent, Action, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, StyleProperty, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetPod,
 };
-use masonry_winit::dpi::LogicalSize;
-use masonry_winit::kurbo::{Point, Size};
-use masonry_winit::peniko::Color;
-use masonry_winit::peniko::color::AlphaColor;
-use masonry_winit::properties::{Background, Padding};
-use masonry_winit::theme::default_property_set;
-use masonry_winit::widgets::{Align, CrossAxisAlignment, Flex, Label, RootWidget, SizedBox};
+use masonry::dpi::LogicalSize;
+use masonry::kurbo::{Point, Size};
+use masonry::peniko::Color;
+use masonry::peniko::color::AlphaColor;
+use masonry::properties::{Background, Padding};
+use masonry::smallvec::{SmallVec, smallvec};
+use masonry::theme::default_property_set;
+use masonry::widgets::{Align, CrossAxisAlignment, Flex, Label, RootWidget, SizedBox};
+use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
 use tracing::{Span, trace, trace_span};
 use vello::Scene;
 use winit::window::Window;
@@ -455,9 +455,9 @@ fn main() {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use masonry_winit::assert_render_snapshot;
-    use masonry_winit::testing::TestHarness;
-    use masonry_winit::theme::default_property_set;
+    use masonry::assert_render_snapshot;
+    use masonry::testing::TestHarness;
+    use masonry::theme::default_property_set;
 
     use super::*;
 

--- a/masonry_winit/examples/custom_widget.rs
+++ b/masonry_winit/examples/custom_widget.rs
@@ -10,16 +10,16 @@
 #![expect(clippy::cast_possible_truncation, reason = "Deferred: Noisy")]
 
 use masonry::accesskit::{Node, Role};
-use masonry::smallvec::SmallVec;
-use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use masonry_winit::core::{
+use masonry::core::{
     AccessCtx, AccessEvent, Action, BoxConstraints, EventCtx, LayoutCtx, ObjectFit, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId,
 };
-use masonry_winit::kurbo::{Affine, BezPath, Point, Rect, Size, Stroke};
-use masonry_winit::palette;
-use masonry_winit::peniko::Color;
-use masonry_winit::widgets::RootWidget;
+use masonry::kurbo::{Affine, BezPath, Point, Rect, Size, Stroke};
+use masonry::palette;
+use masonry::peniko::Color;
+use masonry::smallvec::SmallVec;
+use masonry::widgets::RootWidget;
+use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
 use parley::layout::{Alignment, AlignmentOptions};
 use parley::style::{FontFamily, FontStack, StyleProperty};
 use tracing::{Span, trace_span};
@@ -147,7 +147,7 @@ impl Widget for CustomWidget {
         text_layout.align(None, Alignment::Start, AlignmentOptions::default());
 
         // We can pass a transform matrix to rotate the text we render
-        masonry_winit::core::render_text(
+        masonry::core::render_text(
             scene,
             Affine::rotate(std::f64::consts::FRAC_PI_4).then_translate((80.0, 40.0).into()),
             &text_layout,
@@ -215,9 +215,9 @@ fn make_image_data(width: usize, height: usize) -> Vec<u8> {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use masonry_winit::assert_render_snapshot;
-    use masonry_winit::testing::TestHarness;
-    use masonry_winit::theme::default_property_set;
+    use masonry::assert_render_snapshot;
+    use masonry::testing::TestHarness;
+    use masonry::theme::default_property_set;
 
     use super::*;
 

--- a/masonry_winit/examples/grid_masonry.rs
+++ b/masonry_winit/examples/grid_masonry.rs
@@ -5,11 +5,11 @@
 
 // On Windows platform, don't show a console when opening the app.
 #![cfg_attr(not(test), windows_subsystem = "windows")]
+use masonry::core::{Action, PointerButton, StyleProperty, WidgetId};
+use masonry::dpi::LogicalSize;
+use masonry::peniko::Color;
+use masonry::widgets::{Button, Grid, GridParams, Prose, RootWidget, SizedBox, TextArea};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use masonry_winit::core::{Action, PointerButton, StyleProperty, WidgetId};
-use masonry_winit::dpi::LogicalSize;
-use masonry_winit::peniko::Color;
-use masonry_winit::widgets::{Button, Grid, GridParams, Prose, RootWidget, SizedBox, TextArea};
 use parley::layout::Alignment;
 use winit::window::Window;
 
@@ -144,9 +144,9 @@ fn main() {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use masonry_winit::assert_render_snapshot;
-    use masonry_winit::testing::TestHarness;
-    use masonry_winit::theme::default_property_set;
+    use masonry::assert_render_snapshot;
+    use masonry::testing::TestHarness;
+    use masonry::theme::default_property_set;
 
     use super::*;
 

--- a/masonry_winit/examples/hello_masonry.rs
+++ b/masonry_winit/examples/hello_masonry.rs
@@ -7,11 +7,11 @@
 // On Windows platform, don't show a console when opening the app.
 #![windows_subsystem = "windows"]
 
+use masonry::core::{Action, StyleProperty, WidgetId};
+use masonry::dpi::LogicalSize;
+use masonry::parley::style::FontWeight;
+use masonry::widgets::{Button, Flex, Label, RootWidget};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use masonry_winit::core::{Action, StyleProperty, WidgetId};
-use masonry_winit::dpi::LogicalSize;
-use masonry_winit::parley::style::FontWeight;
-use masonry_winit::widgets::{Button, Flex, Label, RootWidget};
 use winit::window::Window;
 
 const VERTICAL_WIDGET_SPACING: f64 = 20.0;

--- a/masonry_winit/examples/simple_image.rs
+++ b/masonry_winit/examples/simple_image.rs
@@ -8,10 +8,10 @@
 // On Windows platform, don't show a console when opening the app.
 #![cfg_attr(not(test), windows_subsystem = "windows")]
 
+use masonry::core::{Action, ObjectFit, WidgetId};
+use masonry::dpi::LogicalSize;
+use masonry::widgets::{Image, RootWidget};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use masonry_winit::core::{Action, ObjectFit, WidgetId};
-use masonry_winit::dpi::LogicalSize;
-use masonry_winit::widgets::{Image, RootWidget};
 use vello::peniko::{Image as ImageBuf, ImageFormat};
 use winit::window::Window;
 
@@ -64,9 +64,9 @@ fn main() {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use masonry_winit::assert_render_snapshot;
-    use masonry_winit::testing::TestHarness;
-    use masonry_winit::theme::default_property_set;
+    use masonry::assert_render_snapshot;
+    use masonry::testing::TestHarness;
+    use masonry::theme::default_property_set;
 
     use super::*;
 

--- a/masonry_winit/examples/to_do_list.rs
+++ b/masonry_winit/examples/to_do_list.rs
@@ -7,10 +7,10 @@
 // On Windows platform, don't show a console when opening the app.
 #![cfg_attr(not(test), windows_subsystem = "windows")]
 
+use masonry::core::{Action, Widget, WidgetId};
+use masonry::dpi::LogicalSize;
+use masonry::widgets::{Button, Flex, Label, Portal, RootWidget, TextArea, Textbox};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use masonry_winit::core::{Action, Widget, WidgetId};
-use masonry_winit::dpi::LogicalSize;
-use masonry_winit::widgets::{Button, Flex, Label, Portal, RootWidget, TextArea, Textbox};
 use winit::window::Window;
 
 const VERTICAL_WIDGET_SPACING: f64 = 20.0;
@@ -93,9 +93,9 @@ fn main() {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use masonry_winit::assert_render_snapshot;
-    use masonry_winit::testing::TestHarness;
-    use masonry_winit::theme::default_property_set;
+    use masonry::assert_render_snapshot;
+    use masonry::testing::TestHarness;
+    use masonry::theme::default_property_set;
 
     use super::*;
 

--- a/masonry_winit/examples/two_textboxes.rs
+++ b/masonry_winit/examples/two_textboxes.rs
@@ -7,10 +7,10 @@
 // On Windows platform, don't show a console when opening the app.
 #![windows_subsystem = "windows"]
 
+use masonry::core::{Action, WidgetId};
+use masonry::dpi::LogicalSize;
+use masonry::widgets::{Flex, RootWidget, Textbox};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use masonry_winit::core::{Action, WidgetId};
-use masonry_winit::dpi::LogicalSize;
-use masonry_winit::widgets::{Flex, RootWidget, Textbox};
 use winit::window::Window;
 
 const VERTICAL_WIDGET_SPACING: f64 = 20.0;

--- a/masonry_winit/examples/virtual_fizzbuzz.rs
+++ b/masonry_winit/examples/virtual_fizzbuzz.rs
@@ -9,14 +9,14 @@
 // On Windows platform, don't show a console when opening the app.
 #![windows_subsystem = "windows"]
 
+use masonry::core::{Action, ArcStr, StyleProperty, WidgetId, WidgetPod};
+use masonry::dpi::LogicalSize;
+use masonry::widgets::{Label, RootWidget, VirtualScroll, VirtualScrollAction};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use masonry_winit::core::{Action, ArcStr, StyleProperty, WidgetId, WidgetPod};
-use masonry_winit::dpi::LogicalSize;
-use masonry_winit::widgets::{Label, RootWidget, VirtualScroll, VirtualScrollAction};
 use winit::window::Window;
 
 /// The widget kind contained in the scroll area. This is a type parameter (`W`) of [`VirtualScroll`],
-/// although note that [`dyn Widget`](masonry_winit::core::Widget) can also be used for dynamic children kinds.
+/// although note that [`dyn Widget`](masonry::core::Widget) can also be used for dynamic children kinds.
 ///
 /// We use a type alias for this, as when we downcast to the `VirtualScroll`, we need to be sure to
 /// always use the same type for `W`.

--- a/masonry_winit/src/app_driver.rs
+++ b/masonry_winit/src/app_driver.rs
@@ -6,13 +6,13 @@ use std::hash::Hash;
 use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use masonry::core::Widget;
+use masonry::app::RenderRoot;
+use masonry::core::{Action, Widget, WidgetId};
 use tracing::field::DisplayValue;
 use winit::event_loop::ActiveEventLoop;
 use winit::window::{Window as WindowHandle, WindowAttributes};
 
-use crate::app::{MasonryState, RenderRoot};
-use crate::core::{Action, WidgetId};
+use crate::app::MasonryState;
 use crate::event_loop_runner::WindowState;
 
 /// A unique and persistent identifier for a window.

--- a/masonry_winit/src/convert_winit_event.rs
+++ b/masonry_winit/src/convert_winit_event.rs
@@ -5,10 +5,9 @@
 // https://github.com/DioxusLabs/blitz/blob/main/packages/blitz-shell/src/convert_events.rs
 // Should be removed once https://github.com/rust-windowing/winit/pull/4026 is merged.
 
+use masonry::core::{Ime, ResizeDirection};
 use winit::event::Ime as WinitIme;
 use winit::window::ResizeDirection as WinitResizeDirection;
-
-use crate::core::{Ime, ResizeDirection};
 
 pub(crate) fn masonry_resize_direction_to_winit(dir: ResizeDirection) -> WinitResizeDirection {
     match dir {

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -9,12 +9,14 @@ use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex, mpsc};
 
 use accesskit_winit::Adapter;
-use masonry::core::DefaultProperties;
+use masonry::app::{RenderRoot, RenderRootOptions, RenderRootSignal};
+use masonry::core::{DefaultProperties, TextEvent, Widget, WidgetId, WindowEvent};
 use masonry::theme::default_property_set;
 use masonry::util::Instant;
 use tracing::{debug, error, info, info_span};
 use ui_events_winit::{WindowEventReducer, WindowEventTranslation};
 use vello::kurbo::Affine;
+use vello::peniko::Color;
 use vello::util::{RenderContext, RenderSurface};
 use vello::{AaSupport, RenderParams, Renderer, RendererOptions, Scene};
 use wgpu::PresentMode;
@@ -25,18 +27,15 @@ use winit::event_loop::ActiveEventLoop;
 use winit::window::{Window as WindowHandle, WindowAttributes, WindowId as HandleId};
 
 use crate::app::{
-    AppDriver, DriverCtx, RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy,
-    masonry_resize_direction_to_winit, winit_ime_to_masonry,
+    AppDriver, DriverCtx, WindowSizePolicy, masonry_resize_direction_to_winit, winit_ime_to_masonry,
 };
 use crate::app_driver::WindowId;
-use crate::core::{TextEvent, Widget, WidgetId, WindowEvent};
-use crate::peniko::Color;
 
 #[derive(Debug)]
 pub enum MasonryUserEvent {
     AccessKit(HandleId, accesskit_winit::WindowEvent),
     // TODO: A more considered design here
-    Action(WindowId, crate::core::Action, WidgetId),
+    Action(WindowId, masonry::core::Action, WidgetId),
 }
 
 impl From<accesskit_winit::Event> for MasonryUserEvent {

--- a/masonry_winit/src/lib.rs
+++ b/masonry_winit/src/lib.rs
@@ -18,9 +18,9 @@
 //!
 //! ```rust
 //! use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-//! use masonry_winit::core::{Action, Widget, WidgetId};
-//! use masonry_winit::dpi::LogicalSize;
-//! use masonry_winit::widgets::{Button, Flex, Label, Portal, RootWidget, Textbox};
+//! use masonry::core::{Action, Widget, WidgetId};
+//! use masonry::dpi::LogicalSize;
+//! use masonry::widgets::{Button, Flex, Label, Portal, RootWidget, Textbox};
 //! use winit::window::Window;
 //!
 //! struct Driver {
@@ -136,10 +136,6 @@
 #![expect(missing_debug_implementations, reason = "Deferred: Noisy")]
 
 // TODO - Add logo
-
-pub use masonry::*;
-
-// TODO - Restructure re-exports.
 
 mod app_driver;
 mod convert_winit_event;

--- a/xilem/Cargo.toml
+++ b/xilem/Cargo.toml
@@ -33,6 +33,7 @@ name = "android.permission.INTERNET"
 
 [dependencies]
 xilem_core.workspace = true
+masonry.workspace = true
 masonry_winit.workspace = true
 winit.workspace = true
 tracing.workspace = true

--- a/xilem/README.md
+++ b/xilem/README.md
@@ -37,9 +37,9 @@ See https://linebender.org/blog/doc-include/ for related discussion. -->
 [crate::view::task]: https://docs.rs/xilem/latest/xilem/view/fn.task.html
 [crate::view::textbox]: https://docs.rs/xilem/latest/xilem/view/fn.textbox.html
 [crate::view::zstack]: https://docs.rs/xilem/latest/xilem/view/fn.zstack.html
-[masonry_winit::parley]: https://docs.rs/parley/latest/parley
-[masonry_winit::vello::wgpu]: https://docs.rs/wgpu/latest/wgpu
-[masonry_winit::vello]: https://docs.rs/vello/latest/vello/
+[masonry::parley]: https://docs.rs/parley/latest/parley
+[masonry::vello::wgpu]: https://docs.rs/wgpu/latest/wgpu
+[masonry::vello]: https://docs.rs/vello/latest/vello/
 [xilem_core]: https://docs.rs/parley_core/latest/xilem_core
 [xilem_examples]: ./examples/
 
@@ -55,9 +55,9 @@ was presented at the RustNL conference in 2024, and gives a video introduction t
 Xilem is implemented as a reactive layer on top of [Masonry][masonry], a widget toolkit which is developed alongside Xilem.
 Masonry itself is built on top of a wide array of foundational Rust UI projects:
 
-* Rendering is provided by [Vello][masonry_winit::vello], a high performance GPU compute-centric 2D renderer.
-* GPU compute infrastructure is provided by [wgpu][masonry_winit::vello::wgpu].
-* Text layout is provided by [Parley][masonry_winit::parley].
+* Rendering is provided by [Vello][masonry::vello], a high performance GPU compute-centric 2D renderer.
+* GPU compute infrastructure is provided by [wgpu][masonry::vello::wgpu].
+* Text layout is provided by [Parley][masonry::parley].
 * Accessibility is provided by [AccessKit][] ([docs][accesskit_docs]).
 * Window handling is provided by [winit][].
 

--- a/xilem/examples/calc.rs
+++ b/xilem/examples/calc.rs
@@ -4,7 +4,7 @@
 //! A simple calculator example
 #![expect(clippy::cast_possible_truncation, reason = "Deferred: Noisy")]
 
-use masonry_winit::widgets::{CrossAxisAlignment, GridParams, MainAxisAlignment};
+use masonry::widgets::{CrossAxisAlignment, GridParams, MainAxisAlignment};
 use winit::dpi::LogicalSize;
 use winit::error::EventLoopError;
 use winit::window::Window;

--- a/xilem/examples/components.rs
+++ b/xilem/examples/components.rs
@@ -3,7 +3,7 @@
 
 //! Modularizing state can be done with `lens` which allows using modular components.
 
-use masonry_winit::widgets::MainAxisAlignment;
+use masonry::widgets::MainAxisAlignment;
 use winit::error::EventLoopError;
 use xilem::core::lens;
 use xilem::view::{Axis, button, flex, label};

--- a/xilem/examples/elm.rs
+++ b/xilem/examples/elm.rs
@@ -5,7 +5,7 @@
 //! You can also emulate the elm architecture for a subset of your app.
 //! Though usually it's more idiomatic to modularize state with `map_state` and update state directly within event callbacks, as seen in the `components` example.
 
-use masonry_winit::widgets::{CrossAxisAlignment, MainAxisAlignment};
+use masonry::widgets::{CrossAxisAlignment, MainAxisAlignment};
 use winit::error::EventLoopError;
 use xilem::core::{MessageResult, adapt, map_action};
 use xilem::view::{Axis, button, flex, label};

--- a/xilem/examples/external_event_loop.rs
+++ b/xilem/examples/external_event_loop.rs
@@ -6,9 +6,9 @@
 //! accessing raw events from winit.
 //! Support for more custom embeddings would be welcome, but needs more design work
 
+use masonry::theme::default_property_set;
+use masonry::widgets::{CrossAxisAlignment, MainAxisAlignment};
 use masonry_winit::app::{AppDriver, MasonryUserEvent};
-use masonry_winit::theme::default_property_set;
-use masonry_winit::widgets::{CrossAxisAlignment, MainAxisAlignment};
 use winit::application::ApplicationHandler;
 use winit::error::EventLoopError;
 use winit::event::ElementState;

--- a/xilem/examples/flex.rs
+++ b/xilem/examples/flex.rs
@@ -3,7 +3,7 @@
 
 //! Flex properties can be set in Xilem.
 
-use masonry_winit::widgets::{CrossAxisAlignment, MainAxisAlignment};
+use masonry::widgets::{CrossAxisAlignment, MainAxisAlignment};
 use winit::error::EventLoopError;
 use xilem::view::{Axis, FlexExt as _, FlexSpacer, Label, button, flex, label, sized_box};
 use xilem::{EventLoop, WidgetView, Xilem};

--- a/xilem/examples/http_cats.rs
+++ b/xilem/examples/http_cats.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use masonry_winit::widgets::{Alignment, LineBreaking};
+use masonry::widgets::{Alignment, LineBreaking};
 use vello::peniko::{Blob, Image};
 use winit::dpi::LogicalSize;
 use winit::error::EventLoopError;
@@ -169,7 +169,7 @@ impl Status {
             button("Select", move |state: &mut HttpCats| {
                 state.selected_code = Some(code);
             }),
-            FlexSpacer::Fixed(masonry_winit::theme::SCROLLBAR_WIDTH),
+            FlexSpacer::Fixed(masonry::theme::SCROLLBAR_WIDTH),
         ))
         .direction(Axis::Horizontal)
     }

--- a/xilem/examples/stopwatch.rs
+++ b/xilem/examples/stopwatch.rs
@@ -6,9 +6,9 @@
 use std::ops::{Add, Sub};
 use std::time::{Duration, SystemTime};
 
+use masonry::dpi::LogicalSize;
+use masonry::widgets::{Axis, CrossAxisAlignment, MainAxisAlignment};
 use masonry_winit::app::{EventLoop, EventLoopBuilder};
-use masonry_winit::dpi::LogicalSize;
-use masonry_winit::widgets::{Axis, CrossAxisAlignment, MainAxisAlignment};
 use tokio::time;
 use tracing::warn;
 use winit::error::EventLoopError;

--- a/xilem/examples/variable_clock.rs
+++ b/xilem/examples/variable_clock.rs
@@ -124,7 +124,7 @@ impl TimeZone {
                         // TODO: Consider accessibility here.
                         palette::css::ORANGE
                     } else {
-                        masonry_winit::theme::TEXT_COLOR
+                        masonry::theme::TEXT_COLOR
                     },
                 ),
             ))

--- a/xilem/examples/virtual_cats.rs
+++ b/xilem/examples/virtual_cats.rs
@@ -10,8 +10,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use masonry_winit::core::ArcStr;
-use masonry_winit::widgets::Alignment;
+use masonry::core::ArcStr;
+use masonry::widgets::Alignment;
 use vello::peniko::{Blob, Image};
 use winit::dpi::LogicalSize;
 use winit::error::EventLoopError;

--- a/xilem/examples/widgets.rs
+++ b/xilem/examples/widgets.rs
@@ -3,8 +3,8 @@
 
 //! A widget gallery for xilem/masonry
 
+use masonry::dpi::LogicalSize;
 use masonry_winit::app::{EventLoop, EventLoopBuilder};
-use masonry_winit::dpi::LogicalSize;
 use winit::error::EventLoopError;
 use winit::window::Window;
 use xilem::core::adapt;

--- a/xilem/src/any_view.rs
+++ b/xilem/src/any_view.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use accesskit::{Node, Role};
-use masonry_winit::core::{
+use masonry::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, FromDynWidget, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId,
     WidgetMut, WidgetPod,
 };
-use masonry_winit::kurbo::{Point, Size};
+use masonry::kurbo::{Point, Size};
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
 use vello::Scene;

--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -6,10 +6,10 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use masonry::core::{Widget, WidgetId};
+use masonry::peniko::Blob;
+use masonry::widgets::RootWidget;
 use masonry_winit::app::{AppDriver, MasonryState, MasonryUserEvent, WindowId};
-use masonry_winit::core::{Widget, WidgetId};
-use masonry_winit::peniko::Blob;
-use masonry_winit::widgets::RootWidget;
 
 use crate::core::{DynMessage, MessageResult, ProxyError, RawProxy, ViewId};
 use crate::{ViewCtx, WidgetMap, WidgetView};
@@ -70,8 +70,8 @@ where
 pub const ASYNC_MARKER_WIDGET: WidgetId = WidgetId::reserved(0x1000);
 
 /// The action which should be used for async events.
-pub fn async_action(path: Arc<[ViewId]>, message: DynMessage) -> masonry_winit::core::Action {
-    masonry_winit::core::Action::Other(Box::<MessagePackage>::new((path, message)))
+pub fn async_action(path: Arc<[ViewId]>, message: DynMessage) -> masonry::core::Action {
+    masonry::core::Action::Other(Box::<MessagePackage>::new((path, message)))
 }
 
 /// The type used to send a message for async events.
@@ -91,8 +91,7 @@ impl MasonryProxy {
         )) {
             Ok(()) => Ok(()),
             Err(err) => {
-                let MasonryUserEvent::Action(_, masonry_winit::core::Action::Other(res), _) = err
-                else {
+                let MasonryUserEvent::Action(_, masonry::core::Action::Other(res), _) = err else {
                     unreachable!(
                         "We know this is the value we just created, which matches this pattern"
                     )
@@ -142,12 +141,12 @@ where
         window_id: WindowId,
         masonry_ctx: &mut masonry_winit::app::DriverCtx<'_, '_>,
         widget_id: WidgetId,
-        action: masonry_winit::core::Action,
+        action: masonry::core::Action,
     ) {
         debug_assert_eq!(window_id, self.window_id, "unknown window");
 
         let message_result = if widget_id == ASYNC_MARKER_WIDGET {
-            let masonry_winit::core::Action::Other(action) = action else {
+            let masonry::core::Action::Other(action) = action else {
                 panic!();
             };
             let (path, message) = *action.downcast::<MessagePackage>().unwrap();

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -10,9 +10,9 @@
 //! Xilem is implemented as a reactive layer on top of [Masonry][masonry], a widget toolkit which is developed alongside Xilem.
 //! Masonry itself is built on top of a wide array of foundational Rust UI projects:
 //!
-//! * Rendering is provided by [Vello][masonry_winit::vello], a high performance GPU compute-centric 2D renderer.
-//! * GPU compute infrastructure is provided by [wgpu][masonry_winit::vello::wgpu].
-//! * Text layout is provided by [Parley][masonry_winit::parley].
+//! * Rendering is provided by [Vello][masonry::vello], a high performance GPU compute-centric 2D renderer.
+//! * GPU compute infrastructure is provided by [wgpu][masonry::vello::wgpu].
+//! * Text layout is provided by [Parley][masonry::parley].
 //! * Accessibility is provided by [AccessKit][] ([docs][accesskit_docs]).
 //! * Window handling is provided by [winit][].
 //!
@@ -133,13 +133,13 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use masonry_winit::app::{MasonryUserEvent, WindowId};
-use masonry_winit::core::{
+use masonry::core::{
     DefaultProperties, FromDynWidget, Properties, Widget, WidgetId, WidgetMut, WidgetOptions,
     WidgetPod,
 };
-use masonry_winit::dpi::LogicalSize;
-use masonry_winit::theme::default_property_set;
+use masonry::dpi::LogicalSize;
+use masonry::theme::default_property_set;
+use masonry_winit::app::{MasonryUserEvent, WindowId};
 use view::{Transformed, transformed};
 use winit::error::EventLoopError;
 use winit::window::{Window, WindowAttributes};
@@ -148,13 +148,13 @@ use crate::core::{
     AsyncCtx, MessageResult, Mut, RawProxy, SuperElement, View, ViewElement, ViewId,
     ViewPathTracker, ViewSequence,
 };
+pub use masonry::kurbo::{Affine, Vec2};
+pub use masonry::parley::Alignment as TextAlignment;
+pub use masonry::parley::style::FontWeight;
+pub use masonry::peniko::{Blob, Color};
+pub use masonry::widgets::{InsertNewline, LineBreaking};
+pub use masonry::{dpi, palette};
 pub use masonry_winit::app::{EventLoop, EventLoopBuilder};
-pub use masonry_winit::kurbo::{Affine, Vec2};
-pub use masonry_winit::parley::Alignment as TextAlignment;
-pub use masonry_winit::parley::style::FontWeight;
-pub use masonry_winit::peniko::{Blob, Color};
-pub use masonry_winit::widgets::{InsertNewline, LineBreaking};
-pub use masonry_winit::{dpi, palette};
 pub use xilem_core as core;
 
 /// Tokio is the async runner used with Xilem.
@@ -290,7 +290,7 @@ where
     }
 }
 
-/// A container for a yet to be inserted [Masonry](masonry_winit) widget
+/// A container for a yet to be inserted [Masonry](masonry) widget
 /// to be used with Xilem.
 ///
 /// This exists for two reasons:
@@ -358,7 +358,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Pod<W> {
     ///
     /// In most cases, you will use the return value for adding to a layout
     /// widget which supports heterogenous widgets.
-    /// For example, [`Flex`](masonry_winit::widgets::Flex) accepts type-erased widget pods.
+    /// For example, [`Flex`](masonry::widgets::Flex) accepts type-erased widget pods.
     pub fn erased_widget_pod(self) -> WidgetPod<dyn Widget> {
         WidgetPod::new_with(self.widget, self.id, self.options, self.properties).erased()
     }

--- a/xilem/src/one_of.rs
+++ b/xilem/src/one_of.rs
@@ -4,12 +4,12 @@
 //! Statically typed alternatives to the type-erased [`AnyWidgetView`](`crate::any_view::AnyWidgetView`).
 
 use accesskit::{Node, Role};
-use masonry_winit::core::{
+use masonry::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, FromDynWidget, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Widget, WidgetId,
     WidgetPod,
 };
-use masonry_winit::kurbo::{Point, Size};
+use masonry::kurbo::{Point, Size};
 use smallvec::{SmallVec, smallvec};
 use vello::Scene;
 

--- a/xilem/src/property_tuple.rs
+++ b/xilem/src/property_tuple.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry_winit::core::{Properties, Property, Widget, WidgetMut};
+use masonry::core::{Properties, Property, Widget, WidgetMut};
 
 /// Helper trait implemented for all tuples of `Option<SomeProperty>` up to 12 items.
 pub trait PropertyTuple {

--- a/xilem/src/style.rs
+++ b/xilem/src/style.rs
@@ -3,9 +3,9 @@
 
 //! Traits used to set custom styles on views.
 
-use masonry_winit::core::Property;
-use masonry_winit::properties::types::Gradient;
-use masonry_winit::properties::{
+use masonry::core::Property;
+use masonry::properties::types::Gradient;
+use masonry::properties::{
     ActiveBackground, Background, BorderColor, BorderWidth, BoxShadow, CornerRadius,
     DisabledBackground, HoveredBorderColor, Padding,
 };
@@ -23,7 +23,7 @@ pub trait HasProperty<P: Property>: Style {
 /// Trait implemented by most views that lets you set some styling properties on them.
 ///
 /// Which methods you can use will depend on which parameter the element implements [`HasProperty`] with,
-/// which matches which [`Properties`](masonry_winit::core::Properties) the underlying widget handles.
+/// which matches which [`Properties`](masonry::core::Properties) the underlying widget handles.
 pub trait Style: Sized {
     /// The tuple type used by the element to store properties.
     type Props;

--- a/xilem/src/view/button.rs
+++ b/xilem/src/view/button.rs
@@ -1,12 +1,12 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-pub use masonry_winit::core::PointerButton;
-use masonry_winit::properties::{
+pub use masonry::core::PointerButton;
+use masonry::properties::{
     ActiveBackground, Background, BorderColor, BorderWidth, BoxShadow, CornerRadius,
     DisabledBackground, HoveredBorderColor, Padding,
 };
-use masonry_winit::widgets;
+use masonry::widgets;
 use xilem_core::ViewPathTracker;
 
 use crate::core::{DynMessage, Mut, View, ViewMarker};
@@ -205,9 +205,9 @@ where
     ) -> MessageResult<Action> {
         match id_path.split_first() {
             Some((&LABEL_VIEW_ID, rest)) => self.label.message(&mut (), rest, message, app_state),
-            None => match message.downcast::<masonry_winit::core::Action>() {
+            None => match message.downcast::<masonry::core::Action>() {
                 Ok(action) => {
-                    if let masonry_winit::core::Action::ButtonPressed(button) = *action {
+                    if let masonry::core::Action::ButtonPressed(button) = *action {
                         (self.callback)(app_state, button)
                     } else {
                         tracing::error!("Wrong action type in Button::message: {action:?}");

--- a/xilem/src/view/checkbox.rs
+++ b/xilem/src/view/checkbox.rs
@@ -1,8 +1,8 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry_winit::core::ArcStr;
-use masonry_winit::widgets;
+use masonry::core::ArcStr;
+use masonry::widgets;
 
 use crate::core::{DynMessage, Mut, ViewMarker};
 use crate::{MessageResult, Pod, View, ViewCtx, ViewId};
@@ -109,9 +109,9 @@ where
             id_path.is_empty(),
             "id path should be empty in Checkbox::message"
         );
-        match message.downcast::<masonry_winit::core::Action>() {
+        match message.downcast::<masonry::core::Action>() {
             Ok(action) => {
-                if let masonry_winit::core::Action::CheckboxToggled(checked) = *action {
+                if let masonry::core::Action::CheckboxToggled(checked) = *action {
                     MessageResult::Action((self.callback)(app_state, checked))
                 } else {
                     tracing::error!("Wrong action type in Checkbox::message: {action:?}");

--- a/xilem/src/view/flex.rs
+++ b/xilem/src/view/flex.rs
@@ -3,9 +3,9 @@
 
 use std::marker::PhantomData;
 
-use masonry_winit::core::{FromDynWidget, Widget, WidgetMut};
-use masonry_winit::widgets::{self};
-pub use masonry_winit::widgets::{Axis, CrossAxisAlignment, FlexParams, MainAxisAlignment};
+use masonry::core::{FromDynWidget, Widget, WidgetMut};
+use masonry::widgets::{self};
+pub use masonry::widgets::{Axis, CrossAxisAlignment, FlexParams, MainAxisAlignment};
 
 use crate::core::{
     AppendVec, DynMessage, ElementSplice, MessageResult, Mut, SuperElement, View, ViewElement,
@@ -17,7 +17,7 @@ use crate::{AnyWidgetView, Pod, ViewCtx, WidgetView};
 ///
 /// # Example
 /// ```rust,no_run
-/// use masonry_winit::widgets::{CrossAxisAlignment, MainAxisAlignment};
+/// use masonry::widgets::{CrossAxisAlignment, MainAxisAlignment};
 /// use winit::error::EventLoopError;
 /// use xilem::view::{button, flex, label, sized_box, Axis, FlexExt as _, FlexSpacer, Label};
 /// use xilem::{EventLoop, WidgetView, Xilem};
@@ -119,8 +119,8 @@ impl<Seq, State, Action> Flex<Seq, State, Action> {
     /// If `gap` is not a non-negative finite value.
     ///
     /// [gap]: https://developer.mozilla.org/en-US/docs/Web/CSS/gap
-    /// [`WIDGET_PADDING_VERTICAL`]: masonry_winit::theme::WIDGET_PADDING_VERTICAL
-    /// [`WIDGET_PADDING_HORIZONTAL`]: masonry_winit::theme::WIDGET_PADDING_VERTICAL
+    /// [`WIDGET_PADDING_VERTICAL`]: masonry::theme::WIDGET_PADDING_VERTICAL
+    /// [`WIDGET_PADDING_HORIZONTAL`]: masonry::theme::WIDGET_PADDING_VERTICAL
     #[track_caller]
     pub fn gap(mut self, gap: f64) -> Self {
         if gap.is_finite() && gap >= 0.0 {

--- a/xilem/src/view/grid.rs
+++ b/xilem/src/view/grid.rs
@@ -3,8 +3,8 @@
 
 use std::marker::PhantomData;
 
-use masonry_winit::core::{FromDynWidget, Widget, WidgetMut};
-use masonry_winit::widgets::{
+use masonry::core::{FromDynWidget, Widget, WidgetMut};
+use masonry::widgets::{
     GridParams, {self},
 };
 
@@ -19,7 +19,7 @@ use crate::{Pod, ViewCtx, WidgetView};
 ///
 /// # Example
 /// ```ignore
-/// use masonry_winit::widgets::GridParams;
+/// use masonry::widgets::GridParams;
 /// use xilem::view::{
 ///     button, grid, label, GridExt,
 /// };
@@ -284,7 +284,7 @@ pub trait GridExt<State, Action>: WidgetView<State, Action> {
     ///
     /// # Examples
     /// ```
-    /// use masonry_winit::widgets::GridParams;
+    /// use masonry::widgets::GridParams;
     /// use xilem::{view::{button, prose, grid, GridExt}};
     /// # use xilem::{WidgetView};
     ///
@@ -311,7 +311,7 @@ pub trait GridExt<State, Action>: WidgetView<State, Action> {
     ///
     /// # Examples
     /// ```
-    /// use masonry_winit::widgets::GridParams;
+    /// use masonry::widgets::GridParams;
     /// use xilem::{view::{button, prose, grid, GridExt}};
     /// # use xilem::{WidgetView};
     ///

--- a/xilem/src/view/image.rs
+++ b/xilem/src/view/image.rs
@@ -3,12 +3,12 @@
 
 //! The bitmap image widget.
 
-use masonry_winit::widgets::{self};
+use masonry::widgets::{self};
 
 use crate::core::{DynMessage, Mut, ViewMarker};
 use crate::{MessageResult, Pod, View, ViewCtx, ViewId};
 
-pub use masonry_winit::core::ObjectFit;
+pub use masonry::core::ObjectFit;
 /// Displays the bitmap `image`.
 ///
 /// By default, the Image will scale to fit its box constraints ([`ObjectFit::Fill`]).

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -1,9 +1,9 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry_winit::core::{ArcStr, StyleProperty};
-use masonry_winit::parley::style::{FontStack, FontWeight};
-use masonry_winit::widgets::{
+use masonry::core::{ArcStr, StyleProperty};
+use masonry::parley::style::{FontStack, FontWeight};
+use masonry::widgets::{
     LineBreaking, {self},
 };
 use vello::peniko::Brush;
@@ -17,8 +17,8 @@ use crate::{Color, MessageResult, Pod, TextAlignment, View, ViewCtx, ViewId};
 /// ```ignore
 /// use xilem::palette;
 /// use xilem::view::label;
-/// use masonry_winit::TextAlignment;
-/// use masonry_winit::parley::fontique;
+/// use masonry::TextAlignment;
+/// use masonry::parley::fontique;
 ///
 /// label("Text example.")
 ///     .brush(palette::css::RED)
@@ -32,7 +32,7 @@ pub fn label(label: impl Into<ArcStr>) -> Label {
         label: label.into(),
         text_brush: Color::WHITE.into(),
         alignment: TextAlignment::default(),
-        text_size: masonry_winit::theme::TEXT_SIZE_NORMAL,
+        text_size: masonry::theme::TEXT_SIZE_NORMAL,
         weight: FontWeight::NORMAL,
         font: FontStack::List(std::borrow::Cow::Borrowed(&[])),
         line_break_mode: LineBreaking::Overflow,
@@ -50,7 +50,7 @@ pub struct Label {
     text_size: f32,
     weight: FontWeight,
     font: FontStack<'static>,
-    line_break_mode: LineBreaking, // TODO: add more attributes of `masonry_winit::widgets::Label`
+    line_break_mode: LineBreaking, // TODO: add more attributes of `masonry::widgets::Label`
 }
 
 impl Label {

--- a/xilem/src/view/portal.rs
+++ b/xilem/src/view/portal.rs
@@ -3,14 +3,14 @@
 
 use std::marker::PhantomData;
 
-use masonry_winit::widgets;
+use masonry::widgets;
 
 use crate::core::{DynMessage, Mut, ViewMarker};
 use crate::{MessageResult, Pod, View, ViewCtx, ViewId, WidgetView};
 
 /// A view which puts `child` into a scrollable region.
 ///
-/// This corresponds to the Masonry [`Portal`](masonry_winit::widgets::Portal) widget.
+/// This corresponds to the Masonry [`Portal`](masonry::widgets::Portal) widget.
 pub fn portal<Child, State, Action>(child: Child) -> Portal<Child, State, Action>
 where
     Child: WidgetView<State, Action>,

--- a/xilem/src/view/progress_bar.rs
+++ b/xilem/src/view/progress_bar.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry_winit::widgets;
+use masonry::widgets;
 
 use crate::core::{DynMessage, Mut, ViewMarker};
 use crate::{MessageResult, Pod, View, ViewCtx, ViewId};

--- a/xilem/src/view/prose.rs
+++ b/xilem/src/view/prose.rs
@@ -1,9 +1,9 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry_winit::core::{ArcStr, StyleProperty};
-use masonry_winit::parley::FontWeight;
-use masonry_winit::widgets::{
+use masonry::core::{ArcStr, StyleProperty};
+use masonry::parley::FontWeight;
+use masonry::widgets::{
     LineBreaking, {self},
 };
 use vello::peniko::Brush;
@@ -17,7 +17,7 @@ pub fn prose(content: impl Into<ArcStr>) -> Prose {
         content: content.into(),
         text_brush: Color::WHITE.into(),
         alignment: TextAlignment::default(),
-        text_size: masonry_winit::theme::TEXT_SIZE_NORMAL,
+        text_size: masonry::theme::TEXT_SIZE_NORMAL,
         line_break_mode: LineBreaking::WordWrap,
         weight: FontWeight::NORMAL,
     }
@@ -44,7 +44,7 @@ pub struct Prose {
     line_break_mode: LineBreaking,
     weight: FontWeight,
     // TODO: disabled: bool,
-    // TODO: add more attributes of `masonry_winit::widgets::Prose`
+    // TODO: add more attributes of `masonry::widgets::Prose`
 }
 
 impl Prose {

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -3,8 +3,8 @@
 
 use std::marker::PhantomData;
 
-pub use masonry_winit::properties::Padding;
-use masonry_winit::widgets;
+pub use masonry::properties::Padding;
+use masonry::widgets;
 use vello::kurbo::RoundedRectRadii;
 use vello::peniko::Brush;
 
@@ -23,7 +23,7 @@ use crate::{Pod, ViewCtx, WidgetView};
 /// use xilem::view::{sized_box, button};
 /// use xilem::palette;
 /// use vello::kurbo::RoundedRectRadii;
-/// use masonry_winit::properties::Padding;
+/// use masonry::properties::Padding;
 ///
 /// sized_box(button("Button", |data: &mut i32| *data+=1))
 ///     .expand()

--- a/xilem/src/view/spinner.rs
+++ b/xilem/src/view/spinner.rs
@@ -1,8 +1,8 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry_winit::peniko::Color;
-use masonry_winit::widgets;
+use masonry::peniko::Color;
+use masonry::widgets;
 
 use crate::core::{DynMessage, Mut, ViewMarker};
 use crate::{MessageResult, Pod, View, ViewCtx, ViewId};

--- a/xilem/src/view/split.rs
+++ b/xilem/src/view/split.rs
@@ -3,7 +3,7 @@
 
 use std::marker::PhantomData;
 
-use masonry_winit::widgets::{self, Axis};
+use masonry::widgets::{self, Axis};
 use xilem_core::{DynMessage, MessageResult, View, ViewId, ViewMarker, ViewPathTracker};
 
 use crate::{Pod, ViewCtx, WidgetView};

--- a/xilem/src/view/textbox.rs
+++ b/xilem/src/view/textbox.rs
@@ -1,8 +1,8 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry_winit::core::{WidgetOptions, WidgetPod};
-use masonry_winit::widgets;
+use masonry::core::{WidgetOptions, WidgetPod};
+use masonry::widgets;
 use vello::kurbo::Affine;
 use vello::peniko::Brush;
 
@@ -42,7 +42,7 @@ pub struct Textbox<State, Action> {
     alignment: TextAlignment,
     insert_newline: InsertNewline,
     disabled: bool,
-    // TODO: add more attributes of `masonry_winit::widgets::TextBox`
+    // TODO: add more attributes of `masonry::widgets::TextBox`
 }
 
 impl<State, Action> Textbox<State, Action> {
@@ -157,15 +157,15 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
             id_path.is_empty(),
             "id path should be empty in Textbox::message"
         );
-        match message.downcast::<masonry_winit::core::Action>() {
+        match message.downcast::<masonry::core::Action>() {
             Ok(action) => match *action {
-                masonry_winit::core::Action::TextChanged(text) => {
+                masonry::core::Action::TextChanged(text) => {
                     MessageResult::Action((self.on_changed)(app_state, text))
                 }
-                masonry_winit::core::Action::TextEntered(text) if self.on_enter.is_some() => {
+                masonry::core::Action::TextEntered(text) if self.on_enter.is_some() => {
                     MessageResult::Action((self.on_enter.as_ref().unwrap())(app_state, text))
                 }
-                masonry_winit::core::Action::TextEntered(_) => {
+                masonry::core::Action::TextEntered(_) => {
                     tracing::error!("Textbox::message: on_enter is not set");
                     MessageResult::Stale(DynMessage(action))
                 }

--- a/xilem/src/view/variable_label.rs
+++ b/xilem/src/view/variable_label.rs
@@ -1,10 +1,10 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry_winit::core::ArcStr;
-use masonry_winit::parley::Alignment as TextAlignment;
-use masonry_winit::parley::style::{FontStack, FontWeight};
-use masonry_winit::widgets;
+use masonry::core::ArcStr;
+use masonry::parley::Alignment as TextAlignment;
+use masonry::parley::style::{FontStack, FontWeight};
+use masonry::widgets;
 use vello::peniko::Brush;
 use xilem_core::ViewPathTracker;
 
@@ -12,7 +12,7 @@ use super::{Label, label};
 use crate::core::{DynMessage, Mut, ViewMarker};
 use crate::{MessageResult, Pod, View, ViewCtx, ViewId};
 
-/// A view for displaying non-editable text, with a variable [weight](masonry_winit::parley::style::FontWeight).
+/// A view for displaying non-editable text, with a variable [weight](masonry::parley::style::FontWeight).
 pub fn variable_label(text: impl Into<ArcStr>) -> VariableLabel {
     VariableLabel {
         label: label(text),

--- a/xilem/src/view/virtual_scroll.rs
+++ b/xilem/src/view/virtual_scroll.rs
@@ -3,8 +3,8 @@
 
 use std::{collections::HashMap, marker::PhantomData, ops::Range};
 
-use masonry_winit::core::{FromDynWidget, Widget, WidgetPod};
-use masonry_winit::widgets::{self, VirtualScrollAction};
+use masonry::core::{FromDynWidget, Widget, WidgetPod};
+use masonry::widgets::{self, VirtualScrollAction};
 use private::VirtualScrollState;
 use xilem_core::{AsyncCtx, DynMessage, MessageResult, View, ViewId, ViewMarker, ViewPathTracker};
 
@@ -77,7 +77,7 @@ where
 mod private {
     use std::{collections::HashMap, sync::Arc};
 
-    use masonry_winit::widgets::VirtualScrollAction;
+    use masonry::widgets::VirtualScrollAction;
     use xilem_core::ViewId;
 
     #[expect(
@@ -339,15 +339,15 @@ where
                 return MessageResult::Stale(message);
             }
         }
-        if message.is::<masonry_winit::core::Action>() {
-            let action = message.downcast::<masonry_winit::core::Action>().unwrap();
-            if let masonry_winit::core::Action::Other(action) = *action {
+        if message.is::<masonry::core::Action>() {
+            let action = message.downcast::<masonry::core::Action>().unwrap();
+            if let masonry::core::Action::Other(action) = *action {
                 if !action.is::<VirtualScrollAction>() {
                     tracing::error!("Wrong action type in VirtualScroll::message: {action:?}");
                     // Ideally we'd avoid this extra box, but it's not easy to write this kind of code in a clean way
-                    return MessageResult::Stale(DynMessage::new(
-                        masonry_winit::core::Action::Other(action),
-                    ));
+                    return MessageResult::Stale(DynMessage::new(masonry::core::Action::Other(
+                        action,
+                    )));
                 }
                 // We check then unwrap to avoid unwrapping a box (also, it makes the check path an early-exit)
                 let action = action.downcast::<VirtualScrollAction>().unwrap();

--- a/xilem/src/view/zstack.rs
+++ b/xilem/src/view/zstack.rs
@@ -3,8 +3,8 @@
 
 use std::marker::PhantomData;
 
-use masonry_winit::core::{FromDynWidget, Widget, WidgetMut};
-use masonry_winit::widgets;
+use masonry::core::{FromDynWidget, Widget, WidgetMut};
+use masonry::widgets;
 use xilem_core::{MessageResult, ViewId};
 
 use crate::core::{
@@ -13,7 +13,7 @@ use crate::core::{
 };
 use crate::{Pod, ViewCtx, WidgetView};
 
-pub use masonry_winit::widgets::{Alignment, ChildAlignment};
+pub use masonry::widgets::{Alignment, ChildAlignment};
 
 /// A widget that lays out its children on top of each other.
 /// The children are laid out back to front.


### PR DESCRIPTION
People should use `masonry` for all of the general purpose stuff and only use `masonry_winit` for the Winit integration.

Further cleanups to the `masonry_winit` crate can come after this.