### PR TITLE
refactor: introduce AnyWidget trait

### DIFF
--- a/masonry/src/doc/01_creating_app.md
+++ b/masonry/src/doc/01_creating_app.md
@@ -131,7 +131,7 @@ Because our widget tree only has one button and one textbox, there is no possibl
 When handling `ButtonPressed`:
 
 - `ctx.render_root()` returns a reference to the `RenderRoot`, which owns the widget tree and all the associated visual state.
-- `RenderRoot::edit_root_widget()` takes a closure; that closure takes a `WidgetMut<dyn Widget>` which we call `root`. Once the closure returns, `RenderRoot` runs some passes to update the app's internal states.
+- `RenderRoot::edit_root_widget()` takes a closure; that closure takes a `WidgetMut<dyn AnyWidget>` which we call `root`. Once the closure returns, `RenderRoot` runs some passes to update the app's internal states.
 - `root.downcast::<...>()` returns a `WidgetMut<Portal<Flex>>`.
 - `Portal::child_mut()` returns a `WidgetMut<Flex>`.
 

--- a/masonry/src/doc/03_implementing_container_widget.md
+++ b/masonry/src/doc/03_implementing_container_widget.md
@@ -28,7 +28,7 @@ As an example, let's write a `VerticalStack` widget, which lays out its children
 
 ```rust,ignore
 struct VerticalStack {
-    children: Vec<WidgetPod<dyn Widget>>,
+    children: Vec<WidgetPod<dyn AnyWidget>>,
     gap: f64,
 }
 
@@ -200,7 +200,7 @@ Let's write WidgetMut methods for our `VerticalStack`:
 
 ```rust,ignore
 impl VerticalStack {
-    pub fn add_child(this: &mut WidgetMut<'_, Self>, child: WidgetPod<dyn Widget>) {
+    pub fn add_child(this: &mut WidgetMut<'_, Self>, child: WidgetPod<dyn AnyWidget>) {
         this.widget.children.push(child);
         this.ctx.children_changed();
     }

--- a/masonry/src/widgets/align.rs
+++ b/masonry/src/widgets/align.rs
@@ -9,6 +9,7 @@
 // its computed size. See https://github.com/linebender/xilem/issues/378
 
 use accesskit::{Node, Role};
+use masonry_core::core::AnyWidget;
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
 use vello::Scene;
@@ -27,7 +28,7 @@ use crate::util::UnitPoint;
 #[doc = crate::include_screenshot!("align_right.png", "Right-aligned label.")]
 pub struct Align {
     align: UnitPoint,
-    child: WidgetPod<dyn Widget>,
+    child: WidgetPod<dyn AnyWidget>,
     width_factor: Option<f64>,
     height_factor: Option<f64>,
 }

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -4,7 +4,7 @@
 use std::any::TypeId;
 
 use accesskit::{Node, Role};
-use masonry_core::core::UpdateCtx;
+use masonry_core::core::{AnyWidget, UpdateCtx};
 use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
@@ -29,7 +29,7 @@ pub struct Grid {
 }
 
 struct Child {
-    widget: WidgetPod<dyn Widget>,
+    widget: WidgetPod<dyn AnyWidget>,
     x: i32,
     y: i32,
     width: i32,
@@ -78,7 +78,7 @@ impl Grid {
     }
 
     /// Builder-style method to add a child widget already wrapped in a [`WidgetPod`].
-    pub fn with_child_pod(mut self, widget: WidgetPod<dyn Widget>, params: GridParams) -> Self {
+    pub fn with_child_pod(mut self, widget: WidgetPod<dyn AnyWidget>, params: GridParams) -> Self {
         let child = Child {
             widget,
             x: params.x,
@@ -101,7 +101,7 @@ impl Child {
     }
 }
 
-fn new_grid_child(params: GridParams, widget: WidgetPod<dyn Widget>) -> Child {
+fn new_grid_child(params: GridParams, widget: WidgetPod<dyn AnyWidget>) -> Child {
     Child {
         widget,
         x: params.x,
@@ -157,7 +157,7 @@ impl Grid {
     ///
     /// See also [`with_child`](Grid::with_child).
     pub fn add_child(this: &mut WidgetMut<'_, Self>, child: impl Widget, params: GridParams) {
-        let child_pod: WidgetPod<dyn Widget> = WidgetPod::new(child).erased();
+        let child_pod: WidgetPod<dyn AnyWidget> = WidgetPod::new(child).erased();
         Self::add_child_pod(this, child_pod, params);
     }
 
@@ -170,7 +170,7 @@ impl Grid {
         id: WidgetId,
         params: GridParams,
     ) {
-        let child_pod: WidgetPod<dyn Widget> = WidgetPod::new_with_id(child, id).erased();
+        let child_pod: WidgetPod<dyn AnyWidget> = WidgetPod::new_with_id(child, id).erased();
         Self::add_child_pod(this, child_pod, params);
     }
 
@@ -179,7 +179,7 @@ impl Grid {
     /// See also [`with_child_pod`](Grid::with_child_pod).
     pub fn add_child_pod(
         this: &mut WidgetMut<'_, Self>,
-        widget: WidgetPod<dyn Widget>,
+        widget: WidgetPod<dyn AnyWidget>,
         params: GridParams,
     ) {
         let child = new_grid_child(params, widget);
@@ -216,7 +216,7 @@ impl Grid {
     pub fn insert_grid_child_pod(
         this: &mut WidgetMut<'_, Self>,
         idx: usize,
-        child: WidgetPod<dyn Widget>,
+        child: WidgetPod<dyn AnyWidget>,
         params: impl Into<GridParams>,
     ) {
         let child = new_grid_child(params.into(), child);
@@ -253,7 +253,7 @@ impl Grid {
     pub fn child_mut<'t>(
         this: &'t mut WidgetMut<'_, Self>,
         idx: usize,
-    ) -> WidgetMut<'t, dyn Widget> {
+    ) -> WidgetMut<'t, dyn AnyWidget> {
         let child = &mut this.widget.children[idx].widget;
         this.ctx.get_mut(child)
     }

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -11,9 +11,9 @@ use vello::Scene;
 use vello::kurbo::{Point, Rect, Size, Vec2};
 
 use crate::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, FromDynWidget, LayoutCtx,
-    PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, ScrollDelta,
-    TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, AccessEvent, AnyWidget, BoxConstraints, ComposeCtx, EventCtx, FromDynWidget,
+    LayoutCtx, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx,
+    ScrollDelta, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::widgets::{Axis, ScrollBar};
 
@@ -23,7 +23,7 @@ use crate::widgets::{Axis, ScrollBar};
 // Conceptually, a Portal is a Widget giving a restricted view of a child widget
 // Imagine a very large widget, and a rect that represents the part of the widget we see
 #[expect(missing_docs, reason = "TODO")]
-pub struct Portal<W: Widget + ?Sized> {
+pub struct Portal<W: AnyWidget + ?Sized> {
     child: WidgetPod<W>,
     // TODO - differentiate between the "explicit" viewport pos determined
     // by user input, and the computed viewport pos that may change based
@@ -48,7 +48,7 @@ impl<W: Widget> Portal<W> {
     }
 }
 
-impl<W: Widget + ?Sized> Portal<W> {
+impl<W: AnyWidget + ?Sized> Portal<W> {
     #[expect(missing_docs, reason = "TODO")]
     pub fn new_pod(child: WidgetPod<W>) -> Self {
         Self {
@@ -133,7 +133,7 @@ fn compute_pan_range(mut viewport: Range<f64>, target: Range<f64>) -> Range<f64>
     viewport
 }
 
-impl<W: Widget + ?Sized> Portal<W> {
+impl<W: AnyWidget + ?Sized> Portal<W> {
     // TODO - rename
     fn set_viewport_pos_raw(&mut self, portal_size: Size, content_size: Size, pos: Point) -> bool {
         let viewport_max_pos =
@@ -173,7 +173,7 @@ impl<W: Widget + ?Sized> Portal<W> {
 }
 
 // --- MARK: WIDGETMUT
-impl<W: Widget + FromDynWidget + ?Sized> Portal<W> {
+impl<W: AnyWidget + FromDynWidget + ?Sized> Portal<W> {
     #[expect(missing_docs, reason = "TODO")]
     pub fn child_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, W> {
         this.ctx.get_mut(&mut this.widget.child)
@@ -263,7 +263,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Portal<W> {
 }
 
 // --- MARK: IMPL WIDGET
-impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
+impl<W: AnyWidget + FromDynWidget + ?Sized> Widget for Portal<W> {
     fn on_pointer_event(
         &mut self,
         ctx: &mut EventCtx<'_>,

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -6,6 +6,7 @@
 use std::any::TypeId;
 
 use accesskit::{Node, Role};
+use masonry_core::core::AnyWidget;
 use masonry_core::util::fill;
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span, warn};
@@ -31,7 +32,7 @@ use crate::util::stroke;
 ///
 #[doc = crate::include_screenshot!("sized_box_label_box_with_outer_padding.png", "Box with blue border, pink background and a child label.")]
 pub struct SizedBox {
-    child: Option<WidgetPod<dyn Widget>>,
+    child: Option<WidgetPod<dyn AnyWidget>>,
     width: Option<f64>,
     height: Option<f64>,
 }
@@ -57,7 +58,7 @@ impl SizedBox {
     }
 
     /// Construct container with child in a pod, and both width and height not set.
-    pub fn new_pod(child: WidgetPod<dyn Widget>) -> Self {
+    pub fn new_pod(child: WidgetPod<dyn AnyWidget>) -> Self {
         Self {
             child: Some(child),
             width: None,
@@ -181,7 +182,9 @@ impl SizedBox {
     }
 
     /// Get mutable reference to the child widget, if any.
-    pub fn child_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> Option<WidgetMut<'t, dyn Widget>> {
+    pub fn child_mut<'t>(
+        this: &'t mut WidgetMut<'_, Self>,
+    ) -> Option<WidgetMut<'t, dyn AnyWidget>> {
         let child = this.widget.child.as_mut()?;
         Some(this.ctx.get_mut(child))
     }

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -5,6 +5,7 @@
 
 use accesskit::{Node, Role};
 use cursor_icon::CursorIcon;
+use masonry_core::core::AnyWidget;
 use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span, warn};
 use vello::Scene;
@@ -25,8 +26,8 @@ use crate::widgets::flex::Axis;
 #[doc = crate::include_screenshot!("split_columns.png", "Split panel with two labels.")]
 pub struct Split<ChildA, ChildB>
 where
-    ChildA: Widget + ?Sized,
-    ChildB: Widget + ?Sized,
+    ChildA: AnyWidget + ?Sized,
+    ChildB: AnyWidget + ?Sized,
 {
     split_axis: Axis,
     split_point_chosen: f64,
@@ -52,7 +53,7 @@ impl<ChildA: Widget, ChildB: Widget> Split<ChildA, ChildB> {
     }
 }
 
-impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
+impl<ChildA: AnyWidget + ?Sized, ChildB: AnyWidget + ?Sized> Split<ChildA, ChildB> {
     /// Build split panel from two children already wrapped in [`WidgetPod`]s.
     pub fn new_pod(child1: WidgetPod<ChildA>, child2: WidgetPod<ChildB>) -> Self {
         Self {
@@ -150,7 +151,7 @@ impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
 }
 
 // --- MARK: INTERNALS
-impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
+impl<ChildA: AnyWidget + ?Sized, ChildB: AnyWidget + ?Sized> Split<ChildA, ChildB> {
     /// Returns the size of the splitter bar area.
     #[inline]
     fn bar_area(&self) -> f64 {
@@ -301,8 +302,8 @@ impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
 // --- MARK: WIDGETMUT
 impl<ChildA, ChildB> Split<ChildA, ChildB>
 where
-    ChildA: Widget + FromDynWidget + ?Sized,
-    ChildB: Widget + FromDynWidget + ?Sized,
+    ChildA: AnyWidget + FromDynWidget + ?Sized,
+    ChildB: AnyWidget + FromDynWidget + ?Sized,
 {
     /// Get a mutable reference to the first child widget.
     pub fn child1_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, ChildA> {
@@ -394,8 +395,8 @@ where
 // --- MARK: IMPL WIDGET
 impl<ChildA, ChildB> Widget for Split<ChildA, ChildB>
 where
-    ChildA: Widget + ?Sized,
-    ChildB: Widget + ?Sized,
+    ChildA: AnyWidget + ?Sized,
+    ChildB: AnyWidget + ?Sized,
 {
     fn on_pointer_event(
         &mut self,

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -8,12 +8,12 @@ use vello::Scene;
 use vello::kurbo::{Point, Size};
 
 use crate::core::{
-    AccessCtx, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef, QueryCtx,
-    RegisterCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, AnyWidget, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef,
+    QueryCtx, RegisterCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 
 struct Child {
-    widget: WidgetPod<dyn Widget>,
+    widget: WidgetPod<dyn AnyWidget>,
     alignment: ChildAlignment,
 }
 
@@ -166,7 +166,7 @@ impl From<Alignment> for ChildAlignment {
 }
 
 impl Child {
-    fn new(widget: WidgetPod<dyn Widget>, alignment: ChildAlignment) -> Self {
+    fn new(widget: WidgetPod<dyn AnyWidget>, alignment: ChildAlignment) -> Self {
         Self { widget, alignment }
     }
 
@@ -209,7 +209,7 @@ impl ZStack {
     /// See also [`Self::with_child`] if the widget is not already wrapped in a [`WidgetPod`].
     pub fn with_child_pod(
         mut self,
-        child: WidgetPod<dyn Widget>,
+        child: WidgetPod<dyn AnyWidget>,
         alignment: impl Into<ChildAlignment>,
     ) -> Self {
         let child = Child::new(child, alignment.into());
@@ -229,7 +229,7 @@ impl ZStack {
         child: impl Widget,
         alignment: impl Into<ChildAlignment>,
     ) {
-        let child_pod: WidgetPod<dyn Widget> = WidgetPod::new(child).erased();
+        let child_pod: WidgetPod<dyn AnyWidget> = WidgetPod::new(child).erased();
         Self::insert_child_pod(this, child_pod, alignment);
     }
 
@@ -242,14 +242,14 @@ impl ZStack {
         id: WidgetId,
         alignment: impl Into<ChildAlignment>,
     ) {
-        let child_pod: WidgetPod<dyn Widget> = WidgetPod::new_with_id(child, id).erased();
+        let child_pod: WidgetPod<dyn AnyWidget> = WidgetPod::new_with_id(child, id).erased();
         Self::insert_child_pod(this, child_pod, alignment);
     }
 
     /// Add a child widget to the `ZStack`.
     pub fn insert_child_pod(
         this: &mut WidgetMut<'_, Self>,
-        widget: WidgetPod<dyn Widget>,
+        widget: WidgetPod<dyn AnyWidget>,
         alignment: impl Into<ChildAlignment>,
     ) {
         let child = Child::new(widget, alignment.into());
@@ -269,7 +269,7 @@ impl ZStack {
     pub fn child_mut<'t>(
         this: &'t mut WidgetMut<'_, Self>,
         idx: usize,
-    ) -> Option<WidgetMut<'t, dyn Widget>> {
+    ) -> Option<WidgetMut<'t, dyn AnyWidget>> {
         let child = &mut this.widget.children[idx].widget;
         Some(this.ctx.get_mut(child))
     }

--- a/masonry_core/src/core/mod.rs
+++ b/masonry_core/src/core/mod.rs
@@ -28,7 +28,7 @@ pub use object_fit::ObjectFit;
 pub use properties::{DefaultProperties, Properties, PropertiesMut, PropertiesRef, Property};
 pub use text::{ArcStr, BrushIndex, StyleProperty, StyleSet, render_text};
 pub use widget::find_widget_under_pointer;
-pub use widget::{AllowRawMut, FromDynWidget, Widget, WidgetId};
+pub use widget::{AllowRawMut, AnyWidget, FromDynWidget, Widget, WidgetId};
 pub use widget_mut::WidgetMut;
 pub use widget_pod::WidgetPod;
 pub use widget_ref::WidgetRef;

--- a/masonry_core/src/core/widget_arena.rs
+++ b/masonry_core/src/core/widget_arena.rs
@@ -3,11 +3,11 @@
 
 use tree_arena::{ArenaMut, ArenaRef, TreeArena};
 
-use crate::core::{Widget, WidgetId, WidgetState};
+use crate::core::{AnyWidget, WidgetId, WidgetState};
 use crate::util::AnyMap;
 
 pub(crate) struct WidgetArena {
-    pub(crate) widgets: TreeArena<Box<dyn Widget>>,
+    pub(crate) widgets: TreeArena<Box<dyn AnyWidget>>,
     pub(crate) states: TreeArena<WidgetState>,
     pub(crate) properties: TreeArena<AnyMap>,
 }
@@ -33,7 +33,7 @@ impl WidgetArena {
         &self,
         widget_id: WidgetId,
     ) -> (
-        ArenaRef<'_, Box<dyn Widget>>,
+        ArenaRef<'_, Box<dyn AnyWidget>>,
         ArenaRef<'_, WidgetState>,
         ArenaRef<'_, AnyMap>,
     ) {
@@ -57,7 +57,7 @@ impl WidgetArena {
         &mut self,
         widget_id: WidgetId,
     ) -> (
-        ArenaMut<'_, Box<dyn Widget>>,
+        ArenaMut<'_, Box<dyn AnyWidget>>,
         ArenaMut<'_, WidgetState>,
         ArenaMut<'_, AnyMap>,
     ) {
@@ -78,7 +78,7 @@ impl WidgetArena {
 
     #[allow(dead_code)]
     #[track_caller]
-    pub(crate) fn get_widget(&self, widget_id: WidgetId) -> ArenaRef<'_, Box<dyn Widget>> {
+    pub(crate) fn get_widget(&self, widget_id: WidgetId) -> ArenaRef<'_, Box<dyn AnyWidget>> {
         self.widgets
             .find(widget_id)
             .expect("get_widget: widget not in widget tree")
@@ -86,7 +86,10 @@ impl WidgetArena {
 
     #[allow(dead_code)]
     #[track_caller]
-    pub(crate) fn get_widget_mut(&mut self, widget_id: WidgetId) -> ArenaMut<'_, Box<dyn Widget>> {
+    pub(crate) fn get_widget_mut(
+        &mut self,
+        widget_id: WidgetId,
+    ) -> ArenaMut<'_, Box<dyn AnyWidget>> {
         self.widgets
             .find_mut(widget_id)
             .expect("get_widget_mut: widget not in widget tree")

--- a/masonry_core/src/core/widget_pod.rs
+++ b/masonry_core/src/core/widget_pod.rs
@@ -1,7 +1,7 @@
 // Copyright 2018 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::core::{Properties, Widget, WidgetId, WidgetOptions};
+use crate::core::{AnyWidget, Properties, WidgetId, WidgetOptions};
 
 /// A container for one widget in the hierarchy.
 ///
@@ -30,7 +30,7 @@ enum WidgetPodInner<W: ?Sized> {
     Inserted,
 }
 
-impl<W: Widget> WidgetPod<W> {
+impl<W: AnyWidget> WidgetPod<W> {
     /// Create a new widget pod.
     ///
     /// In a widget hierarchy, each widget is wrapped in a `WidgetPod`
@@ -56,7 +56,7 @@ impl<W: Widget> WidgetPod<W> {
     }
 }
 
-impl<W: Widget + ?Sized> WidgetPod<W> {
+impl<W: AnyWidget + ?Sized> WidgetPod<W> {
     /// Create a new widget pod with custom options.
     pub fn new_with_options(inner: Box<W>, options: WidgetOptions) -> Self {
         Self::new_with_id_and_options(inner, WidgetId::next(), options)
@@ -110,8 +110,8 @@ impl<W: Widget + ?Sized> WidgetPod<W> {
     /// Type-erase the contained widget.
     ///
     /// Convert a `WidgetPod` pointing to a widget of a specific concrete type
-    /// `WidgetPod` pointing to a `dyn Widget`.
-    pub fn erased(self) -> WidgetPod<dyn Widget> {
+    /// `WidgetPod` pointing to a `dyn AnyWidget`.
+    pub fn erased(self) -> WidgetPod<dyn AnyWidget> {
         let WidgetPodInner::Create(inner) = self.inner else {
             // TODO - Enabling this case isn't impossible anymore.
             // We're keeping it forbidden for now.

--- a/masonry_core/src/passes/accessibility.rs
+++ b/masonry_core/src/passes/accessibility.rs
@@ -7,7 +7,7 @@ use tree_arena::ArenaMut;
 use vello::kurbo::Rect;
 
 use crate::app::{RenderRoot, RenderRootState};
-use crate::core::{AccessCtx, DefaultProperties, PropertiesRef, Widget, WidgetState};
+use crate::core::{AccessCtx, AnyWidget, DefaultProperties, PropertiesRef, WidgetState};
 use crate::passes::{enter_span_if, recurse_on_children};
 use crate::util::AnyMap;
 
@@ -16,7 +16,7 @@ fn build_accessibility_tree(
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
     tree_update: &mut TreeUpdate,
-    mut widget: ArenaMut<'_, Box<dyn Widget>>,
+    mut widget: ArenaMut<'_, Box<dyn AnyWidget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
     rebuild_all: bool,
@@ -98,7 +98,7 @@ fn build_accessibility_tree(
 
 // --- MARK: BUILD NODE
 fn build_access_node(
-    widget: &mut dyn Widget,
+    widget: &mut dyn AnyWidget,
     ctx: &mut AccessCtx<'_>,
     scale_factor: Option<f64>,
 ) -> Node {

--- a/masonry_core/src/passes/anim.rs
+++ b/masonry_core/src/passes/anim.rs
@@ -5,7 +5,7 @@ use tracing::info_span;
 use tree_arena::ArenaMut;
 
 use crate::app::{RenderRoot, RenderRootState};
-use crate::core::{DefaultProperties, PropertiesMut, UpdateCtx, Widget, WidgetState};
+use crate::core::{AnyWidget, DefaultProperties, PropertiesMut, UpdateCtx, WidgetState};
 use crate::passes::{enter_span_if, recurse_on_children};
 use crate::util::AnyMap;
 
@@ -13,7 +13,7 @@ use crate::util::AnyMap;
 fn update_anim_for_widget(
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
-    mut widget: ArenaMut<'_, Box<dyn Widget>>,
+    mut widget: ArenaMut<'_, Box<dyn AnyWidget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
     elapsed_ns: u64,

--- a/masonry_core/src/passes/compose.rs
+++ b/masonry_core/src/passes/compose.rs
@@ -6,7 +6,7 @@ use tree_arena::ArenaMut;
 use vello::kurbo::Affine;
 
 use crate::app::{RenderRoot, RenderRootState};
-use crate::core::{ComposeCtx, DefaultProperties, Widget, WidgetState};
+use crate::core::{AnyWidget, ComposeCtx, DefaultProperties, WidgetState};
 use crate::passes::{enter_span_if, recurse_on_children};
 use crate::util::AnyMap;
 
@@ -14,7 +14,7 @@ use crate::util::AnyMap;
 fn compose_widget(
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
-    mut widget: ArenaMut<'_, Box<dyn Widget>>,
+    mut widget: ArenaMut<'_, Box<dyn AnyWidget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
     parent_transformed: bool,

--- a/masonry_core/src/passes/event.rs
+++ b/masonry_core/src/passes/event.rs
@@ -8,8 +8,8 @@ use crate::Handled;
 use crate::app::{RenderRoot, RenderRootSignal};
 use crate::core::keyboard::{Key, KeyState, NamedKey};
 use crate::core::{
-    AccessEvent, EventCtx, PointerEvent, PointerInfo, PointerUpdate, PropertiesMut, TextEvent,
-    Widget, WidgetId,
+    AccessEvent, AnyWidget, EventCtx, PointerEvent, PointerInfo, PointerUpdate, PropertiesMut,
+    TextEvent, WidgetId,
 };
 use crate::debug_panic;
 use crate::dpi::{LogicalPosition, PhysicalPosition};
@@ -71,7 +71,7 @@ fn run_event_pass<E>(
     target: Option<WidgetId>,
     event: &E,
     allow_pointer_capture: bool,
-    pass_fn: impl FnMut(&mut dyn Widget, &mut EventCtx<'_>, &mut PropertiesMut<'_>, &E),
+    pass_fn: impl FnMut(&mut dyn AnyWidget, &mut EventCtx<'_>, &mut PropertiesMut<'_>, &E),
     trace: bool,
 ) -> Handled {
     let mut pass_fn = pass_fn;

--- a/masonry_core/src/passes/layout.rs
+++ b/masonry_core/src/passes/layout.rs
@@ -11,14 +11,14 @@ use tracing::{info_span, trace};
 use vello::kurbo::{Point, Rect, Size};
 
 use crate::app::{RenderRoot, RenderRootSignal, WindowSizePolicy};
-use crate::core::{BoxConstraints, LayoutCtx, PropertiesMut, Widget, WidgetPod, WidgetState};
+use crate::core::{AnyWidget, BoxConstraints, LayoutCtx, PropertiesMut, WidgetPod, WidgetState};
 use crate::debug_panic;
 use crate::passes::{enter_span_if, recurse_on_children};
 
 // --- MARK: RUN LAYOUT
 /// Run [`Widget::layout`] method on the widget contained in `pod`.
 /// This will be called by [`LayoutCtx::run_layout`], which is itself called in the parent widget's `layout`.
-pub(crate) fn run_layout_on<W: Widget + ?Sized>(
+pub(crate) fn run_layout_on<W: AnyWidget + ?Sized>(
     parent_ctx: &mut LayoutCtx<'_>,
     pod: &mut WidgetPod<W>,
     bc: &BoxConstraints,

--- a/masonry_core/src/passes/mod.rs
+++ b/masonry_core/src/passes/mod.rs
@@ -12,7 +12,7 @@ use tree_arena::{ArenaMut, ArenaMutList, ArenaRef};
 
 use crate::app::RenderRootState;
 use crate::core::{
-    DefaultProperties, PropertiesRef, QueryCtx, Widget, WidgetArena, WidgetId, WidgetState,
+    AnyWidget, DefaultProperties, PropertiesRef, QueryCtx, WidgetArena, WidgetId, WidgetState,
 };
 use crate::util::AnyMap;
 
@@ -30,7 +30,7 @@ pub(crate) fn enter_span_if(
     enabled: bool,
     global_state: &RenderRootState,
     default_properties: &DefaultProperties,
-    widget: ArenaRef<'_, Box<dyn Widget>>,
+    widget: ArenaRef<'_, Box<dyn AnyWidget>>,
     state: ArenaRef<'_, WidgetState>,
     properties: ArenaRef<'_, AnyMap>,
 ) -> Option<EnteredSpan> {
@@ -51,7 +51,7 @@ pub(crate) fn enter_span_if(
 pub(crate) fn enter_span(
     global_state: &RenderRootState,
     default_properties: &DefaultProperties,
-    widget: ArenaRef<'_, Box<dyn Widget>>,
+    widget: ArenaRef<'_, Box<dyn AnyWidget>>,
     state: ArenaRef<'_, WidgetState>,
     properties: ArenaRef<'_, AnyMap>,
 ) -> EnteredSpan {
@@ -73,11 +73,11 @@ pub(crate) fn enter_span(
 
 pub(crate) fn recurse_on_children(
     id: WidgetId,
-    mut widget: ArenaMut<'_, Box<dyn Widget>>,
+    mut widget: ArenaMut<'_, Box<dyn AnyWidget>>,
     mut state: ArenaMutList<'_, WidgetState>,
     mut properties: ArenaMutList<'_, AnyMap>,
     mut callback: impl FnMut(
-        ArenaMut<'_, Box<dyn Widget>>,
+        ArenaMut<'_, Box<dyn AnyWidget>>,
         ArenaMut<'_, WidgetState>,
         ArenaMut<'_, AnyMap>,
     ),

--- a/masonry_core/src/passes/mutate.rs
+++ b/masonry_core/src/passes/mutate.rs
@@ -4,13 +4,13 @@
 use tracing::info_span;
 
 use crate::app::RenderRoot;
-use crate::core::{MutateCtx, PropertiesMut, Widget, WidgetId, WidgetMut};
+use crate::core::{AnyWidget, MutateCtx, PropertiesMut, WidgetId, WidgetMut};
 use crate::passes::merge_state_up;
 
 pub(crate) fn mutate_widget<R>(
     root: &mut RenderRoot,
     id: WidgetId,
-    mutate_fn: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R,
+    mutate_fn: impl FnOnce(WidgetMut<'_, dyn AnyWidget>) -> R,
 ) -> R {
     let (widget_mut, state_mut, properties_mut) = root.widget_arena.get_all_mut(id);
 

--- a/masonry_core/src/passes/paint.rs
+++ b/masonry_core/src/passes/paint.rs
@@ -10,7 +10,7 @@ use vello::kurbo::{Affine, Rect};
 use vello::peniko::{Color, Fill, Mix};
 
 use crate::app::{RenderRoot, RenderRootState};
-use crate::core::{DefaultProperties, PaintCtx, PropertiesRef, Widget, WidgetId, WidgetState};
+use crate::core::{AnyWidget, DefaultProperties, PaintCtx, PropertiesRef, WidgetId, WidgetState};
 use crate::passes::{enter_span_if, recurse_on_children};
 use crate::util::{AnyMap, get_debug_color, stroke};
 
@@ -20,7 +20,7 @@ fn paint_widget(
     default_properties: &DefaultProperties,
     complete_scene: &mut Scene,
     scenes: &mut HashMap<WidgetId, Scene>,
-    mut widget: ArenaMut<'_, Box<dyn Widget>>,
+    mut widget: ArenaMut<'_, Box<dyn AnyWidget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
     debug_paint: bool,

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -10,8 +10,8 @@ use ui_events::pointer::PointerType;
 
 use crate::app::{RenderRoot, RenderRootSignal, RenderRootState};
 use crate::core::{
-    DefaultProperties, Ime, PointerEvent, PointerInfo, PropertiesMut, PropertiesRef, QueryCtx,
-    RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetState,
+    AnyWidget, DefaultProperties, Ime, PointerEvent, PointerInfo, PropertiesMut, PropertiesRef,
+    QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, WidgetId, WidgetState,
 };
 use crate::passes::event::{run_on_pointer_event_pass, run_on_text_event_pass};
 use crate::passes::{enter_span, enter_span_if, merge_state_up, recurse_on_children};
@@ -46,7 +46,7 @@ fn dummy_pointer_cancel() -> PointerEvent {
 fn run_targeted_update_pass(
     root: &mut RenderRoot,
     target: Option<WidgetId>,
-    mut pass_fn: impl FnMut(&mut dyn Widget, &mut UpdateCtx<'_>, &mut PropertiesMut<'_>),
+    mut pass_fn: impl FnMut(&mut dyn AnyWidget, &mut UpdateCtx<'_>, &mut PropertiesMut<'_>),
 ) {
     let mut current_id = target;
     while let Some(widget_id) = current_id {
@@ -75,7 +75,7 @@ fn run_targeted_update_pass(
 fn run_single_update_pass(
     root: &mut RenderRoot,
     target: Option<WidgetId>,
-    mut pass_fn: impl FnMut(&mut dyn Widget, &mut UpdateCtx<'_>, &mut PropertiesMut<'_>),
+    mut pass_fn: impl FnMut(&mut dyn AnyWidget, &mut UpdateCtx<'_>, &mut PropertiesMut<'_>),
 ) {
     let Some(target) = target else {
         return;
@@ -112,7 +112,7 @@ fn run_single_update_pass(
 fn update_widget_tree(
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
-    mut widget: ArenaMut<'_, Box<dyn Widget>>,
+    mut widget: ArenaMut<'_, Box<dyn AnyWidget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
 ) {
@@ -257,7 +257,7 @@ pub(crate) fn run_update_widget_tree_pass(root: &mut RenderRoot) {
 fn update_disabled_for_widget(
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
-    mut widget: ArenaMut<'_, Box<dyn Widget>>,
+    mut widget: ArenaMut<'_, Box<dyn AnyWidget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
     parent_disabled: bool,
@@ -349,7 +349,7 @@ pub(crate) fn run_update_disabled_pass(root: &mut RenderRoot) {
 fn update_stashed_for_widget(
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
-    mut widget: ArenaMut<'_, Box<dyn Widget>>,
+    mut widget: ArenaMut<'_, Box<dyn AnyWidget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
     parent_stashed: bool,
@@ -448,7 +448,7 @@ pub(crate) fn run_update_stashed_pass(root: &mut RenderRoot) {
 fn update_focus_chain_for_widget(
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
-    mut widget: ArenaMut<'_, Box<dyn Widget>>,
+    mut widget: ArenaMut<'_, Box<dyn AnyWidget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
     parent_focus_chain: &mut Vec<WidgetId>,

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -29,7 +29,7 @@ use masonry_core::app::{
     RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy, try_init_test_tracing,
 };
 use masonry_core::core::{
-    Action, DefaultProperties, Ime, PointerButton, PointerEvent, PointerId, PointerInfo,
+    Action, AnyWidget, DefaultProperties, Ime, PointerButton, PointerEvent, PointerId, PointerInfo,
     PointerState, PointerType, PointerUpdate, ScrollDelta, TextEvent, Widget, WidgetId, WidgetMut,
     WidgetRef, WindowEvent,
 };
@@ -616,7 +616,7 @@ impl TestHarness {
     // --- MARK: GETTERS
 
     /// Return a [`WidgetRef`] to the root widget.
-    pub fn root_widget(&self) -> WidgetRef<'_, dyn Widget> {
+    pub fn root_widget(&self) -> WidgetRef<'_, dyn AnyWidget> {
         self.render_root.get_root_widget()
     }
 
@@ -626,25 +626,25 @@ impl TestHarness {
     ///
     /// Panics if no Widget with this id can be found.
     #[track_caller]
-    pub fn get_widget(&self, id: WidgetId) -> WidgetRef<'_, dyn Widget> {
+    pub fn get_widget(&self, id: WidgetId) -> WidgetRef<'_, dyn AnyWidget> {
         self.render_root
             .get_widget(id)
             .unwrap_or_else(|| panic!("could not find widget {}", id))
     }
 
     /// Try to return a [`WidgetRef`] to the widget with the given id.
-    pub fn try_get_widget(&self, id: WidgetId) -> Option<WidgetRef<'_, dyn Widget>> {
+    pub fn try_get_widget(&self, id: WidgetId) -> Option<WidgetRef<'_, dyn AnyWidget>> {
         self.render_root.get_widget(id)
     }
 
     /// Return a [`WidgetRef`] to the [focused widget](masonry_core::doc::doc_06_masonry_concepts#text-focus).
-    pub fn focused_widget(&self) -> Option<WidgetRef<'_, dyn Widget>> {
+    pub fn focused_widget(&self) -> Option<WidgetRef<'_, dyn AnyWidget>> {
         self.root_widget()
             .find_widget_by_id(self.render_root.focused_widget()?)
     }
 
     /// Return a [`WidgetRef`] to the widget which [captures pointer events](masonry_core::doc::doc_06_masonry_concepts#pointer-capture).
-    pub fn pointer_capture_target(&self) -> Option<WidgetRef<'_, dyn Widget>> {
+    pub fn pointer_capture_target(&self) -> Option<WidgetRef<'_, dyn AnyWidget>> {
         self.render_root
             .get_widget(self.render_root.pointer_capture_target()?)
     }
@@ -656,10 +656,10 @@ impl TestHarness {
     }
 
     /// Call the provided visitor on every widget in the widget tree.
-    pub fn inspect_widgets(&mut self, f: impl Fn(WidgetRef<'_, dyn Widget>) + 'static) {
+    pub fn inspect_widgets(&mut self, f: impl Fn(WidgetRef<'_, dyn AnyWidget>) + 'static) {
         fn inspect(
-            widget: WidgetRef<'_, dyn Widget>,
-            f: &(impl Fn(WidgetRef<'_, dyn Widget>) + 'static),
+            widget: WidgetRef<'_, dyn AnyWidget>,
+            f: &(impl Fn(WidgetRef<'_, dyn AnyWidget>) + 'static),
         ) {
             f(widget);
             for child in widget.children() {
@@ -673,7 +673,7 @@ impl TestHarness {
     /// Get a [`WidgetMut`] to the root widget.
     ///
     /// Because of how `WidgetMut` works, it can only be passed to a user-provided callback.
-    pub fn edit_root_widget<R>(&mut self, f: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R) -> R {
+    pub fn edit_root_widget<R>(&mut self, f: impl FnOnce(WidgetMut<'_, dyn AnyWidget>) -> R) -> R {
         let ret = self.render_root.edit_root_widget(f);
         self.process_signals();
         ret
@@ -685,7 +685,7 @@ impl TestHarness {
     pub fn edit_widget<R>(
         &mut self,
         id: WidgetId,
-        f: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R,
+        f: impl FnOnce(WidgetMut<'_, dyn AnyWidget>) -> R,
     ) -> R {
         let ret = self.render_root.edit_widget(id, f);
         self.process_signals();

--- a/masonry_testing/src/modular_widget.rs
+++ b/masonry_testing/src/modular_widget.rs
@@ -11,7 +11,7 @@ use vello::Scene;
 use vello::kurbo::{Point, Size};
 
 use masonry_core::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
+    AccessCtx, AccessEvent, AnyWidget, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetRef, find_widget_under_pointer,
 };
@@ -368,7 +368,7 @@ impl<S: 'static> Widget for ModularWidget<S> {
         &'c self,
         ctx: QueryCtx<'c>,
         pos: Point,
-    ) -> Option<WidgetRef<'c, dyn Widget>> {
+    ) -> Option<WidgetRef<'c, dyn AnyWidget>> {
         find_widget_under_pointer(self, ctx, pos)
     }
 

--- a/masonry_testing/src/recorder_widget.rs
+++ b/masonry_testing/src/recorder_widget.rs
@@ -20,7 +20,7 @@ use vello::Scene;
 use vello::kurbo::{Point, Size};
 
 use masonry_core::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
+    AccessCtx, AccessEvent, AnyWidget, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetRef,
 };
@@ -254,7 +254,7 @@ impl<W: Widget> Widget for Recorder<W> {
         &'c self,
         ctx: QueryCtx<'c>,
         pos: Point,
-    ) -> Option<WidgetRef<'c, dyn Widget>> {
+    ) -> Option<WidgetRef<'c, dyn AnyWidget>> {
         self.child.find_widget_under_pointer(ctx, pos)
     }
 

--- a/masonry_testing/src/wrapper_widget.rs
+++ b/masonry_testing/src/wrapper_widget.rs
@@ -9,14 +9,14 @@ use vello::Scene;
 use vello::kurbo::{Point, Size};
 
 use masonry_core::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
+    AccessCtx, AccessEvent, AnyWidget, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update, UpdateCtx, Widget,
     WidgetId, WidgetMut, WidgetPod,
 };
 
 /// A basic wrapper widget that can replace its child.
 pub struct WrapperWidget {
-    child: WidgetPod<dyn Widget>,
+    child: WidgetPod<dyn AnyWidget>,
 }
 
 impl WrapperWidget {
@@ -30,12 +30,12 @@ impl WrapperWidget {
     /// Create a new `WrapperWidget` with a `WidgetPod`.
     ///
     /// The `child` is the initial child widget.
-    pub fn new_pod(child: WidgetPod<dyn Widget>) -> Self {
+    pub fn new_pod(child: WidgetPod<dyn AnyWidget>) -> Self {
         Self { child }
     }
 
     /// Get mutable reference to the child widget.
-    pub fn child_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, dyn Widget> {
+    pub fn child_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> WidgetMut<'t, dyn AnyWidget> {
         this.ctx.get_mut(&mut this.widget.child)
     }
 }
@@ -47,7 +47,7 @@ impl WrapperWidget {
     }
 
     /// Replace the container's child widget with a `WidgetPod`.
-    pub fn set_child_pod(this: &mut WidgetMut<'_, Self>, child: WidgetPod<dyn Widget>) {
+    pub fn set_child_pod(this: &mut WidgetMut<'_, Self>, child: WidgetPod<dyn AnyWidget>) {
         let old_child = std::mem::replace(&mut this.widget.child, child);
         this.ctx.remove_child(old_child);
 

--- a/masonry_winit/examples/virtual_fizzbuzz.rs
+++ b/masonry_winit/examples/virtual_fizzbuzz.rs
@@ -16,7 +16,7 @@ use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
 use winit::window::Window;
 
 /// The widget kind contained in the scroll area. This is a type parameter (`W`) of [`VirtualScroll`],
-/// although note that [`dyn Widget`](masonry::core::Widget) can also be used for dynamic children kinds.
+/// although note that [`dyn AnyWidget`](masonry::core::Widget) can also be used for dynamic children kinds.
 ///
 /// We use a type alias for this, as when we downcast to the `VirtualScroll`, we need to be sure to
 /// always use the same type for `W`.

--- a/masonry_winit/src/app_driver.rs
+++ b/masonry_winit/src/app_driver.rs
@@ -7,7 +7,7 @@ use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use masonry::app::RenderRoot;
-use masonry::core::{Action, Widget, WidgetId, WidgetPod};
+use masonry::core::{Action, AnyWidget, WidgetId, WidgetPod};
 use tracing::field::DisplayValue;
 use winit::event_loop::ActiveEventLoop;
 use winit::window::{Window as WindowHandle, WindowAttributes};
@@ -135,7 +135,7 @@ impl DriverCtx<'_, '_> {
         &mut self,
         window_id: WindowId,
         attributes: WindowAttributes,
-        root_widget: WidgetPod<dyn Widget>,
+        root_widget: WidgetPod<dyn AnyWidget>,
     ) {
         self.state
             .create_window(self.event_loop, window_id, attributes, root_widget);

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex, mpsc};
 
 use accesskit_winit::Adapter;
 use masonry::app::{RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy};
-use masonry::core::{DefaultProperties, TextEvent, Widget, WidgetId, WidgetPod, WindowEvent};
+use masonry::core::{AnyWidget, DefaultProperties, TextEvent, WidgetId, WidgetPod, WindowEvent};
 use masonry::kurbo::Affine;
 use masonry::peniko::Color;
 use masonry::theme::default_property_set;
@@ -80,7 +80,7 @@ pub(crate) struct Window {
 impl Window {
     pub(crate) fn new(
         window_id: WindowId,
-        root_widget: WidgetPod<dyn Widget>,
+        root_widget: WidgetPod<dyn AnyWidget>,
         attributes: WindowAttributes,
         signal_sender: Arc<Mutex<Sender<(WindowId, RenderRootSignal)>>>,
         default_properties: Arc<DefaultProperties>,
@@ -137,7 +137,7 @@ pub struct MasonryState<'a> {
     signal_sender: Arc<Mutex<Sender<(WindowId, RenderRootSignal)>>>,
     default_properties: Arc<DefaultProperties>,
     pub(crate) exit: bool,
-    initial_windows: Vec<(WindowId, WindowAttributes, WidgetPod<dyn Widget>)>,
+    initial_windows: Vec<(WindowId, WindowAttributes, WidgetPod<dyn AnyWidget>)>,
     need_first_frame: Vec<HandleId>,
 }
 
@@ -163,7 +163,7 @@ pub fn run(
     // Clearly, this API needs to be refactored, so we don't mind forcing this to be passed in here directly
     // This is passed in mostly to allow configuring the Android app
     mut loop_builder: EventLoopBuilder,
-    windows: Vec<(WindowId, WindowAttributes, WidgetPod<dyn Widget>)>,
+    windows: Vec<(WindowId, WindowAttributes, WidgetPod<dyn AnyWidget>)>,
     app_driver: impl AppDriver + 'static,
 ) -> Result<(), EventLoopError> {
     let event_loop = loop_builder.build()?;
@@ -173,7 +173,7 @@ pub fn run(
 
 pub fn run_with(
     event_loop: EventLoop,
-    windows: Vec<(WindowId, WindowAttributes, WidgetPod<dyn Widget>)>,
+    windows: Vec<(WindowId, WindowAttributes, WidgetPod<dyn AnyWidget>)>,
     app_driver: impl AppDriver + 'static,
     default_properties: DefaultProperties,
 ) -> Result<(), EventLoopError> {
@@ -265,7 +265,7 @@ impl ApplicationHandler<MasonryUserEvent> for MainState<'_> {
 impl MasonryState<'_> {
     pub fn new(
         event_loop_proxy: EventLoopProxy,
-        initial_windows: Vec<(WindowId, WindowAttributes, WidgetPod<dyn Widget>)>,
+        initial_windows: Vec<(WindowId, WindowAttributes, WidgetPod<dyn AnyWidget>)>,
         default_properties: DefaultProperties,
     ) -> Self {
         let render_cx = RenderContext::new();
@@ -335,7 +335,7 @@ impl MasonryState<'_> {
         event_loop: &ActiveEventLoop,
         window_id: WindowId,
         attributes: WindowAttributes,
-        root_widget: WidgetPod<dyn Widget>,
+        root_widget: WidgetPod<dyn AnyWidget>,
     ) {
         let window = Window::new(
             window_id,

--- a/xilem/src/app.rs
+++ b/xilem/src/app.rs
@@ -7,7 +7,7 @@ use masonry_winit::app::{EventLoopBuilder, WindowId};
 use std::iter::Once;
 use std::sync::Arc;
 
-use masonry::core::{DefaultProperties, Widget, WidgetPod};
+use masonry::core::{AnyWidget, DefaultProperties, WidgetPod};
 use masonry::theme::default_property_set;
 use masonry_winit::app::MasonryUserEvent;
 use winit::error::EventLoopError;
@@ -168,7 +168,7 @@ where
         proxy: impl Fn(MasonryUserEvent) -> Result<(), MasonryUserEvent> + Send + Sync + 'static,
     ) -> (
         MasonryDriver<State, Logic>,
-        Vec<(WindowId, WindowAttributes, WidgetPod<dyn Widget>)>,
+        Vec<(WindowId, WindowAttributes, WidgetPod<dyn AnyWidget>)>,
     ) {
         MasonryDriver::new(self.state, self.logic, proxy, self.runtime, self.fonts)
     }

--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use masonry::core::{Widget, WidgetId, WidgetPod};
+use masonry::core::{AnyWidget, WidgetId, WidgetPod};
 use masonry::peniko::Blob;
 use masonry_winit::app::{AppDriver, DriverCtx, MasonryState, MasonryUserEvent, WindowId};
 use winit::window::WindowAttributes;
@@ -49,7 +49,7 @@ where
         fonts: Vec<Blob<u8>>,
     ) -> (
         Self,
-        Vec<(WindowId, WindowAttributes, WidgetPod<dyn Widget>)>,
+        Vec<(WindowId, WindowAttributes, WidgetPod<dyn AnyWidget>)>,
     ) {
         let mut driver = Self {
             state,
@@ -145,7 +145,7 @@ where
         &mut self,
         window_id: WindowId,
         view: WindowView<State>,
-    ) -> (WindowAttributes, WidgetPod<dyn Widget>) {
+    ) -> (WindowAttributes, WidgetPod<dyn AnyWidget>) {
         let mut view_ctx = ViewCtx::new(
             Arc::new(WindowProxy(window_id, self.proxy.clone())),
             self.runtime.clone(),

--- a/xilem/src/one_of.rs
+++ b/xilem/src/one_of.rs
@@ -5,8 +5,8 @@
 
 use accesskit::{Node, Role};
 use masonry::core::{
-    AccessCtx, AccessEvent, BoxConstraints, EventCtx, FromDynWidget, LayoutCtx, PaintCtx,
-    PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Widget, WidgetId,
+    AccessCtx, AccessEvent, AnyWidget, BoxConstraints, EventCtx, FromDynWidget, LayoutCtx,
+    PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Widget, WidgetId,
     WidgetPod,
 };
 use masonry::kurbo::{Point, Size};
@@ -18,15 +18,15 @@ use crate::core::one_of::OneOf;
 use crate::{Pod, ViewCtx};
 
 impl<
-    A: Widget + FromDynWidget + ?Sized,
-    B: Widget + FromDynWidget + ?Sized,
-    C: Widget + FromDynWidget + ?Sized,
-    D: Widget + FromDynWidget + ?Sized,
-    E: Widget + FromDynWidget + ?Sized,
-    F: Widget + FromDynWidget + ?Sized,
-    G: Widget + FromDynWidget + ?Sized,
-    H: Widget + FromDynWidget + ?Sized,
-    I: Widget + FromDynWidget + ?Sized,
+    A: AnyWidget + FromDynWidget + ?Sized,
+    B: AnyWidget + FromDynWidget + ?Sized,
+    C: AnyWidget + FromDynWidget + ?Sized,
+    D: AnyWidget + FromDynWidget + ?Sized,
+    E: AnyWidget + FromDynWidget + ?Sized,
+    F: AnyWidget + FromDynWidget + ?Sized,
+    G: AnyWidget + FromDynWidget + ?Sized,
+    H: AnyWidget + FromDynWidget + ?Sized,
+    I: AnyWidget + FromDynWidget + ?Sized,
 >
     crate::core::one_of::OneOfCtx<
         Pod<A>,
@@ -145,7 +145,7 @@ impl<
 }
 
 impl crate::core::one_of::PhantomElementCtx for ViewCtx {
-    type PhantomElement = Pod<dyn Widget>;
+    type PhantomElement = Pod<dyn AnyWidget>;
 }
 
 #[allow(unnameable_types)] // reason: Implementation detail, public because of trait visibility rules
@@ -172,15 +172,15 @@ pub enum OneOfWidget<
 }
 
 impl<
-    A: Widget + FromDynWidget + ?Sized,
-    B: Widget + FromDynWidget + ?Sized,
-    C: Widget + FromDynWidget + ?Sized,
-    D: Widget + FromDynWidget + ?Sized,
-    E: Widget + FromDynWidget + ?Sized,
-    F: Widget + FromDynWidget + ?Sized,
-    G: Widget + FromDynWidget + ?Sized,
-    H: Widget + FromDynWidget + ?Sized,
-    I: Widget + FromDynWidget + ?Sized,
+    A: AnyWidget + FromDynWidget + ?Sized,
+    B: AnyWidget + FromDynWidget + ?Sized,
+    C: AnyWidget + FromDynWidget + ?Sized,
+    D: AnyWidget + FromDynWidget + ?Sized,
+    E: AnyWidget + FromDynWidget + ?Sized,
+    F: AnyWidget + FromDynWidget + ?Sized,
+    G: AnyWidget + FromDynWidget + ?Sized,
+    H: AnyWidget + FromDynWidget + ?Sized,
+    I: AnyWidget + FromDynWidget + ?Sized,
 > Widget for OneOfWidget<A, B, C, D, E, F, G, H, I>
 {
     fn on_pointer_event(

--- a/xilem/src/pod.rs
+++ b/xilem/src/pod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use masonry::core::{
-    FromDynWidget, Properties, Widget, WidgetId, WidgetMut, WidgetOptions, WidgetPod,
+    AnyWidget, FromDynWidget, Properties, WidgetId, WidgetMut, WidgetOptions, WidgetPod,
 };
 
 use crate::ViewCtx;
@@ -19,7 +19,7 @@ use crate::core::{Mut, SuperElement, ViewElement};
 ///    When creating widgets in Xilem, layered views all want access to the - using
 ///    `WidgetPod` for this purpose would require fallible unwrapping.
 #[expect(missing_docs, reason = "TODO - Document these items")]
-pub struct Pod<W: Widget + FromDynWidget + ?Sized> {
+pub struct Pod<W: AnyWidget + FromDynWidget + ?Sized> {
     pub widget: Box<W>,
     pub id: WidgetId,
     /// The options the widget will be created with.
@@ -35,7 +35,7 @@ pub struct Pod<W: Widget + FromDynWidget + ?Sized> {
     pub properties: Properties,
 }
 
-impl<W: Widget + FromDynWidget> Pod<W> {
+impl<W: AnyWidget + FromDynWidget> Pod<W> {
     /// Create a new `Pod` from a `widget`.
     ///
     /// This contains the widget value, and other metadata which will
@@ -50,12 +50,12 @@ impl<W: Widget + FromDynWidget> Pod<W> {
     }
 }
 
-impl<W: Widget + FromDynWidget + ?Sized> Pod<W> {
+impl<W: AnyWidget + FromDynWidget + ?Sized> Pod<W> {
     /// Type-erase the contained widget.
     ///
     /// Convert a `Pod` pointing to a widget of a specific concrete type
-    /// `Pod` pointing to a `dyn Widget`.
-    pub fn erased(self) -> Pod<dyn Widget> {
+    /// `Pod` pointing to a `dyn AnyWidget`.
+    pub fn erased(self) -> Pod<dyn AnyWidget> {
         Pod {
             widget: self.widget.as_box_dyn(),
             id: self.id,
@@ -80,16 +80,16 @@ impl<W: Widget + FromDynWidget + ?Sized> Pod<W> {
     /// In most cases, you will use the return value for adding to a layout
     /// widget which supports heterogenous widgets.
     /// For example, [`Flex`](masonry::widgets::Flex) accepts type-erased widget pods.
-    pub fn erased_widget_pod(self) -> WidgetPod<dyn Widget> {
+    pub fn erased_widget_pod(self) -> WidgetPod<dyn AnyWidget> {
         WidgetPod::new_with(self.widget, self.id, self.options, self.properties).erased()
     }
 }
 
-impl<W: Widget + FromDynWidget + ?Sized> ViewElement for Pod<W> {
+impl<W: AnyWidget + FromDynWidget + ?Sized> ViewElement for Pod<W> {
     type Mut<'a> = WidgetMut<'a, W>;
 }
 
-impl<W: Widget + FromDynWidget + ?Sized> SuperElement<Pod<W>, ViewCtx> for Pod<dyn Widget> {
+impl<W: AnyWidget + FromDynWidget + ?Sized> SuperElement<Pod<W>, ViewCtx> for Pod<dyn AnyWidget> {
     fn upcast(_: &mut ViewCtx, child: Pod<W>) -> Self {
         child.erased()
     }

--- a/xilem/src/view/flex.rs
+++ b/xilem/src/view/flex.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 
 use crate::style::Style;
 
-use masonry::core::{FromDynWidget, Widget, WidgetMut};
+use masonry::core::{AnyWidget, FromDynWidget, WidgetMut};
 use masonry::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use masonry::widgets::{self};
 pub use masonry::widgets::{Axis, CrossAxisAlignment, FlexParams, MainAxisAlignment};
@@ -250,7 +250,7 @@ where
 /// A child element of a [`Flex`] view.
 pub enum FlexElement {
     /// Child widget.
-    Child(Pod<dyn Widget>, FlexParams),
+    Child(Pod<dyn AnyWidget>, FlexParams),
     /// Child spacer with fixed size.
     FixedSpacer(f64),
     /// Child spacer with flex size.
@@ -304,7 +304,7 @@ impl SuperElement<Self, ViewCtx> for FlexElement {
     }
 }
 
-impl<W: Widget + FromDynWidget + ?Sized> SuperElement<Pod<W>, ViewCtx> for FlexElement {
+impl<W: AnyWidget + FromDynWidget + ?Sized> SuperElement<Pod<W>, ViewCtx> for FlexElement {
     fn upcast(_: &mut ViewCtx, child: Pod<W>) -> Self {
         Self::Child(child.erased(), FlexParams::default())
     }

--- a/xilem/src/view/grid.rs
+++ b/xilem/src/view/grid.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 
 use crate::style::Style;
 
-use masonry::core::{FromDynWidget, Widget, WidgetMut};
+use masonry::core::{AnyWidget, FromDynWidget, WidgetMut};
 use masonry::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use masonry::widgets;
 
@@ -36,7 +36,7 @@ pub use masonry::widgets::GridParams;
 /// let mut state = State::default();
 ///
 /// grid(
-///     (   
+///     (
 ///         label(state.int.to_string()).grid_item(GridParams::new(0, 0, 3, 1)),
 ///         button("Decrease by 1", |state: &mut State| state.int -= 1).grid_pos(1, 1),
 ///         button("To zero", |state: &mut State| state.int = 0).grid_pos(2, 1),
@@ -215,7 +215,7 @@ impl SuperElement<Self, ViewCtx> for GridElement {
     }
 }
 
-impl<W: Widget + FromDynWidget + ?Sized> SuperElement<Pod<W>, ViewCtx> for GridElement {
+impl<W: AnyWidget + FromDynWidget + ?Sized> SuperElement<Pod<W>, ViewCtx> for GridElement {
     fn upcast(_: &mut ViewCtx, child: Pod<W>) -> Self {
         // Getting here means that the widget didn't use .grid_item or .grid_pos.
         // This currently places the widget in the top left cell.
@@ -367,7 +367,7 @@ impl<State, Action, V: WidgetView<State, Action>> GridExt<State, Action> for V {
 /// A child widget within a [`Grid`] view.
 pub struct GridElement {
     /// The child widget.
-    child: Pod<dyn Widget>,
+    child: Pod<dyn AnyWidget>,
     /// The grid parameters of the child widget.
     params: GridParams,
 }

--- a/xilem/src/view/virtual_scroll.rs
+++ b/xilem/src/view/virtual_scroll.rs
@@ -3,7 +3,7 @@
 
 use std::{collections::HashMap, marker::PhantomData, ops::Range};
 
-use masonry::core::{FromDynWidget, Widget, WidgetPod};
+use masonry::core::{AnyWidget, FromDynWidget, WidgetPod};
 use masonry::widgets::{self, VirtualScrollAction};
 use private::VirtualScrollState;
 use xilem_core::{AsyncCtx, DynMessage, MessageResult, View, ViewId, ViewMarker, ViewPathTracker};
@@ -44,7 +44,7 @@ pub fn virtual_scroll<State, Action, ChildrenViews, F, Element>(
 where
     ChildrenViews: WidgetView<State, Action, Widget = Element>,
     F: Fn(&mut State, i64) -> ChildrenViews + 'static,
-    Element: Widget + FromDynWidget + ?Sized,
+    Element: AnyWidget + FromDynWidget + ?Sized,
 {
     VirtualScroll {
         phantom: PhantomData,
@@ -120,7 +120,7 @@ const fn index_for_view_id(id: ViewId) -> i64 {
 #[derive(Debug)]
 struct UpdateVirtualChildren;
 
-impl<State, Action, ChildrenViews, F, Element: Widget + FromDynWidget + ?Sized> ViewMarker
+impl<State, Action, ChildrenViews, F, Element: AnyWidget + FromDynWidget + ?Sized> ViewMarker
     for VirtualScroll<State, Action, ChildrenViews, F, Element>
 {
 }
@@ -131,7 +131,7 @@ where
     Action: 'static,
     ChildrenViews: WidgetView<State, Action, Widget = Element>,
     F: Fn(&mut State, i64) -> ChildrenViews + 'static,
-    Element: Widget + FromDynWidget + ?Sized,
+    Element: AnyWidget + FromDynWidget + ?Sized,
 {
     type Element = Pod<widgets::VirtualScroll<Element>>;
 

--- a/xilem/src/view/zstack.rs
+++ b/xilem/src/view/zstack.rs
@@ -3,7 +3,7 @@
 
 use std::marker::PhantomData;
 
-use masonry::core::{FromDynWidget, Widget, WidgetMut};
+use masonry::core::{AnyWidget, FromDynWidget, WidgetMut};
 use masonry::widgets;
 use xilem_core::{MessageResult, ViewId};
 
@@ -235,7 +235,7 @@ where
 
 /// A struct implementing [`ViewElement`] for a `ZStack`.
 pub struct ZStackElement {
-    widget: Pod<dyn Widget>,
+    widget: Pod<dyn AnyWidget>,
     alignment: ChildAlignment,
 }
 
@@ -246,7 +246,7 @@ pub struct ZStackElementMut<'w> {
 }
 
 impl ZStackElement {
-    fn new(widget: Pod<dyn Widget>, alignment: ChildAlignment) -> Self {
+    fn new(widget: Pod<dyn AnyWidget>, alignment: ChildAlignment) -> Self {
         Self { widget, alignment }
     }
 }
@@ -276,7 +276,7 @@ impl SuperElement<Self, ViewCtx> for ZStackElement {
     }
 }
 
-impl<W: Widget + FromDynWidget + ?Sized> SuperElement<Pod<W>, ViewCtx> for ZStackElement {
+impl<W: AnyWidget + FromDynWidget + ?Sized> SuperElement<Pod<W>, ViewCtx> for ZStackElement {
     fn upcast(_: &mut ViewCtx, child: Pod<W>) -> Self {
         Self::new(child.erased(), ChildAlignment::ParentAligned)
     }

--- a/xilem/src/view_ctx.rs
+++ b/xilem/src/view_ctx.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use masonry::core::{FromDynWidget, Widget, WidgetId, WidgetMut};
+use masonry::core::{AnyWidget, FromDynWidget, WidgetId, WidgetMut};
 
 use crate::Pod;
 use crate::core::{AsyncCtx, RawProxy, ViewId, ViewPathTracker};
@@ -58,18 +58,18 @@ impl ViewCtx {
 
 #[expect(missing_docs, reason = "TODO - Document these items")]
 impl ViewCtx {
-    pub fn create_pod<W: Widget + FromDynWidget>(&mut self, widget: W) -> Pod<W> {
+    pub fn create_pod<W: AnyWidget + FromDynWidget>(&mut self, widget: W) -> Pod<W> {
         Pod::new(widget)
     }
 
-    pub fn with_leaf_action_widget<W: Widget + FromDynWidget + ?Sized>(
+    pub fn with_leaf_action_widget<W: AnyWidget + FromDynWidget + ?Sized>(
         &mut self,
         f: impl FnOnce(&mut Self) -> Pod<W>,
     ) -> (Pod<W>, ()) {
         (self.with_action_widget(f), ())
     }
 
-    pub fn with_action_widget<W: Widget + FromDynWidget + ?Sized>(
+    pub fn with_action_widget<W: AnyWidget + FromDynWidget + ?Sized>(
         &mut self,
         f: impl FnOnce(&mut Self) -> Pod<W>,
     ) -> Pod<W> {
@@ -92,7 +92,10 @@ impl ViewCtx {
         self.state_changed
     }
 
-    pub fn teardown_leaf<W: Widget + FromDynWidget + ?Sized>(&mut self, widget: WidgetMut<'_, W>) {
+    pub fn teardown_leaf<W: AnyWidget + FromDynWidget + ?Sized>(
+        &mut self,
+        widget: WidgetMut<'_, W>,
+    ) {
         self.widget_map.remove(&widget.ctx.widget_id());
     }
 

--- a/xilem/src/widget_view.rs
+++ b/xilem/src/widget_view.rs
@@ -3,7 +3,7 @@
 
 use masonry::kurbo::Affine;
 
-use masonry::core::{FromDynWidget, Widget};
+use masonry::core::{AnyWidget, FromDynWidget};
 
 use crate::core::{View, ViewSequence};
 use crate::view::{Transformed, transformed};
@@ -13,7 +13,7 @@ use crate::{AnyWidgetView, Pod, ViewCtx};
 pub trait WidgetView<State, Action = ()>:
     View<State, Action, ViewCtx, Element = Pod<Self::Widget>> + Send + Sync
 {
-    type Widget: Widget + FromDynWidget + ?Sized;
+    type Widget: AnyWidget + FromDynWidget + ?Sized;
 
     /// Returns a boxed type erased [`AnyWidgetView`]
     ///
@@ -51,7 +51,7 @@ pub trait WidgetView<State, Action = ()>:
 impl<V, State, Action, W> WidgetView<State, Action> for V
 where
     V: View<State, Action, ViewCtx, Element = Pod<W>> + Send + Sync,
-    W: Widget + FromDynWidget + ?Sized,
+    W: AnyWidget + FromDynWidget + ?Sized,
 {
     type Widget = W;
 }
@@ -71,11 +71,11 @@ where
 /// }
 /// ```
 pub trait WidgetViewSequence<State, Action = ()>:
-    ViewSequence<State, Action, ViewCtx, Pod<dyn Widget>>
+    ViewSequence<State, Action, ViewCtx, Pod<dyn AnyWidget>>
 {
 }
 
 impl<Seq, State, Action> WidgetViewSequence<State, Action> for Seq where
-    Seq: ViewSequence<State, Action, ViewCtx, Pod<dyn Widget>>
+    Seq: ViewSequence<State, Action, ViewCtx, Pod<dyn AnyWidget>>
 {
 }

--- a/xilem/src/window_view.rs
+++ b/xilem/src/window_view.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use masonry::app::RenderRoot;
-use masonry::core::{Widget, WidgetPod};
+use masonry::core::{AnyWidget, WidgetPod};
 use winit::window::{Window, WindowAttributes};
 use xilem_core::{AnyViewState, View, ViewElement, ViewMarker};
 
@@ -25,7 +25,7 @@ impl<State> WindowView<State> {
     }
 }
 
-pub(crate) struct CreateWindow(pub WindowAttributes, pub WidgetPod<dyn Widget>);
+pub(crate) struct CreateWindow(pub WindowAttributes, pub WidgetPod<dyn AnyWidget>);
 
 impl ViewElement for CreateWindow {
     type Mut<'a> = (&'a Window, &'a mut RenderRoot);


### PR DESCRIPTION
We want the Widget trait to have an associated type of which actions the widgets can emit. That makes Widget not dyn-safe, so we need a dyn-safe version.