### PR TITLE
masonry_winit: fix libwayland-client crash due to wrong drop order

### DIFF
--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -126,8 +126,9 @@ pub struct MasonryState<'a> {
     frame: Option<tracing_tracy::client::Frame>,
 
     window_id_to_handle_id: HashMap<WindowId, HandleId>,
-    windows: HashMap<HandleId, Window>,
+
     surfaces: HashMap<HandleId, RenderSurface<'a>>,
+    windows: HashMap<HandleId, Window>,
 
     // Is `Some` if the most recently displayed frame was an animation frame.
     last_anim: Option<Instant>,


### PR DESCRIPTION
We need to garbage collect surfaces before window.

Tested on linux wayland.

Would be helpful if someone could test on windows and mac?