### PR TITLE
Remove unused direct deps on `web-time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,7 +2131,6 @@ dependencies = [
  "tracing",
  "ui-events",
  "vello",
- "web-time",
 ]
 
 [[package]]
@@ -2180,7 +2179,6 @@ dependencies = [
  "tracing",
  "ui-events",
  "vello",
- "web-time",
  "wgpu",
 ]
 
@@ -2196,7 +2194,6 @@ dependencies = [
  "tracing",
  "tracing-tracy",
  "ui-events-winit",
- "web-time",
  "wgpu",
  "wgpu-profiler",
  "winit",

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -32,9 +32,6 @@ tracing = { workspace = true, features = ["default"] }
 ui-events.workspace = true
 vello.workspace = true
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-web-time.workspace = true
-
 [dev-dependencies]
 assert_matches = "1.5.0"
 float-cmp = { version = "0.10.0", features = ["std"], default-features = false }

--- a/masonry_testing/Cargo.toml
+++ b/masonry_testing/Cargo.toml
@@ -35,9 +35,6 @@ ui-events.workspace = true
 vello.workspace = true
 wgpu.workspace = true
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-web-time.workspace = true
-
 [dev-dependencies]
 assert_matches = "1.5.0"
 

--- a/masonry_winit/Cargo.toml
+++ b/masonry_winit/Cargo.toml
@@ -34,9 +34,6 @@ pollster = "0.4.0"
 accesskit_winit.workspace = true
 wgpu-profiler = { optional = true, version = "0.22.0", default-features = false }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-web-time.workspace = true
-
 [dev-dependencies]
 image = { workspace = true, features = ["png"] }
 masonry = { workspace = true, features = ["testing"] }


### PR DESCRIPTION
This is handled in `masonry_core` and re-exported types from there so these direct dependencies are not used.