### PR TITLE
Add Properties to Flex and Grid

### DIFF
--- a/masonry/screenshots/flex_row_cross_axis_baseline.png
+++ b/masonry/screenshots/flex_row_cross_axis_baseline.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:12b63c65a4a6c932b0bbc81d201a9ea93a867a96f08f73c345dcb24264adb6c4
-size 1545
+oid sha256:878f5c27d5835b195891c3988067e77b65101f51b4d918651572f1e68dd80afe
+size 1548

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -996,7 +996,7 @@ impl Widget for Flex {
         }
     }
 
-    fn property_changed(&mut self, ctx: &mut UpdateCtx, property_type: TypeId) {
+    fn property_changed(&mut self, ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
         Background::prop_changed(ctx, property_type);
         BorderColor::prop_changed(ctx, property_type);
         BorderWidth::prop_changed(ctx, property_type);

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -3,7 +3,10 @@
 
 //! A widget that arranges its children in a one-dimensional array.
 
+use std::any::TypeId;
+
 use accesskit::{Node, Role};
+use masonry_core::core::RegisterCtx;
 use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
@@ -12,10 +15,12 @@ use vello::kurbo::{Affine, Line, Point, Rect, Size, Stroke, Vec2};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
-    PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut,
+    PropertiesMut, PropertiesRef, QueryCtx, TextEvent, UpdateCtx, Widget, WidgetId, WidgetMut,
     WidgetPod,
 };
 use crate::debug_panic;
+use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
+use crate::util::{fill, stroke};
 
 /// A container with either horizontal or vertical layout.
 ///
@@ -991,12 +996,32 @@ impl Widget for Flex {
         }
     }
 
