### PR TITLE
Xilem: Pass `app_state` as a parameter to `View::{build, rebuild, teardown}`

### DIFF
--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -150,7 +150,8 @@ where
             Arc::new(WindowProxy(window_id, self.proxy.clone())),
             self.runtime.clone(),
         );
-        let (CreateWindow(attrs, root_widget), view_state) = view.build(&mut view_ctx);
+        let (CreateWindow(attrs, root_widget), view_state) =
+            view.build(&mut view_ctx, &mut self.state);
         self.windows.insert(
             window_id,
             Window {
@@ -178,6 +179,7 @@ where
             &mut window.view_state,
             &mut window.view_ctx,
             ctx.window_handle_and_render_root(window_id),
+            &mut self.state,
         );
         self.windows.remove(&window_id);
         ctx.close_window(window_id);
@@ -206,6 +208,7 @@ where
                         view_state,
                         view_ctx,
                         driver_ctx.window_handle_and_render_root(window_id),
+                        &mut self.state,
                     );
                     *view = next_view;
                 }
@@ -284,6 +287,7 @@ where
                     &mut window.view_state,
                     &mut window.view_ctx,
                     masonry_ctx.render_root(window_id),
+                    &mut self.state,
                 );
             }
             MessageResult::Nop => {}

--- a/xilem/src/view/button.rs
+++ b/xilem/src/view/button.rs
@@ -144,9 +144,9 @@ where
     type Element = Pod<widgets::Button>;
     type ViewState = ();
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
         let (child, ()) = ctx.with_id(LABEL_VIEW_ID, |ctx| {
-            View::<State, Action, _>::build(&self.label, ctx)
+            View::<State, Action, _>::build(&self.label, ctx, app_state)
         });
         ctx.with_leaf_action_widget(|ctx| {
             let mut pod = ctx.create_pod(widgets::Button::from_label_pod(child.into_widget_pod()));
@@ -162,6 +162,7 @@ where
         state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         self.properties
             .rebuild_properties(&prev.properties, &mut element);
@@ -175,6 +176,7 @@ where
                 state,
                 ctx,
                 widgets::Button::label_mut(&mut element),
+                app_state,
             );
         });
     }
@@ -184,6 +186,7 @@ where
         _: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         ctx.with_id(LABEL_VIEW_ID, |ctx| {
             View::<State, Action, _>::teardown(
@@ -191,6 +194,7 @@ where
                 &mut (),
                 ctx,
                 widgets::Button::label_mut(&mut element),
+                app_state,
             );
         });
         ctx.teardown_leaf(element);

