### PR TITLE
masonry_winit: Let caller pass default properties into run

### DIFF
--- a/masonry_winit/README.md
+++ b/masonry_winit/README.md
@@ -43,6 +43,7 @@ The to-do-list example looks like this:
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
 use masonry::core::{Action, Widget, WidgetId, WidgetPod};
 use masonry::dpi::LogicalSize;
+use masonry::theme::default_property_set;
 use masonry::widgets::{Button, Flex, Label, Portal, TextInput};
 use winit::window::Window;
 
@@ -108,6 +109,7 @@ fn main() {
             WidgetPod::new(main_widget).erased(),
         )],
         driver,
+        default_property_set(),
     )
     .unwrap();
 }

--- a/masonry_winit/examples/custom_widget.rs
+++ b/masonry_winit/examples/custom_widget.rs
@@ -20,6 +20,7 @@ use masonry::parley::layout::{Alignment, AlignmentOptions};
 use masonry::parley::style::{FontFamily, FontStack, GenericFamily, StyleProperty};
 use masonry::peniko::{Color, Fill, Image, ImageFormat};
 use masonry::smallvec::SmallVec;
+use masonry::theme::default_property_set;
 use masonry::vello::Scene;
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
 use tracing::{Span, trace_span};
@@ -197,6 +198,7 @@ fn main() {
             WidgetPod::new(CustomWidget(my_string)).erased(),
         )],
         Driver,
+        default_property_set(),
     )
     .unwrap();
 }

--- a/masonry_winit/examples/grid_masonry.rs
+++ b/masonry_winit/examples/grid_masonry.rs
@@ -12,6 +12,7 @@ use masonry::dpi::LogicalSize;
 use masonry::parley::layout::Alignment;
 use masonry::peniko::Color;
 use masonry::properties::{BorderColor, BorderWidth};
+use masonry::theme::default_property_set;
 use masonry::widgets::{Button, Grid, GridParams, Prose, SizedBox, TextArea};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
 use winit::window::Window;
@@ -149,6 +150,7 @@ fn main() {
             WidgetPod::new(main_widget).erased(),
         )],
         driver,
+        default_property_set(),
     )
     .unwrap();
 }

--- a/masonry_winit/examples/hello_masonry.rs
+++ b/masonry_winit/examples/hello_masonry.rs
@@ -10,6 +10,7 @@
 use masonry::core::{Action, StyleProperty, WidgetId, WidgetPod};
 use masonry::dpi::LogicalSize;
 use masonry::parley::style::FontWeight;
+use masonry::theme::default_property_set;
 use masonry::widgets::{Button, Flex, Label};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
 use winit::window::Window;
@@ -72,6 +73,7 @@ fn main() {
             WidgetPod::new(main_widget).erased(),
         )],
         driver,
+        default_property_set(),
     )
     .unwrap();
 }

--- a/masonry_winit/examples/simple_image.rs
+++ b/masonry_winit/examples/simple_image.rs
@@ -11,6 +11,7 @@
 use masonry::core::{Action, ObjectFit, WidgetId, WidgetPod};
 use masonry::dpi::LogicalSize;
 use masonry::peniko::{Image as ImageBuf, ImageFormat};
+use masonry::theme::default_property_set;
 use masonry::widgets::Image;
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
 use winit::window::Window;
@@ -57,6 +58,7 @@ fn main() {
             WidgetPod::new(make_image()).erased(),
         )],
         Driver,
+        default_property_set(),
     )
     .unwrap();
 }

--- a/masonry_winit/examples/virtual_fizzbuzz.rs
+++ b/masonry_winit/examples/virtual_fizzbuzz.rs
@@ -11,6 +11,7 @@
 
 use masonry::core::{Action, ArcStr, StyleProperty, WidgetId, WidgetPod};
 use masonry::dpi::LogicalSize;
+use masonry::theme::default_property_set;
 use masonry::widgets::{Label, VirtualScroll, VirtualScrollAction};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
 use winit::window::Window;
@@ -107,6 +108,7 @@ fn main() {
         masonry_winit::app::EventLoop::with_user_event(),
         vec![(driver.window_id, window_attributes, main_widget)],
         driver,
+        default_property_set(),
     )
     .unwrap();
 }

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -13,7 +13,6 @@ use masonry::app::{RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePo
 use masonry::core::{DefaultProperties, TextEvent, Widget, WidgetId, WidgetPod, WindowEvent};
 use masonry::kurbo::Affine;
 use masonry::peniko::Color;
-use masonry::theme::default_property_set;
 use masonry::util::Instant;
 use masonry::vello::util::{RenderContext, RenderSurface};
 use masonry::vello::{AaConfig, AaSupport, RenderParams, Renderer, RendererOptions, Scene};
@@ -161,10 +160,11 @@ pub fn run(
     mut loop_builder: EventLoopBuilder,
     windows: Vec<(WindowId, WindowAttributes, WidgetPod<dyn Widget>)>,
     app_driver: impl AppDriver + 'static,
+    default_property_set: DefaultProperties,
 ) -> Result<(), EventLoopError> {
     let event_loop = loop_builder.build()?;
 
-    run_with(event_loop, windows, app_driver, default_property_set())
+    run_with(event_loop, windows, app_driver, default_property_set)
 }
 
 pub fn run_with(

--- a/masonry_winit/src/lib.rs
+++ b/masonry_winit/src/lib.rs
@@ -20,6 +20,7 @@
 //! use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
 //! use masonry::core::{Action, Widget, WidgetId, WidgetPod};
 //! use masonry::dpi::LogicalSize;
+//! use masonry::theme::default_property_set;
 //! use masonry::widgets::{Button, Flex, Label, Portal, TextInput};
 //! use winit::window::Window;
 //!
@@ -86,6 +87,7 @@
 //!             WidgetPod::new(main_widget).erased(),
 //!         )],
 //!         driver,
+//!         default_property_set(),
 //!     )
 //!     .unwrap();
 //! }


### PR DESCRIPTION
The `run_with` function accepted the default properties as an argument, but `run` was creating them via a dependency on `masonry`.

This removes a usage of something only available in `masonry` from `masonry_winit`.