### PR TITLE
Re-export from `masonry_core`, use in `masonry_testing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,21 +2163,15 @@ dependencies = [
 name = "masonry_testing"
 version = "0.3.0"
 dependencies = [
- "accesskit",
  "accesskit_consumer",
  "assert_matches",
- "cursor-icon",
- "dpi",
  "futures-intrusive",
  "image",
  "masonry_core",
  "oxipng",
  "pollster",
  "profiling",
- "smallvec",
  "tracing",
- "ui-events",
- "vello",
  "wgpu",
 ]
 

--- a/masonry_core/src/lib.rs
+++ b/masonry_core/src/lib.rs
@@ -37,6 +37,9 @@
 )]
 // TODO - Add logo
 
+pub use vello::{kurbo, peniko, peniko::color::palette};
+pub use {accesskit, cursor_icon, dpi, parley, smallvec, ui_events, vello};
+
 // TODO - re-add #[doc(hidden)]
 pub mod doc;
 
@@ -50,6 +53,3 @@ pub mod core;
 
 // TODO - Move to core?
 pub use util::{Handled, UnitPoint};
-
-// TODO - Remove re-exports
-pub(crate) use {::dpi, ::vello, vello::peniko};

--- a/masonry_testing/Cargo.toml
+++ b/masonry_testing/Cargo.toml
@@ -19,19 +19,13 @@ targets = []
 default = []
 
 [dependencies]
-accesskit.workspace = true
 accesskit_consumer.workspace = true
-cursor-icon = "1.1.0"
-dpi.workspace = true
 futures-intrusive = "0.5.0"
 image = { workspace = true, features = ["png"] }
 masonry_core.workspace = true
 oxipng = { version = "9.1.5", default-features = false }
 pollster = "0.4.0"
-smallvec.workspace = true
 tracing = { workspace = true, features = ["default"] }
-ui-events.workspace = true
-vello.workspace = true
 wgpu.workspace = true
 
 [dev-dependencies]

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -9,16 +9,9 @@ use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::{Arc, mpsc};
 
-use cursor_icon::CursorIcon;
-use dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
 use image::{DynamicImage, ImageFormat, ImageReader, Rgba, RgbaImage};
-use masonry_core::core::{Properties, WidgetPod};
 use oxipng::{Options, optimize_from_memory};
 use tracing::debug;
-use vello::RendererOptions;
-use vello::kurbo::{Point, Size, Vec2};
-use vello::peniko::{Blob, Color};
-use vello::util::{RenderContext, block_on_wgpu};
 use wgpu::{
     BufferDescriptor, BufferUsages, CommandEncoderDescriptor, Extent3d, TexelCopyBufferInfo,
     TextureDescriptor, TextureFormat, TextureUsages,
@@ -33,7 +26,14 @@ use masonry_core::core::{
     PointerState, PointerType, PointerUpdate, ScrollDelta, TextEvent, Widget, WidgetId, WidgetMut,
     WidgetRef, WindowEvent,
 };
+use masonry_core::core::{Properties, WidgetPod};
+use masonry_core::cursor_icon::CursorIcon;
+use masonry_core::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
+use masonry_core::kurbo::{Point, Size, Vec2};
+use masonry_core::peniko::{Blob, Color};
 use masonry_core::util::Duration;
+use masonry_core::vello;
+use masonry_core::vello::util::{RenderContext, block_on_wgpu};
 
 use crate::screenshots::get_image_diff;
 
@@ -389,7 +389,7 @@ impl TestHarness {
         let queue = &device_handle.queue;
         let mut renderer = vello::Renderer::new(
             device,
-            RendererOptions {
+            vello::RendererOptions {
                 // TODO - Examine this value
                 use_cpu: true,
                 num_init_threads: NonZeroUsize::new(1),

--- a/masonry_testing/src/lib.rs
+++ b/masonry_testing/src/lib.rs
@@ -15,12 +15,11 @@ mod screenshots;
 mod wrapper_widget;
 
 pub use harness::{PRIMARY_MOUSE, TestHarness, TestHarnessParams};
-use masonry_core::core::{Properties, WidgetOptions};
 pub use modular_widget::ModularWidget;
 pub use recorder_widget::{Record, Recorder, Recording};
 pub use wrapper_widget::WrapperWidget;
 
-use masonry_core::core::{Widget, WidgetId, WidgetPod};
+use masonry_core::core::{Properties, Widget, WidgetId, WidgetOptions, WidgetPod};
 
 // TODO - Split off into separate file
 

--- a/masonry_testing/src/modular_widget.rs
+++ b/masonry_testing/src/modular_widget.rs
@@ -3,18 +3,18 @@
 
 use std::any::TypeId;
 
-use accesskit::{Node, Role};
-use cursor_icon::CursorIcon;
-use smallvec::SmallVec;
 use tracing::trace_span;
-use vello::Scene;
-use vello::kurbo::{Point, Size};
 
+use masonry_core::accesskit::{Node, Role};
 use masonry_core::core::{
     AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetRef, find_widget_under_pointer,
 };
+use masonry_core::cursor_icon::CursorIcon;
+use masonry_core::kurbo::{Point, Size};
+use masonry_core::smallvec::SmallVec;
+use masonry_core::vello::Scene;
 
 pub type PointerEventFn<S> =
     dyn FnMut(&mut S, &mut EventCtx<'_>, &mut PropertiesMut<'_>, &PointerEvent);

--- a/masonry_testing/src/recorder_widget.rs
+++ b/masonry_testing/src/recorder_widget.rs
@@ -13,17 +13,16 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
-use accesskit::{Node, Role};
-use cursor_icon::CursorIcon;
-use smallvec::SmallVec;
-use vello::Scene;
-use vello::kurbo::{Point, Size};
-
+use masonry_core::accesskit::{Node, Role};
 use masonry_core::core::{
     AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetRef,
 };
+use masonry_core::cursor_icon::CursorIcon;
+use masonry_core::kurbo::{Point, Size};
+use masonry_core::smallvec::SmallVec;
+use masonry_core::vello::Scene;
 
 // TODO - Re-enable doc test.
 // Doc test is currently disabled because it depends on a parent crate.

--- a/masonry_testing/src/wrapper_widget.rs
+++ b/masonry_testing/src/wrapper_widget.rs
@@ -3,16 +3,15 @@
 
 use std::any::TypeId;
 
-use accesskit::{Node, Role};
-use smallvec::{SmallVec, smallvec};
-use vello::Scene;
-use vello::kurbo::{Point, Size};
-
+use masonry_core::accesskit::{Node, Role};
 use masonry_core::core::{
     AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update, UpdateCtx, Widget,
     WidgetId, WidgetMut, WidgetPod,
 };
+use masonry_core::kurbo::{Point, Size};
+use masonry_core::smallvec::{SmallVec, smallvec};
+use masonry_core::vello::Scene;
 
 /// A basic wrapper widget that can replace its child.
 pub struct WrapperWidget {


### PR DESCRIPTION
We have things that are deps of `masonry_core`, `masonry`, and `masonry_testing` and if you use `masonry_core`, you need to know that and use the right versions.

Instead, we should be exporting these things from `masonry_core` and using them from there.

This updates `masonry_testing` to use things from `masonry_core` instead and subsequent commits can further improve upon this with the `masonry` crate and so on.