--- a/xilem/src/view/checkbox.rs
+++ b/xilem/src/view/checkbox.rs
@@ -98,7 +98,7 @@ where
     type Element = Pod<widgets::Checkbox>;
     type ViewState = ();
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, _: &mut State) -> (Self::Element, Self::ViewState) {
         ctx.with_leaf_action_widget(|ctx| {
             let mut pod = ctx.create_pod(widgets::Checkbox::new(self.checked, self.label.clone()));
             pod.properties = self.properties.build_properties();
@@ -113,6 +113,7 @@ where
         (): &mut Self::ViewState,
         _ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         self.properties
             .rebuild_properties(&prev.properties, &mut element);
@@ -132,6 +133,7 @@ where
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         ctx.teardown_leaf(element);
     }

--- a/xilem/src/view/image.rs
+++ b/xilem/src/view/image.rs
@@ -51,7 +51,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Image {
     type Element = Pod<widgets::Image>;
     type ViewState = ();
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, _: &mut State) -> (Self::Element, Self::ViewState) {
         let pod = ctx.create_pod(widgets::Image::new(self.image.clone()));
         (pod, ())
     }
@@ -62,6 +62,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Image {
         (): &mut Self::ViewState,
         _: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         if prev.object_fit != self.object_fit {
             widgets::Image::set_fit_mode(&mut element, self.object_fit);
@@ -71,7 +72,14 @@ impl<State, Action> View<State, Action, ViewCtx> for Image {
         }
     }
 
-    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Self::Element>) {}
+    fn teardown(
+        &self,
+        (): &mut Self::ViewState,
+        _: &mut ViewCtx,
+        _: Mut<'_, Self::Element>,
+        _: &mut State,
+    ) {
+    }
 
     fn message(
         &self,

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -110,7 +110,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
     type Element = Pod<widgets::Label>;
     type ViewState = ();
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, _: &mut State) -> (Self::Element, Self::ViewState) {
         let widget_pod = ctx.create_pod(
             widgets::Label::new(self.label.clone())
                 .with_brush(self.text_brush.clone())
@@ -129,6 +129,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
         (): &mut Self::ViewState,
         _ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         if prev.label != self.label {
             widgets::Label::set_text(&mut element, self.label.clone());
@@ -153,7 +154,14 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
         }
     }
 
-    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Self::Element>) {}
+    fn teardown(
+        &self,
+        (): &mut Self::ViewState,
+        _: &mut ViewCtx,
+        _: Mut<'_, Self::Element>,
+        _: &mut State,
+    ) {
+    }
 
     fn message(
         &self,

--- a/xilem/src/view/portal.rs
+++ b/xilem/src/view/portal.rs
@@ -38,10 +38,10 @@ where
     type Element = Pod<widgets::Portal<Child::Widget>>;
     type ViewState = Child::ViewState;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
         // The Portal `View` doesn't get any messages directly (yet - scroll events?), so doesn't need to
         // use ctx.with_id.
-        let (child, child_state) = self.child.build(ctx);
+        let (child, child_state) = self.child.build(ctx, app_state);
         let widget_pod = ctx.create_pod(widgets::Portal::new_pod(child.into_widget_pod()));
         (widget_pod, child_state)
     }
@@ -52,10 +52,11 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         let child_element = widgets::Portal::child_mut(&mut element);
         self.child
-            .rebuild(&prev.child, view_state, ctx, child_element);
+            .rebuild(&prev.child, view_state, ctx, child_element, app_state);
     }
 
     fn teardown(
@@ -63,9 +64,11 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         let child_element = widgets::Portal::child_mut(&mut element);
-        self.child.teardown(view_state, ctx, child_element);
+        self.child
+            .teardown(view_state, ctx, child_element, app_state);
     }
 
     fn message(

--- a/xilem/src/view/progress_bar.rs
+++ b/xilem/src/view/progress_bar.rs
@@ -24,7 +24,7 @@ impl<State, Action> View<State, Action, ViewCtx> for ProgressBar {
     type Element = Pod<widgets::ProgressBar>;
     type ViewState = ();
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, _: &mut State) -> (Self::Element, Self::ViewState) {
         ctx.with_leaf_action_widget(|ctx| ctx.create_pod(widgets::ProgressBar::new(self.progress)))
     }
 
@@ -34,6 +34,7 @@ impl<State, Action> View<State, Action, ViewCtx> for ProgressBar {
         (): &mut Self::ViewState,
         _ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         if prev.progress != self.progress {
             widgets::ProgressBar::set_progress(&mut element, self.progress);
@@ -45,6 +46,7 @@ impl<State, Action> View<State, Action, ViewCtx> for ProgressBar {
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         ctx.teardown_leaf(element);
     }

--- a/xilem/src/view/prose.rs
+++ b/xilem/src/view/prose.rs
@@ -90,7 +90,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
     type Element = Pod<widgets::Prose>;
     type ViewState = ();
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, _: &mut State) -> (Self::Element, Self::ViewState) {
         let text_area = widgets::TextArea::new_immutable(&self.content)
             .with_brush(self.text_brush.clone())
             .with_alignment(self.alignment)
@@ -110,6 +110,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
         (): &mut Self::ViewState,
         _ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         let mut text_area = widgets::Prose::text_mut(&mut element);
         if prev.content != self.content {
@@ -140,7 +141,14 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
         }
     }
 
-    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Self::Element>) {}
+    fn teardown(
+        &self,
+        (): &mut Self::ViewState,
+        _: &mut ViewCtx,
+        _: Mut<'_, Self::Element>,
+        _: &mut State,
+    ) {
+    }
 
     fn message(
         &self,

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -130,8 +130,8 @@ where
     type Element = Pod<widgets::SizedBox>;
     type ViewState = V::ViewState;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        let (child, child_state) = self.inner.build(ctx);
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
+        let (child, child_state) = self.inner.build(ctx, app_state);
         let widget = widgets::SizedBox::new_pod(child.erased_widget_pod())
             .raw_width(self.width)
             .raw_height(self.height);
@@ -146,6 +146,7 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         self.properties
             .rebuild_properties(&prev.properties, &mut element);
@@ -165,7 +166,7 @@ where
             let mut child = widgets::SizedBox::child_mut(&mut element)
                 .expect("We only create SizedBox with a child");
             self.inner
-                .rebuild(&prev.inner, view_state, ctx, child.downcast());
+                .rebuild(&prev.inner, view_state, ctx, child.downcast(), app_state);
         }
     }
 
@@ -174,10 +175,12 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         let mut child = widgets::SizedBox::child_mut(&mut element)
             .expect("We only create SizedBox with a child");
-        self.inner.teardown(view_state, ctx, child.downcast());
+        self.inner
+            .teardown(view_state, ctx, child.downcast(), app_state);
     }
 
     fn message(

--- a/xilem/src/view/spinner.rs
+++ b/xilem/src/view/spinner.rs
@@ -57,7 +57,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Spinner {
     type Element = Pod<widgets::Spinner>;
     type ViewState = ();
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, _: &mut State) -> (Self::Element, Self::ViewState) {
         let pod = ctx.create_pod(widgets::Spinner::new());
         (pod, ())
     }
@@ -68,6 +68,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Spinner {
         (): &mut Self::ViewState,
         _: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         if prev.color != self.color {
             match self.color {
@@ -77,7 +78,14 @@ impl<State, Action> View<State, Action, ViewCtx> for Spinner {
         }
     }
 
-    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Self::Element>) {}
+    fn teardown(
+        &self,
+        (): &mut Self::ViewState,
+        _: &mut ViewCtx,
+        _: Mut<'_, Self::Element>,
+        _: &mut State,
+    ) {
+    }
 
     fn message(
         &self,

--- a/xilem/src/view/split.rs
+++ b/xilem/src/view/split.rs
@@ -176,9 +176,11 @@ where
 
     type ViewState = (ChildA::ViewState, ChildB::ViewState);
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        let (child1, child1_state) = ctx.with_id(CHILD1_VIEW_ID, |ctx| self.child1.build(ctx));
-        let (child2, child2_state) = ctx.with_id(CHILD2_VIEW_ID, |ctx| self.child2.build(ctx));
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
+        let (child1, child1_state) =
+            ctx.with_id(CHILD1_VIEW_ID, |ctx| self.child1.build(ctx, app_state));
+        let (child2, child2_state) =
+            ctx.with_id(CHILD2_VIEW_ID, |ctx| self.child2.build(ctx, app_state));
 
         let widget_pod = ctx.create_pod(
             widgets::Split::new_pod(child1.into_widget_pod(), child2.into_widget_pod())
@@ -200,6 +202,7 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: xilem_core::Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         if prev.split_axis != self.split_axis {
             widgets::Split::set_split_axis(&mut element, self.split_axis);
@@ -231,14 +234,24 @@ where
 
         ctx.with_id(CHILD1_VIEW_ID, |ctx| {
             let child1_element = widgets::Split::child1_mut(&mut element);
-            self.child1
-                .rebuild(&prev.child1, &mut view_state.0, ctx, child1_element);
+            self.child1.rebuild(
+                &prev.child1,
+                &mut view_state.0,
+                ctx,
+                child1_element,
+                app_state,
+            );
         });
 
         ctx.with_id(CHILD2_VIEW_ID, |ctx| {
             let child2_element = widgets::Split::child2_mut(&mut element);
-            self.child2
-                .rebuild(&prev.child2, &mut view_state.1, ctx, child2_element);
+            self.child2.rebuild(
+                &prev.child2,
+                &mut view_state.1,
+                ctx,
+                child2_element,
+                app_state,
+            );
         });
     }
 
@@ -247,12 +260,15 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: xilem_core::Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         let child1_element = widgets::Split::child1_mut(&mut element);
-        self.child1.teardown(&mut view_state.0, ctx, child1_element);
+        self.child1
+            .teardown(&mut view_state.0, ctx, child1_element, app_state);
 
         let child2_element = widgets::Split::child2_mut(&mut element);
-        self.child2.teardown(&mut view_state.1, ctx, child2_element);
+        self.child2
+            .teardown(&mut view_state.1, ctx, child2_element, app_state);
     }
 
     fn message(

--- a/xilem/src/view/task.rs
+++ b/xilem/src/view/task.rs
@@ -28,6 +28,7 @@ use crate::core::{
 /// See [`run_once`](crate::core::run_once) for details.
 pub fn task<M, F, H, State, Action, Fut>(init_future: F, on_event: H) -> Task<F, H, M>
 where
+    // TODO: Accept the state in this function
     F: Fn(MessageProxy<M>) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
@@ -83,7 +84,7 @@ where
 
     type ViewState = JoinHandle<()>;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, _: &mut State) -> (Self::Element, Self::ViewState) {
         let path: Arc<[ViewId]> = ctx.view_path().into();
 
         let proxy = ctx.proxy();
@@ -99,6 +100,7 @@ where
         _: &mut Self::ViewState,
         _: &mut ViewCtx,
         (): Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         // Nothing to do
     }
@@ -108,6 +110,7 @@ where
         join_handle: &mut Self::ViewState,
         _: &mut ViewCtx,
         _: Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         join_handle.abort();
     }

--- a/xilem/src/view/textbox.rs
+++ b/xilem/src/view/textbox.rs
@@ -114,7 +114,7 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
     type Element = Pod<widgets::Textbox>;
     type ViewState = ();
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, _: &mut State) -> (Self::Element, Self::ViewState) {
         // TODO: Maybe we want a shared TextArea View?
         let text_area = widgets::TextArea::new_editable(&self.contents)
             .with_brush(self.text_brush.clone())
@@ -142,6 +142,7 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
         _: &mut Self::ViewState,
         _ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         self.properties
             .rebuild_properties(&prev.properties, &mut element);
@@ -178,6 +179,7 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
         _: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         ctx.teardown_leaf(element);
     }

--- a/xilem/src/view/transform.rs
+++ b/xilem/src/view/transform.rs
@@ -96,8 +96,8 @@ where
     type Element = Pod<Child::Widget>;
     type ViewState = private::TransformedState<Child::ViewState>;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        let (mut child_pod, child_state) = self.child.build(ctx);
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
+        let (mut child_pod, child_state) = self.child.build(ctx, app_state);
         let state = private::TransformedState {
             child: child_state,
             previous_transform: child_pod.options.transform,
@@ -112,12 +112,14 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: xilem_core::Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         self.child.rebuild(
             &prev.child,
             &mut view_state.child,
             ctx,
             element.reborrow_mut(),
+            app_state,
         );
         let transform_changed = element.ctx.transform_has_changed();
         // If the child view changed the transform, we know we're out of date.
@@ -142,8 +144,10 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: xilem_core::Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
-        self.child.teardown(&mut view_state.child, ctx, element);
+        self.child
+            .teardown(&mut view_state.child, ctx, element, app_state);
     }
 
     fn message(

--- a/xilem/src/view/variable_label.rs
+++ b/xilem/src/view/variable_label.rs
@@ -90,9 +90,9 @@ impl<State, Action> View<State, Action, ViewCtx> for VariableLabel {
     type Element = Pod<widgets::VariableLabel>;
     type ViewState = ();
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
         let (label, ()) = ctx.with_id(ViewId::new(0), |ctx| {
-            View::<State, Action, _, _>::build(&self.label, ctx)
+            View::<State, Action, _, _>::build(&self.label, ctx, app_state)
         });
         let widget_pod = ctx.create_pod(
             widgets::VariableLabel::from_label_pod(label.into_widget_pod())
@@ -107,6 +107,7 @@ impl<State, Action> View<State, Action, ViewCtx> for VariableLabel {
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         ctx.with_id(ViewId::new(0), |ctx| {
             View::<State, Action, _, _>::rebuild(
@@ -115,6 +116,7 @@ impl<State, Action> View<State, Action, ViewCtx> for VariableLabel {
                 &mut (),
                 ctx,
                 widgets::VariableLabel::label_mut(&mut element),
+                app_state,
             );
         });
 
@@ -132,6 +134,7 @@ impl<State, Action> View<State, Action, ViewCtx> for VariableLabel {
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         ctx.with_id(ViewId::new(0), |ctx| {
             View::<State, Action, _, _>::teardown(
@@ -139,6 +142,7 @@ impl<State, Action> View<State, Action, ViewCtx> for VariableLabel {
                 &mut (),
                 ctx,
                 widgets::VariableLabel::label_mut(&mut element),
+                app_state,
             );
         });
     }

--- a/xilem/src/view/worker.rs
+++ b/xilem/src/view/worker.rs
@@ -64,6 +64,7 @@ pub fn worker_raw<M, V, F, H, State, Action, Fut>(
     on_response: H,
 ) -> Worker<F, H, M, V>
 where
+    // TODO(DJMcNab): Accept app_state here
     F: Fn(MessageProxy<M>, UnboundedReceiver<V>) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
@@ -104,7 +105,7 @@ where
 
     type ViewState = WorkerState<V>;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, _: &mut State) -> (Self::Element, Self::ViewState) {
         let path: Arc<[ViewId]> = ctx.view_path().into();
 
         let proxy = ctx.proxy();
@@ -123,6 +124,7 @@ where
         view_state: &mut Self::ViewState,
         _: &mut ViewCtx,
         (): Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         if self.value != prev.value {
             // TODO: Error handling
@@ -135,6 +137,7 @@ where
         view_state: &mut Self::ViewState,
         _: &mut ViewCtx,
         _: Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         view_state.handle.abort();
     }

--- a/xilem/src/window_view.rs
+++ b/xilem/src/window_view.rs
@@ -41,8 +41,8 @@ where
 
     type ViewState = AnyViewState;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        let (pod, view_state) = self.root_widget_view.build(ctx);
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
+        let (pod, view_state) = self.root_widget_view.build(ctx, app_state);
         let root_widget = RootWidget::from_pod(pod.into_widget_pod().erased());
         let initial_attributes = self.options.build_initial_attrs();
         (CreateWindow(initial_attributes, root_widget), view_state)
@@ -54,11 +54,12 @@ where
         root_widget_view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         (window, render_root): xilem_core::Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         self.options.rebuild(&prev.options, window);
 
         ctx.set_state_changed(true);
-        self.rebuild_root_widget(prev, root_widget_view_state, ctx, render_root);
+        self.rebuild_root_widget(prev, root_widget_view_state, ctx, render_root, app_state);
     }
 
     fn teardown(
@@ -66,6 +67,7 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         (_, render_root): xilem_core::Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         render_root.edit_root_widget(|mut root| {
             let mut root = root.downcast::<RootWidget>();
@@ -73,6 +75,7 @@ where
                 view_state,
                 ctx,
                 RootWidget::child_mut(&mut root).downcast(),
+                app_state,
             );
         });
     }
@@ -99,6 +102,7 @@ where
         root_widget_view_state: &mut AnyViewState,
         ctx: &mut ViewCtx,
         render_root: &mut RenderRoot,
+        app_state: &mut State,
     ) {
         render_root.edit_root_widget(|mut root| {
             let mut root = root.downcast::<RootWidget>();
@@ -107,6 +111,7 @@ where
                 root_widget_view_state,
                 ctx,
                 RootWidget::child_mut(&mut root).downcast(),
+                app_state,
             );
         });
         if cfg!(debug_assertions) && !render_root.needs_rewrite_passes() {

--- a/xilem_core/examples/filesystem.rs
+++ b/xilem_core/examples/filesystem.rs
@@ -58,7 +58,7 @@ fn main() {
         current_folder_path: path.clone(),
         view_path: Vec::new(),
     };
-    let (mut element, mut initial_state) = previous.build(&mut root_ctx);
+    let (mut element, mut initial_state) = previous.build(&mut root_ctx, &mut state);
     loop {
         input_buf.clear();
         let read_count = stdin()
@@ -87,7 +87,13 @@ fn main() {
         };
         let new_view = app_logic(&mut state);
         root_ctx.current_folder_path.clone_from(&path);
-        new_view.rebuild(&previous, &mut initial_state, &mut root_ctx, &mut element.0);
+        new_view.rebuild(
+            &previous,
+            &mut initial_state,
+            &mut root_ctx,
+            &mut element.0,
+            &mut state,
+        );
         previous = new_view;
     }
 }
@@ -153,7 +159,7 @@ impl<State, Action> View<State, Action, ViewCtx> for File {
     type Element = FsPath;
     type ViewState = ();
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, _app_state: &mut State) -> (Self::Element, Self::ViewState) {
         let path = ctx.current_folder_path.join(&*self.name);
 
         // TODO: How to handle errors here?
@@ -167,6 +173,7 @@ impl<State, Action> View<State, Action, ViewCtx> for File {
         _view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
+        _app_state: &mut State,
     ) {
         if prev.name != self.name {
             let new_path = ctx.current_folder_path.join(&*self.name);
@@ -183,6 +190,7 @@ impl<State, Action> View<State, Action, ViewCtx> for File {
         _view_state: &mut Self::ViewState,
         _ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
+        _app_state: &mut State,
     ) {
         let _ = std::fs::remove_file(element);
     }

--- a/xilem_core/examples/user_interface.rs
+++ b/xilem_core/examples/user_interface.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Model version of Masonry for exploration
+// TODO(DJMcNab): Remove this file
 
 use core::any::Any;
 
@@ -15,9 +16,10 @@ fn app_logic(_: &mut u32) -> impl WidgetView<u32> + use<> {
 }
 
 fn main() {
-    let view = app_logic(&mut 10);
+    let mut state = 10;
+    let view = app_logic(&mut state);
     let mut ctx = ViewCtx { path: vec![] };
-    let (_widget_tree, _state) = view.build(&mut ctx);
+    let (_widget_tree, _state) = view.build(&mut ctx, &mut state);
     // TODO: dbg!(widget_tree);
 }
 
@@ -50,7 +52,11 @@ impl<State, Action> View<State, Action, ViewCtx> for Button {
     type Element = WidgetBox<ButtonWidget>;
     type ViewState = ();
 
-    fn build(&self, _ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(
+        &self,
+        _ctx: &mut ViewCtx,
+        _app_state: &mut State,
+    ) -> (Self::Element, Self::ViewState) {
         (
             WidgetBox {
                 widget: ButtonWidget {},
@@ -65,6 +71,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Button {
         _view_state: &mut Self::ViewState,
         _ctx: &mut ViewCtx,
         _element: Mut<'_, Self::Element>,
+        _app_state: &mut State,
     ) {
         // Nothing to do
     }
@@ -74,6 +81,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Button {
         _view_state: &mut Self::ViewState,
         _ctx: &mut ViewCtx,
         _element: Mut<'_, Self::Element>,
+        _app_state: &mut State,
     ) {
         // Nothing to do
     }

--- a/xilem_core/src/views/adapt.rs
+++ b/xilem_core/src/views/adapt.rs
@@ -174,33 +174,33 @@ where
 
     fn build(
         &self,
-        ctx: &mut Context,
-        app_state: &mut ParentState,
+        _ctx: &mut Context,
+        _app_state: &mut ParentState,
     ) -> (Self::Element, Self::ViewState) {
-        todo!("TODO(DJMcNab)");
+        unimplemented!("TODO(DJMcNab)");
         // self.child.build(ctx)
     }
 
     fn rebuild(
         &self,
-        prev: &Self,
-        view_state: &mut Self::ViewState,
-        ctx: &mut Context,
-        element: Mut<'_, Self::Element>,
-        app_state: &mut ParentState,
+        _prev: &Self,
+        _view_state: &mut Self::ViewState,
+        _ctx: &mut Context,
+        _element: Mut<'_, Self::Element>,
+        _app_state: &mut ParentState,
     ) {
-        todo!("TODO(DJMcNab)");
+        unimplemented!("TODO(DJMcNab)");
         // self.child.rebuild(&prev.child, view_state, ctx, element);
     }
 
     fn teardown(
         &self,
-        view_state: &mut Self::ViewState,
-        ctx: &mut Context,
-        element: Mut<'_, Self::Element>,
-        app_state: &mut ParentState,
+        _view_state: &mut Self::ViewState,
+        _ctx: &mut Context,
+        _element: Mut<'_, Self::Element>,
+        _app_state: &mut ParentState,
     ) {
-        todo!("TODO(DJMcNab)");
+        unimplemented!("TODO(DJMcNab)");
         // self.child.teardown(view_state, ctx, element);
     }
 

--- a/xilem_core/src/views/adapt.rs
+++ b/xilem_core/src/views/adapt.rs
@@ -172,8 +172,13 @@ where
 
     type Element = V::Element;
 
-    fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
-        self.child.build(ctx)
+    fn build(
+        &self,
+        ctx: &mut Context,
+        app_state: &mut ParentState,
+    ) -> (Self::Element, Self::ViewState) {
+        todo!("TODO(DJMcNab)");
+        // self.child.build(ctx)
     }
 
     fn rebuild(
@@ -182,8 +187,10 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
+        app_state: &mut ParentState,
     ) {
-        self.child.rebuild(&prev.child, view_state, ctx, element);
+        todo!("TODO(DJMcNab)");
+        // self.child.rebuild(&prev.child, view_state, ctx, element);
     }
 
     fn teardown(
@@ -191,8 +198,10 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
+        app_state: &mut ParentState,
     ) {
-        self.child.teardown(view_state, ctx, element);
+        todo!("TODO(DJMcNab)");
+        // self.child.teardown(view_state, ctx, element);
     }
 
     fn message(

--- a/xilem_core/src/views/fork.rs
+++ b/xilem_core/src/views/fork.rs
@@ -39,12 +39,12 @@ where
 
     type ViewState = (Active::ViewState, Alongside::SeqState);
 
-    fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut Context, app_state: &mut State) -> (Self::Element, Self::ViewState) {
         let (element, active_state) =
-            ctx.with_id(ViewId::new(0), |ctx| self.active_view.build(ctx));
+            ctx.with_id(ViewId::new(0), |ctx| self.active_view.build(ctx, app_state));
         let alongside_state = ctx.with_id(ViewId::new(1), |ctx| {
             self.alongside_view
-                .seq_build(ctx, &mut AppendVec::default())
+                .seq_build(ctx, &mut AppendVec::default(), app_state)
         });
         (element, (active_state, alongside_state))
     }
@@ -55,10 +55,11 @@ where
         (active_state, alongside_state): &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         ctx.with_id(ViewId::new(0), |ctx| {
             self.active_view
-                .rebuild(&prev.active_view, active_state, ctx, element);
+                .rebuild(&prev.active_view, active_state, ctx, element, app_state);
         });
         ctx.with_id(ViewId::new(1), |ctx| {
             self.alongside_view.seq_rebuild(
@@ -66,6 +67,7 @@ where
                 alongside_state,
                 ctx,
                 &mut NoElements,
+                app_state,
             );
         });
     }
@@ -75,13 +77,15 @@ where
         (active_state, alongside_state): &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         ctx.with_id(ViewId::new(0), |ctx| {
             self.alongside_view
-                .seq_teardown(alongside_state, ctx, &mut NoElements);
+                .seq_teardown(alongside_state, ctx, &mut NoElements, app_state);
         });
         ctx.with_id(ViewId::new(1), |ctx| {
-            self.active_view.teardown(active_state, ctx, element);
+            self.active_view
+                .teardown(active_state, ctx, element, app_state);
         });
     }
 

--- a/xilem_core/src/views/map_action.rs
+++ b/xilem_core/src/views/map_action.rs
@@ -103,8 +103,8 @@ where
     type ViewState = V::ViewState;
     type Element = V::Element;
 
-    fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
-        self.child.build(ctx)
+    fn build(&self, ctx: &mut Context, app_state: &mut State) -> (Self::Element, Self::ViewState) {
+        self.child.build(ctx, app_state)
     }
 
     fn rebuild(
@@ -113,8 +113,10 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
-        self.child.rebuild(&prev.child, view_state, ctx, element);
+        self.child
+            .rebuild(&prev.child, view_state, ctx, element, app_state);
     }
 
     fn teardown(
@@ -122,8 +124,9 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
-        self.child.teardown(view_state, ctx, element);
+        self.child.teardown(view_state, ctx, element, app_state);
     }
 
     fn message(

--- a/xilem_core/src/views/map_state.rs
+++ b/xilem_core/src/views/map_state.rs
@@ -145,8 +145,12 @@ where
     type ViewState = V::ViewState;
     type Element = V::Element;
 
-    fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
-        self.child.build(ctx)
+    fn build(
+        &self,
+        ctx: &mut Context,
+        app_state: &mut ParentState,
+    ) -> (Self::Element, Self::ViewState) {
+        self.child.build(ctx, (self.map_state)(app_state))
     }
 
     fn rebuild(
@@ -155,8 +159,15 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
+        app_state: &mut ParentState,
     ) {
-        self.child.rebuild(&prev.child, view_state, ctx, element);
+        self.child.rebuild(
+            &prev.child,
+            view_state,
+            ctx,
+            element,
+            (self.map_state)(app_state),
+        );
     }
 
     fn teardown(
@@ -164,8 +175,10 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
+        app_state: &mut ParentState,
     ) {
-        self.child.teardown(view_state, ctx, element);
+        self.child
+            .teardown(view_state, ctx, element, (self.map_state)(app_state));
     }
 
     fn message(

--- a/xilem_core/src/views/one_of.rs
+++ b/xilem_core/src/views/one_of.rs
@@ -226,43 +226,43 @@ where
     >;
 
     #[doc(hidden)]
-    fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut Context, app_state: &mut State) -> (Self::Element, Self::ViewState) {
         let generation = 0;
         let (element, state) = ctx.with_id(ViewId::new(generation), |ctx| match self {
             Self::A(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::A(new_element), OneOf::A(state))
             }
             Self::B(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::B(new_element), OneOf::B(state))
             }
             Self::C(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::C(new_element), OneOf::C(state))
             }
             Self::D(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::D(new_element), OneOf::D(state))
             }
             Self::E(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::E(new_element), OneOf::E(state))
             }
             Self::F(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::F(new_element), OneOf::F(state))
             }
             Self::G(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::G(new_element), OneOf::G(state))
             }
             Self::H(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::H(new_element), OneOf::H(state))
             }
             Self::I(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::I(new_element), OneOf::I(state))
             }
         });
@@ -282,6 +282,7 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         mut element: Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         let id = ViewId::new(view_state.generation);
         // If both elements are of the same type, do a simple rebuild
@@ -289,7 +290,7 @@ where
             (Self::A(this), Self::A(prev), OneOf::A(state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_a(&mut element, |element| {
-                        this.rebuild(prev, state, ctx, element);
+                        this.rebuild(prev, state, ctx, element, app_state);
                     });
                 });
                 return;
@@ -297,7 +298,7 @@ where
             (Self::B(this), Self::B(prev), OneOf::B(state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_b(&mut element, |element| {
-                        this.rebuild(prev, state, ctx, element);
+                        this.rebuild(prev, state, ctx, element, app_state);
                     });
                 });
                 return;
@@ -305,7 +306,7 @@ where
             (Self::C(this), Self::C(prev), OneOf::C(state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_c(&mut element, |element| {
-                        this.rebuild(prev, state, ctx, element);
+                        this.rebuild(prev, state, ctx, element, app_state);
                     });
                 });
                 return;
@@ -313,7 +314,7 @@ where
             (Self::D(this), Self::D(prev), OneOf::D(state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_d(&mut element, |element| {
-                        this.rebuild(prev, state, ctx, element);
+                        this.rebuild(prev, state, ctx, element, app_state);
                     });
                 });
                 return;
@@ -321,7 +322,7 @@ where
             (Self::E(this), Self::E(prev), OneOf::E(state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_e(&mut element, |element| {
-                        this.rebuild(prev, state, ctx, element);
+                        this.rebuild(prev, state, ctx, element, app_state);
                     });
                 });
                 return;
@@ -329,7 +330,7 @@ where
             (Self::F(this), Self::F(prev), OneOf::F(state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_f(&mut element, |element| {
-                        this.rebuild(prev, state, ctx, element);
+                        this.rebuild(prev, state, ctx, element, app_state);
                     });
                 });
                 return;
@@ -337,7 +338,7 @@ where
             (Self::G(this), Self::G(prev), OneOf::G(state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_g(&mut element, |element| {
-                        this.rebuild(prev, state, ctx, element);
+                        this.rebuild(prev, state, ctx, element, app_state);
                     });
                 });
                 return;
@@ -345,7 +346,7 @@ where
             (Self::H(this), Self::H(prev), OneOf::H(state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_h(&mut element, |element| {
-                        this.rebuild(prev, state, ctx, element);
+                        this.rebuild(prev, state, ctx, element, app_state);
                     });
                 });
                 return;
@@ -353,7 +354,7 @@ where
             (Self::I(this), Self::I(prev), OneOf::I(state)) => {
                 ctx.with_id(id, |ctx| {
                     Context::with_downcast_i(&mut element, |element| {
-                        this.rebuild(prev, state, ctx, element);
+                        this.rebuild(prev, state, ctx, element, app_state);
                     });
                 });
                 return;
@@ -365,47 +366,47 @@ where
         ctx.with_id(id, |ctx| match (prev, &mut view_state.inner_state) {
             (Self::A(prev), OneOf::A(state)) => {
                 Context::with_downcast_a(&mut element, |element| {
-                    prev.teardown(state, ctx, element);
+                    prev.teardown(state, ctx, element, app_state);
                 });
             }
             (Self::B(prev), OneOf::B(state)) => {
                 Context::with_downcast_b(&mut element, |element| {
-                    prev.teardown(state, ctx, element);
+                    prev.teardown(state, ctx, element, app_state);
                 });
             }
             (Self::C(prev), OneOf::C(state)) => {
                 Context::with_downcast_c(&mut element, |element| {
-                    prev.teardown(state, ctx, element);
+                    prev.teardown(state, ctx, element, app_state);
                 });
             }
             (Self::D(prev), OneOf::D(state)) => {
                 Context::with_downcast_d(&mut element, |element| {
-                    prev.teardown(state, ctx, element);
+                    prev.teardown(state, ctx, element, app_state);
                 });
             }
             (Self::E(prev), OneOf::E(state)) => {
                 Context::with_downcast_e(&mut element, |element| {
-                    prev.teardown(state, ctx, element);
+                    prev.teardown(state, ctx, element, app_state);
                 });
             }
             (Self::F(prev), OneOf::F(state)) => {
                 Context::with_downcast_f(&mut element, |element| {
-                    prev.teardown(state, ctx, element);
+                    prev.teardown(state, ctx, element, app_state);
                 });
             }
             (Self::G(prev), OneOf::G(state)) => {
                 Context::with_downcast_g(&mut element, |element| {
-                    prev.teardown(state, ctx, element);
+                    prev.teardown(state, ctx, element, app_state);
                 });
             }
             (Self::H(prev), OneOf::H(state)) => {
                 Context::with_downcast_h(&mut element, |element| {
-                    prev.teardown(state, ctx, element);
+                    prev.teardown(state, ctx, element, app_state);
                 });
             }
             (Self::I(prev), OneOf::I(state)) => {
                 Context::with_downcast_i(&mut element, |element| {
-                    prev.teardown(state, ctx, element);
+                    prev.teardown(state, ctx, element, app_state);
                 });
             }
             _ => unreachable!(),
@@ -419,39 +420,39 @@ where
         let id = ViewId::new(view_state.generation);
         let (new_element, state) = ctx.with_id(id, |ctx| match self {
             Self::A(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::A(new_element), OneOf::A(state))
             }
             Self::B(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::B(new_element), OneOf::B(state))
             }
             Self::C(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::C(new_element), OneOf::C(state))
             }
             Self::D(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::D(new_element), OneOf::D(state))
             }
             Self::E(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::E(new_element), OneOf::E(state))
             }
             Self::F(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::F(new_element), OneOf::F(state))
             }
             Self::G(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::G(new_element), OneOf::G(state))
             }
             Self::H(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::H(new_element), OneOf::H(state))
             }
             Self::I(v) => {
-                let (new_element, state) = v.build(ctx);
+                let (new_element, state) = v.build(ctx, app_state);
                 (OneOf::I(new_element), OneOf::I(state))
             }
         });
