### PR TITLE
`masonry_winit`: Remove most dev dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,17 +1917,13 @@ dependencies = [
 name = "masonry_winit"
 version = "0.3.0"
 dependencies = [
- "accesskit",
  "accesskit_winit",
  "image",
- "insta",
  "masonry",
- "parley",
  "pollster",
  "profiling",
  "tracing",
  "tracing-tracy",
- "ui-events",
  "ui-events-winit",
  "web-time",
  "wgpu",

--- a/masonry_winit/Cargo.toml
+++ b/masonry_winit/Cargo.toml
@@ -38,12 +38,7 @@ wgpu-profiler = { optional = true, version = "0.22.0", default-features = false 
 web-time.workspace = true
 
 [dev-dependencies]
-parley.workspace = true
-tracing = { workspace = true, features = ["default"] }
-ui-events.workspace = true
 image = { workspace = true, features = ["png"] }
-insta = { version = "1.43.1" }
-accesskit.workspace = true
 
 # Make wgpu use tracing for its spans.
 profiling = { version = "1.0.16", features = ["profile-with-tracing"] }

--- a/masonry_winit/examples/calc_masonry.rs
+++ b/masonry_winit/examples/calc_masonry.rs
@@ -13,7 +13,7 @@
 
 use std::str::FromStr;
 
-use masonry::accesskit::{Node, Role};
+use masonry::accesskit;
 use masonry::core::{
     AccessCtx, AccessEvent, Action, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, StyleProperty, TextEvent, Update,
@@ -249,15 +249,15 @@ impl Widget for CalcButton {
 
     fn paint(&mut self, _ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, _scene: &mut Scene) {}
 
-    fn accessibility_role(&self) -> Role {
-        Role::Button
+    fn accessibility_role(&self) -> accesskit::Role {
+        accesskit::Role::Button
     }
 
     fn accessibility(
         &mut self,
         _ctx: &mut AccessCtx<'_>,
         _props: &PropertiesRef<'_>,
-        node: &mut Node,
+        node: &mut accesskit::Node,
     ) {
         let _name = match self.action {
             CalcAction::Digit(digit) => digit.to_string(),

--- a/masonry_winit/examples/custom_widget.rs
+++ b/masonry_winit/examples/custom_widget.rs
@@ -15,13 +15,13 @@ use masonry::core::{
 };
 use masonry::kurbo::{Affine, BezPath, Point, Rect, Size, Stroke};
 use masonry::palette;
+use masonry::parley::layout::{Alignment, AlignmentOptions};
+use masonry::parley::style::{FontFamily, FontStack, GenericFamily, StyleProperty};
 use masonry::peniko::{Color, Fill, Image, ImageFormat};
 use masonry::smallvec::SmallVec;
 use masonry::vello::Scene;
 use masonry::widgets::RootWidget;
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use parley::layout::{Alignment, AlignmentOptions};
-use parley::style::{FontFamily, FontStack, StyleProperty};
 use tracing::{Span, trace_span};
 use winit::window::Window;
 
@@ -136,7 +136,7 @@ impl Widget for CustomWidget {
         let mut text_layout_builder = lcx.ranged_builder(fcx, &self.0, 1.0, true);
 
         text_layout_builder.push_default(StyleProperty::FontStack(FontStack::Single(
-            FontFamily::Generic(parley::style::GenericFamily::Serif),
+            FontFamily::Generic(GenericFamily::Serif),
         )));
         text_layout_builder.push_default(StyleProperty::FontSize(24.0));
 

--- a/masonry_winit/examples/grid_masonry.rs
+++ b/masonry_winit/examples/grid_masonry.rs
@@ -7,10 +7,10 @@
 #![cfg_attr(not(test), windows_subsystem = "windows")]
 use masonry::core::{Action, PointerButton, StyleProperty, WidgetId};
 use masonry::dpi::LogicalSize;
+use masonry::parley::layout::Alignment;
 use masonry::peniko::Color;
 use masonry::widgets::{Button, Grid, GridParams, Prose, RootWidget, SizedBox, TextArea};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use parley::layout::Alignment;
 use winit::window::Window;
 
 struct Driver {


### PR DESCRIPTION
Some of the dev dependencies were unused or could be made to be unused by using the re-exports from `masonry`.