### PR TITLE
Cache tracing spans

### DIFF
--- a/masonry_core/src/core/widget_state.rs
+++ b/masonry_core/src/core/widget_state.rs
@@ -1,6 +1,7 @@
 // Copyright 2018 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
+use tracing::Span;
 use vello::kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
 
 use crate::core::WidgetId;
@@ -176,6 +177,7 @@ pub(crate) struct WidgetState {
     ///
     /// Used in some guard rails to provide richer error messages when a parent forgets
     /// to iterate over some children.
+    pub(crate) trace_span: Span,
     #[cfg(debug_assertions)]
     pub(crate) widget_name: &'static str,
 }
@@ -234,6 +236,7 @@ impl WidgetState {
             widget_name,
             window_transform: Affine::IDENTITY,
             bounding_rect: Rect::ZERO,
+            trace_span: Span::none(),
             transform: options.transform,
         }
     }

--- a/masonry_core/src/passes/accessibility.rs
+++ b/masonry_core/src/passes/accessibility.rs
@@ -22,14 +22,7 @@ fn build_accessibility_tree(
     rebuild_all: bool,
     scale_factor: Option<f64>,
 ) {
-    let _span = enter_span_if(
-        global_state.trace.access,
-        global_state,
-        default_properties,
-        widget.reborrow(),
-        state.reborrow(),
-        properties.reborrow(),
-    );
+    let _span = enter_span_if(global_state.trace.access, state.reborrow());
     let id = state.item.id;
 
     if !rebuild_all && !state.item.needs_accessibility {

--- a/masonry_core/src/passes/anim.rs
+++ b/masonry_core/src/passes/anim.rs
@@ -18,14 +18,7 @@ fn update_anim_for_widget(
     mut properties: ArenaMut<'_, AnyMap>,
     elapsed_ns: u64,
 ) {
-    let _span = enter_span_if(
-        global_state.trace.anim,
-        global_state,
-        default_properties,
-        widget.reborrow(),
-        state.reborrow(),
-        properties.reborrow(),
-    );
+    let _span = enter_span_if(global_state.trace.anim, state.reborrow());
     if !state.item.needs_anim {
         return;
     }

--- a/masonry_core/src/passes/compose.rs
+++ b/masonry_core/src/passes/compose.rs
@@ -6,28 +6,20 @@ use tree_arena::ArenaMut;
 use vello::kurbo::Affine;
 
 use crate::app::{RenderRoot, RenderRootState};
-use crate::core::{ComposeCtx, DefaultProperties, Widget, WidgetState};
+use crate::core::{ComposeCtx, Widget, WidgetState};
 use crate::passes::{enter_span_if, recurse_on_children};
 use crate::util::AnyMap;
 
 // --- MARK: RECURSE
 fn compose_widget(
     global_state: &mut RenderRootState,
-    default_properties: &DefaultProperties,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
-    mut properties: ArenaMut<'_, AnyMap>,
+    properties: ArenaMut<'_, AnyMap>,
     parent_transformed: bool,
     parent_window_transform: Affine,
 ) {
-    let _span = enter_span_if(
-        global_state.trace.compose,
-        global_state,
-        default_properties,
-        widget.reborrow(),
-        state.reborrow(),
-        properties.reborrow(),
-    );
+    let _span = enter_span_if(global_state.trace.compose, state.reborrow());
 
     let transformed = parent_transformed || state.item.transform_changed;
 
@@ -74,7 +66,6 @@ fn compose_widget(
         |widget, mut state, properties| {
             compose_widget(
                 global_state,
-                default_properties,
                 widget,
                 state.reborrow_mut(),
                 properties,
@@ -106,7 +97,6 @@ pub(crate) fn run_compose_pass(root: &mut RenderRoot) {
     let (root_widget, root_state, root_properties) = root.widget_arena.get_all_mut(root.root.id());
     compose_widget(
         &mut root.global_state,
-        &root.default_properties,
         root_widget,
         root_state,
         root_properties,

--- a/masonry_core/src/passes/event.rs
+++ b/masonry_core/src/passes/event.rs
@@ -90,17 +90,11 @@ fn run_event_pass<E>(
     let mut is_handled = false;
     while let Some(widget_id) = target_widget_id {
         let parent_id = root.widget_arena.parent_of(widget_id);
-        let (mut widget_mut, mut state_mut, mut properties_mut) =
+        let (widget_mut, mut state_mut, mut properties_mut) =
             root.widget_arena.get_all_mut(widget_id);
 
         if !is_handled {
-            let _span = enter_span(
-                &root.global_state,
-                &root.default_properties,
-                widget_mut.reborrow(),
-                state_mut.reborrow(),
-                properties_mut.reborrow(),
-            );
+            let _span = enter_span(state_mut.reborrow());
             let mut ctx = EventCtx {
                 global_state: &mut root.global_state,
                 widget_state: state_mut.item,

--- a/masonry_core/src/passes/layout.rs
+++ b/masonry_core/src/passes/layout.rs
@@ -29,14 +29,7 @@ pub(crate) fn run_layout_on<W: Widget + ?Sized>(
     let mut properties = parent_ctx.properties_children.item_mut(id).unwrap();
 
     let trace = parent_ctx.global_state.trace.layout;
-    let _span = enter_span_if(
-        trace,
-        parent_ctx.global_state,
-        parent_ctx.default_properties,
-        widget.reborrow(),
-        state.reborrow(),
-        properties.reborrow(),
-    );
+    let _span = enter_span_if(trace, state.reborrow());
 
     let mut children_ids = SmallVec::new();
     if cfg!(debug_assertions) {

--- a/masonry_core/src/passes/paint.rs
+++ b/masonry_core/src/passes/paint.rs
@@ -22,18 +22,11 @@ fn paint_widget(
     scenes: &mut HashMap<WidgetId, Scene>,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
-    mut properties: ArenaMut<'_, AnyMap>,
+    properties: ArenaMut<'_, AnyMap>,
     debug_paint: bool,
 ) {
     let trace = global_state.trace.paint;
-    let _span = enter_span_if(
-        trace,
-        global_state,
-        default_properties,
-        widget.reborrow(),
-        state.reborrow(),
-        properties.reborrow(),
-    );
+    let _span = enter_span_if(trace, state.reborrow());
 
     let id = state.item.id;
 


### PR DESCRIPTION
This is implementing the idea discussed in https://github.com/linebender/xilem/pull/687#discussion_r1808472248

The reason I didn't do this before was that I thought you needed to get the parents right. However, having re-read tracing's docs since then, I've discovered that this isn't necessary.

As discussed in https://github.com/bevyengine/bevy/pull/9390, this can get you pretty close to removing all the overhead; it's possible that #687 could be undone.