### PR TITLE
Re-export `winit` from `masonry_winit`

### DIFF
--- a/masonry/src/doc/01_creating_app.md
+++ b/masonry/src/doc/01_creating_app.md
@@ -165,7 +165,7 @@ The last step is to create our Winit window and start our main loop.
 
 ```rust,ignore
     use masonry::dpi::LogicalSize;
-    use winit::window::Window;
+    use masonry_winit::winit::window::Window;
 
     let window_attributes = Window::default_attributes()
         .with_title("To-do list")
@@ -230,7 +230,7 @@ fn main() {
     };
 
     use masonry::dpi::LogicalSize;
-    use winit::window::Window;
+    use masonry_winit::winit::window::Window;
 
     let window_attributes = Window::default_attributes()
         .with_title("To-do list")

--- a/masonry_winit/README.md
+++ b/masonry_winit/README.md
@@ -41,11 +41,11 @@ The to-do-list example looks like this:
 
 ```rust
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
+use masonry_winit::winit::window::Window;
 use masonry::core::{Action, Widget, WidgetId, WidgetPod};
 use masonry::dpi::LogicalSize;
 use masonry::theme::default_property_set;
 use masonry::widgets::{Button, Flex, Label, Portal, TextInput};
-use winit::window::Window;
 
 struct Driver {
     next_task: String,

--- a/masonry_winit/examples/calc_masonry.rs
+++ b/masonry_winit/examples/calc_masonry.rs
@@ -29,8 +29,8 @@ use masonry::theme::default_property_set;
 use masonry::vello::Scene;
 use masonry::widgets::{Align, CrossAxisAlignment, Flex, Label, SizedBox};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
+use masonry_winit::winit::window::Window;
 use tracing::{Span, trace, trace_span};
-use winit::window::Window;
 
 // TODO - Rewrite this example to be simpler,
 // use properties directly and remove the CalcButton widget.

--- a/masonry_winit/examples/custom_widget.rs
+++ b/masonry_winit/examples/custom_widget.rs
@@ -23,8 +23,8 @@ use masonry::theme::default_property_set;
 use masonry::vello::Scene;
 use masonry::{TextAlign, TextAlignOptions};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
+use masonry_winit::winit::window::Window;
 use tracing::{Span, trace_span};
-use winit::window::Window;
 
 struct Driver;
 

--- a/masonry_winit/examples/grid_masonry.rs
+++ b/masonry_winit/examples/grid_masonry.rs
@@ -15,7 +15,7 @@ use masonry::properties::{BorderColor, BorderWidth};
 use masonry::theme::default_property_set;
 use masonry::widgets::{Button, Grid, GridParams, Prose, SizedBox, TextArea};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use winit::window::Window;
+use masonry_winit::winit::window::Window;
 
 struct Driver {
     grid_spacing: f64,

--- a/masonry_winit/examples/hello_masonry.rs
+++ b/masonry_winit/examples/hello_masonry.rs
@@ -13,7 +13,7 @@ use masonry::parley::style::FontWeight;
 use masonry::theme::default_property_set;
 use masonry::widgets::{Button, Flex, Label};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use winit::window::Window;
+use masonry_winit::winit::window::Window;
 
 const VERTICAL_WIDGET_SPACING: f64 = 20.0;
 

--- a/masonry_winit/examples/simple_image.rs
+++ b/masonry_winit/examples/simple_image.rs
@@ -14,7 +14,7 @@ use masonry::peniko::{Image as ImageBuf, ImageFormat};
 use masonry::theme::default_property_set;
 use masonry::widgets::Image;
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use winit::window::Window;
+use masonry_winit::winit::window::Window;
 
 struct Driver;
 

--- a/masonry_winit/examples/to_do_list.rs
+++ b/masonry_winit/examples/to_do_list.rs
@@ -13,7 +13,7 @@ use masonry::properties::Padding;
 use masonry::theme::default_property_set;
 use masonry::widgets::{Button, Flex, Label, Portal, TextArea, TextInput};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use winit::window::Window;
+use masonry_winit::winit::window::Window;
 
 const WIDGET_SPACING: f64 = 5.0;
 

--- a/masonry_winit/examples/two_text_inputs.rs
+++ b/masonry_winit/examples/two_text_inputs.rs
@@ -13,7 +13,7 @@ use masonry::properties::Padding;
 use masonry::theme::default_property_set;
 use masonry::widgets::{Flex, TextInput};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use winit::window::Window;
+use masonry_winit::winit::window::Window;
 
 const VERTICAL_WIDGET_SPACING: f64 = 20.0;
 

--- a/masonry_winit/examples/virtual_fizzbuzz.rs
+++ b/masonry_winit/examples/virtual_fizzbuzz.rs
@@ -14,7 +14,7 @@ use masonry::dpi::LogicalSize;
 use masonry::theme::default_property_set;
 use masonry::widgets::{Label, VirtualScroll, VirtualScrollAction};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
-use winit::window::Window;
+use masonry_winit::winit::window::Window;
 
 /// The widget kind contained in the scroll area. This is a type parameter (`W`) of [`VirtualScroll`],
 /// although note that [`dyn Widget`](masonry::core::Widget) can also be used for dynamic children kinds.

--- a/masonry_winit/src/lib.rs
+++ b/masonry_winit/src/lib.rs
@@ -18,11 +18,11 @@
 //!
 //! ```rust
 //! use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
+//! use masonry_winit::winit::window::Window;
 //! use masonry::core::{Action, Widget, WidgetId, WidgetPod};
 //! use masonry::dpi::LogicalSize;
 //! use masonry::theme::default_property_set;
 //! use masonry::widgets::{Button, Flex, Label, Portal, TextInput};
-//! use winit::window::Window;
 //!
 //! struct Driver {
 //!     next_task: String,
@@ -141,6 +141,8 @@
 mod app_driver;
 mod convert_winit_event;
 mod event_loop_runner;
+
+pub use winit;
 
 /// Types needed for running a Masonry app.
 pub mod app {


### PR DESCRIPTION
This reduces the dependencies to use things and removes the need for a sibling dependency.

When we move the examples back into `masonry`, it will avoid the need for a direct dev dependency on `winit` from `masonry`.