### PR TITLE
masonry: Get `wgpu` from `vello`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,7 +2172,6 @@ dependencies = [
  "pollster",
  "profiling",
  "tracing",
- "wgpu",
 ]
 
 [[package]]
@@ -2188,7 +2187,6 @@ dependencies = [
  "tracing",
  "tracing-tracy",
  "ui-events-winit",
- "wgpu",
  "wgpu-profiler",
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ masonry_winit = { version = "0.3.0", path = "masonry_winit" }
 xilem_core = { version = "0.3.0", path = "xilem_core" }
 tree_arena = { version = "0.1.0", path = "tree_arena" }
 vello = "0.5.0"
-wgpu = "24.0.3"
 kurbo = "0.11.2"
 parley = { version = "0.5.0", features = ["accesskit"] }
 peniko = "0.4.0"

--- a/masonry_testing/Cargo.toml
+++ b/masonry_testing/Cargo.toml
@@ -26,7 +26,6 @@ masonry_core.workspace = true
 oxipng = { version = "9.1.5", default-features = false }
 pollster = "0.4.0"
 tracing = { workspace = true, features = ["default"] }
-wgpu.workspace = true
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -12,10 +12,6 @@ use std::sync::{Arc, mpsc};
 use image::{DynamicImage, ImageFormat, ImageReader, Rgba, RgbaImage};
 use oxipng::{Options, optimize_from_memory};
 use tracing::debug;
-use wgpu::{
-    BufferDescriptor, BufferUsages, CommandEncoderDescriptor, Extent3d, TexelCopyBufferInfo,
-    TextureDescriptor, TextureFormat, TextureUsages,
-};
 
 use masonry_core::Handled;
 use masonry_core::app::{
@@ -34,6 +30,11 @@ use masonry_core::peniko::{Blob, Color};
 use masonry_core::util::Duration;
 use masonry_core::vello;
 use masonry_core::vello::util::{RenderContext, block_on_wgpu};
+use masonry_core::vello::wgpu::{
+    BufferDescriptor, BufferUsages, CommandEncoderDescriptor, Extent3d, MapMode,
+    TexelCopyBufferInfo, TexelCopyBufferLayout, TextureDescriptor, TextureDimension, TextureFormat,
+    TextureUsages, TextureViewDescriptor,
+};
 
 use crate::screenshots::get_image_diff;
 
@@ -419,12 +420,12 @@ impl TestHarness {
             size,
             mip_level_count: 1,
             sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
+            dimension: TextureDimension::D2,
             format: TextureFormat::Rgba8Unorm,
             usage: TextureUsages::STORAGE_BINDING | TextureUsages::COPY_SRC,
             view_formats: &[],
         });
-        let view = target.create_view(&wgpu::TextureViewDescriptor::default());
+        let view = target.create_view(&TextureViewDescriptor::default());
         renderer
             .render_to_texture(device, queue, &scene, &view, &render_params)
             .expect("Got non-Send/Sync error from rendering");
@@ -443,7 +444,7 @@ impl TestHarness {
             target.as_image_copy(),
             TexelCopyBufferInfo {
                 buffer: &buffer,
-                layout: wgpu::TexelCopyBufferLayout {
+                layout: TexelCopyBufferLayout {
                     offset: 0,
                     bytes_per_row: Some(padded_byte_width),
                     rows_per_image: None,
@@ -456,7 +457,7 @@ impl TestHarness {
         let buf_slice = buffer.slice(..);
 
         let (sender, receiver) = futures_intrusive::channel::shared::oneshot_channel();
-        buf_slice.map_async(wgpu::MapMode::Read, move |v| sender.send(v).unwrap());
+        buf_slice.map_async(MapMode::Read, move |v| sender.send(v).unwrap());
         let recv_result = block_on_wgpu(device, receiver.receive()).expect("channel was closed");
         recv_result.expect("failed to map buffer");
 

--- a/masonry_winit/Cargo.toml
+++ b/masonry_winit/Cargo.toml
@@ -25,7 +25,6 @@ tracy = ["dep:tracing-tracy", "dep:wgpu-profiler", "wgpu-profiler/tracy", "mason
 
 [dependencies]
 masonry_core.workspace = true
-wgpu.workspace = true
 winit.workspace = true
 tracing = { workspace = true, features = ["default"] }
 tracing-tracy = { version = "0.11.4", optional = true }

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -15,10 +15,10 @@ use masonry_core::kurbo::Affine;
 use masonry_core::peniko::Color;
 use masonry_core::util::Instant;
 use masonry_core::vello::util::{RenderContext, RenderSurface};
+use masonry_core::vello::wgpu;
 use masonry_core::vello::{AaConfig, AaSupport, RenderParams, Renderer, RendererOptions, Scene};
 use tracing::{debug, error, info, info_span};
 use ui_events_winit::{WindowEventReducer, WindowEventTranslation};
-use wgpu::PresentMode;
 use winit::application::ApplicationHandler;
 use winit::error::EventLoopError;
 use winit::event::{DeviceEvent as WinitDeviceEvent, DeviceId, WindowEvent as WinitWindowEvent};
@@ -379,7 +379,7 @@ impl MasonryState<'_> {
             handle.clone(),
             size.width,
             size.height,
-            PresentMode::AutoVsync,
+            wgpu::PresentMode::AutoVsync,
         ))
         .unwrap();
         let scale_factor = handle.scale_factor();


### PR DESCRIPTION
This simplifies updating things as it is one less sibling dependency version to keep in sync.