### PR TITLE
Prepare to split Xilem's lib.rs into multiple files

### DIFF
--- a/xilem/src/any_view.rs
+++ b/xilem/src/any_view.rs
@@ -28,7 +28,7 @@ pub type AnyWidgetView<State, Action = ()> =
 
 impl<W: Widget + FromDynWidget + ?Sized> SuperElement<Pod<W>, ViewCtx> for Pod<DynWidget> {
     fn upcast(ctx: &mut ViewCtx, child: Pod<W>) -> Self {
-        ctx.new_pod(DynWidget {
+        ctx.create_pod(DynWidget {
             inner: child.erased_widget_pod(),
         })
     }

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -498,14 +498,12 @@ impl<Seq, State, Action> WidgetViewSequence<State, Action> for Seq where
 {
 }
 
-type WidgetMap = HashMap<WidgetId, Vec<ViewId>>;
-
 /// A context type passed to various methods of Xilem traits.
 pub struct ViewCtx {
     /// The map from a widgets id to its position in the View tree.
     ///
     /// This includes only the widgets which might send actions
-    widget_map: WidgetMap,
+    widget_map: HashMap<WidgetId, Vec<ViewId>>,
     id_path: Vec<ViewId>,
     proxy: Arc<dyn RawProxy>,
     runtime: Arc<tokio::runtime::Runtime>,
@@ -526,11 +524,11 @@ impl ViewPathTracker for ViewCtx {
     }
 }
 
-#[expect(missing_docs, reason = "TODO - Document these items")]
+// Private items
 impl ViewCtx {
     pub(crate) fn new(proxy: Arc<dyn RawProxy>, runtime: Arc<tokio::runtime::Runtime>) -> Self {
         Self {
-            widget_map: WidgetMap::default(),
+            widget_map: HashMap::default(),
             id_path: Vec::new(),
             proxy,
             runtime,
@@ -538,6 +536,17 @@ impl ViewCtx {
         }
     }
 
+    pub(crate) fn set_state_changed(&mut self, value: bool) {
+        self.state_changed = value;
+    }
+
+    pub(crate) fn get_id_path(&self, widget_id: WidgetId) -> Option<&Vec<ViewId>> {
+        self.widget_map.get(&widget_id)
+    }
+}
+
+#[expect(missing_docs, reason = "TODO - Document these items")]
+impl ViewCtx {
     pub fn create_pod<W: Widget + FromDynWidget>(&mut self, widget: W) -> Pod<W> {
         Pod::new(widget)
     }
@@ -572,16 +581,8 @@ impl ViewCtx {
         self.state_changed
     }
 
-    pub(crate) fn set_state_changed(&mut self, value: bool) {
-        self.state_changed = value;
-    }
-
     pub fn teardown_leaf<W: Widget + FromDynWidget + ?Sized>(&mut self, widget: WidgetMut<'_, W>) {
         self.widget_map.remove(&widget.ctx.widget_id());
-    }
-
-    pub fn get_id_path(&self, widget_id: WidgetId) -> Option<&Vec<ViewId>> {
-        self.widget_map.get(&widget_id)
     }
 
     pub fn runtime(&self) -> &tokio::runtime::Runtime {

--- a/xilem/src/one_of.rs
+++ b/xilem/src/one_of.rs
@@ -101,15 +101,15 @@ impl<
         elem: OneOf<Pod<A>, Pod<B>, Pod<C>, Pod<D>, Pod<E>, Pod<F>, Pod<G>, Pod<H>, Pod<I>>,
     ) -> Self::OneOfElement {
         match elem {
-            OneOf::A(w) => self.new_pod(OneOfWidget::A(w.into_widget_pod())),
-            OneOf::B(w) => self.new_pod(OneOfWidget::B(w.into_widget_pod())),
-            OneOf::C(w) => self.new_pod(OneOfWidget::C(w.into_widget_pod())),
-            OneOf::D(w) => self.new_pod(OneOfWidget::D(w.into_widget_pod())),
-            OneOf::E(w) => self.new_pod(OneOfWidget::E(w.into_widget_pod())),
-            OneOf::F(w) => self.new_pod(OneOfWidget::F(w.into_widget_pod())),
-            OneOf::G(w) => self.new_pod(OneOfWidget::G(w.into_widget_pod())),
-            OneOf::H(w) => self.new_pod(OneOfWidget::H(w.into_widget_pod())),
-            OneOf::I(w) => self.new_pod(OneOfWidget::I(w.into_widget_pod())),
+            OneOf::A(w) => self.create_pod(OneOfWidget::A(w.into_widget_pod())),
+            OneOf::B(w) => self.create_pod(OneOfWidget::B(w.into_widget_pod())),
+            OneOf::C(w) => self.create_pod(OneOfWidget::C(w.into_widget_pod())),
+            OneOf::D(w) => self.create_pod(OneOfWidget::D(w.into_widget_pod())),
+            OneOf::E(w) => self.create_pod(OneOfWidget::E(w.into_widget_pod())),
+            OneOf::F(w) => self.create_pod(OneOfWidget::F(w.into_widget_pod())),
+            OneOf::G(w) => self.create_pod(OneOfWidget::G(w.into_widget_pod())),
+            OneOf::H(w) => self.create_pod(OneOfWidget::H(w.into_widget_pod())),
+            OneOf::I(w) => self.create_pod(OneOfWidget::I(w.into_widget_pod())),
         }
     }
 

--- a/xilem/src/view/button.rs
+++ b/xilem/src/view/button.rs
@@ -149,7 +149,7 @@ where
             View::<State, Action, _>::build(&self.label, ctx)
         });
         ctx.with_leaf_action_widget(|ctx| {
-            let mut pod = ctx.new_pod(widgets::Button::from_label_pod(child.into_widget_pod()));
+            let mut pod = ctx.create_pod(widgets::Button::from_label_pod(child.into_widget_pod()));
             pod.properties = self.properties.build_properties();
             pod.options.disabled = self.disabled;
             pod

--- a/xilem/src/view/checkbox.rs
+++ b/xilem/src/view/checkbox.rs
@@ -100,7 +100,7 @@ where
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         ctx.with_leaf_action_widget(|ctx| {
-            let mut pod = ctx.new_pod(widgets::Checkbox::new(self.checked, self.label.clone()));
+            let mut pod = ctx.create_pod(widgets::Checkbox::new(self.checked, self.label.clone()));
             pod.properties = self.properties.build_properties();
             pod.options.disabled = self.disabled;
             pod

--- a/xilem/src/view/flex.rs
+++ b/xilem/src/view/flex.rs
@@ -161,7 +161,7 @@ where
                 FlexElement::FlexSpacer(flex) => widget.with_flex_spacer(flex),
             }
         }
-        let pod = ctx.new_pod(widget);
+        let pod = ctx.create_pod(widget);
         (pod, seq_state)
     }
 

--- a/xilem/src/view/grid.rs
+++ b/xilem/src/view/grid.rs
@@ -108,7 +108,7 @@ where
         for element in elements.into_inner() {
             widget = widget.with_child_pod(element.child.erased_widget_pod(), element.params);
         }
-        let pod = ctx.new_pod(widget);
+        let pod = ctx.create_pod(widget);
         (pod, seq_state)
     }
 

--- a/xilem/src/view/image.rs
+++ b/xilem/src/view/image.rs
@@ -52,7 +52,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Image {
     type ViewState = ();
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        let pod = ctx.new_pod(widgets::Image::new(self.image.clone()));
+        let pod = ctx.create_pod(widgets::Image::new(self.image.clone()));
         (pod, ())
     }
 

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -111,7 +111,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
     type ViewState = ();
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        let widget_pod = ctx.new_pod(
+        let widget_pod = ctx.create_pod(
             widgets::Label::new(self.label.clone())
                 .with_brush(self.text_brush.clone())
                 .with_alignment(self.alignment)

--- a/xilem/src/view/portal.rs
+++ b/xilem/src/view/portal.rs
@@ -42,7 +42,7 @@ where
         // The Portal `View` doesn't get any messages directly (yet - scroll events?), so doesn't need to
         // use ctx.with_id.
         let (child, child_state) = self.child.build(ctx);
-        let widget_pod = ctx.new_pod(widgets::Portal::new_pod(child.into_widget_pod()));
+        let widget_pod = ctx.create_pod(widgets::Portal::new_pod(child.into_widget_pod()));
         (widget_pod, child_state)
     }
 

--- a/xilem/src/view/progress_bar.rs
+++ b/xilem/src/view/progress_bar.rs
@@ -25,7 +25,7 @@ impl<State, Action> View<State, Action, ViewCtx> for ProgressBar {
     type ViewState = ();
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        ctx.with_leaf_action_widget(|ctx| ctx.new_pod(widgets::ProgressBar::new(self.progress)))
+        ctx.with_leaf_action_widget(|ctx| ctx.create_pod(widgets::ProgressBar::new(self.progress)))
     }
 
     fn rebuild(

--- a/xilem/src/view/prose.rs
+++ b/xilem/src/view/prose.rs
@@ -97,7 +97,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
             .with_style(StyleProperty::FontSize(self.text_size))
             .with_style(StyleProperty::FontWeight(self.weight))
             .with_word_wrap(self.line_break_mode == LineBreaking::WordWrap);
-        let widget_pod = ctx.new_pod(
+        let widget_pod = ctx.create_pod(
             widgets::Prose::from_text_area(text_area)
                 .with_clip(line_break_clips(self.line_break_mode)),
         );

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -135,7 +135,7 @@ where
         let widget = widgets::SizedBox::new_pod(child.erased_widget_pod())
             .raw_width(self.width)
             .raw_height(self.height);
-        let mut pod = ctx.new_pod(widget);
+        let mut pod = ctx.create_pod(widget);
         pod.properties = self.properties.build_properties();
         (pod, child_state)
     }

--- a/xilem/src/view/spinner.rs
+++ b/xilem/src/view/spinner.rs
@@ -58,7 +58,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Spinner {
     type ViewState = ();
 
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        let pod = ctx.new_pod(widgets::Spinner::new());
+        let pod = ctx.create_pod(widgets::Spinner::new());
         (pod, ())
     }
 

--- a/xilem/src/view/split.rs
+++ b/xilem/src/view/split.rs
@@ -180,7 +180,7 @@ where
         let (child1, child1_state) = ctx.with_id(CHILD1_VIEW_ID, |ctx| self.child1.build(ctx));
         let (child2, child2_state) = ctx.with_id(CHILD2_VIEW_ID, |ctx| self.child2.build(ctx));
 
-        let widget_pod = ctx.new_pod(
+        let widget_pod = ctx.create_pod(
             widgets::Split::new_pod(child1.into_widget_pod(), child2.into_widget_pod())
                 .split_axis(self.split_axis)
                 .split_point(self.split_point)

--- a/xilem/src/view/task.rs
+++ b/xilem/src/view/task.rs
@@ -86,7 +86,7 @@ where
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let path: Arc<[ViewId]> = ctx.view_path().into();
 
-        let proxy = ctx.proxy.clone();
+        let proxy = ctx.proxy();
         let handle = ctx
             .runtime()
             .spawn((self.init_future)(MessageProxy::new(proxy, path)));

--- a/xilem/src/view/textbox.rs
+++ b/xilem/src/view/textbox.rs
@@ -131,7 +131,7 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
         // Ensure that the actions from the *inner* TextArea get routed correctly.
         let id = textbox.area_pod().id();
         ctx.record_action(id);
-        let mut pod = ctx.new_pod(textbox);
+        let mut pod = ctx.create_pod(textbox);
         pod.properties = self.properties.build_properties();
         (pod, ())
     }

--- a/xilem/src/view/variable_label.rs
+++ b/xilem/src/view/variable_label.rs
@@ -94,7 +94,7 @@ impl<State, Action> View<State, Action, ViewCtx> for VariableLabel {
         let (label, ()) = ctx.with_id(ViewId::new(0), |ctx| {
             View::<State, Action, _, _>::build(&self.label, ctx)
         });
-        let widget_pod = ctx.new_pod(
+        let widget_pod = ctx.create_pod(
             widgets::VariableLabel::from_label_pod(label.into_widget_pod())
                 .with_initial_weight(self.target_weight.value()),
         );

--- a/xilem/src/view/worker.rs
+++ b/xilem/src/view/worker.rs
@@ -107,7 +107,7 @@ where
     fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let path: Arc<[ViewId]> = ctx.view_path().into();
 
-        let proxy = ctx.proxy.clone();
+        let proxy = ctx.proxy();
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         // No opportunity for the channel to be closed.
         tx.send(self.value.clone()).unwrap();

--- a/xilem/src/view/zstack.rs
+++ b/xilem/src/view/zstack.rs
@@ -75,7 +75,7 @@ where
         for child in elements.into_inner() {
             widget = widget.with_child_pod(child.widget.erased_widget_pod(), child.alignment);
         }
-        let pod = ctx.new_pod(widget);
+        let pod = ctx.create_pod(widget);
         (pod, seq_state)
     }
 

--- a/xilem/src/window_view.rs
+++ b/xilem/src/window_view.rs
@@ -57,7 +57,7 @@ where
     ) {
         self.options.rebuild(&prev.options, window);
 
-        ctx.state_changed = true;
+        ctx.set_state_changed(true);
         self.rebuild_root_widget(prev, root_widget_view_state, ctx, render_root);
     }
 


### PR DESCRIPTION
Change code to remove reliance on private items.
Rename `ViewCtx::new_pod` to `ViewCtx::create_pod` to avoid ambiguity with constructor.