### PR TITLE
Fix possessive form of "children"

### DIFF
--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -152,13 +152,13 @@ impl Flex {
         Self::for_axis(Axis::Vertical)
     }
 
-    /// Builder-style method for specifying the childrens' [`CrossAxisAlignment`].
+    /// Builder-style method for specifying the children's [`CrossAxisAlignment`].
     pub fn cross_axis_alignment(mut self, alignment: CrossAxisAlignment) -> Self {
         self.cross_alignment = alignment;
         self
     }
 
-    /// Builder-style method for specifying the childrens' [`MainAxisAlignment`].
+    /// Builder-style method for specifying the children's [`MainAxisAlignment`].
     pub fn main_axis_alignment(mut self, alignment: MainAxisAlignment) -> Self {
         self.main_alignment = alignment;
         self
@@ -318,13 +318,13 @@ impl Flex {
         this.ctx.request_layout();
     }
 
-    /// Set the childrens' [`CrossAxisAlignment`].
+    /// Set the children's [`CrossAxisAlignment`].
     pub fn set_cross_axis_alignment(this: &mut WidgetMut<'_, Self>, alignment: CrossAxisAlignment) {
         this.widget.cross_alignment = alignment;
         this.ctx.request_layout();
     }
 
-    /// Set the childrens' [`MainAxisAlignment`].
+    /// Set the children's [`MainAxisAlignment`].
     pub fn set_main_axis_alignment(this: &mut WidgetMut<'_, Self>, alignment: MainAxisAlignment) {
         this.widget.main_alignment = alignment;
         this.ctx.request_layout();

--- a/xilem/src/view/flex.rs
+++ b/xilem/src/view/flex.rs
@@ -104,12 +104,12 @@ impl<Seq, State, Action> Flex<Seq, State, Action> {
         self.axis = axis;
         self
     }
-    /// Set the childrens' [`CrossAxisAlignment`].
+    /// Set the children's [`CrossAxisAlignment`].
     pub fn cross_axis_alignment(mut self, axis: CrossAxisAlignment) -> Self {
         self.cross_axis_alignment = axis;
         self
     }
-    /// Set the childrens' [`MainAxisAlignment`].
+    /// Set the children's [`MainAxisAlignment`].
     pub fn main_axis_alignment(mut self, axis: MainAxisAlignment) -> Self {
         self.main_axis_alignment = axis;
         self


### PR DESCRIPTION
This is already plural, so it doesn't become "childrens".