### PR TITLE
Placehero: Get initial list of statuses for first exploration

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -17,3 +17,8 @@ doc-valid-idents = ["FizzBuzz", "MathML", "RustNL", ".."]
 # like Box<dyn Fn(&mut Env, &T)>, which seems overly strict. The new value of 400 is
 # a simple guess. It might be worth lowering this, or using the default, in the future.
 type-complexity-threshold = 400
+
+disallowed-types = [
+    # For Placehero
+    { path = "megalodon::mastodon::Mastodon", reason = "In case of future changes, we want to keep all our assumptions about using Mastodon centralised", replacement = "placehero::Mastodon" },
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2891,6 +2891,7 @@ name = "placehero"
 version = "0.3.0"
 dependencies = [
  "megalodon",
+ "tracing",
  "xilem",
 ]
 

--- a/placehero/Cargo.toml
+++ b/placehero/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [dependencies]
 megalodon = "1.0.0"
+tracing.workspace = true
 xilem = { version = "0.3.0", path = "../xilem" }
 
 [lints]

--- a/placehero/src/lib.rs
+++ b/placehero/src/lib.rs
@@ -187,6 +187,7 @@ fn load_statuses(
                         id,
                         Some(&GetAccountStatusesInputOptions {
                             exclude_reblogs: Some(true),
+                            exclude_replies: Some(true),
                             ..Default::default()
                         }),
                     )

--- a/placehero/src/lib.rs
+++ b/placehero/src/lib.rs
@@ -19,10 +19,7 @@ use megalodon::{
 };
 use xilem::{
     EventLoopBuilder, ViewCtx, WidgetView, WindowOptions, Xilem,
-    core::{
-        NoElement, View, fork,
-        one_of::{Either, OneOf},
-    },
+    core::{NoElement, View, fork, one_of::Either},
     palette::css::{LIME, WHITE, YELLOW},
     style::{Gradient, Style},
     view::{GridExt, GridParams, flex, grid, label, portal, prose, sized_box, split, task_raw},
@@ -58,13 +55,13 @@ impl Placehero {
                 prose(instance.title.as_str()),
             )))
         } else {
-            OneOf::B(prose("Not yet connected (or other unhandled error)"))
+            Either::B(prose("Not yet connected (or other unhandled error)"))
         }
     }
 
     fn main_view(&mut self) -> impl WidgetView<Self> + use<> {
         if self.statuses.is_empty() {
-            OneOf::A(prose("No statuses yet loaded"))
+            Either::A(prose("No statuses yet loaded"))
         } else {
             Either::B(portal(flex(
                 self.statuses.iter().map(status_view).collect::<Vec<_>>(),

--- a/xilem/src/style.rs
+++ b/xilem/src/style.rs
@@ -4,12 +4,13 @@
 //! Traits used to set custom styles on views.
 
 use masonry::core::Property;
-use masonry::properties::types::Gradient;
-use masonry::properties::{
+use vello::peniko::Color;
+
+pub use masonry::properties::types::{Gradient, GradientShape};
+pub use masonry::properties::{
     ActiveBackground, Background, BorderColor, BorderWidth, BoxShadow, CornerRadius,
     DisabledBackground, HoveredBorderColor, Padding,
 };
-use vello::peniko::Color;
 
 /// Trait implemented by views to signal that a given property can be set on them.
 ///

--- a/xilem/src/view/grid.rs
+++ b/xilem/src/view/grid.rs
@@ -7,9 +7,7 @@ use crate::style::Style;
 
 use masonry::core::{FromDynWidget, Widget, WidgetMut};
 use masonry::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
-use masonry::widgets::{
-    GridParams, {self},
-};
+use masonry::widgets;
 
 use crate::core::{
     AppendVec, DynMessage, ElementSplice, MessageResult, Mut, SuperElement, View, ViewElement,
@@ -17,6 +15,7 @@ use crate::core::{
 };
 use crate::{Pod, PropertyTuple as _, ViewCtx, WidgetView};
 
+pub use masonry::widgets::GridParams;
 /// A Grid layout divides a window into regions and defines the relationship
 /// between inner elements in terms of size and position.
 ///


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b2a0ca3b-b47f-49df-865f-9797bca49caa)

This is an exploration into using the Mastodon API, continuing work on the hero app.
The actual changes here won't be all that useful, in the long term, but it's helpful for getting an understanding of how to use the API.

One big, unfortunate surprise is that we really need some HTML parsing (although only as described [in the docs](https://docs.joinmastodon.org/spec/activitypub/#sanitization)). That is something I'm not looking forward to!

One discovery in this PR is that our logging isn't set-up for the first `build` in Xilem. That makes sense with how logging is owned, but it's also very unfortunate).

I do intend to land this, to keep progress moving in a piecemeal way, and potentially to allow collaboration. It might be that hero app PRs should be largely rubber-stamped. Note that there are "real" changes to Xilem in this PR (limited to new re-exports)