### PR TITLE
Add a flex row helper to Xilem

### DIFF
--- a/placehero/src/components.rs
+++ b/placehero/src/components.rs
@@ -6,6 +6,7 @@ use xilem::WidgetView;
 use xilem::palette::css;
 use xilem::style::Padding;
 use xilem::style::Style;
+use xilem::view::flex_row;
 use xilem::view::portal;
 use xilem::view::{
     CrossAxisAlignment, FlexExt, FlexSpacer, MainAxisAlignment, flex, inline_prose, label, prose,
@@ -33,7 +34,8 @@ pub(crate) fn timeline_status(
     status: &Status,
 ) -> impl WidgetView<Placehero> + use<> {
     sized_box(flex((
-        flex((
+        // Account info/message time
+        flex_row((
             avatars.avatar(&status.account.avatar_static),
             flex((
                 inline_prose(status.account.display_name.as_str())
@@ -52,15 +54,13 @@ pub(crate) fn timeline_status(
             inline_prose(status.created_at.format("%Y-%m-%d %H:%M:%S").to_string())
                 .alignment(xilem::TextAlignment::End),
         ))
-        .must_fill_major_axis(true)
-        .direction(xilem::view::Axis::Horizontal),
+        .must_fill_major_axis(true),
         prose(status_html_to_plaintext(status.content.as_str())),
-        flex((
+        flex_row((
             label(format!("💬 {}", status.replies_count)).flex(1.0),
             label(format!("🔄 {}", status.reblogs_count)).flex(1.0),
             label(format!("⭐ {}", status.favourites_count)).flex(1.0),
         ))
-        .direction(xilem::view::Axis::Horizontal)
         // TODO: The "extra space" amount actually ends up being zero, so this doesn't do anything.
         .main_axis_alignment(MainAxisAlignment::SpaceEvenly),
     )))

--- a/xilem/examples/components.rs
+++ b/xilem/examples/components.rs
@@ -6,7 +6,7 @@
 use masonry::widgets::MainAxisAlignment;
 use winit::error::EventLoopError;
 use xilem::core::lens;
-use xilem::view::{Axis, button, flex, label};
+use xilem::view::{button, flex, flex_row, label};
 use xilem::{EventLoop, WidgetView, WindowOptions, Xilem};
 
 #[derive(Default)]
@@ -24,7 +24,7 @@ fn modular_counter(count: &mut i32) -> impl WidgetView<i32> + use<> {
 }
 
 fn app_logic(state: &mut AppState) -> impl WidgetView<AppState> + use<> {
-    flex((
+    flex_row((
         lens(modular_counter, |state: &mut AppState| {
             &mut state.modularized_count
         }),
@@ -33,7 +33,6 @@ fn app_logic(state: &mut AppState) -> impl WidgetView<AppState> + use<> {
             |state: &mut AppState| state.global_count += 1,
         ),
     ))
-    .direction(Axis::Horizontal)
     .main_axis_alignment(MainAxisAlignment::Center)
 }
 

--- a/xilem/examples/elm.rs
+++ b/xilem/examples/elm.rs
@@ -7,7 +7,7 @@
 
 use masonry::widgets::{CrossAxisAlignment, MainAxisAlignment};
 use xilem::core::{MessageResult, map_action};
-use xilem::view::{Axis, button, flex, label};
+use xilem::view::{button, flex, flex_row, label};
 use xilem::winit::dpi::LogicalSize;
 use xilem::winit::error::EventLoopError;
 use xilem::{EventLoop, WidgetView, WindowOptions, Xilem};
@@ -44,7 +44,7 @@ enum CounterChanged {
 // `map_message` is the most flexible but also most verbose way to modularize the views by action.
 // It's very similar to `map_action`, but it also allows to change the `MessageResult` for the parent view
 fn map_message_counter(count: i32) -> impl WidgetView<i32, CounterChanged> {
-    flex((
+    flex_row((
         flex((
             label(format!("map_message count: {count}")),
             button("+", |count| {
@@ -63,11 +63,10 @@ fn map_message_counter(count: i32) -> impl WidgetView<i32, CounterChanged> {
             }),
         )),
     ))
-    .direction(Axis::Horizontal)
 }
 
 fn app_logic(state: &mut AppState) -> impl WidgetView<AppState> + use<> {
-    flex((
+    flex_row((
         map_action(
             elm_counter(state.map_action_count),
             |state: &mut AppState, message| match message {
@@ -93,7 +92,6 @@ fn app_logic(state: &mut AppState) -> impl WidgetView<AppState> + use<> {
             },
         ),
     ))
-    .direction(Axis::Horizontal)
     .cross_axis_alignment(CrossAxisAlignment::Center)
     .main_axis_alignment(MainAxisAlignment::Center)
 }

--- a/xilem/examples/emoji_picker.rs
+++ b/xilem/examples/emoji_picker.rs
@@ -7,14 +7,14 @@ use winit::error::EventLoopError;
 use xilem::core::map_state;
 use xilem::style::Style as _;
 use xilem::view::{
-    Axis, FlexExt, FlexSpacer, GridExt, button, flex, grid, label, prose, sized_box,
+    Axis, FlexExt, FlexSpacer, GridExt, button, flex, flex_row, grid, label, prose, sized_box,
 };
 use xilem::{Color, EventLoop, EventLoopBuilder, WidgetView, WindowOptions, Xilem, palette};
 
 fn app_logic(data: &mut EmojiPagination) -> impl WidgetView<EmojiPagination> + use<> {
     flex((
-        sized_box(flex(()).must_fill_major_axis(true)).height(50.), // Padding because of the info bar on Android
-        flex((
+        FlexSpacer::Fixed(50.), // Padding because of the info bar on Android
+        flex_row((
             // TODO: Expose that this is a "zoom out" button accessibly
             button("🔍-", |data: &mut EmojiPagination| {
                 data.size = (data.size + 1).min(5);
@@ -23,8 +23,7 @@ fn app_logic(data: &mut EmojiPagination) -> impl WidgetView<EmojiPagination> + u
             button("🔍+", |data: &mut EmojiPagination| {
                 data.size = (data.size - 1).max(2);
             }),
-        ))
-        .direction(Axis::Horizontal),
+        )),
         picker(data).flex(1.0),
         map_state(
             paginate(
@@ -98,7 +97,7 @@ fn paginate(
     let percentage_start = (current_start * 100) / max_count;
     let percentage_end = (current_end * 100) / max_count;
 
-    flex((
+    flex_row((
         // TODO: Expose that this is a previous page button to accessibility
         button(label("⬅️").text_size(24.0), move |data| {
             *data = current_start.saturating_sub(count_per_page);
@@ -113,7 +112,6 @@ fn paginate(
         })
         .disabled(current_end == max_count),
     ))
-    .direction(Axis::Horizontal)
 }
 
 struct EmojiPagination {

--- a/xilem/examples/external_event_loop.rs
+++ b/xilem/examples/external_event_loop.rs
@@ -13,7 +13,7 @@ use winit::application::ApplicationHandler;
 use winit::error::EventLoopError;
 use winit::event::ElementState;
 use winit::keyboard::{KeyCode, PhysicalKey};
-use xilem::view::{Axis, Label, button, flex, label, sized_box};
+use xilem::view::{Label, button, flex_row, label, sized_box};
 use xilem::{EventLoop, WidgetView, WindowOptions, Xilem};
 
 /// A component to make a bigger than usual button
@@ -25,7 +25,7 @@ fn big_button(
 }
 
 fn app_logic(data: &mut i32) -> impl WidgetView<i32> + use<> {
-    flex((
+    flex_row((
         big_button("-", |data| {
             *data -= 1;
         }),
@@ -34,7 +34,6 @@ fn app_logic(data: &mut i32) -> impl WidgetView<i32> + use<> {
             *data += 1;
         }),
     ))
-    .direction(Axis::Horizontal)
     .cross_axis_alignment(CrossAxisAlignment::Center)
     .main_axis_alignment(MainAxisAlignment::Center)
 }

--- a/xilem/examples/flex.rs
+++ b/xilem/examples/flex.rs
@@ -5,7 +5,7 @@
 
 use masonry::widgets::{CrossAxisAlignment, MainAxisAlignment};
 use winit::error::EventLoopError;
-use xilem::view::{Axis, FlexExt as _, FlexSpacer, Label, button, flex, label, sized_box};
+use xilem::view::{FlexExt as _, FlexSpacer, Label, button, flex_row, label, sized_box};
 use xilem::{EventLoop, WidgetView, WindowOptions, Xilem};
 
 /// A component to make a bigger than usual button
@@ -17,7 +17,7 @@ fn big_button(
 }
 
 fn app_logic(data: &mut i32) -> impl WidgetView<i32> + use<> {
-    flex((
+    flex_row((
         FlexSpacer::Fixed(30.0),
         big_button("-", |data| {
             *data -= 1;
@@ -30,7 +30,6 @@ fn app_logic(data: &mut i32) -> impl WidgetView<i32> + use<> {
         }),
         FlexSpacer::Fixed(30.0),
     ))
-    .direction(Axis::Horizontal)
     .cross_axis_alignment(CrossAxisAlignment::Center)
     .main_axis_alignment(MainAxisAlignment::Center)
 }

--- a/xilem/examples/http_cats.rs
+++ b/xilem/examples/http_cats.rs
@@ -18,7 +18,7 @@ use xilem::core::fork;
 use xilem::core::one_of::OneOf3;
 use xilem::style::Style as _;
 use xilem::view::{
-    Axis, FlexSpacer, ZStackExt, button, flex, image, inline_prose, portal, prose, sized_box,
+    FlexSpacer, ZStackExt, button, flex, flex_row, image, inline_prose, portal, prose, sized_box,
     spinner, split, worker, zstack,
 };
 use xilem::{
@@ -147,7 +147,7 @@ async fn image_from_url(url: &str) -> anyhow::Result<Image> {
 impl Status {
     fn list_view(&mut self) -> impl WidgetView<HttpCats> + use<> {
         let code = self.code;
-        flex((
+        flex_row((
             // TODO: Reduce allocations here?
             inline_prose(self.code.to_string()),
             inline_prose(self.message),
@@ -170,7 +170,6 @@ impl Status {
             }),
             FlexSpacer::Fixed(masonry::theme::SCROLLBAR_WIDTH),
         ))
-        .direction(Axis::Horizontal)
     }
 
     fn details_view(&mut self) -> impl WidgetView<HttpCats> + use<> {

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -14,7 +14,7 @@ use xilem::style::Style as _;
 use xilem::tokio::time;
 use xilem::view::{
     Axis, FlexExt as _, FlexSpacer, PointerButton, button, button_any_pointer, checkbox, flex,
-    label, prose, task, textbox,
+    flex_row, label, prose, task, textbox,
 };
 use xilem::{
     EventLoop, EventLoopBuilder, FontWeight, InsertNewline, TextAlignment, WidgetView,
@@ -67,13 +67,12 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> + use<> {
 
     fork(
         flex((
-            flex((
+            flex_row((
                 label("Label").brush(palette::css::REBECCA_PURPLE),
                 label("Bold Label").weight(FontWeight::BOLD),
                 // TODO masonry doesn't allow setting disabled manually anymore?
                 // label("Disabled label").disabled(),
-            ))
-            .direction(Axis::Horizontal),
+            )),
             flex(
                 textbox(
                     data.textbox_contents.clone(),
@@ -83,6 +82,7 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> + use<> {
                 )
                 .insert_newline(InsertNewline::OnEnter),
             )
+            // Manually adding a direction is equivalent to using flex_row
             .direction(Axis::Horizontal),
             prose(LOREM).alignment(TextAlignment::Middle).text_size(18.),
             button_any_pointer(button_label, |data: &mut AppData, button| match button {
@@ -126,7 +126,7 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> + use<> {
 
 fn toggleable(data: &mut AppData) -> impl WidgetView<AppData> + use<> {
     if data.active {
-        flex((
+        flex_row((
             button("Deactivate", |data: &mut AppData| {
                 data.active = false;
             }),
@@ -137,7 +137,6 @@ fn toggleable(data: &mut AppData) -> impl WidgetView<AppData> + use<> {
                 tracing::warn!("The pathway to unlimited power has been revealed");
             })),
         ))
-        .direction(Axis::Horizontal)
         .boxed()
     } else {
         button("Activate", |data: &mut AppData| data.active = true).boxed()

--- a/xilem/examples/stopwatch.rs
+++ b/xilem/examples/stopwatch.rs
@@ -7,14 +7,14 @@ use std::ops::{Add, Sub};
 use std::time::{Duration, SystemTime};
 
 use masonry::dpi::LogicalSize;
-use masonry::widgets::{Axis, CrossAxisAlignment, MainAxisAlignment};
+use masonry::widgets::{CrossAxisAlignment, MainAxisAlignment};
 use masonry_winit::app::{EventLoop, EventLoopBuilder};
 use tokio::time;
 use tracing::warn;
 use winit::error::EventLoopError;
 use xilem::core::fork;
 use xilem::core::one_of::Either;
-use xilem::view::{FlexSequence, FlexSpacer, button, flex, label, task};
+use xilem::view::{FlexSequence, FlexSpacer, button, flex, flex_row, label, task};
 use xilem::{WidgetView, WindowOptions, Xilem};
 
 /// The state of the entire application.
@@ -110,7 +110,7 @@ fn app_logic(data: &mut Stopwatch) -> impl WidgetView<Stopwatch> + use<> {
         flex((
             FlexSpacer::Fixed(5.0),
             label(get_formatted_duration(data.displayed_duration)).text_size(70.0),
-            flex((lap_reset_button(data), start_stop_button(data))).direction(Axis::Horizontal),
+            flex_row((lap_reset_button(data), start_stop_button(data))),
             FlexSpacer::Fixed(1.0),
             laps_section(data),
             label(data.displayed_error.as_ref()),
@@ -160,14 +160,13 @@ fn single_lap(
     split_dur: Duration,
     total_dur: Duration,
 ) -> impl WidgetView<Stopwatch> {
-    flex((
+    flex_row((
         FlexSpacer::Flex(1.0),
         label(format!("Lap {}", lap_id + 1)),
         label(get_formatted_duration(split_dur)),
         label(get_formatted_duration(total_dur)),
         FlexSpacer::Flex(1.0),
     ))
-    .direction(Axis::Horizontal)
     .cross_axis_alignment(CrossAxisAlignment::Center)
     .main_axis_alignment(MainAxisAlignment::Start)
     .must_fill_major_axis(true)

--- a/xilem/examples/to_do_mvc.rs
+++ b/xilem/examples/to_do_mvc.rs
@@ -8,7 +8,7 @@
 
 use winit::error::EventLoopError;
 use xilem::style::Style as _;
-use xilem::view::{Axis, button, checkbox, flex, textbox};
+use xilem::view::{Axis, button, checkbox, flex, flex_row, textbox};
 use xilem::{EventLoop, EventLoopBuilder, InsertNewline, WidgetView, WindowOptions, Xilem};
 
 struct Task {
@@ -67,7 +67,7 @@ fn app_logic(task_list: &mut TaskList) -> impl WidgetView<TaskList> + use<> {
             let delete_button = button("Delete", move |data: &mut TaskList| {
                 data.tasks.remove(i);
             });
-            flex((checkbox, delete_button)).direction(Axis::Horizontal)
+            flex_row((checkbox, delete_button))
         })
         .collect::<Vec<_>>();
 

--- a/xilem/examples/variable_clock.rs
+++ b/xilem/examples/variable_clock.rs
@@ -13,8 +13,8 @@ use winit::error::EventLoopError;
 use xilem::core::fork;
 use xilem::style::Style as _;
 use xilem::view::{
-    Axis, FlexExt, FlexSpacer, button, flex, inline_prose, label, portal, prose, sized_box, task,
-    variable_label,
+    FlexExt, FlexSpacer, button, flex, flex_row, inline_prose, label, portal, prose, sized_box,
+    task, variable_label,
 };
 use xilem::{
     Blob, EventLoop, EventLoopBuilder, FontWeight, WidgetView, WindowOptions, Xilem, palette,
@@ -97,7 +97,7 @@ fn local_time(data: &mut Clocks) -> impl WidgetView<Clocks> + use<> {
 
 /// Controls for the variable font weight.
 fn controls() -> impl WidgetView<Clocks> {
-    flex((
+    flex_row((
         button("Increase", |data: &mut Clocks| {
             data.weight = (data.weight + 100.).clamp(1., 1000.);
         }),
@@ -111,7 +111,6 @@ fn controls() -> impl WidgetView<Clocks> {
             data.weight = 1000.;
         }),
     ))
-    .direction(Axis::Horizontal)
 }
 
 impl TimeZone {
@@ -119,7 +118,7 @@ impl TimeZone {
     fn view(&self, data: &mut Clocks) -> impl WidgetView<Clocks> + use<> {
         let date_time_in_self = data.now_utc.to_offset(self.offset);
         sized_box(flex((
-            flex((
+            flex_row((
                 inline_prose(self.region),
                 FlexSpacer::Flex(1.),
                 label(format!("UTC{}", self.offset)).brush(
@@ -132,9 +131,8 @@ impl TimeZone {
                 ),
             ))
             .must_fill_major_axis(true)
-            .direction(Axis::Horizontal)
             .flex(1.),
-            flex((
+            flex_row((
                 variable_label(
                     date_time_in_self
                         .format(format_description!("[hour repr:24]:[minute]:[second]"))
@@ -153,8 +151,7 @@ impl TimeZone {
                             .unwrap(),
                     )
                 }),
-            ))
-            .direction(Axis::Horizontal),
+            )),
         )))
         .expand_width()
         .height(72.)

--- a/xilem/examples/widgets.rs
+++ b/xilem/examples/widgets.rs
@@ -7,7 +7,9 @@ use masonry::dpi::LogicalSize;
 use masonry_winit::app::{EventLoop, EventLoopBuilder};
 use winit::error::EventLoopError;
 use xilem::style::Style as _;
-use xilem::view::{Axis, FlexSpacer, button, checkbox, flex, flex_item, progress_bar, sized_box};
+use xilem::view::{
+    FlexSpacer, button, checkbox, flex, flex_item, flex_row, progress_bar, sized_box,
+};
 use xilem::{Color, WidgetView, WindowOptions, Xilem};
 use xilem_core::lens;
 
@@ -52,14 +54,11 @@ fn checkbox_view(data: bool) -> impl WidgetView<bool> {
 fn border_box<State: 'static, Action: 'static>(
     inner: impl WidgetView<State, Action>,
 ) -> impl WidgetView<State, Action> {
-    sized_box(
-        flex((
-            FlexSpacer::Flex(1.),
-            flex((FlexSpacer::Flex(1.), inner, FlexSpacer::Flex(1.))),
-            FlexSpacer::Flex(1.),
-        ))
-        .direction(Axis::Horizontal),
-    )
+    sized_box(flex_row((
+        FlexSpacer::Flex(1.),
+        flex((FlexSpacer::Flex(1.), inner, FlexSpacer::Flex(1.))),
+        FlexSpacer::Flex(1.),
+    )))
     .border(Color::WHITE, 2.)
     .width(450.)
     .height(200.)
@@ -69,7 +68,7 @@ fn border_box<State: 'static, Action: 'static>(
 fn app_logic(_data: &mut WidgetGallery) -> impl WidgetView<WidgetGallery> + use<> {
     // Use a `sized_box` to pad the window contents
     sized_box(
-        flex((
+        flex_row((
             lens(
                 |progress| flex_item(border_box(progress_bar_view(*progress)), 1.),
                 |data: &mut WidgetGallery| &mut data.progress,
@@ -79,10 +78,9 @@ fn app_logic(_data: &mut WidgetGallery) -> impl WidgetView<WidgetGallery> + use<
                 |data: &mut WidgetGallery| &mut data.checked,
             ),
         ))
-        .gap(SPACER_WIDTH)
-        .direction(Axis::Horizontal),
+        .gap(SPACER_WIDTH),
     )
-    .border(Color::TRANSPARENT, SPACER_WIDTH)
+    .padding(SPACER_WIDTH)
 }
 
 fn run(event_loop: EventLoopBuilder) -> Result<(), EventLoopError> {

--- a/xilem/src/view/flex.rs
+++ b/xilem/src/view/flex.rs
@@ -73,6 +73,16 @@ pub fn flex<State, Action, Seq: FlexSequence<State, Action>>(
     }
 }
 
+/// A layout where the children are laid out in a row.
+///
+/// This is equivalent to [`flex`] with a pre-applied horizontal
+/// [`direction`](Flex::direction).
+pub fn flex_row<State, Action, Seq: FlexSequence<State, Action>>(
+    sequence: Seq,
+) -> Flex<Seq, State, Action> {
+    flex(sequence).direction(Axis::Horizontal)
+}
+
 /// The [`View`] created by [`flex`] from a sequence.
 ///
 /// See `flex` documentation for more context.


### PR DESCRIPTION
This is a little papercut that I often run into, that the flex direction being defined after the sequence means that it can be hard to understand what element a piece of code relates to.

This is especially prevalent in nested flexes (e.g. a vertical flex containing horizontal flexes), as the changing flow direction is important to understand.