### PR TITLE
Sketch: An Axum/Bevy inspired component model for Xilem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4936,6 +4936,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "xilem_3"
+version = "0.3.0"
+dependencies = [
+ "xilem_core",
+]
+
+[[package]]
 name = "xilem_core"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
     "xilem_core",
     "masonry",
     "masonry_winit",
+    # An experiment in how Xilem should work.
+    "xilem_3",
 
     "xilem_web",
     "xilem_web/web_examples/counter",

--- a/xilem_3/Cargo.toml
+++ b/xilem_3/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "xilem_3"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+xilem_core = { workspace = true }
+
+
+[lints]
+workspace = true

--- a/xilem_3/src/lib.rs
+++ b/xilem_3/src/lib.rs
@@ -1,0 +1,115 @@
+//! An unproven extension of Xilem.
+
+use std::{marker::PhantomData, sync::Arc};
+
+use xilem_core::{View, ViewPathTracker};
+
+struct AppState;
+
+struct ViewCtx {}
+
+impl ViewPathTracker for ViewCtx {
+    fn push_id(&mut self, _: xilem_core::ViewId) {
+        todo!()
+    }
+
+    fn pop_id(&mut self) {
+        todo!()
+    }
+
+    fn view_path(&mut self) -> &[xilem_core::ViewId] {
+        todo!()
+    }
+}
+
+// pub trait HyperView<State, Action = ()>:
+//     for <'a> View< State, Action, ViewCtx, ViewState = Hyper<AppState,>,Element = Hyper<State>> + Send + Sync
+
+// {
+
+//     type Widget: ?Sized;
+// }
+
+struct Action;
+
+// TODO: Maybe this type should be renamed View.
+/// Functionality which runs on the main UI thread with your app's state.
+pub trait HyperView<State> {
+    type Element;
+    type View: View<State, Action, ViewCtx, Element = Self::Element>;
+    type HyperState;
+    fn build(
+        // &mut self,
+        self,
+        // previous: Option<&mut Self>,
+        hyper_state: &mut Option<Self::HyperState>,
+        app_state: &mut State,
+    ) -> Self::View;
+}
+
+pub trait WidgetView<State>:
+    View<State, Action, ViewCtx, Element = Pod<Self::Widget>> + Send + Sync
+{
+    type Widget: ?Sized;
+}
+
+struct Pod<T: ?Sized> {
+    val: PhantomData<T>,
+}
+
+fn app_logic(state: &mut AppState) -> impl HyperView<AppState> {}
+
+struct Memoized<Data, NewData, AppState, ResultView, Component, InitData>
+where
+    // TODO: Should these be FnOnce?
+    InitData: Fn(&mut AppState) -> Data,
+    NewData: Fn(&mut AppState, &mut Data) -> bool,
+    Component: Fn(&mut AppState, &Data) -> ResultView,
+{
+    memoize: NewData,
+    init_data: InitData,
+    component: Component,
+    phantom: PhantomData<(
+        fn(&mut AppState, Data) -> Data,
+        fn(&mut AppState, &Data) -> ResultView,
+    )>,
+}
+
+impl<Data, NewData, AppState, ResultView, Component, InitData> HyperView<AppState>
+    for Memoized<Data, NewData, AppState, ResultView, Component, InitData>
+where
+    InitData: Fn(&mut AppState) -> Data,
+    NewData: Fn(&mut AppState, &mut Data) -> bool,
+    Component: Fn(&mut AppState, &Data) -> ResultView,
+    ResultView: View<AppState, Action, ViewCtx>,
+{
+    type Element = ResultView::Element;
+    type View = Arc<ResultView>;
+    type HyperState = (Data, Arc<ResultView>);
+
+    fn build(
+        // &mut self,
+        self,
+        // previous: Option<&mut Self>,
+        hyper_state: &mut Option<Self::HyperState>,
+        app_state: &mut AppState,
+    ) -> Self::View {
+        match hyper_state {
+            Some((data, stored_view)) => {
+                if (self.memoize)(app_state, data) {
+                    // TODO: We could optimisitically store the old version of `stored_view`,
+                    // so as to reuse this allocation if `Arc::get_mut` doesn't error.
+                    *stored_view = Arc::new((self.component)(app_state, &data));
+                }
+                stored_view.clone()
+            }
+            None => {
+                let data = (self.init_data)(app_state);
+                let view = (self.component)(app_state, &data);
+                let view = Arc::new(view);
+                *hyper_state = Some((data, view.clone()));
+                return view;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request is the result of an experiment I started during travel back from RustWeek, thinking about the shortcomings of Xilem's lifecycle/threading model (e.g. #1032, the hacks in #921).

> [!WARNING]
>
> This work is extremely incomplete.
> I'd love to push this work forward, but I don't have anywhere near all the answers for how this will work.
> This PR is largely to have something to point towards when discussing this idea.

The current model in Xilem has two distinct phases, the app logic and view "rebuild"/reconciliation. In the theoretical version of the model, the app logic is where all "user code" happens, and produces a pure view tree. However, in practise, the app logic cannot have local state, and so work is deferred to "rebuild" in order to access local state; see e.g. `memoize`. However, rebuild time doesn't have access to the app state.

Essentially, the idea in this work is to have a formalisation of the app logic into explicit "components", which both have access to the app state, and to their own local state. Components know how to create a view, which is the true lightweight description of the state of a widget tree.
The true advancement of this model, is that any function which returns a component is itself a component. That child component "works" by running the function, then running the component method on the function's return value. The user generally "actually writes" these components.
Importantly, these component functions can have parameters other than the app state, including e.g. "local" variables, as seen in [Bevy](https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.Local.html).
(This isn't implemented yet, but it's worth noting that I have been in the weeds of the equivalent in Bevy, and understand how it works)

---

Note that in theory, we could go even further here, and also give the components access to the tree element itself; this would mix app logic and rebuild time directly. This might be the more natural expansion of the Xilem model. I haven't reasoned carefully about how that would look like.
This is likely the direction I'd like this exploration to go in next.

Other notes:
- The model proposed here interacts reasonably nicely with hot reloading; the app logic can be hot reloaded, and only the final views need to be sent to the "main thread".