### PR TITLE
`masonry_winit`: Remove dev dependency on `smallvec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,7 +1925,6 @@ dependencies = [
  "parley",
  "pollster",
  "profiling",
- "smallvec",
  "tracing",
  "tracing-tracy",
  "ui-events",

--- a/masonry_winit/Cargo.toml
+++ b/masonry_winit/Cargo.toml
@@ -40,7 +40,6 @@ web-time.workspace = true
 
 [dev-dependencies]
 parley.workspace = true
-smallvec.workspace = true
 tracing = { workspace = true, features = ["default"] }
 ui-events.workspace = true
 image = { workspace = true, features = ["png"] }


### PR DESCRIPTION
This wasn't used or needed.