### PR TITLE
Fix some `clippy::doc_markdown` lints

### DIFF
--- a/masonry/src/doc/02_implementing_widget.md
+++ b/masonry/src/doc/02_implementing_widget.md
@@ -378,19 +378,19 @@ That is to say, even if you own a window, and even if that window holds a widget
 
 Instead, there are two ways to mutate `Label`:
 
-- Inside a Widget method. Most methods (`on_pointer_event`, `update`, `layout`, etc) take a `&mut self` argument.
+- Inside a `Widget` method. Most methods (`on_pointer_event`, `update`, `layout`, etc) take a `&mut self` argument.
 - Through a [`WidgetMut`] wrapper. So, to change your label's text, you will call [`Label::set_text()`], which takes a [`WidgetMut`] argument. This helps Masonry make sure that internal metadata is propagated after every widget change.
 
-As mentioned in the previous chapter, a `WidgetMut` is a smart reference type to the Widget tree.
-Most Widgets will implement methods that let their users "project" a WidgetMut from a parent to its child.
+As mentioned in the previous chapter, a `WidgetMut` is a smart reference type to the widget tree.
+Most widgets will implement methods that let their users "project" a `WidgetMut` from a parent to its child.
 For example, `WidgetMut<Portal<MyWidget>>` has a `get_child_mut()` method that returns a `WidgetMut<MyWidget>`.
 
-So far, we've seen one way to get a WidgetMut: the [`RenderRoot::edit_root_widget()`] method.
-This methods returns a WidgetMut to the root widget, which you can then project into a WidgetMut reference to its descendants.
+So far, we've seen one way to get a `WidgetMut`: the [`RenderRoot::edit_root_widget()`] method.
+This methods returns a `WidgetMut` to the root widget, which you can then project into a `WidgetMut` reference to its descendants.
 
-### Using WidgetMut in your custom Widget code
+### Using `WidgetMut` in your custom widget code
 
-The WidgetMut type only has two fields, both public:
+The `WidgetMut` type only has two fields, both public:
 
 ```rust,ignore
 pub struct WidgetMut<'a, W: Widget> {
@@ -401,7 +401,7 @@ pub struct WidgetMut<'a, W: Widget> {
 
 `W` is your widget type. `MutateCtx` is yet another context type, with methods that let you get information about your widget and report that it changed in some ways.
 
-If you want your widget to be mutable outside of its pass methods, you should write setter functions taking WidgetMut as a parameter.
+If you want your widget to be mutable outside of its pass methods, you should write setter functions taking `WidgetMut` as a parameter.
 
 These functions should modify the internal values of your widget, then set flags using `MutateCtx` depending on which values changed.
 For instance, a `set_padding()` function should probably call `ctx.request_layout()`, whereas a `set_background_color()` function should probably call `ctx.request_render()` or `ctx.request_paint_only()`.
@@ -430,7 +430,7 @@ impl ColorRectangle {
 }
 ```
 
-By making ColorRectangle's fields private, and making it so the only way to mutate them is through a WidgetMut, we make it "watertight".
+By making `ColorRectangle`'s fields private, and making it so the only way to mutate them is through a `WidgetMut`, we make it "watertight".
 Our users can never find themselves in a situation where they forget to propagate invalidation flags, and end up with confusing bugs.
 
 

--- a/masonry/src/doc/03_implementing_container_widget.md
+++ b/masonry/src/doc/03_implementing_container_widget.md
@@ -196,7 +196,7 @@ We've seen how to deal with the children of a container widget once they're alre
 But how do we add them in the first place?
 
 Widgets will usually be added or removed through a [`WidgetMut`] wrapper.
-Let's write WidgetMut methods for our `VerticalStack`:
+Let's write `WidgetMut` methods for our `VerticalStack`:
 
 ```rust,ignore
 impl VerticalStack {

--- a/masonry/src/doc/04b_widget_properties.md
+++ b/masonry/src/doc/04b_widget_properties.md
@@ -61,11 +61,11 @@ Properties should be defined to represent self-contained values that a widget ca
 Some examples:
 
 - `BackgroundColor`
-- BorderColor
-- Padding
-- TextFont
-- TextSize
-- TextWeight
+- `BorderColor`
+- `Padding`
+- `TextFont`
+- `TextSize`
+- `TextWeight`
 
 **TODO: Most of the properties cited above do *not* exist in Masonry's codebase. They should hopefully be added quickly.**
 

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -1010,7 +1010,7 @@ impl_context_method!(MutateCtx<'_>, EventCtx<'_>, UpdateCtx<'_>, {
     /// Request a [`paint`](crate::core::Widget::paint) pass.
     ///
     /// Unlike [`request_render`](Self::request_render), this does not request an [`accessibility`](crate::core::Widget::accessibility) pass.
-    /// Use request_render unless you're sure an accessibility pass is not needed.
+    /// Use `request_render` unless you're sure an accessibility pass is not needed.
     pub fn request_paint_only(&mut self) {
         trace!("request_paint");
         self.widget_state.request_paint = true;

--- a/masonry_core/src/doc/06_masonry_concepts.md
+++ b/masonry_core/src/doc/06_masonry_concepts.md
@@ -46,7 +46,7 @@ The hovered status of the capturing widget will be updated, meaning a widget tha
 - If the widget loses pointer capture for some reason (e.g. the pointer is disconnected), the Widget will get a [`Cancel`] event.
 
 Masonry should guarantee that pointers can only be captured by one widget at a time.
-Masonry should force the widget to lose pointer capture when some events occur; not just MouseLeave, but also `Tab` being pressed, the window losing focus, the widget being disabled, etc.
+Masonry should force the widget to lose pointer capture when some events occur; not just "mouse leave", but also `Tab` being pressed, the window losing focus, the widget being disabled, etc.
 
 Examples of use cases for pointer capture include selecting text, dragging a slider, or long-pressing a button.
 


### PR DESCRIPTION
These are not happening in `stable` Rust. Some remain that need slightly more consideration to resolve.