### PR TITLE
Placehero: Add support for showing a single thread

### DIFF
--- a/placehero/src/avatars.rs
+++ b/placehero/src/avatars.rs
@@ -1,17 +1,16 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use xilem::core::one_of::Either;
 use xilem::core::{MessageProxy, NoElement, View};
 use xilem::palette::css;
 use xilem::style::{Gradient, Style};
 use xilem::tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-
 use xilem::view::{image, sized_box, spinner, worker};
 use xilem::{Blob, Image, ImageFormat, ViewCtx, WidgetView, tokio};
-
-use std::collections::HashMap;
-use std::sync::Arc;
 
 #[derive(Debug)]
 struct AvatarRequest {

--- a/placehero/src/components.rs
+++ b/placehero/src/components.rs
@@ -55,7 +55,7 @@ fn base_status(avatars: &mut Avatars, status: &Status) -> impl FlexSequence<Plac
             label(format!("💬 {}", status.replies_count)).flex(1.0),
             label(format!("🔄 {}", status.reblogs_count)).flex(1.0),
             label(format!("⭐ {}", status.favourites_count)).flex(1.0),
-            button("🔗", move |state: &mut Placehero| {
+            button("View Replies", move |state: &mut Placehero| {
                 state
                     .context_sender
                     .as_ref()

--- a/placehero/src/components.rs
+++ b/placehero/src/components.rs
@@ -1,52 +1,17 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+use megalodon::entities::Status;
 use xilem::FontWeight;
-use xilem::WidgetView;
-use xilem::palette::css;
-use xilem::style::Padding;
-use xilem::style::Style;
-use xilem::view::FlexSequence;
-use xilem::view::flex_row;
-use xilem::view::portal;
 use xilem::view::{
-    CrossAxisAlignment, FlexExt, FlexSpacer, MainAxisAlignment, flex, inline_prose, label, prose,
-    sized_box,
+    CrossAxisAlignment, FlexExt, FlexSequence, FlexSpacer, MainAxisAlignment, flex, flex_row,
+    inline_prose, label, prose,
 };
 
-use super::Placehero;
-use crate::avatars::Avatars;
-use crate::html_content::status_html_to_plaintext;
+use crate::{Avatars, Placehero, status_html_to_plaintext};
 
-use megalodon::entities::Status;
-
-/// The component for a single status in a [`timeline`].
-///
-/// These statuses are currently not currently rendered with a reply indicator, media, etc.
-/// This is planned. Reblogged statuses are also not currently handled correctly.
-///
-/// They are rendered with a surrounding padded box.
-// TODO: Work out how much of this component can be reused in a reply timeline.
-// I think you want the same thing, but without the box, and without any "this is a reply" indicator.
-// It also wouldn't need to handle reblogs (the API doesn't provide any way to make a reply status which is a reblog).
-// N.b. API wise, there's no reason that you can't reply to a "reblog" status. TODO: Confirm this
-pub(crate) fn timeline_status(
-    avatars: &mut Avatars,
-    status: &Status,
-) -> impl WidgetView<Placehero> + use<> {
-    let (info_line, primary_status) = if let Some(reblog) = status.reblog.as_ref() {
-        (
-            Some(prose(format!("🔄 {} boosted", status.account.display_name))),
-            &**reblog,
-        )
-    } else {
-        (None, status)
-    };
-    sized_box(flex((info_line, base_status(avatars, primary_status))))
-        .border(css::WHITE, 2.0)
-        .padding(10.0)
-        .corner_radius(5.)
-}
+mod timeline;
+pub(crate) use timeline::timeline;
 
 /// Renders the key parts of a Status, in a shared way.
 ///
@@ -88,28 +53,5 @@ fn base_status(avatars: &mut Avatars, status: &Status) -> impl FlexSequence<Plac
         ))
         // TODO: The "extra space" amount actually ends up being zero, so this doesn't do anything.
         .main_axis_alignment(MainAxisAlignment::SpaceEvenly),
-    )
-}
-
-/// A [`timeline`]; statuses are rendered individually.
-///
-/// These statuses are currently not rendered with a reply indicator, etc.
-/// and own their own boxes
-pub(crate) fn timeline(
-    statuses: &mut [Status],
-    avatars: &mut Avatars,
-) -> impl WidgetView<Placehero> + use<> {
-    portal(
-        flex(
-            statuses
-                .iter()
-                .map(|status| timeline_status(avatars, status))
-                .collect::<Vec<_>>(),
-        )
-        .padding(Padding {
-            // Leave room for scrollbar
-            right: 20.,
-            ..Padding::all(5.0)
-        }),
     )
 }

--- a/placehero/src/components/thread.rs
+++ b/placehero/src/components/thread.rs
@@ -46,7 +46,7 @@ pub(crate) fn thread(
         flex((
             ancestor_views,
             base_status(avatars, root_status),
-            label("Replies:"),
+            label("Replies:").flex(CrossAxisAlignment::Start),
             descendant_views,
         ))
         .padding(Padding {
@@ -57,6 +57,10 @@ pub(crate) fn thread(
     )
 }
 
+/// The component for a single post in a thread.
+///
+/// These are rendered without a containing box, and with an adjoining "reply indicator"
+/// (which is currently known to be terrible!).
 fn thread_ancestor(avatars: &mut Avatars, status: &Status) -> impl WidgetView<Placehero> + use<> {
     sized_box(
         flex_row((

--- a/placehero/src/components/thread.rs
+++ b/placehero/src/components/thread.rs
@@ -1,0 +1,75 @@
+// Copyright 2025 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use megalodon::entities::{Context, Status};
+use xilem::WidgetView;
+use xilem::palette::css;
+use xilem::style::{Padding, Style};
+use xilem::view::{CrossAxisAlignment, FlexExt, flex, flex_row, label, portal, sized_box};
+
+use crate::components::base_status;
+use crate::{Avatars, Placehero};
+
+/// Display a status in the context of its thread.
+///
+/// Notes:
+/// 1) We don't try and do anything "fancy", i.e. we just display all the items as one thing.
+pub(crate) fn thread(
+    avatars: &mut Avatars,
+    root_status: &Status,
+    // TODO: Maybe the context should be optional (for async loading)
+    // The hard part there would be locking the scroll properly (i.e. once the thread loads)
+    thread: &Context,
+    // TODO: Think about allowing composing a reply.
+) -> impl WidgetView<Placehero> + use<> {
+    let mut ancestor_views = Vec::new();
+    let mut previous_parent = None;
+    for ancestor in &thread.ancestors {
+        if previous_parent != ancestor.in_reply_to_id.as_deref() {
+            if previous_parent.is_none() {
+                tracing::warn!("Couldn't load all ancestors, presumably due to context limits?");
+            } else {
+                // TODO: This should maybe be `debug_panic`, but that's not exposed currently.
+                panic!("For correct ordering, we currently assume that the Mastodon API gives");
+            }
+        }
+        previous_parent = ancestor.in_reply_to_id.as_deref();
+        ancestor_views.push(thread_ancestor(avatars, ancestor));
+    }
+    // TODO: Determine depth; maybe turn into a "real" tree.
+    let mut descendant_views = Vec::new();
+    for descendant in &thread.descendants {
+        descendant_views.push(thread_ancestor(avatars, descendant));
+    }
+
+    portal(
+        flex((
+            ancestor_views,
+            base_status(avatars, root_status),
+            label("Replies:"),
+            descendant_views,
+        ))
+        .padding(Padding {
+            // Leave room for scrollbar
+            // For reasons unknown, the ~8 pixel left bar messes with things.
+            // We just stick some extra amount on.
+            right: 30.,
+            ..Padding::all(5.0)
+        }),
+    )
+}
+
+fn thread_ancestor(avatars: &mut Avatars, status: &Status) -> impl WidgetView<Placehero> + use<> {
+    sized_box(
+        flex_row((
+            // An awful left-side border.
+            sized_box(flex(()))
+                .width(3.)
+                .height(50.)
+                .background_color(css::WHITE)
+                .flex(CrossAxisAlignment::Start),
+            flex(base_status(avatars, status)),
+        ))
+        .must_fill_major_axis(true),
+    )
+}

--- a/placehero/src/components/thread.rs
+++ b/placehero/src/components/thread.rs
@@ -51,9 +51,7 @@ pub(crate) fn thread(
         ))
         .padding(Padding {
             // Leave room for scrollbar
-            // For reasons unknown, the ~8 pixel left bar messes with things.
-            // We just stick some extra amount on.
-            right: 30.,
+            right: 20.,
             ..Padding::all(5.0)
         }),
     )
@@ -68,7 +66,7 @@ fn thread_ancestor(avatars: &mut Avatars, status: &Status) -> impl WidgetView<Pl
                 .height(50.)
                 .background_color(css::WHITE)
                 .flex(CrossAxisAlignment::Start),
-            flex(base_status(avatars, status)),
+            flex(base_status(avatars, status)).flex(1.0),
         ))
         .must_fill_major_axis(true),
     )

--- a/placehero/src/components/timeline.rs
+++ b/placehero/src/components/timeline.rs
@@ -1,3 +1,6 @@
+// Copyright 2025 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
 use megalodon::entities::Status;
 use xilem::WidgetView;
 use xilem::palette::css;

--- a/placehero/src/components/timeline.rs
+++ b/placehero/src/components/timeline.rs
@@ -1,0 +1,59 @@
+use megalodon::entities::Status;
+use xilem::WidgetView;
+use xilem::palette::css;
+use xilem::style::{Padding, Style};
+use xilem::view::{flex, portal, prose, sized_box};
+
+use super::base_status;
+use crate::{Avatars, Placehero};
+
+/// A [`timeline`]; statuses are rendered individually.
+///
+/// These statuses are currently not rendered with a reply indicator, etc.
+/// and own their own boxes
+pub(crate) fn timeline(
+    statuses: &mut [Status],
+    avatars: &mut Avatars,
+) -> impl WidgetView<Placehero> + use<> {
+    portal(
+        flex(
+            statuses
+                .iter()
+                .map(|status| timeline_status(avatars, status))
+                .collect::<Vec<_>>(),
+        )
+        .padding(Padding {
+            // Leave room for scrollbar
+            right: 20.,
+            ..Padding::all(5.0)
+        }),
+    )
+}
+
+/// The component for a single status in a [`timeline`].
+///
+/// These statuses are currently not currently rendered with a reply indicator, media, etc.
+/// This is planned. Reblogged statuses are also not currently handled correctly.
+///
+/// They are rendered with a surrounding padded box.
+// TODO: Work out how much of this component can be reused in a reply timeline.
+// I think you want the same thing, but without the box, and without any "this is a reply" indicator.
+// It also wouldn't need to handle reblogs (the API doesn't provide any way to make a reply status which is a reblog).
+// N.b. API wise, there's no reason that you can't reply to a "reblog" status. TODO: Confirm this
+pub(crate) fn timeline_status(
+    avatars: &mut Avatars,
+    status: &Status,
+) -> impl WidgetView<Placehero> + use<> {
+    let (info_line, primary_status) = if let Some(reblog) = status.reblog.as_ref() {
+        (
+            Some(prose(format!("🔄 {} boosted", status.account.display_name))),
+            &**reblog,
+        )
+    } else {
+        (None, status)
+    };
+    sized_box(flex((info_line, base_status(avatars, primary_status))))
+        .border(css::WHITE, 2.0)
+        .padding(10.0)
+        .corner_radius(5.)
+}

--- a/placehero/src/lib.rs
+++ b/placehero/src/lib.rs
@@ -11,24 +11,22 @@
 
 use std::sync::Arc;
 
-use megalodon::{
-    Megalodon,
-    entities::{Account, Instance, Status},
-    mastodon,
-    megalodon::GetAccountStatusesInputOptions,
-};
-use xilem::{
-    EventLoopBuilder, ViewCtx, WidgetView, WindowOptions, Xilem,
-    core::{NoElement, View, fork, lens, one_of::Either},
-    view::{flex, label, prose, split, task_raw},
-    winit::error::EventLoopError,
-};
-
-use crate::{avatars::Avatars, components::timeline};
+use components::timeline;
+use megalodon::entities::{Account, Instance, Status};
+use megalodon::megalodon::GetAccountStatusesInputOptions;
+use megalodon::{Megalodon, mastodon};
+use xilem::core::one_of::Either;
+use xilem::core::{NoElement, View, fork, lens};
+use xilem::view::{flex, label, prose, split, task_raw};
+use xilem::winit::error::EventLoopError;
+use xilem::{EventLoopBuilder, ViewCtx, WidgetView, WindowOptions, Xilem};
 
 mod avatars;
 mod components;
 mod html_content;
+
+pub(crate) use avatars::Avatars;
+pub(crate) use html_content::status_html_to_plaintext;
 
 /// Our shared API client type.
 ///

--- a/placehero/src/lib.rs
+++ b/placehero/src/lib.rs
@@ -92,7 +92,10 @@ impl Placehero {
     fn sidebar(&mut self) -> impl WidgetView<Self> + use<> {
         if let Some(instance) = &self.instance {
             let back = if self.show_context.is_some() {
-                Some(button("🔙", |app_state: &mut Self| {
+                // TODO: Make the ⬅️ arrow not be available to screen readers.
+                Some(button("⬅️ Back to Timeline", |app_state: &mut Self| {
+                    // TODO: Maintain scroll state in the timeline.
+                    // TODO: More of a back stack.
                     app_state.show_context = None;
                     app_state.context = None;
                 }))

--- a/placehero/src/main.rs
+++ b/placehero/src/main.rs
@@ -3,7 +3,8 @@
 
 //! The boilerplate run function for desktop platforms
 
-use xilem::{EventLoop, winit::error::EventLoopError};
+use xilem::EventLoop;
+use xilem::winit::error::EventLoopError;
 
 fn main() -> Result<(), EventLoopError> {
     placehero::run(EventLoop::with_user_event())


### PR DESCRIPTION
On the timeline (there is now a `View Replies` button on each post):
![image](https://github.com/user-attachments/assets/5fc42a93-5004-4ae5-89f4-405ec89da730)

In a thread (i.e. once the button has been pressed):
![image](https://github.com/user-attachments/assets/86d57972-91cd-408f-8312-91ab5d03df2b)

Note that to get this image, I followed two "View Replies"; the first to get to [this post](https://mastodon.online/@raph/114530193780235287).

Note a few features:
- There is now a `⬅️ Back to Timeline` button in the sidebar. This jumps you back to Raph's timeline.
- The ancestors and descendants of the "thread" are now visible.
- There is a "replies" label after the "main" post in the new thread

A few caveats (which I'm treating as out of scope for this PR):
- The "continuity" of replies is not visible, i.e. which thread items are actually replies to the previous item or one before.
- The scroll position is not handled very well; every page change jumps to the top.
   - See also [#masonry > Scrolling on (tab) Focus](https://xi.zulipchat.com/#narrow/channel/317477-masonry/topic/Scrolling.20on.20.28tab.29.20Focus/with/526109923)
- The "replies" label is not great design