+    fn property_changed(&mut self, ctx: &mut UpdateCtx, property_type: TypeId) {
+        Background::prop_changed(ctx, property_type);
+        BorderColor::prop_changed(ctx, property_type);
+        BorderWidth::prop_changed(ctx, property_type);
+        CornerRadius::prop_changed(ctx, property_type);
+        Padding::prop_changed(ctx, property_type);
+    }
+
     fn layout(
         &mut self,
         ctx: &mut LayoutCtx<'_>,
-        _props: &mut PropertiesMut<'_>,
+        props: &mut PropertiesMut<'_>,
         bc: &BoxConstraints,
     ) -> Size {
+        let border = props.get::<BorderWidth>();
+        let padding = props.get::<Padding>();
+
+        let bc = *bc;
+        let bc = border.layout_down(bc);
+        let bc = padding.layout_down(bc);
+
+        // Indicates that the box constrains for the following children have changed.
+        // Therefore they have to calculate layout again.
+        let bc_changed = self.old_bc != bc;
+        self.old_bc = bc;
+
         // we loosen our constraints when passing to children.
         let loosened_bc = bc.loosen();
 
@@ -1007,11 +1032,7 @@ impl Widget for Flex {
         let mut max_below_baseline = 0_f64;
         let mut any_use_baseline = false;
 
-        // indicates that the box constrains for the following children have changed. Therefore they
-        // have to calculate layout again.
-        let bc_changed = self.old_bc != *bc;
-        let mut any_changed = bc_changed;
-        self.old_bc = *bc;
+        let mut any_changed = bc_changed || ctx.needs_layout();
 
         let gap = self.gap.unwrap_or(axis_default_spacer(self.direction));
         // The gaps are only between the items, so 2 children means 1 gap.
@@ -1188,6 +1209,8 @@ impl Widget for Flex {
                     };
 
                     let child_pos: Point = self.direction.pack(major, child_minor_offset).into();
+                    let child_pos = border.place_down(child_pos);
+                    let child_pos = padding.place_down(child_pos);
                     ctx.place_child(widget, child_pos);
                     major += self.direction.major(child_size).expand();
                     major += spacing.next().unwrap_or(0.);
@@ -1221,7 +1244,7 @@ impl Widget for Flex {
         // or be clipped (e.g. if its parent is a Portal).
         let my_size: Size = self.direction.pack(major, minor_dim).into();
 
-        let baseline_offset = match self.direction {
+        let baseline = match self.direction {
             Axis::Horizontal => max_below_baseline,
             Axis::Vertical => self
                 .children
@@ -1240,11 +1263,25 @@ impl Widget for Flex {
                 .unwrap_or(0.0),
         };
 
-        ctx.set_baseline_offset(baseline_offset);
+        let (my_size, baseline) = padding.layout_up(my_size, baseline);
+        let (my_size, baseline) = border.layout_up(my_size, baseline);
+        ctx.set_baseline_offset(baseline);
         my_size
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, scene: &mut Scene) {
+    fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
+        let border_width = props.get::<BorderWidth>();
+        let border_radius = props.get::<CornerRadius>();
+        let bg = props.get::<Background>();
+        let border_color = props.get::<BorderColor>();
+
+        let bg_rect = border_width.bg_rect(ctx.size(), border_radius);
+        let border_rect = border_width.border_rect(ctx.size(), border_radius);
+
+        let brush = bg.get_peniko_brush_for_rect(bg_rect.rect());
+        fill(scene, &bg_rect, &brush);
+        stroke(scene, &border_rect, border_color.color, border_width.width);
+
         // paint the baseline if we're debugging layout
         if ctx.debug_paint_enabled() && ctx.baseline_offset() != 0.0 {
             let color = ctx.debug_color();

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -318,7 +318,7 @@ impl Widget for Grid {
         }
     }
 
-    fn property_changed(&mut self, ctx: &mut UpdateCtx, property_type: TypeId) {
+    fn property_changed(&mut self, ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
         Background::prop_changed(ctx, property_type);
         BorderColor::prop_changed(ctx, property_type);
         BorderWidth::prop_changed(ctx, property_type);

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -1,7 +1,10 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::any::TypeId;
+
 use accesskit::{Node, Role};
+use masonry_core::core::UpdateCtx;
 use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
@@ -13,6 +16,8 @@ use crate::core::{
     WidgetPod,
 };
 use crate::debug_panic;
+use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
+use crate::util::{fill, stroke};
 
 /// A widget that arranges its children in a grid.
 ///
@@ -313,12 +318,32 @@ impl Widget for Grid {
         }
     }
 
+    fn property_changed(&mut self, ctx: &mut UpdateCtx, property_type: TypeId) {
+        Background::prop_changed(ctx, property_type);
+        BorderColor::prop_changed(ctx, property_type);
+        BorderWidth::prop_changed(ctx, property_type);
+        CornerRadius::prop_changed(ctx, property_type);
+        Padding::prop_changed(ctx, property_type);
+    }
+
     fn layout(
         &mut self,
         ctx: &mut LayoutCtx<'_>,
-        _props: &mut PropertiesMut<'_>,
+        props: &mut PropertiesMut<'_>,
         bc: &BoxConstraints,
     ) -> Size {
+        let border = props.get::<BorderWidth>();
+        let padding = props.get::<Padding>();
+
+        let bc = *bc;
+        let bc = border.layout_down(bc);
+        let bc = padding.layout_down(bc);
+
+        let origin = Point::ORIGIN;
+        let origin = border.place_down(origin);
+        let origin = padding.place_down(origin);
+        let origin = origin.to_vec2();
+
         let total_size = bc.max();
         if !total_size.is_finite() {
             debug_panic!(
@@ -335,15 +360,29 @@ impl Widget for Grid {
             );
             let child_bc = BoxConstraints::new(cell_size, cell_size);
             let _ = ctx.run_layout(&mut child.widget, &child_bc);
-            ctx.place_child(
-                &mut child.widget,
-                Point::new(child.x as f64 * width_unit, child.y as f64 * height_unit),
-            );
+
+            let child_pos = Point::new(child.x as f64 * width_unit, child.y as f64 * height_unit);
+            ctx.place_child(&mut child.widget, child_pos + origin);
         }
+
+        let (total_size, _) = padding.layout_up(total_size, 0.);
+        let (total_size, _) = border.layout_up(total_size, 0.);
         total_size
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, scene: &mut Scene) {
+    fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
+        let border_width = props.get::<BorderWidth>();
+        let border_radius = props.get::<CornerRadius>();
+        let bg = props.get::<Background>();
+        let border_color = props.get::<BorderColor>();
+
+        let bg_rect = border_width.bg_rect(ctx.size(), border_radius);
+        let border_rect = border_width.border_rect(ctx.size(), border_radius);
+
+        let brush = bg.get_peniko_brush_for_rect(bg_rect.rect());
+        fill(scene, &bg_rect, &brush);
+        stroke(scene, &border_rect, border_color.color, border_width.width);
+
         // paint the baseline if we're debugging layout
         if ctx.debug_paint_enabled() && ctx.baseline_offset() != 0.0 {
             let color = ctx.debug_color();

--- a/xilem/examples/emoji_picker.rs
+++ b/xilem/examples/emoji_picker.rs
@@ -80,14 +80,12 @@ fn picker(data: &mut EmojiPagination) -> impl WidgetView<EmojiPagination> + use<
         }
     }
 
-    sized_box(
-        grid(
-            grid_items,
-            data.size.try_into().unwrap(),
-            data.size.try_into().unwrap(),
-        )
-        .spacing(10.0),
+    grid(
+        grid_items,
+        data.size.try_into().unwrap(),
+        data.size.try_into().unwrap(),
     )
+    .spacing(10.0)
     .padding(20.0)
 }
 

--- a/xilem/examples/http_cats.rs
+++ b/xilem/examples/http_cats.rs
@@ -49,14 +49,16 @@ enum ImageState {
 
 impl HttpCats {
     fn view(&mut self) -> impl WidgetView<Self> + use<> {
-        let left_column = sized_box(portal(flex((
-            prose("Status"),
-            self.statuses
-                .iter_mut()
-                .map(Status::list_view)
-                .collect::<Vec<_>>(),
-        ))))
-        .padding(Padding::left(5.));
+        let left_column = portal(
+            flex((
+                prose("Status"),
+                self.statuses
+                    .iter_mut()
+                    .map(Status::list_view)
+                    .collect::<Vec<_>>(),
+            ))
+            .padding(Padding::left(5.)),
+        );
 
         let (info_area, worker_value) = if let Some(selected_code) = self.selected_code {
             if let Some(selected_status) =

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -14,7 +14,7 @@ use xilem::style::Style as _;
 use xilem::tokio::time;
 use xilem::view::{
     Axis, FlexExt as _, FlexSpacer, PointerButton, button, button_any_pointer, checkbox, flex,
-    label, prose, sized_box, task, textbox,
+    label, prose, task, textbox,
 };
 use xilem::{
     EventLoop, EventLoopBuilder, FontWeight, InsertNewline, TextAlignment, WidgetView,
@@ -66,7 +66,7 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> + use<> {
     });
 
     fork(
-        sized_box(flex((
+        flex((
             flex((
                 label("Label").brush(palette::css::REBECCA_PURPLE),
                 label("Bold Label").weight(FontWeight::BOLD),
@@ -101,7 +101,7 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> + use<> {
             button("Decrement", |data: &mut AppData| data.count -= 1),
             button("Reset", |data: &mut AppData| data.count = 0),
             flex((fizz_buzz_flex_sequence, flex_sequence)).direction(axis),
-        )))
+        ))
         .padding(8.0),
         // The following `task` view only exists whilst the example is in the "active" state, so
         // the updates it performs will only be running whilst we are in that state.

--- a/xilem/examples/state_machine.rs
+++ b/xilem/examples/state_machine.rs
@@ -59,7 +59,7 @@ fn sequence_button(value: &'static str, target_state: IsEven) -> impl WidgetView
 }
 
 fn app_logic(app_data: &mut StateMachine) -> impl WidgetView<StateMachine> + use<> {
-    sized_box(flex((
+    flex((
         button("Reset", |app_data: &mut StateMachine| {
             app_data.history.clear();
             app_data.state = IsEven::Initial;
@@ -70,7 +70,7 @@ fn app_logic(app_data: &mut StateMachine) -> impl WidgetView<StateMachine> + use
         sized_box(spinner()).height(40.).width(40.),
         state_machine(app_data),
         // TODO: When we have a canvas widget, visualise the entire state machine here.
-    )))
+    ))
     .padding(15.0)
 }
 

--- a/xilem/examples/to_do_mvc.rs
+++ b/xilem/examples/to_do_mvc.rs
@@ -7,6 +7,7 @@
 #![windows_subsystem = "windows"]
 
 use winit::error::EventLoopError;
+use xilem::style::Style as _;
 use xilem::view::{Axis, FlexSpacer, button, checkbox, flex, textbox};
 use xilem::{EventLoop, EventLoopBuilder, InsertNewline, WidgetView, WindowOptions, Xilem};
 
@@ -75,6 +76,7 @@ fn app_logic(task_list: &mut TaskList) -> impl WidgetView<TaskList> + use<> {
         first_line,
         tasks,
     ))
+    .padding(50.)
 }
 
 fn run(event_loop: EventLoopBuilder) -> Result<(), EventLoopError> {

--- a/xilem/examples/to_do_mvc.rs
+++ b/xilem/examples/to_do_mvc.rs
@@ -8,7 +8,7 @@
 
 use winit::error::EventLoopError;
 use xilem::style::Style as _;
-use xilem::view::{Axis, FlexSpacer, button, checkbox, flex, textbox};
+use xilem::view::{Axis, button, checkbox, flex, textbox};
 use xilem::{EventLoop, EventLoopBuilder, InsertNewline, WidgetView, WindowOptions, Xilem};
 
 struct Task {
@@ -71,12 +71,7 @@ fn app_logic(task_list: &mut TaskList) -> impl WidgetView<TaskList> + use<> {
         })
         .collect::<Vec<_>>();
 
-    flex((
-        FlexSpacer::Fixed(40.), // HACK: Spacer for Androird
-        first_line,
-        tasks,
-    ))
-    .padding(50.)
+    flex((first_line, tasks)).padding(50.)
 }
 
 fn run(event_loop: EventLoopBuilder) -> Result<(), EventLoopError> {

--- a/xilem/examples/variable_clock.rs
+++ b/xilem/examples/variable_clock.rs
@@ -39,7 +39,7 @@ struct TimeZone {
 }
 
 fn app_logic(data: &mut Clocks) -> impl WidgetView<Clocks> + use<> {
-    let view = sized_box(flex((
+    let view = flex((
         // HACK: We add a spacer at the top for Android. See https://github.com/rust-windowing/winit/issues/2308
         FlexSpacer::Fixed(40.),
         local_time(data),
@@ -49,7 +49,7 @@ fn app_logic(data: &mut Clocks) -> impl WidgetView<Clocks> + use<> {
             TIMEZONES.iter().map(|it| it.view(data)).collect::<Vec<_>>(),
         ))
         .flex(1.),
-    )))
+    ))
     .padding(10.0);
     fork(
         view,


### PR DESCRIPTION
Add padding to to_do_mvc example.
Remove uses of sized_box from examples.
Fix flex baseline default alignment.