@@ -465,52 +466,53 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         mut element: Mut<'_, Self::Element>,
+        app_state: &mut State,
     ) {
         ctx.with_id(ViewId::new(view_state.generation), |ctx| {
             match (self, &mut view_state.inner_state) {
                 (Self::A(v), OneOf::A(state)) => {
                     Context::with_downcast_a(&mut element, |element| {
-                        v.teardown(state, ctx, element);
+                        v.teardown(state, ctx, element, app_state);
                     });
                 }
                 (Self::B(v), OneOf::B(state)) => {
                     Context::with_downcast_b(&mut element, |element| {
-                        v.teardown(state, ctx, element);
+                        v.teardown(state, ctx, element, app_state);
                     });
                 }
                 (Self::C(v), OneOf::C(state)) => {
                     Context::with_downcast_c(&mut element, |element| {
-                        v.teardown(state, ctx, element);
+                        v.teardown(state, ctx, element, app_state);
                     });
                 }
                 (Self::D(v), OneOf::D(state)) => {
                     Context::with_downcast_d(&mut element, |element| {
-                        v.teardown(state, ctx, element);
+                        v.teardown(state, ctx, element, app_state);
                     });
                 }
                 (Self::E(v), OneOf::E(state)) => {
                     Context::with_downcast_e(&mut element, |element| {
-                        v.teardown(state, ctx, element);
+                        v.teardown(state, ctx, element, app_state);
                     });
                 }
                 (Self::F(v), OneOf::F(state)) => {
                     Context::with_downcast_f(&mut element, |element| {
-                        v.teardown(state, ctx, element);
+                        v.teardown(state, ctx, element, app_state);
                     });
                 }
                 (Self::G(v), OneOf::G(state)) => {
                     Context::with_downcast_g(&mut element, |element| {
-                        v.teardown(state, ctx, element);
+                        v.teardown(state, ctx, element, app_state);
                     });
                 }
                 (Self::H(v), OneOf::H(state)) => {
                     Context::with_downcast_h(&mut element, |element| {
-                        v.teardown(state, ctx, element);
+                        v.teardown(state, ctx, element, app_state);
                     });
                 }
                 (Self::I(v), OneOf::I(state)) => {
                     Context::with_downcast_i(&mut element, |element| {
-                        v.teardown(state, ctx, element);
+                        v.teardown(state, ctx, element, app_state);
                     });
                 }
                 _ => unreachable!(),
@@ -566,7 +568,7 @@ mod hidden {
 
         type ViewState = Self;
 
-        fn build(&self, _: &mut Context) -> (Self::Element, Self::ViewState) {
+        fn build(&self, _: &mut Context, _: &mut State) -> (Self::Element, Self::ViewState) {
             match *self {}
         }
 
@@ -576,6 +578,7 @@ mod hidden {
             _: &mut Self::ViewState,
             _: &mut Context,
             _: crate::Mut<'_, Self::Element>,
+            _: &mut State,
         ) {
             match *self {}
         }
@@ -585,6 +588,7 @@ mod hidden {
             _: &mut Self::ViewState,
             _: &mut Context,
             _: crate::Mut<'_, Self::Element>,
+            _: &mut State,
         ) {
             match *self {}
         }

--- a/xilem_core/src/views/orphan.rs
+++ b/xilem_core/src/views/orphan.rs
@@ -15,7 +15,11 @@ pub trait OrphanView<V, State, Action, Message = DynMessage>: ViewPathTracker + 
     type OrphanViewState;
 
     /// See [`View::build`]
-    fn orphan_build(view: &V, ctx: &mut Self) -> (Self::OrphanElement, Self::OrphanViewState);
+    fn orphan_build(
+        view: &V,
+        ctx: &mut Self,
+        app_state: &mut State,
+    ) -> (Self::OrphanElement, Self::OrphanViewState);
 
     /// See [`View::rebuild`]
     fn orphan_rebuild(
@@ -24,6 +28,7 @@ pub trait OrphanView<V, State, Action, Message = DynMessage>: ViewPathTracker + 
         view_state: &mut Self::OrphanViewState,
         ctx: &mut Self,
         element: Mut<'_, Self::OrphanElement>,
+        app_state: &mut State,
     );
 
     /// See [`View::teardown`]
@@ -32,6 +37,7 @@ pub trait OrphanView<V, State, Action, Message = DynMessage>: ViewPathTracker + 
         view_state: &mut Self::OrphanViewState,
         ctx: &mut Self,
         element: Mut<'_, Self::OrphanElement>,
+        app_state: &mut State,
     );
 
     /// See [`View::message`]
@@ -56,8 +62,12 @@ macro_rules! impl_orphan_view_for {
 
             type ViewState = Context::OrphanViewState;
 
-            fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState) {
-                Context::orphan_build(self, ctx)
+            fn build(
+                &self,
+                ctx: &mut Context,
+                app_state: &mut State,
+            ) -> (Self::Element, Self::ViewState) {
+                Context::orphan_build(self, ctx, app_state)
             }
 
             fn rebuild(
@@ -66,8 +76,9 @@ macro_rules! impl_orphan_view_for {
                 view_state: &mut Self::ViewState,
                 ctx: &mut Context,
                 element: Mut<'_, Self::Element>,
+                app_state: &mut State,
             ) {
-                Context::orphan_rebuild(self, prev, view_state, ctx, element);
+                Context::orphan_rebuild(self, prev, view_state, ctx, element, app_state);
             }
 
             fn teardown(
@@ -75,8 +86,9 @@ macro_rules! impl_orphan_view_for {
                 view_state: &mut Self::ViewState,
                 ctx: &mut Context,
                 element: Mut<'_, Self::Element>,
+                app_state: &mut State,
             ) {
-                Context::orphan_teardown(self, view_state, ctx, element);
+                Context::orphan_teardown(self, view_state, ctx, element, app_state);
             }
 
             fn message(

--- a/xilem_core/src/views/run_once.rs
+++ b/xilem_core/src/views/run_once.rs
@@ -45,6 +45,7 @@ use crate::{MessageResult, NoElement, View, ViewMarker, ViewPathTracker};
 /// ```
 pub fn run_once<F>(once: F) -> RunOnce<F>
 where
+    // TODO(DJMcNab): Accept
     F: Fn() + 'static,
 {
     const {
@@ -94,7 +95,7 @@ where
 
     type ViewState = ();
 
-    fn build(&self, _: &mut Context) -> (Self::Element, Self::ViewState) {
+    fn build(&self, _: &mut Context, _: &mut State) -> (Self::Element, Self::ViewState) {
         (self.once)();
         (NoElement, ())
     }
@@ -105,6 +106,7 @@ where
         (): &mut Self::ViewState,
         _: &mut Context,
         (): crate::Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         // Nothing to do
     }
@@ -114,6 +116,7 @@ where
         (): &mut Self::ViewState,
         _: &mut Context,
         _: crate::Mut<'_, Self::Element>,
+        _: &mut State,
     ) {
         // Nothing to do
     }

--- a/xilem_core/tests/any_view.rs
+++ b/xilem_core/tests/any_view.rs
@@ -14,7 +14,7 @@ type AnyNoopView = dyn AnyView<(), Action, TestCtx, TestElement>;
 fn messages_to_inner_view() {
     let view: Box<AnyNoopView> = Box::new(OperationView::<0>(0));
     let mut ctx = TestCtx::default();
-    let (element, mut state) = view.build(&mut ctx);
+    let (element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
@@ -26,12 +26,12 @@ fn messages_to_inner_view() {
 fn message_after_rebuild() {
     let view: Box<AnyNoopView> = Box::new(OperationView::<0>(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     let path = element.view_path.clone();
 
     let view2: Box<AnyNoopView> = Box::new(OperationView::<0>(1));
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -46,12 +46,12 @@ fn message_after_rebuild() {
 fn no_message_after_stale() {
     let view: Box<AnyNoopView> = Box::new(OperationView::<0>(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     let path = element.view_path.clone();
 
     let view2: Box<AnyNoopView> = Box::new(OperationView::<1>(1));
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -70,12 +70,12 @@ fn no_message_after_stale() {
 fn no_message_after_stale_then_same_type() {
     let view: Box<AnyNoopView> = Box::new(OperationView::<0>(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     let path = element.view_path.clone();
 
     let view2: Box<AnyNoopView> = Box::new(OperationView::<1>(1));
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -87,7 +87,7 @@ fn no_message_after_stale_then_same_type() {
     );
 
     let view3: Box<AnyNoopView> = Box::new(OperationView::<0>(2));
-    view3.rebuild(&view2, &mut state, &mut ctx, &mut element);
+    view3.rebuild(&view2, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,

--- a/xilem_core/tests/arc.rs
+++ b/xilem_core/tests/arc.rs
@@ -23,7 +23,7 @@ fn record_ops(id: u32) -> OperationView<0> {
 fn arc_no_path() {
     let view1 = Arc::new(record_ops(0));
     let mut ctx = TestCtx::default();
-    let (element, _) = view1.build(&mut ctx);
+    let (element, _) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert!(element.view_path.is_empty());
 }
@@ -32,12 +32,12 @@ fn arc_no_path() {
 fn same_arc_skip_rebuild() {
     let view1 = Arc::new(record_ops(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view1.build(&mut ctx);
+    let (mut element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
     let view2 = Arc::clone(&view1);
-    view2.rebuild(&view1, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view1, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 }
@@ -47,12 +47,12 @@ fn same_arc_skip_rebuild() {
 fn new_arc_rebuild() {
     let view1 = Arc::new(record_ops(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view1.build(&mut ctx);
+    let (mut element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
     let view2 = Arc::new(record_ops(1));
-    view2.rebuild(&view1, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view1, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -65,12 +65,12 @@ fn new_arc_rebuild() {
 fn new_arc_rebuild_same_value() {
     let view1 = Arc::new(record_ops(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view1.build(&mut ctx);
+    let (mut element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
     let view2 = Arc::new(record_ops(0));
-    view2.rebuild(&view1, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view1, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -83,11 +83,11 @@ fn new_arc_rebuild_same_value() {
 fn arc_passthrough_teardown() {
     let view1 = Arc::new(record_ops(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view1.build(&mut ctx);
+    let (mut element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
-    view1.teardown(&mut state, &mut ctx, &mut element);
+    view1.teardown(&mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -99,7 +99,7 @@ fn arc_passthrough_teardown() {
 fn arc_passthrough_message() {
     let view1 = Arc::new(record_ops(0));
     let mut ctx = TestCtx::default();
-    let (element, mut state) = view1.build(&mut ctx);
+    let (element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
@@ -113,7 +113,7 @@ fn arc_passthrough_message() {
 fn box_no_path() {
     let view1 = Box::new(record_ops(0));
     let mut ctx = TestCtx::default();
-    let (element, ()) = view1.build(&mut ctx);
+    let (element, ()) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert!(element.view_path.is_empty());
 }
@@ -123,12 +123,12 @@ fn box_no_path() {
 fn box_passthrough_rebuild() {
     let view1 = Box::new(record_ops(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view1.build(&mut ctx);
+    let (mut element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
     let view2 = Box::new(record_ops(1));
-    view2.rebuild(&view1, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view1, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -141,12 +141,12 @@ fn box_passthrough_rebuild() {
 fn box_passthrough_rebuild_same_value() {
     let view1 = Box::new(record_ops(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view1.build(&mut ctx);
+    let (mut element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
     let view2 = Box::new(record_ops(0));
-    view2.rebuild(&view1, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view1, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -158,11 +158,11 @@ fn box_passthrough_rebuild_same_value() {
 fn box_passthrough_teardown() {
     let view1 = Box::new(record_ops(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view1.build(&mut ctx);
+    let (mut element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
-    view1.teardown(&mut state, &mut ctx, &mut element);
+    view1.teardown(&mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -174,7 +174,7 @@ fn box_passthrough_teardown() {
 fn box_passthrough_message() {
     let view1 = Box::new(record_ops(0));
     let mut ctx = TestCtx::default();
-    let (element, mut state) = view1.build(&mut ctx);
+    let (element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 

--- a/xilem_core/tests/array_sequence.rs
+++ b/xilem_core/tests/array_sequence.rs
@@ -16,7 +16,7 @@ fn record_ops(id: u32) -> OperationView<0> {
 fn two_element_passthrough() {
     let view = sequence(2, [record_ops(0), record_ops(1)]);
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(2)]);
     assert_eq!(element.view_path, &[]);
@@ -32,7 +32,7 @@ fn two_element_passthrough() {
     assert_eq!(second_child.view_path.len(), 1);
 
     let view2 = sequence(5, [record_ops(3), record_ops(4)]);
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -53,7 +53,7 @@ fn two_element_passthrough() {
         &[Operation::Build(1), Operation::Rebuild { from: 1, to: 4 }]
     );
 
-    view2.teardown(&mut state, &mut ctx, &mut element);
+    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
     assert_eq!(
         element.operations,
         &[
@@ -95,7 +95,7 @@ fn two_element_passthrough() {
 fn two_element_message() {
     let view = sequence(2, [record_ops(0), record_ops(1)]);
     let mut ctx = TestCtx::default();
-    let (element, mut state) = view.build(&mut ctx);
+    let (element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(2)]);
     assert_eq!(element.view_path, &[]);

--- a/xilem_core/tests/base_sequence.rs
+++ b/xilem_core/tests/base_sequence.rs
@@ -18,7 +18,7 @@ fn record_ops(id: u32) -> OperationView<0> {
 fn one_element_sequence_passthrough() {
     let view = sequence(1, record_ops(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(1)]);
     assert_eq!(element.view_path, &[]);
@@ -35,7 +35,7 @@ fn one_element_sequence_passthrough() {
     );
 
     let view2 = sequence(3, record_ops(2));
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     let seq_children = element.children.as_ref().unwrap();
     assert_eq!(
@@ -55,7 +55,7 @@ fn one_element_sequence_passthrough() {
     // The message should have been routed to the only child
     assert_action(result, 2);
 
-    view2.teardown(&mut state, &mut ctx, &mut element);
+    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
     assert_eq!(
         element.operations,
         &[
@@ -85,7 +85,7 @@ fn one_element_sequence_passthrough() {
 fn option_none_none() {
     let view = sequence(0, None::<OperationView<0>>);
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
     assert_eq!(element.view_path, &[]);
@@ -95,7 +95,7 @@ fn option_none_none() {
     assert!(seq_children.active.is_empty());
 
     let view2 = sequence(1, None);
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -106,7 +106,7 @@ fn option_none_none() {
     assert!(seq_children.deleted.is_empty());
     assert!(seq_children.active.is_empty());
 
-    view2.teardown(&mut state, &mut ctx, &mut element);
+    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -126,7 +126,7 @@ fn option_none_none() {
 fn option_some_some() {
     let view = sequence(1, Some(record_ops(0)));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(1)]);
     assert_eq!(element.view_path, &[]);
@@ -140,7 +140,7 @@ fn option_some_some() {
     assert_eq!(child.view_path.len(), 1);
 
     let view2 = sequence(3, Some(record_ops(2)));
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -156,7 +156,7 @@ fn option_some_some() {
         &[Operation::Build(0), Operation::Rebuild { from: 0, to: 2 }]
     );
 
-    view2.teardown(&mut state, &mut ctx, &mut element);
+    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -186,7 +186,7 @@ fn option_some_some() {
 fn option_none_some() {
     let view = sequence(0, None);
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
     assert_eq!(element.view_path, &[]);
@@ -196,7 +196,7 @@ fn option_none_some() {
     assert!(seq_children.active.is_empty());
 
     let view2 = sequence(2, Some(record_ops(1)));
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -209,7 +209,7 @@ fn option_none_some() {
     let child = seq_children.active.first().unwrap();
     assert_eq!(child.operations, &[Operation::Build(1)]);
 
-    view2.teardown(&mut state, &mut ctx, &mut element);
+    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -235,7 +235,7 @@ fn option_none_some() {
 fn option_some_none() {
     let view = sequence(1, Some(record_ops(0)));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(1)]);
     assert_eq!(element.view_path, &[]);
@@ -249,7 +249,7 @@ fn option_some_none() {
     assert_eq!(child.view_path.len(), 1);
 
     let view2 = sequence(2, None);
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -266,7 +266,7 @@ fn option_some_none() {
         &[Operation::Build(0), Operation::Teardown(0)]
     );
 
-    view2.teardown(&mut state, &mut ctx, &mut element);
+    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -286,7 +286,7 @@ fn option_some_none() {
 fn option_message_some() {
     let view = sequence(1, Some(record_ops(0)));
     let mut ctx = TestCtx::default();
-    let (element, mut state) = view.build(&mut ctx);
+    let (element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
 
     let seq_children = element.children.as_ref().unwrap();
@@ -302,7 +302,7 @@ fn option_message_some() {
 fn option_message_some_some() {
     let view = sequence(0, Some(record_ops(0)));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
 
     let seq_children = element.children.as_ref().unwrap();
@@ -311,7 +311,7 @@ fn option_message_some_some() {
     let path = child.view_path.to_vec();
 
     let view2 = sequence(0, Some(record_ops(1)));
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
 
     let result = view2.message(&mut state, &path, DynMessage::new(()), &mut ());
     assert_action(result, 1);
@@ -321,7 +321,7 @@ fn option_message_some_some() {
 fn option_message_some_none_stale() {
     let view = sequence(0, Some(record_ops(0)));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
 
     let seq_children = element.children.as_ref().unwrap();
@@ -330,7 +330,7 @@ fn option_message_some_none_stale() {
     let path = child.view_path.to_vec();
 
     let view2 = sequence(0, None);
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
 
     let result = view2.message(&mut state, &path, DynMessage::new(()), &mut ());
     assert!(matches!(result, MessageResult::Stale(_)));
@@ -340,7 +340,7 @@ fn option_message_some_none_stale() {
 fn option_message_some_none_some_stale() {
     let view = sequence(0, Some(record_ops(0)));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
 
     let seq_children = element.children.as_ref().unwrap();
@@ -349,10 +349,10 @@ fn option_message_some_none_some_stale() {
     let path = child.view_path.to_vec();
 
     let view2 = sequence(0, None);
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
 
     let view3 = sequence(0, Some(record_ops(1)));
-    view3.rebuild(&view2, &mut state, &mut ctx, &mut element);
+    view3.rebuild(&view2, &mut state, &mut ctx, &mut element, &mut ());
 
     let result = view2.message(&mut state, &path, DynMessage::new(()), &mut ());
     assert!(matches!(result, MessageResult::Stale(_)));

--- a/xilem_core/tests/common/mod.rs
+++ b/xilem_core/tests/common/mod.rs
@@ -92,9 +92,9 @@ where
 
     type ViewState = (Seq::SeqState, AppendVec<TestElement>);
 
-    fn build(&self, ctx: &mut TestCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut TestCtx, app_state: &mut ()) -> (Self::Element, Self::ViewState) {
         let mut elements = AppendVec::default();
-        let state = self.seq.seq_build(ctx, &mut elements);
+        let state = self.seq.seq_build(ctx, &mut elements, app_state);
         (
             TestElement {
                 operations: vec![Operation::Build(self.id)],
@@ -114,6 +114,7 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut TestCtx,
         element: Mut<'_, Self::Element>,
+        app_state: &mut (),
     ) {
         assert_eq!(&*element.view_path, ctx.view_path());
         element.operations.push(Operation::Rebuild {
@@ -126,7 +127,7 @@ where
             scratch: &mut view_state.1,
         };
         self.seq
-            .seq_rebuild(&prev.seq, &mut view_state.0, ctx, &mut elements);
+            .seq_rebuild(&prev.seq, &mut view_state.0, ctx, &mut elements, app_state);
     }
 
     fn teardown(
@@ -134,6 +135,7 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut TestCtx,
         element: Mut<'_, Self::Element>,
+        app_state: &mut (),
     ) {
         assert_eq!(&*element.view_path, ctx.view_path());
         element.operations.push(Operation::Teardown(self.id));
@@ -142,7 +144,8 @@ where
             ix: 0,
             scratch: &mut view_state.1,
         };
-        self.seq.seq_teardown(&mut view_state.0, ctx, &mut elements);
+        self.seq
+            .seq_teardown(&mut view_state.0, ctx, &mut elements, app_state);
     }
 
     fn message(
@@ -163,7 +166,7 @@ impl<const N: u32> View<(), Action, TestCtx> for OperationView<N> {
 
     type ViewState = ();
 
-    fn build(&self, ctx: &mut TestCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut TestCtx, (): &mut ()) -> (Self::Element, Self::ViewState) {
         (
             TestElement {
                 operations: vec![Operation::Build(self.0)],
@@ -180,6 +183,7 @@ impl<const N: u32> View<(), Action, TestCtx> for OperationView<N> {
         _: &mut Self::ViewState,
         ctx: &mut TestCtx,
         element: Mut<'_, Self::Element>,
+        (): &mut (),
     ) {
         assert_eq!(&*element.view_path, ctx.view_path());
         element.operations.push(Operation::Rebuild {
@@ -193,6 +197,7 @@ impl<const N: u32> View<(), Action, TestCtx> for OperationView<N> {
         _: &mut Self::ViewState,
         ctx: &mut TestCtx,
         element: Mut<'_, Self::Element>,
+        (): &mut (),
     ) {
         assert_eq!(&*element.view_path, ctx.view_path());
         element.operations.push(Operation::Teardown(self.0));

--- a/xilem_core/tests/one_of.rs
+++ b/xilem_core/tests/one_of.rs
@@ -159,7 +159,7 @@ impl
 fn one_of_path() {
     let view1: OneOf2<OperationView<0>, OperationView<1>> = OneOf2::A(record_ops_0(0));
     let mut ctx = TestCtx::default();
-    let (element, _state) = view1.build(&mut ctx);
+    let (element, _state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.view_path.len(), 1);
     assert_eq!(element.view_path[0], ViewId::new(0));
@@ -170,11 +170,11 @@ fn one_of_path() {
 fn one_of_same_type_rebuild() {
     let view1: OneOf2<OperationView<0>, OperationView<1>> = OneOf2::A(record_ops_0(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view1.build(&mut ctx);
+    let (mut element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
 
     let view2 = OneOf2::A(record_ops_0(1));
-    view2.rebuild(&view1, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view1, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(element.view_path[0], ViewId::new(0));
     assert_eq!(
@@ -188,11 +188,11 @@ fn one_of_same_type_rebuild() {
 fn one_of_type_change_rebuild() {
     let view1 = OneOf2::A(record_ops_0(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view1.build(&mut ctx);
+    let (mut element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
 
     let view2 = OneOf2::B(record_ops_1(1));
-    view2.rebuild(&view1, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view1, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(element.view_path[0], ViewId::new(1));
     assert_eq!(
@@ -210,11 +210,11 @@ fn one_of_type_change_rebuild() {
 fn one_of_passthrough_teardown() {
     let view1: OneOf2<OperationView<0>, OperationView<1>> = OneOf2::A(record_ops_0(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view1.build(&mut ctx);
+    let (mut element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
-    view1.teardown(&mut state, &mut ctx, &mut element);
+    view1.teardown(&mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(element.view_path[0], ViewId::new(0));
     assert_eq!(
@@ -227,7 +227,7 @@ fn one_of_passthrough_teardown() {
 fn one_of_passthrough_message() {
     let view1: OneOf2<OperationView<0>, OperationView<1>> = OneOf2::A(record_ops_0(0));
     let mut ctx = TestCtx::default();
-    let (element, mut state) = view1.build(&mut ctx);
+    let (element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
@@ -239,12 +239,12 @@ fn one_of_passthrough_message() {
 fn one_of_no_message_after_stale() {
     let view1 = OneOf2::A(OperationView::<0>(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view1.build(&mut ctx);
+    let (mut element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     let path = element.view_path.clone();
 
     let view2 = OneOf2::B(OperationView::<1>(1));
-    view2.rebuild(&view1, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view1, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -263,12 +263,12 @@ fn one_of_no_message_after_stale() {
 fn one_of_no_message_after_stale_then_same_type() {
     let view1 = OneOf2::A(OperationView::<0>(0));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view1.build(&mut ctx);
+    let (mut element, mut state) = view1.build(&mut ctx, &mut ());
     ctx.assert_empty();
     let path = element.view_path.clone();
 
     let view2 = OneOf2::B(OperationView::<1>(1));
-    view2.rebuild(&view1, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view1, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -280,7 +280,7 @@ fn one_of_no_message_after_stale_then_same_type() {
     );
 
     let view3 = OneOf2::A(OperationView::<0>(2));
-    view3.rebuild(&view2, &mut state, &mut ctx, &mut element);
+    view3.rebuild(&view2, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,

--- a/xilem_core/tests/orphan.rs
+++ b/xilem_core/tests/orphan.rs
@@ -23,6 +23,7 @@ impl<State, Action> OrphanView<&'static str, State, Action> for TestCtx {
     fn orphan_build(
         _view: &&'static str,
         ctx: &mut Self,
+        _app_state: &mut State,
     ) -> (Self::OrphanElement, Self::OrphanViewState) {
         let id = 0;
         (
@@ -41,6 +42,7 @@ impl<State, Action> OrphanView<&'static str, State, Action> for TestCtx {
         generation: &mut Self::OrphanViewState,
         ctx: &mut Self,
         element: Mut<'_, Self::OrphanElement>,
+        _app_state: &mut State,
     ) {
         assert_eq!(&*element.view_path, ctx.view_path());
 
@@ -61,6 +63,7 @@ impl<State, Action> OrphanView<&'static str, State, Action> for TestCtx {
         generation: &mut Self::OrphanViewState,
         _ctx: &mut Self,
         element: Mut<'_, Self::OrphanElement>,
+        _app_state: &mut State,
     ) {
         element.operations.push(Operation::Teardown(*generation));
     }
@@ -80,12 +83,19 @@ impl<State, Action> OrphanView<&'static str, State, Action> for TestCtx {
 fn str_as_orphan_view() {
     let view1 = "This string is now also a view";
     let mut ctx = TestCtx::default();
-    let (mut element, mut generation) = View::<(), (), TestCtx>::build(&view1, &mut ctx);
+    let (mut element, mut generation) = View::<(), (), TestCtx>::build(&view1, &mut ctx, &mut ());
 
     let view2 = "This string is now an updated view";
     assert_eq!(element.operations[0], Operation::Build(0));
-    View::<(), (), TestCtx>::rebuild(&view1, &view2, &mut generation, &mut ctx, &mut element);
+    View::<(), (), TestCtx>::rebuild(
+        &view1,
+        &view2,
+        &mut generation,
+        &mut ctx,
+        &mut element,
+        &mut (),
+    );
     assert_eq!(element.operations[1], Operation::Rebuild { from: 0, to: 1 });
-    View::<(), (), TestCtx>::teardown(&view1, &mut generation, &mut ctx, &mut element);
+    View::<(), (), TestCtx>::teardown(&view1, &mut generation, &mut ctx, &mut element, &mut ());
     assert_eq!(element.operations[2], Operation::Teardown(1));
 }

--- a/xilem_core/tests/tuple_sequence.rs
+++ b/xilem_core/tests/tuple_sequence.rs
@@ -15,7 +15,7 @@ fn record_ops(id: u32) -> OperationView<0> {
 fn unit_no_elements() {
     let view = sequence(0, ());
     let mut ctx = TestCtx::default();
-    let (element, _state) = view.build(&mut ctx);
+    let (element, _state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert!(element.children.unwrap().active.is_empty());
 }
@@ -25,7 +25,7 @@ fn unit_no_elements() {
 fn one_element_passthrough() {
     let view = sequence(1, (record_ops(0),));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(1)]);
     assert_eq!(element.view_path, &[]);
@@ -42,7 +42,7 @@ fn one_element_passthrough() {
     );
 
     let view2 = sequence(3, (record_ops(2),));
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     let seq_children = element.children.as_ref().unwrap();
     assert_eq!(
@@ -62,7 +62,7 @@ fn one_element_passthrough() {
     // The message should have been routed to the only child
     assert_action(result, 2);
 
-    view2.teardown(&mut state, &mut ctx, &mut element);
+    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
     assert_eq!(
         element.operations,
         &[
@@ -93,7 +93,7 @@ fn one_element_passthrough() {
 fn two_element_passthrough() {
     let view = sequence(2, (record_ops(0), record_ops(1)));
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(2)]);
     assert_eq!(element.view_path, &[]);
@@ -109,7 +109,7 @@ fn two_element_passthrough() {
     assert_eq!(second_child.view_path.len(), 1);
 
     let view2 = sequence(5, (record_ops(3), record_ops(4)));
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -130,7 +130,7 @@ fn two_element_passthrough() {
         &[Operation::Build(1), Operation::Rebuild { from: 1, to: 4 }]
     );
 
-    view2.teardown(&mut state, &mut ctx, &mut element);
+    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
     assert_eq!(
         element.operations,
         &[
@@ -172,7 +172,7 @@ fn two_element_passthrough() {
 fn two_element_message() {
     let view = sequence(2, (record_ops(0), record_ops(1)));
     let mut ctx = TestCtx::default();
-    let (element, mut state) = view.build(&mut ctx);
+    let (element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(2)]);
     assert_eq!(element.view_path, &[]);

--- a/xilem_core/tests/vec_sequence.rs
+++ b/xilem_core/tests/vec_sequence.rs
@@ -15,7 +15,7 @@ fn record_ops(id: u32) -> OperationView<0> {
 fn zero_zero() {
     let view = sequence(0, Vec::<OperationView<0>>::new());
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
     assert_eq!(element.view_path, &[]);
@@ -25,7 +25,7 @@ fn zero_zero() {
     assert!(seq_children.active.is_empty());
 
     let view2 = sequence(1, vec![]);
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -36,7 +36,7 @@ fn zero_zero() {
     assert!(seq_children.deleted.is_empty());
     assert!(seq_children.active.is_empty());
 
-    view2.teardown(&mut state, &mut ctx, &mut element);
+    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -56,7 +56,7 @@ fn zero_zero() {
 fn one_zero() {
     let view = sequence(1, vec![record_ops(0)]);
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(1)]);
     assert_eq!(element.view_path, &[]);
@@ -69,7 +69,7 @@ fn one_zero() {
     assert_eq!(child.view_path.len(), 1);
 
     let view2 = sequence(2, vec![]);
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -86,7 +86,7 @@ fn one_zero() {
         &[Operation::Build(0), Operation::Teardown(0)]
     );
 
-    view2.teardown(&mut state, &mut ctx, &mut element);
+    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -112,7 +112,7 @@ fn one_zero() {
 fn one_two() {
     let view = sequence(1, vec![record_ops(0)]);
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(1)]);
     assert_eq!(element.view_path, &[]);
@@ -125,7 +125,7 @@ fn one_two() {
     assert_eq!(child.view_path.len(), 1);
 
     let view2 = sequence(4, vec![record_ops(2), record_ops(3)]);
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -145,7 +145,7 @@ fn one_two() {
     assert_eq!(second_child.operations, &[Operation::Build(3)]);
     assert_eq!(second_child.view_path.len(), 1);
 
-    view2.teardown(&mut state, &mut ctx, &mut element);
+    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -181,7 +181,7 @@ fn one_two() {
 fn normal_messages() {
     let view = sequence(0, vec![record_ops(0), record_ops(1)]);
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.view_path, &[]);
 
@@ -200,7 +200,7 @@ fn normal_messages() {
     assert_action(result, 1);
 
     let view2 = sequence(0, vec![record_ops(2), record_ops(3)]);
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
 
     let result = view2.message(&mut state, &first_path, DynMessage::new(()), &mut ());
@@ -213,7 +213,7 @@ fn normal_messages() {
 fn stale_messages() {
     let view = sequence(0, vec![record_ops(0)]);
     let mut ctx = TestCtx::default();
-    let (mut element, mut state) = view.build(&mut ctx);
+    let (mut element, mut state) = view.build(&mut ctx, &mut ());
     ctx.assert_empty();
     assert_eq!(element.view_path, &[]);
 
@@ -227,14 +227,14 @@ fn stale_messages() {
     assert_action(result, 0);
 
     let view2 = sequence(0, vec![]);
-    view2.rebuild(&view, &mut state, &mut ctx, &mut element);
+    view2.rebuild(&view, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
 
     let result = view2.message(&mut state, &first_path, DynMessage::new(()), &mut ());
     assert!(matches!(result, MessageResult::Stale(_)));
 
     let view3 = sequence(0, vec![record_ops(1)]);
-    view3.rebuild(&view2, &mut state, &mut ctx, &mut element);
+    view3.rebuild(&view2, &mut state, &mut ctx, &mut element, &mut ());
     ctx.assert_empty();
 
     let result = view3.message(&mut state, &first_path, DynMessage::new(()), &mut ());

--- a/xilem_web/src/after_update.rs
+++ b/xilem_web/src/after_update.rs
@@ -117,8 +117,8 @@ where
 
     type ViewState = V::ViewState;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        let (mut el, view_state) = self.element.build(ctx);
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
+        let (mut el, view_state) = self.element.build(ctx, app_state);
         el.node.apply_props(&mut el.props, &mut el.flags);
         (self.callback)(&el.node);
         (el, view_state)
@@ -130,9 +130,10 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
         self.element
-            .rebuild(&prev.element, view_state, ctx, element);
+            .rebuild(&prev.element, view_state, ctx, element, app_state);
     }
 
     fn teardown(
@@ -140,8 +141,9 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         el: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
-        self.element.teardown(view_state, ctx, el);
+        self.element.teardown(view_state, ctx, el, app_state);
     }
 
     fn message(
@@ -168,8 +170,8 @@ where
 
     type ViewState = V::ViewState;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        self.element.build(ctx)
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
+        self.element.build(ctx, app_state)
     }
 
     fn rebuild(
@@ -178,9 +180,15 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
-        self.element
-            .rebuild(&prev.element, view_state, ctx, element.reborrow_mut());
+        self.element.rebuild(
+            &prev.element,
+            view_state,
+            ctx,
+            element.reborrow_mut(),
+            app_state,
+        );
         element.node.apply_props(element.props, element.flags);
         (self.callback)(element.node);
     }
@@ -190,8 +198,9 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         el: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
-        self.element.teardown(view_state, ctx, el);
+        self.element.teardown(view_state, ctx, el, app_state);
     }
 
     fn message(
@@ -218,8 +227,8 @@ where
 
     type ViewState = V::ViewState;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        self.element.build(ctx)
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
+        self.element.build(ctx, app_state)
     }
 
     fn rebuild(
@@ -228,9 +237,10 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
         self.element
-            .rebuild(&prev.element, view_state, ctx, element);
+            .rebuild(&prev.element, view_state, ctx, element, app_state);
     }
 
     fn teardown(
@@ -238,9 +248,10 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         el: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
         (self.callback)(el.node);
-        self.element.teardown(view_state, ctx, el);
+        self.element.teardown(view_state, ctx, el, app_state);
     }
 
     fn message(

--- a/xilem_web/src/app.rs
+++ b/xilem_web/src/app.rs
@@ -92,7 +92,11 @@ impl<State, Fragment: DomFragment<State>, InitFragment: FnMut(&mut State) -> Fra
     fn ensure_app(&mut self) {
         if self.fragment.is_none() {
             let fragment = (self.app_logic)(&mut self.data);
-            let state = fragment.seq_build(&mut self.ctx, &mut self.fragment_append_scratch);
+            let state = fragment.seq_build(
+                &mut self.ctx,
+                &mut self.fragment_append_scratch,
+                &mut self.data,
+            );
             self.fragment = Some(fragment);
             self.fragment_state = Some(state);
 
@@ -149,6 +153,7 @@ where
                 inner.fragment_state.as_mut().unwrap(),
                 &mut inner.ctx,
                 &mut dom_children_splice,
+                &mut inner.data,
             );
             *fragment = new_fragment;
         }

--- a/xilem_web/src/concurrent/interval.rs
+++ b/xilem_web/src/concurrent/interval.rs
@@ -100,7 +100,7 @@ where
 
     type ViewState = IntervalState;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, _: &mut State) -> (Self::Element, Self::ViewState) {
         let thunk = ctx.message_thunk();
         let interval_fn = Closure::new(move || thunk.push_message(()));
         let state = IntervalState {
@@ -117,6 +117,7 @@ where
         view_state: &mut Self::ViewState,
         _: &mut ViewCtx,
         (): Mut<Self::Element>,
+        _: &mut State,
     ) {
         if prev.ms != self.ms {
             clear_interval(view_state.interval_handle);
@@ -124,7 +125,13 @@ where
         }
     }
 
-    fn teardown(&self, view_state: &mut Self::ViewState, _: &mut ViewCtx, _: Mut<Self::Element>) {
+    fn teardown(
+        &self,
+        view_state: &mut Self::ViewState,
+        _: &mut ViewCtx,
+        _: Mut<Self::Element>,
+        _: &mut State,
+    ) {
         clear_interval(view_state.interval_handle);
     }
 

--- a/xilem_web/src/concurrent/memoized_await.rs
+++ b/xilem_web/src/concurrent/memoized_await.rs
@@ -175,7 +175,7 @@ where
 
     type ViewState = MemoizedAwaitState;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, _: &mut State) -> (Self::Element, Self::ViewState) {
         let mut state = MemoizedAwaitState::default();
 
         if self.debounce_ms > 0 {
@@ -193,6 +193,7 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         (): Mut<Self::Element>,
+        _: &mut State,
     ) {
         let debounce_has_changed_and_update_is_scheduled = view_state.schedule_update
             && (prev.reset_debounce_on_update != self.reset_debounce_on_update
@@ -228,7 +229,13 @@ where
         }
     }
 
-    fn teardown(&self, state: &mut Self::ViewState, _: &mut ViewCtx, (): Mut<Self::Element>) {
+    fn teardown(
+        &self,
+        state: &mut Self::ViewState,
+        _: &mut ViewCtx,
+        (): Mut<Self::Element>,
+        _: &mut State,
+    ) {
         state.clear_update_timeout();
     }
 

--- a/xilem_web/src/concurrent/task.rs
+++ b/xilem_web/src/concurrent/task.rs
@@ -140,7 +140,7 @@ where
 
     type ViewState = TaskState;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, _: &mut State) -> (Self::Element, Self::ViewState) {
         let thunk = ctx.message_thunk();
         let (shutdown_signal, abort_handle) = ShutdownSignal::new();
         let view_state = TaskState {
@@ -153,11 +153,24 @@ where
         (NoElement, view_state)
     }
 
-    fn rebuild(&self, _: &Self, _: &mut Self::ViewState, _: &mut ViewCtx, (): Mut<Self::Element>) {
+    fn rebuild(
+        &self,
+        _: &Self,
+        _: &mut Self::ViewState,
+        _: &mut ViewCtx,
+        (): Mut<Self::Element>,
+        _: &mut State,
+    ) {
         // Nothing to do
     }
 
-    fn teardown(&self, view_state: &mut Self::ViewState, _: &mut ViewCtx, _: Mut<Self::Element>) {
+    fn teardown(
+        &self,
+        view_state: &mut Self::ViewState,
+        _: &mut ViewCtx,
+        _: Mut<Self::Element>,
+        _: &mut State,
+    ) {
         let handle = view_state.abort_handle.take().unwrap_throw();
         handle.abort();
     }

--- a/xilem_web/src/events.rs
+++ b/xilem_web/src/events.rs
@@ -410,7 +410,7 @@ macro_rules! event_definitions {
 
             type Element = V::Element;
 
-            fn build(&self, ctx: &mut ViewCtx,app_state: &mut State) -> (Self::Element, Self::ViewState) {
+            fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
                 build_event_listener::<_, _, _, web_sys::$web_sys_ty>(
                     &self.dom_view,
                     $event_name,

--- a/xilem_web/src/modifiers/attribute.rs
+++ b/xilem_web/src/modifiers/attribute.rs
@@ -309,9 +309,9 @@ where
 
     type ViewState = V::ViewState;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
         let (mut element, state) =
-            ctx.with_size_hint::<Attributes, _>(1, |ctx| self.inner.build(ctx));
+            ctx.with_size_hint::<Attributes, _>(1, |ctx| self.inner.build(ctx, app_state));
         Attributes::push(&mut element.modifier(), self.modifier.clone());
         (element, state)
     }
@@ -322,10 +322,16 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
         Attributes::rebuild(element, 1, |mut element| {
-            self.inner
-                .rebuild(&prev.inner, view_state, ctx, element.reborrow_mut());
+            self.inner.rebuild(
+                &prev.inner,
+                view_state,
+                ctx,
+                element.reborrow_mut(),
+                app_state,
+            );
             Attributes::update(&mut element.modifier(), &prev.modifier, &self.modifier);
         });
     }
@@ -335,8 +341,9 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
-        self.inner.teardown(view_state, ctx, element);
+        self.inner.teardown(view_state, ctx, element, app_state);
     }
 
     fn message(

--- a/xilem_web/src/modifiers/class.rs
+++ b/xilem_web/src/modifiers/class.rs
@@ -345,10 +345,11 @@ where
 
     type ViewState = (usize, V::ViewState);
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
         let add_class_iter = self.classes.add_class_iter();
-        let (mut e, s) = ctx
-            .with_size_hint::<Classes, _>(add_class_iter.size_hint().0, |ctx| self.el.build(ctx));
+        let (mut e, s) = ctx.with_size_hint::<Classes, _>(add_class_iter.size_hint().0, |ctx| {
+            self.el.build(ctx, app_state)
+        });
         let len = Classes::extend(&mut e.modifier(), add_class_iter);
         (e, (len, s))
     }
@@ -359,10 +360,11 @@ where
         (len, view_state): &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
         Classes::rebuild(element, *len, |mut elem| {
             self.el
-                .rebuild(&prev.el, view_state, ctx, elem.reborrow_mut());
+                .rebuild(&prev.el, view_state, ctx, elem.reborrow_mut(), app_state);
             *len = Classes::update_as_add_class_iter(
                 &mut elem.modifier(),
                 *len,
@@ -377,8 +379,9 @@ where
         (_, view_state): &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
-        self.el.teardown(view_state, ctx, element);
+        self.el.teardown(view_state, ctx, element, app_state);
     }
 
     fn message(

--- a/xilem_web/src/modifiers/overwrite.rs
+++ b/xilem_web/src/modifiers/overwrite.rs
@@ -195,9 +195,13 @@ macro_rules! overwrite_bool_modifier_view {
 
             type ViewState = V::ViewState;
 
-            fn build(&self, ctx: &mut $crate::ViewCtx) -> (Self::Element, Self::ViewState) {
+            fn build(
+                &self,
+                ctx: &mut $crate::ViewCtx,
+                app_state: &mut State,
+            ) -> (Self::Element, Self::ViewState) {
                 use $crate::modifiers::WithModifier;
-                let (mut el, state) = self.inner.build(ctx);
+                let (mut el, state) = self.inner.build(ctx, app_state);
                 let modifier = &mut super::$modifier::as_overwrite_bool_modifier(el.modifier());
                 $crate::modifiers::OverwriteBool::push(modifier, self.value);
                 (el, state)
@@ -209,11 +213,17 @@ macro_rules! overwrite_bool_modifier_view {
                 view_state: &mut Self::ViewState,
                 ctx: &mut $crate::ViewCtx,
                 mut element: $crate::core::Mut<Self::Element>,
+                app_state: &mut State,
             ) {
                 use $crate::modifiers::WithModifier;
                 element.modifier().modifier.0.rebuild(1);
-                self.inner
-                    .rebuild(&prev.inner, view_state, ctx, element.reborrow_mut());
+                self.inner.rebuild(
+                    &prev.inner,
+                    view_state,
+                    ctx,
+                    element.reborrow_mut(),
+                    app_state,
+                );
                 let mut modifier = super::$modifier::as_overwrite_bool_modifier(element.modifier());
                 $crate::modifiers::OverwriteBool::update(&mut modifier, prev.value, self.value);
             }
@@ -223,8 +233,9 @@ macro_rules! overwrite_bool_modifier_view {
                 view_state: &mut Self::ViewState,
                 ctx: &mut $crate::ViewCtx,
                 element: $crate::core::Mut<Self::Element>,
+                app_state: &mut State,
             ) {
-                self.inner.teardown(view_state, ctx, element);
+                self.inner.teardown(view_state, ctx, element, app_state);
             }
 
             fn message(

--- a/xilem_web/src/modifiers/style.rs
+++ b/xilem_web/src/modifiers/style.rs
@@ -470,10 +470,11 @@ where
 
     type ViewState = (usize, V::ViewState);
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
         let style_iter = self.styles.style_modifiers_iter();
-        let (mut e, s) =
-            ctx.with_size_hint::<Styles, _>(style_iter.size_hint().0, |ctx| self.el.build(ctx));
+        let (mut e, s) = ctx.with_size_hint::<Styles, _>(style_iter.size_hint().0, |ctx| {
+            self.el.build(ctx, app_state)
+        });
         let len = Styles::extend(&mut e.modifier(), style_iter);
         (e, (len, s))
     }
@@ -484,10 +485,11 @@ where
         (len, view_state): &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
         Styles::rebuild(element, *len, |mut elem| {
             self.el
-                .rebuild(&prev.el, view_state, ctx, elem.reborrow_mut());
+                .rebuild(&prev.el, view_state, ctx, elem.reborrow_mut(), app_state);
             let styles = &mut elem.modifier();
             *len = Styles::update_style_modifier_iter(styles, *len, &prev.styles, &self.styles);
         });
@@ -498,8 +500,9 @@ where
         (_, view_state): &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
-        self.el.teardown(view_state, ctx, element);
+        self.el.teardown(view_state, ctx, element, app_state);
     }
 
     fn message(
@@ -555,8 +558,9 @@ where
 
     type ViewState = V::ViewState;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        let (mut element, state) = ctx.with_size_hint::<Styles, _>(1, |ctx| self.el.build(ctx));
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
+        let (mut element, state) =
+            ctx.with_size_hint::<Styles, _>(1, |ctx| self.el.build(ctx, app_state));
         let styles = &mut element.modifier();
         Styles::push(
             styles,
@@ -571,10 +575,11 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
         Styles::rebuild(element, 1, |mut element| {
             self.el
-                .rebuild(&prev.el, view_state, ctx, element.reborrow_mut());
+                .rebuild(&prev.el, view_state, ctx, element.reborrow_mut(), app_state);
             let mut styles = element.modifier();
             Styles::update_with_modify_style(
                 &mut styles,
@@ -591,8 +596,9 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
-        self.el.teardown(view_state, ctx, element);
+        self.el.teardown(view_state, ctx, element, app_state);
     }
 
     fn message(
@@ -678,8 +684,9 @@ where
 
     type ViewState = V::ViewState;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
-        let (mut element, state) = ctx.with_size_hint::<Styles, _>(1, |ctx| self.el.build(ctx));
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
+        let (mut element, state) =
+            ctx.with_size_hint::<Styles, _>(1, |ctx| self.el.build(ctx, app_state));
         let styles = &mut element.modifier();
         Styles::push(
             styles,
@@ -694,10 +701,11 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
         Styles::rebuild(element, 1, |mut element| {
             self.el
-                .rebuild(&prev.el, view_state, ctx, element.reborrow_mut());
+                .rebuild(&prev.el, view_state, ctx, element.reborrow_mut(), app_state);
             let styles = &mut element.modifier();
             Styles::update_with_modify_style(
                 styles,
@@ -714,8 +722,9 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
-        self.el.teardown(view_state, ctx, element);
+        self.el.teardown(view_state, ctx, element, app_state);
     }
 
     fn message(

--- a/xilem_web/src/pointer.rs
+++ b/xilem_web/src/pointer.rs
@@ -148,9 +148,9 @@ where
     type ViewState = PointerState<V::ViewState>;
     type Element = V::Element;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
         ctx.with_id(POINTER_VIEW_ID, |ctx| {
-            let (element, child_state) = self.child.build(ctx);
+            let (element, child_state) = self.child.build(ctx, app_state);
             let el = element.node.as_ref();
 
             let [down_closure, move_closure, up_closure] = build_event_listeners(ctx, el);
@@ -170,10 +170,16 @@ where
         state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut el: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
         ctx.with_id(POINTER_VIEW_ID, |ctx| {
-            self.child
-                .rebuild(&prev.child, &mut state.child_state, ctx, el.reborrow_mut());
+            self.child.rebuild(
+                &prev.child,
+                &mut state.child_state,
+                ctx,
+                el.reborrow_mut(),
+                app_state,
+            );
 
             if el.flags.was_created() {
                 [state.down_closure, state.move_closure, state.up_closure] =
@@ -187,11 +193,12 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
         ctx.with_id(POINTER_VIEW_ID, |ctx| {
             // TODO remove event listeners from child or is this not necessary?
             self.child
-                .teardown(&mut view_state.child_state, ctx, element);
+                .teardown(&mut view_state.child_state, ctx, element, app_state);
         });
     }
 

--- a/xilem_web/src/svg/common_attrs.rs
+++ b/xilem_web/src/svg/common_attrs.rs
@@ -105,9 +105,9 @@ where
     type ViewState = V::ViewState;
     type Element = V::Element;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
         let (mut element, state) =
-            ctx.with_size_hint::<Attributes, _>(2, |ctx| self.child.build(ctx));
+            ctx.with_size_hint::<Attributes, _>(2, |ctx| self.child.build(ctx, app_state));
         let mut attrs = element.modifier();
         Attributes::push(&mut attrs, ("fill", brush_to_string(&self.brush)));
         Attributes::push(
@@ -123,10 +123,16 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
         Attributes::rebuild(element, 2, |mut element| {
-            self.child
-                .rebuild(&prev.child, view_state, ctx, element.reborrow_mut());
+            self.child.rebuild(
+                &prev.child,
+                view_state,
+                ctx,
+                element.reborrow_mut(),
+                app_state,
+            );
             let mut attrs = element.modifier();
             if attrs.flags.was_created() {
                 Attributes::push(&mut attrs, ("fill", brush_to_string(&self.brush)));
@@ -152,8 +158,9 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
-        self.child.teardown(view_state, ctx, element);
+        self.child.teardown(view_state, ctx, element, app_state);
     }
 
     fn message(
@@ -242,9 +249,9 @@ where
     type ViewState = V::ViewState;
     type Element = V::Element;
 
-    fn build(&self, ctx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
         let (mut element, state) =
-            ctx.with_size_hint::<Attributes, _>(5, |ctx| self.child.build(ctx));
+            ctx.with_size_hint::<Attributes, _>(5, |ctx| self.child.build(ctx, app_state));
         push_stroke_modifiers(element.modifier(), &self.style, &self.brush);
         (element, state)
     }
@@ -255,10 +262,16 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
         Attributes::rebuild(element, 5, |mut element| {
-            self.child
-                .rebuild(&prev.child, view_state, ctx, element.reborrow_mut());
+            self.child.rebuild(
+                &prev.child,
+                view_state,
+                ctx,
+                element.reborrow_mut(),
+                app_state,
+            );
             update_stroke_modifiers(
                 element.modifier(),
                 &prev.style,
@@ -274,8 +287,9 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<Self::Element>,
+        app_state: &mut State,
     ) {
-        self.child.teardown(view_state, ctx, element);
+        self.child.teardown(view_state, ctx, element, app_state);
     }
 
     fn message(

--- a/xilem_web/src/svg/kurbo_shape.rs
+++ b/xilem_web/src/svg/kurbo_shape.rs
@@ -29,7 +29,11 @@ impl<State: 'static, Action: 'static> OrphanView<Line, State, Action, DynMessage
     type OrphanViewState = ();
     type OrphanElement = Pod<web_sys::SvgLineElement>;
 
-    fn orphan_build(view: &Line, ctx: &mut Self) -> (Self::OrphanElement, Self::OrphanViewState) {
+    fn orphan_build(
+        view: &Line,
+        ctx: &mut Self,
+        _: &mut State,
+    ) -> (Self::OrphanElement, Self::OrphanViewState) {
         create_element("line", ctx, 4, |element, ctx| {
             let mut element = Self::OrphanElement::from_with_ctx(element, ctx);
             let attrs = &mut element.modifier();
@@ -47,6 +51,7 @@ impl<State: 'static, Action: 'static> OrphanView<Line, State, Action, DynMessage
         (): &mut Self::OrphanViewState,
         _ctx: &mut Self,
         element: Mut<Self::OrphanElement>,
+        _: &mut State,
     ) {
         Attributes::rebuild(element, 4, |mut element| {
             let attrs = &mut element.modifier();
@@ -62,6 +67,7 @@ impl<State: 'static, Action: 'static> OrphanView<Line, State, Action, DynMessage
         (): &mut Self::OrphanViewState,
         _ctx: &mut Self,
         _element: Mut<Self::OrphanElement>,
+        _: &mut State,
     ) {
     }
 
@@ -80,7 +86,11 @@ impl<State: 'static, Action: 'static> OrphanView<Rect, State, Action, DynMessage
     type OrphanViewState = ();
     type OrphanElement = Pod<web_sys::SvgRectElement>;
 
-    fn orphan_build(view: &Rect, ctx: &mut Self) -> (Self::OrphanElement, Self::OrphanViewState) {
+    fn orphan_build(
+        view: &Rect,
+        ctx: &mut Self,
+        _: &mut State,
+    ) -> (Self::OrphanElement, Self::OrphanViewState) {
         create_element("rect", ctx, 4, |element, ctx| {
             let mut element = Self::OrphanElement::from_with_ctx(element, ctx);
             let attrs = &mut element.modifier();
@@ -98,6 +108,7 @@ impl<State: 'static, Action: 'static> OrphanView<Rect, State, Action, DynMessage
         (): &mut Self::OrphanViewState,
         _ctx: &mut Self,
         element: Mut<Self::OrphanElement>,
+        _: &mut State,
     ) {
         Attributes::rebuild(element, 4, |mut element| {
             let attrs = &mut element.modifier();
@@ -113,6 +124,7 @@ impl<State: 'static, Action: 'static> OrphanView<Rect, State, Action, DynMessage
         (): &mut Self::OrphanViewState,
         _ctx: &mut Self,
         _element: Mut<Self::OrphanElement>,
+        _: &mut State,
     ) {
     }
 
@@ -131,7 +143,11 @@ impl<State: 'static, Action: 'static> OrphanView<Circle, State, Action, DynMessa
     type OrphanViewState = ();
     type OrphanElement = Pod<web_sys::SvgCircleElement>;
 
-    fn orphan_build(view: &Circle, ctx: &mut Self) -> (Self::OrphanElement, Self::OrphanViewState) {
+    fn orphan_build(
+        view: &Circle,
+        ctx: &mut Self,
+        _: &mut State,
+    ) -> (Self::OrphanElement, Self::OrphanViewState) {
         create_element("circle", ctx, 3, |element, ctx| {
             let mut element = Self::OrphanElement::from_with_ctx(element, ctx);
             let attrs = &mut element.modifier();
@@ -148,6 +164,7 @@ impl<State: 'static, Action: 'static> OrphanView<Circle, State, Action, DynMessa
         (): &mut Self::OrphanViewState,
         _ctx: &mut Self,
         element: Mut<Self::OrphanElement>,
+        _: &mut State,
     ) {
         Attributes::rebuild(element, 3, |mut element| {
             let attrs = &mut element.modifier();
@@ -162,6 +179,7 @@ impl<State: 'static, Action: 'static> OrphanView<Circle, State, Action, DynMessa
         (): &mut Self::OrphanViewState,
         _ctx: &mut Self,
         _element: Mut<Self::OrphanElement>,
+        _: &mut State,
     ) {
     }
 
@@ -183,6 +201,7 @@ impl<State: 'static, Action: 'static> OrphanView<BezPath, State, Action, DynMess
     fn orphan_build(
         view: &BezPath,
         ctx: &mut Self,
+        _: &mut State,
     ) -> (Self::OrphanElement, Self::OrphanViewState) {
         create_element("path", ctx, 1, |element, ctx| {
             let mut element = Self::OrphanElement::from_with_ctx(element, ctx);
@@ -198,6 +217,7 @@ impl<State: 'static, Action: 'static> OrphanView<BezPath, State, Action, DynMess
         (): &mut Self::OrphanViewState,
         _ctx: &mut Self,
         element: Mut<Self::OrphanElement>,
+        _: &mut State,
     ) {
         Attributes::rebuild(element, 1, |mut element| {
             let attrs = &mut element.modifier();
@@ -216,6 +236,7 @@ impl<State: 'static, Action: 'static> OrphanView<BezPath, State, Action, DynMess
         _view_state: &mut Self::OrphanViewState,
         _ctx: &mut Self,
         _element: Mut<Self::OrphanElement>,
+        _: &mut State,
     ) {
     }
 

--- a/xilem_web/src/text.rs
+++ b/xilem_web/src/text.rs
@@ -17,6 +17,7 @@ macro_rules! impl_string_view {
             fn orphan_build(
                 view: &$ty,
                 ctx: &mut ViewCtx,
+                _: &mut State,
             ) -> (Self::OrphanElement, Self::OrphanViewState) {
                 let node = if ctx.is_hydrating() {
                     ctx.hydrate_node().unwrap().unchecked_into()
@@ -32,6 +33,7 @@ macro_rules! impl_string_view {
                 (): &mut Self::OrphanViewState,
                 _ctx: &mut ViewCtx,
                 element: Mut<Self::OrphanElement>,
+                _: &mut State,
             ) {
                 if prev != new {
                     element.node.set_data(new);
@@ -43,6 +45,7 @@ macro_rules! impl_string_view {
                 _view_state: &mut Self::OrphanViewState,
                 _ctx: &mut ViewCtx,
                 _element: Mut<Self::OrphanElement>,
+                _: &mut State,
             ) {
             }
 
@@ -73,6 +76,7 @@ macro_rules! impl_to_string_view {
             fn orphan_build(
                 view: &$ty,
                 ctx: &mut ViewCtx,
+                _: &mut State,
             ) -> (Self::OrphanElement, Self::OrphanViewState) {
                 let node = if ctx.is_hydrating() {
                     ctx.hydrate_node().unwrap().unchecked_into()
@@ -88,6 +92,7 @@ macro_rules! impl_to_string_view {
                 (): &mut Self::OrphanViewState,
                 _ctx: &mut ViewCtx,
                 element: Mut<Self::OrphanElement>,
+                _: &mut State,
             ) {
                 if prev != new {
                     element.node.set_data(&new.to_string());
@@ -99,6 +104,7 @@ macro_rules! impl_to_string_view {
                 _view_state: &mut Self::OrphanViewState,
                 _ctx: &mut ViewCtx,
                 _element: Mut<Pod<web_sys::Text>>,
+                _: &mut State,
             ) {
             }
 


### PR DESCRIPTION
This change is both a major departure from the prior state, and the most natural thing in the world.

My proposing this change has come from thinking related to #1070, for what build/rebuild/message actually represent, , how distinct important the phases of the lifecycle actually are (they aren't at all), and the reason that the Xilem model actually works. The core insight behind Xilem is that if you can prove to the compiler that you only access a piece of state in one place at once, the compiler will let you access it exclusively. Everything else is following that to its logical conclusion; this just continues that train of thought.

Current state of this PR: 
- This PR is ready to be merged
- This PR makes a lot of changes, so if we want this, merging quickly would be helpful
- The only thing which is broken is the `adapt` view, which currently unconditionally panicks, to avoid making behaviour changes in this PR
- The follow-up changes which make use of this (in task, worker, virtual_scroll, memoize, the new use_state, run_once, etc.) have not been done, to make this PR plausible to review.

Tradeoffs:
- In theory, this makes multi-threaded rebuild harder, but note that this was already probably hard
- This is rejecting the premise that you don't need component local state; this is something I treated as an experiment, but which has probably held us back significantly.

There's some more work to be done here (in particular, I really want to experiment with exclusive references in the app state, especially around `use_state`, for event handling).