### PR TITLE
Improve `masonry` docs

### DIFF
--- a/masonry/src/doc/03_implementing_container_widget.md
+++ b/masonry/src/doc/03_implementing_container_widget.md
@@ -50,7 +50,7 @@ A container widget needs to pay special attention to these methods:
 trait Widget {
     // ...
 
-    fn layout(&mut self, ctx: &mut LayoutCtx<'_>) -> Size;
+    fn layout(&mut self, ctx: &mut LayoutCtx<'_>, _props: &mut PropertiesMut<'_>, bc: &BoxConstraints) -> Size;
     fn compose(&mut self, ctx: &mut ComposeCtx<'_>);
 
     fn register_children(&mut self, ctx: &mut RegisterCtx<'_>);
@@ -78,9 +78,10 @@ When debug assertions are on, Masonry will actively try to detect cases where yo
 For our `VerticalStack`, we'll lay out our children in a vertical line, with a gap between each child; we give each child an equal share of the available height:
 
 ```rust,ignore
-use masonry_winit::core::{
-    LayoutCtx, BoxConstraints
+use masonry::core::{
+    BoxConstraints, LayoutCtx, PropertiesMut, Widget
 };
+use masonry::kurbo::{Point, Size};
 
 impl Widget for VerticalStack {
     // ...
@@ -131,8 +132,8 @@ For instance, if a widget in a list changes size, its siblings and parents must 
 In the case of our `VerticalStack`, we don't implement any transform-only changes, so we don't need to do anything in compose:
 
 ```rust,ignore
-use masonry_winit::core::{
-    LayoutCtx, BoxConstraints
+use masonry::core::{
+    BoxConstraints, ComposeCtx, Widget
 };
 
 impl Widget for VerticalStack {
@@ -147,8 +148,8 @@ impl Widget for VerticalStack {
 The `register_children` method must call [`RegisterCtx::register_child`] for each child:
 
 ```rust,ignore
-use masonry_winit::{
-    Widget, RegisterCtx
+use masonry::core::{
+    RegisterCtx, Widget
 };
 
 impl Widget for VerticalStack {

--- a/masonry/src/doc/04_testing_widget.md
+++ b/masonry/src/doc/04_testing_widget.md
@@ -31,8 +31,8 @@ First, let's write a test module with a first unit test:
 #[cfg(test)]
 mod tests {
     use insta::assert_debug_snapshot;
-    use masonry_winit::testing::{widget_ids, TestHarness, TestWidgetExt};
-    use masonry_winit::theme::default_property_set;
+    use masonry::testing::{widget_ids, TestHarness, TestWidgetExt};
+    use masonry::theme::default_property_set;
 
     use super::*;
 
@@ -78,7 +78,7 @@ Let's add a visual test:
 
 ```rust,ignore
     // ...
-    use masonry_winit::assert_render_snapshot;
+    use masonry::assert_render_snapshot;
 
     #[test]
     fn simple_rect() {
@@ -191,7 +191,7 @@ Since our `WidgetRectangle` doesn't emit actions, let's look at a unit test for 
         harness.mouse_click_on(button_id);
         assert_eq!(
             harness.pop_action(),
-            Some((Action::ButtonPressed(PointerButton::Primary), button_id))
+            Some((Action::ButtonPressed(Some(PointerButton::Primary)), button_id))
         );
     }
 ```

--- a/masonry/src/doc/04b_widget_properties.md
+++ b/masonry/src/doc/04b_widget_properties.md
@@ -83,13 +83,13 @@ Properties should *not* be used to represent an individual widget's state. The f
 With that in mind, let's rewrite our `ColorRectangle` widget to use properties:
 
 ```rust,ignore
-use masonry_winit::properties::BackgroundColor;
+use masonry::properties::BackgroundColor;
 
 impl Widget for ColorRectangle {
     // ...
 
     fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
-        let color = props.get::<BackgroundColor>().unwrap_or(masonry_winit::palette::css::WHITE);
+        let color = props.get::<BackgroundColor>().unwrap_or(masonry::palette::css::WHITE);
         let rect = ctx.size().to_rect();
         scene.fill(
             Fill::NonZero,
@@ -111,7 +111,7 @@ The most idiomatic way to set properties is through `WidgetMut`:
 ```rust,ignore
 let color_rectangle_mut: WidgetMut<ColorRectangle> = ...;
 
-let bg = BackgroundColor { color: masonry_winit::palette::css::BLUE };
+let bg = BackgroundColor { color: masonry::palette::css::BLUE };
 
 color_rectangle_mut.insert_prop(bg);
 ```


### PR DESCRIPTION
This fixes some things that have bitrotted due to API and other changes.

It also removes usages of `masonry_winit` where `masonry` should be used instead.

Dependencies like `kurbo`, `peniko`, `smallvec`, and `vello` should be referenced via their re-exports so that code outside of Masonry doesn't have to keep track of the versions and maintain their own dependencies.