### PR TITLE
test: make TestHarness validate TreeUpdates returned by redraw

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,6 +2136,7 @@ name = "masonry_testing"
 version = "0.3.0"
 dependencies = [
  "accesskit",
+ "accesskit_consumer",
  "assert_matches",
  "cursor-icon",
  "dpi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ web-time = "1.1.0"
 bitflags = "2.9.1"
 accesskit = "0.19.0"
 accesskit_winit = "0.27.0"
+accesskit_consumer = "0.28.0"
 time = "0.3.41"
 
 [workspace.lints]

--- a/masonry_testing/Cargo.toml
+++ b/masonry_testing/Cargo.toml
@@ -20,6 +20,7 @@ default = []
 
 [dependencies]
 accesskit.workspace = true
+accesskit_consumer.workspace = true
 cursor-icon = "1.1.0"
 dpi.workspace = true
 futures-intrusive = "0.5.0"


### PR DESCRIPTION
If you don't have the accessibility feature enabled in your OS then you don't run the accesskit_consumer code which can lead to accessibility being broken without you noticing.

Of course you should still do manual accessibility testing but this change ensures that the accesskit_consumer code at least doesn't crash if your app is tested with the TestHarness.