### PR TITLE
Give useful `reason`s for `missing_docs` of properties

### DIFF
--- a/masonry/src/properties/background.rs
+++ b/masonry/src/properties/background.rs
@@ -13,7 +13,7 @@ use crate::properties::types::Gradient;
 // to BackgroundImage to match CSS spec.
 
 /// The background color/gradient of a widget.
-#[expect(missing_docs, reason = "obvious")]
+#[expect(missing_docs, reason = "field names are self-descriptive")]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Background {
     Color(AlphaColor<Srgb>),

--- a/masonry/src/properties/border_color.rs
+++ b/masonry/src/properties/border_color.rs
@@ -7,7 +7,7 @@ use crate::core::{Property, UpdateCtx};
 use crate::peniko::color::{AlphaColor, Srgb};
 
 /// The color of a widget's border.
-#[expect(missing_docs, reason = "obvious")]
+#[expect(missing_docs, reason = "field names are self-descriptive")]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BorderColor {
     pub color: AlphaColor<Srgb>,

--- a/masonry/src/properties/border_width.rs
+++ b/masonry/src/properties/border_width.rs
@@ -9,7 +9,7 @@ use crate::core::{BoxConstraints, Property, UpdateCtx};
 use crate::properties::CornerRadius;
 
 /// The width of a widget's border, in logical pixels.
-#[expect(missing_docs, reason = "obvious")]
+#[expect(missing_docs, reason = "field names are self-descriptive")]
 #[derive(Default, Clone, Copy, Debug, PartialEq)]
 pub struct BorderWidth {
     pub width: f64,

--- a/masonry/src/properties/corner_radius.rs
+++ b/masonry/src/properties/corner_radius.rs
@@ -6,7 +6,7 @@ use std::any::TypeId;
 use crate::core::{Property, UpdateCtx};
 
 /// The radius of a widget's box corners, in logical pixels.
-#[expect(missing_docs, reason = "obvious")]
+#[expect(missing_docs, reason = "field names are self-descriptive")]
 #[derive(Default, Clone, Copy, Debug, PartialEq)]
 pub struct CornerRadius {
     pub radius: f64,


### PR DESCRIPTION
Follow-up from #1054