### PR TITLE
masonry_core: Add `BoxConstraints::bounded_or`

### DIFF
--- a/masonry_core/src/core/box_constraints.rs
+++ b/masonry_core/src/core/box_constraints.rs
@@ -109,6 +109,22 @@ impl BoxConstraints {
         self.max.height.is_finite()
     }
 
+    /// Return the max in each axis if bounded, else the value given in `size`.
+    pub fn bounded_or(&self, size: Size) -> Size {
+        Size {
+            width: if self.is_width_bounded() {
+                self.max.width
+            } else {
+                size.width
+            },
+            height: if self.is_height_bounded() {
+                self.max.height
+            } else {
+                size.height
+            },
+        }
+    }
+
     /// Check to see if these constraints are legit.
     ///
     /// In Debug mode, logs a warning if `BoxConstraints` are invalid.


### PR DESCRIPTION
A common layout use case is to have an inherent size (not necessarily the minimum) when the layout is unbounded.
`BoxConstraints::bounded_or` handles this on a per-axis basis, which is desirable in a number of cases, but is often not done because it is more code.