### PR TITLE
`masonry_winit`: Use `vello` via `masonry`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,7 +1930,6 @@ dependencies = [
  "tracing-tracy",
  "ui-events",
  "ui-events-winit",
- "vello",
  "web-time",
  "wgpu",
  "wgpu-profiler",

--- a/masonry_winit/Cargo.toml
+++ b/masonry_winit/Cargo.toml
@@ -25,7 +25,6 @@ tracy = ["dep:tracing-tracy", "dep:wgpu-profiler", "wgpu-profiler/tracy", "mason
 
 [dependencies]
 masonry.workspace = true
-vello.workspace = true
 wgpu.workspace = true
 winit.workspace = true
 tracing = { workspace = true, features = ["default"] }

--- a/masonry_winit/examples/calc_masonry.rs
+++ b/masonry_winit/examples/calc_masonry.rs
@@ -26,10 +26,10 @@ use masonry::peniko::color::AlphaColor;
 use masonry::properties::{Background, Padding};
 use masonry::smallvec::{SmallVec, smallvec};
 use masonry::theme::default_property_set;
+use masonry::vello::Scene;
 use masonry::widgets::{Align, CrossAxisAlignment, Flex, Label, RootWidget, SizedBox};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
 use tracing::{Span, trace, trace_span};
-use vello::Scene;
 use winit::window::Window;
 
 #[derive(Clone)]

--- a/masonry_winit/examples/custom_widget.rs
+++ b/masonry_winit/examples/custom_widget.rs
@@ -15,15 +15,14 @@ use masonry::core::{
 };
 use masonry::kurbo::{Affine, BezPath, Point, Rect, Size, Stroke};
 use masonry::palette;
-use masonry::peniko::Color;
+use masonry::peniko::{Color, Fill, Image, ImageFormat};
 use masonry::smallvec::SmallVec;
+use masonry::vello::Scene;
 use masonry::widgets::RootWidget;
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
 use parley::layout::{Alignment, AlignmentOptions};
 use parley::style::{FontFamily, FontStack, StyleProperty};
 use tracing::{Span, trace_span};
-use vello::Scene;
-use vello::peniko::{Fill, Image, ImageFormat};
 use winit::window::Window;
 
 struct Driver;

--- a/masonry_winit/examples/simple_image.rs
+++ b/masonry_winit/examples/simple_image.rs
@@ -10,9 +10,9 @@
 
 use masonry::core::{Action, ObjectFit, WidgetId};
 use masonry::dpi::LogicalSize;
+use masonry::peniko::{Image as ImageBuf, ImageFormat};
 use masonry::widgets::{Image, RootWidget};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use vello::peniko::{Image as ImageBuf, ImageFormat};
 use winit::window::Window;
 
 struct Driver;

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -11,14 +11,14 @@ use std::sync::{Arc, Mutex, mpsc};
 use accesskit_winit::Adapter;
 use masonry::app::{RenderRoot, RenderRootOptions, RenderRootSignal};
 use masonry::core::{DefaultProperties, TextEvent, Widget, WidgetId, WindowEvent};
+use masonry::kurbo::Affine;
+use masonry::peniko::Color;
 use masonry::theme::default_property_set;
 use masonry::util::Instant;
+use masonry::vello::util::{RenderContext, RenderSurface};
+use masonry::vello::{AaConfig, AaSupport, RenderParams, Renderer, RendererOptions, Scene};
 use tracing::{debug, error, info, info_span};
 use ui_events_winit::{WindowEventReducer, WindowEventTranslation};
-use vello::kurbo::Affine;
-use vello::peniko::Color;
-use vello::util::{RenderContext, RenderSurface};
-use vello::{AaSupport, RenderParams, Renderer, RendererOptions, Scene};
 use wgpu::PresentMode;
 use winit::application::ApplicationHandler;
 use winit::error::EventLoopError;
@@ -491,7 +491,7 @@ impl MasonryState<'_> {
             base_color: Color::BLACK,
             width,
             height,
-            antialiasing_method: vello::AaConfig::Area,
+            antialiasing_method: AaConfig::Area,
         };
 
         let _render_span = tracing::info_span!("Rendering using Vello").entered();


### PR DESCRIPTION
`masonry_winit` and its examples shouldn't have a direct dependency on `vello`. This is especially true for example code as it should be able to be copied and pasted without having to add its own dependency upon `vello`.