### PR TITLE
Add TextColor and DisabledTextColor properties.

### DIFF
--- a/masonry/src/properties/mod.rs
+++ b/masonry/src/properties/mod.rs
@@ -12,6 +12,7 @@ mod box_shadow;
 mod checkmark;
 mod corner_radius;
 mod padding;
+mod text_color;
 
 pub mod types;
 
@@ -22,3 +23,4 @@ pub use box_shadow::BoxShadow;
 pub use checkmark::{CheckmarkColor, CheckmarkStrokeWidth, DisabledCheckmarkColor};
 pub use corner_radius::CornerRadius;
 pub use padding::Padding;
+pub use text_color::*;

--- a/masonry/src/properties/mod.rs
+++ b/masonry/src/properties/mod.rs
@@ -23,4 +23,4 @@ pub use box_shadow::BoxShadow;
 pub use checkmark::{CheckmarkColor, CheckmarkStrokeWidth, DisabledCheckmarkColor};
 pub use corner_radius::CornerRadius;
 pub use padding::Padding;
-pub use text_color::*;
+pub use text_color::{DisabledTextColor, TextColor};

--- a/masonry/src/properties/text_color.rs
+++ b/masonry/src/properties/text_color.rs
@@ -8,8 +8,8 @@ use crate::peniko::color::{AlphaColor, Srgb};
 
 /// The color of a widget's text and text decorations.
 ///
-/// **IMPORTANT:** This property is only defined for Label and TextArea, *not*
-/// for widgets embedding them such as Button, Checkbox, TextEdit, Prose, etc.
+/// **IMPORTANT:** This property is only defined for `Label` and `TextArea`, *not*
+/// for widgets embedding them such as `Button`, `Checkbox`, `TextEdit`, `Prose`, etc.
 #[expect(missing_docs, reason = "field names are self-descriptive")]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TextColor {

--- a/masonry/src/properties/text_color.rs
+++ b/masonry/src/properties/text_color.rs
@@ -1,0 +1,82 @@
+// Copyright 2025 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::any::TypeId;
+
+use crate::core::{Property, UpdateCtx};
+use crate::peniko::color::{AlphaColor, Srgb};
+
+/// The color of a widget's text and text decorations.
+///
+/// **IMPORTANT:** This property is only defined for Label and TextArea, *not*
+/// for widgets embedding them such as Button, Checkbox, TextEdit, Prose, etc.
+#[expect(missing_docs, reason = "field names are self-descriptive")]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TextColor {
+    pub color: AlphaColor<Srgb>,
+}
+
+impl Property for TextColor {
+    fn static_default() -> &'static Self {
+        static DEFAULT: TextColor = TextColor {
+            color: AlphaColor::BLACK,
+        };
+        &DEFAULT
+    }
+}
+
+impl TextColor {
+    /// Create new `TextColor` with given value.
+    pub fn new(color: AlphaColor<Srgb>) -> Self {
+        Self { color }
+    }
+}
+
+/// The color of a widget's text and text decorations when disabled.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DisabledTextColor(pub TextColor);
+
+impl Property for DisabledTextColor {
+    fn static_default() -> &'static Self {
+        static DEFAULT: DisabledTextColor = DisabledTextColor(TextColor {
+            color: AlphaColor::BLACK,
+        });
+        &DEFAULT
+    }
+}
+
+// ---
+
+impl Default for TextColor {
+    fn default() -> Self {
+        *Self::static_default()
+    }
+}
+
+impl TextColor {
+    /// Helper function to be called in [`Widget::property_changed`](crate::core::Widget::property_changed).
+    pub fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
+        if property_type != TypeId::of::<Self>() {
+            return;
+        }
+        ctx.request_paint_only();
+    }
+}
+
+// ---
+
+impl Default for DisabledTextColor {
+    fn default() -> Self {
+        *Self::static_default()
+    }
+}
+
+impl DisabledTextColor {
+    /// Helper function to be called in [`Widget::property_changed`](crate::core::Widget::property_changed).
+    pub fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
+        if property_type != TypeId::of::<Self>() {
+            return;
+        }
+        ctx.request_paint_only();
+    }
+}

--- a/masonry/src/properties/text_color.rs
+++ b/masonry/src/properties/text_color.rs
@@ -8,8 +8,15 @@ use crate::peniko::color::{AlphaColor, Srgb};
 
 /// The color of a widget's text and text decorations.
 ///
-/// **IMPORTANT:** This property is only defined for `Label` and `TextArea`, *not*
-/// for widgets embedding them such as `Button`, `Checkbox`, `TextEdit`, `Prose`, etc.
+/// **IMPORTANT:** This property is only defined for [`Label`] and [`TextArea`], *not*
+/// for widgets embedding them such as [`Button`], [`Checkbox`], [`TextInput`], [`Prose`], etc.
+///
+/// [`Label`]: crate::widgets::Label
+/// [`TextArea`]: crate::widgets::TextArea
+/// [`Button`]: crate::widgets::Button
+/// [`Checkbox`]: crate::widgets::Checkbox
+/// [`TextInput`]: crate::widgets::TextInput
+/// [`Prose`]: crate::widgets::Prose
 #[expect(missing_docs, reason = "field names are self-descriptive")]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TextColor {

--- a/masonry/src/theme.rs
+++ b/masonry/src/theme.rs
@@ -11,9 +11,10 @@ use crate::core::{DefaultProperties, StyleProperty, StyleSet};
 use crate::peniko::Color;
 use crate::properties::{
     ActiveBackground, Background, BorderColor, BorderWidth, CheckmarkColor, CheckmarkStrokeWidth,
-    CornerRadius, DisabledBackground, DisabledCheckmarkColor, HoveredBorderColor, Padding,
+    CornerRadius, DisabledBackground, DisabledCheckmarkColor, DisabledTextColor,
+    HoveredBorderColor, Padding, TextColor,
 };
-use crate::widgets::{Button, Checkbox, TextInput};
+use crate::widgets::{Button, Checkbox, Label, TextArea, TextInput};
 
 pub const BORDER_WIDTH: f64 = 1.;
 
@@ -85,6 +86,16 @@ pub fn default_property_set() -> DefaultProperties {
     });
 
     properties.insert::<TextInput, _>(BorderColor { color: ZYNC_600 });
+
+    // TextArea
+    properties.insert::<TextArea<false>, _>(TextColor::new(TEXT_COLOR));
+    properties.insert::<TextArea<false>, _>(DisabledTextColor(TextColor::new(DISABLED_TEXT_COLOR)));
+    properties.insert::<TextArea<true>, _>(TextColor::new(TEXT_COLOR));
+    properties.insert::<TextArea<true>, _>(DisabledTextColor(TextColor::new(DISABLED_TEXT_COLOR)));
+
+    // Label
+    properties.insert::<Label, _>(TextColor::new(TEXT_COLOR));
+    properties.insert::<Label, _>(DisabledTextColor(TextColor::new(DISABLED_TEXT_COLOR)));
 
     properties
 }

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -55,10 +55,11 @@ impl Button {
     /// # Examples
     ///
     /// ```
+    /// use masonry::core::StyleProperty;
     /// use masonry::peniko::Color;
     /// use masonry::widgets::{Button, Label};
     ///
-    /// let label = Label::new("Increment").with_brush(Color::new([0.5, 0.5, 0.5, 1.0]));
+    /// let label = Label::new("Increment").with_style(StyleProperty::FontSize(20.0));
     /// let button = Button::from_label(label);
     /// ```
     pub fn from_label(label: Label) -> Self {
@@ -309,6 +310,7 @@ mod tests {
     use crate::assert_render_snapshot;
     use crate::core::keyboard::NamedKey;
     use crate::core::{PointerButton, StyleProperty};
+    use crate::properties::TextColor;
     use crate::testing::{TestHarness, TestWidgetExt, WrapperWidget, widget_ids};
     use crate::theme::{ACCENT_COLOR, default_property_set};
     use crate::widgets::{Grid, GridParams, SizedBox};
@@ -352,9 +354,13 @@ mod tests {
     fn edit_button() {
         let image_1 = {
             let label = Label::new("The quick brown fox jumps over the lazy dog")
-                .with_brush(ACCENT_COLOR)
                 .with_style(StyleProperty::FontSize(20.0));
-            let button = Button::from_label(label);
+            let label = WidgetPod::new_with_props(
+                label,
+                Properties::new().with(TextColor::new(ACCENT_COLOR)),
+            );
+
+            let button = Button::from_label_pod(label);
 
             let mut harness = TestHarness::create_with_size(
                 default_property_set(),
@@ -379,7 +385,7 @@ mod tests {
                 Button::set_text(&mut button, "The quick brown fox jumps over the lazy dog");
 
                 let mut label = Button::label_mut(&mut button);
-                Label::set_brush(&mut label, ACCENT_COLOR);
+                label.insert_prop(TextColor::new(ACCENT_COLOR));
                 Label::insert_style(&mut label, StyleProperty::FontSize(20.0));
             });
 
@@ -408,7 +414,7 @@ mod tests {
             button.insert_prop(Padding::from_vh(3., 8.));
 
             let mut label = Button::label_mut(&mut button);
-            Label::set_brush(&mut label, red);
+            label.insert_prop(TextColor::new(red));
         });
 
         assert_render_snapshot!(harness, "button_set_properties");

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -51,6 +51,13 @@ impl Checkbox {
             label: WidgetPod::new(label),
         }
     }
+
+    /// Create a new `Checkbox` with the provided label with a predetermined id.
+    ///
+    /// This constructor is useful for toolkits which use Masonry (such as Xilem).
+    pub fn from_label_pod(checked: bool, label: WidgetPod<Label>) -> Self {
+        Self { checked, label }
+    }
 }
 
 // --- MARK: WIDGETMUT
@@ -316,11 +323,13 @@ impl Widget for Checkbox {
 #[cfg(test)]
 mod tests {
 
+    use masonry_core::core::Properties;
     use ui_events::keyboard::NamedKey;
 
     use super::*;
     use crate::assert_render_snapshot;
     use crate::core::StyleProperty;
+    use crate::properties::TextColor;
     use crate::testing::{TestHarness, TestWidgetExt, widget_ids};
     use crate::theme::{ACCENT_COLOR, default_property_set};
 
@@ -366,12 +375,13 @@ mod tests {
     #[test]
     fn edit_checkbox() {
         let image_1 = {
-            let checkbox = Checkbox::from_label(
-                true,
-                Label::new("The quick brown fox jumps over the lazy dog")
-                    .with_brush(ACCENT_COLOR)
-                    .with_style(StyleProperty::FontSize(20.0)),
+            let label = Label::new("The quick brown fox jumps over the lazy dog")
+                .with_style(StyleProperty::FontSize(20.0));
+            let label = WidgetPod::new_with_props(
+                label,
+                Properties::new().with(TextColor::new(ACCENT_COLOR)),
             );
+            let checkbox = Checkbox::from_label_pod(true, label);
 
             let mut harness = TestHarness::create_with_size(
                 default_property_set(),
@@ -400,7 +410,7 @@ mod tests {
                 );
 
                 let mut label = Checkbox::label_mut(&mut checkbox);
-                Label::set_brush(&mut label, ACCENT_COLOR);
+                label.insert_prop(TextColor::new(ACCENT_COLOR));
                 Label::insert_style(&mut label, StyleProperty::FontSize(20.0));
             });
 

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -69,6 +69,8 @@ pub struct Label {
     /// If it has changed, we need to re-perform line-breaking.
     last_max_advance: Option<f32>,
 
+    /// Whether to hint whilst drawing the text.
+    ///
     /// Should be disabled whilst an animation involving this label is ongoing.
     // TODO: What classes of animations?
     hint: bool,

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -446,7 +446,7 @@ mod tests {
 
     #[test]
     fn styled_label() {
-        let label =  Label::new("The quick brown fox jumps over the lazy dog")
+        let label = Label::new("The quick brown fox jumps over the lazy dog")
             .with_style(FontFamily::Generic(GenericFamily::Monospace))
             .with_style(StyleProperty::FontSize(20.0))
             .with_line_break_mode(LineBreaking::WordWrap)
@@ -487,32 +487,32 @@ mod tests {
     /// A wrapping label's text alignment should be respected, regardless of
     /// its parent's text alignment.
     fn label_text_alignment_flex() {
-    fn base_label() -> Label {
-        Label::new("Hello")
-            .with_style(StyleProperty::FontSize(20.0))
-            .with_line_break_mode(LineBreaking::WordWrap)
+        fn base_label() -> Label {
+            Label::new("Hello")
+                .with_style(StyleProperty::FontSize(20.0))
+                .with_line_break_mode(LineBreaking::WordWrap)
+        }
+        let label1 = base_label().with_text_alignment(TextAlign::Start);
+        let label2 = base_label().with_text_alignment(TextAlign::Center);
+        let label3 = base_label().with_text_alignment(TextAlign::End);
+        let label4 = base_label().with_text_alignment(TextAlign::Start);
+        let label5 = base_label().with_text_alignment(TextAlign::Center);
+        let label6 = base_label().with_text_alignment(TextAlign::End);
+        let flex = Flex::column()
+            .with_flex_child(label1, CrossAxisAlignment::Start)
+            .with_flex_child(label2, CrossAxisAlignment::Start)
+            .with_flex_child(label3, CrossAxisAlignment::Start)
+            // Text alignment start is "overwritten" by CrossAxisAlignment::Center.
+            .with_flex_child(label4, CrossAxisAlignment::Center)
+            .with_flex_child(label5, CrossAxisAlignment::Center)
+            .with_flex_child(label6, CrossAxisAlignment::Center)
+            .gap(0.0);
+
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), flex, Size::new(200.0, 200.0));
+
+        assert_render_snapshot!(harness, "label_label_alignment_flex");
     }
-    let label1 = base_label().with_text_alignment(TextAlign::Start);
-    let label2 = base_label().with_text_alignment(TextAlign::Center);
-    let label3 = base_label().with_text_alignment(TextAlign::End);
-    let label4 = base_label().with_text_alignment(TextAlign::Start);
-    let label5 = base_label().with_text_alignment(TextAlign::Center);
-    let label6 = base_label().with_text_alignment(TextAlign::End);
-    let flex = Flex::column()
-        .with_flex_child(label1, CrossAxisAlignment::Start)
-        .with_flex_child(label2, CrossAxisAlignment::Start)
-        .with_flex_child(label3, CrossAxisAlignment::Start)
-        // Text alignment start is "overwritten" by CrossAxisAlignment::Center.
-        .with_flex_child(label4, CrossAxisAlignment::Center)
-        .with_flex_child(label5, CrossAxisAlignment::Center)
-        .with_flex_child(label6, CrossAxisAlignment::Center)
-        .gap(0.0);
-
-    let mut harness =
-        TestHarness::create_with_size(default_property_set(), flex, Size::new(200.0, 200.0));
-
-    assert_render_snapshot!(harness, "label_label_alignment_flex");
-}
 
     #[test]
     fn line_break_modes() {
@@ -552,7 +552,7 @@ mod tests {
     #[test]
     fn edit_label() {
         let image_1 = {
-            let label =  Label::new("The quick brown fox jumps over the lazy dog")
+            let label = Label::new("The quick brown fox jumps over the lazy dog")
                 .with_style(FontFamily::Generic(GenericFamily::Monospace))
                 .with_style(StyleProperty::FontSize(20.0))
                 .with_line_break_mode(LineBreaking::WordWrap)

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -3,6 +3,7 @@
 
 //! A label widget.
 
+use std::any::TypeId;
 use std::mem::Discriminant;
 
 use accesskit::{Node, NodeId, Role};
@@ -11,7 +12,7 @@ use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Affine, Size};
-use vello::peniko::{BlendMode, Brush};
+use vello::peniko::BlendMode;
 
 use crate::core::{
     AccessCtx, ArcStr, BoxConstraints, BrushIndex, LayoutCtx, PaintCtx, PropertiesMut,
@@ -19,6 +20,7 @@ use crate::core::{
     WidgetMut, render_text,
 };
 use crate::debug_panic;
+use crate::properties::{DisabledTextColor, TextColor};
 use crate::theme;
 use crate::theme::default_text_styles;
 use crate::{TextAlign, TextAlignOptions};
@@ -67,17 +69,6 @@ pub struct Label {
     /// If it has changed, we need to re-perform line-breaking.
     last_max_advance: Option<f32>,
 
-    /// The brush for drawing this label's text.
-    ///
-    /// Requires a new paint if edited whilst `disabled_brush` is not being used.
-    brush: Brush,
-    /// The brush to use whilst this widget is disabled.
-    ///
-    /// When this is `None`, `brush` will be used.
-    /// Requires a new paint if edited whilst this widget is disabled.
-    disabled_brush: Option<Brush>,
-    /// Whether to hint whilst drawing the text.
-    ///
     /// Should be disabled whilst an animation involving this label is ongoing.
     // TODO: What classes of animations?
     hint: bool,
@@ -103,8 +94,6 @@ impl Label {
             needs_text_alignment: true,
             last_available_width: None,
             last_max_advance: None,
-            brush: theme::TEXT_COLOR.into(),
-            disabled_brush: Some(theme::DISABLED_TEXT_COLOR.into()),
             hint: true,
         }
     }
@@ -119,7 +108,7 @@ impl Label {
     /// Set a style property for the new label.
     ///
     /// Setting [`StyleProperty::Brush`](parley::StyleProperty::Brush) is not supported.
-    /// Use `with_brush` instead.
+    /// Use [`TextColor`] and [`DisabledTextColor`] properties instead.
     ///
     /// To set a style property on an active label, use [`insert_style`](Self::insert_style).
     pub fn with_style(mut self, property: impl Into<StyleProperty>) -> Self {
@@ -152,27 +141,6 @@ impl Label {
     /// To modify this on an active label, use [`set_text_alignment`](Self::set_text_alignment).
     pub fn with_text_alignment(mut self, text_alignment: TextAlign) -> Self {
         self.text_alignment = text_alignment;
-        self
-    }
-
-    /// Set the brush used to paint this label.
-    ///
-    /// In most cases, this will be the text's color, but gradients and images are also supported.
-    ///
-    /// To modify this on an active label, use [`set_brush`](Self::set_brush).
-    #[doc(alias = "with_color")]
-    pub fn with_brush(mut self, brush: impl Into<Brush>) -> Self {
-        self.brush = brush.into();
-        self
-    }
-
-    /// Set the brush which will be used to paint this label whilst it is disabled.
-    ///
-    /// If this is `None`, the [normal brush](Self::with_brush) will be used.
-    /// To modify this on an active label, use [`set_disabled_brush`](Self::set_disabled_brush).
-    #[doc(alias = "with_color")]
-    pub fn with_disabled_brush(mut self, disabled_brush: impl Into<Option<Brush>>) -> Self {
-        self.disabled_brush = disabled_brush.into();
         self
     }
 
@@ -215,7 +183,7 @@ impl Label {
     /// The runtime equivalent of [`with_style`](Self::with_style).
     ///
     /// Setting [`StyleProperty::Brush`](parley::StyleProperty::Brush) is not supported.
-    /// Use [`set_brush`](Self::set_brush) instead.
+    /// Use [`TextColor`] and [`DisabledTextColor`] properties instead.
     pub fn insert_style(
         this: &mut WidgetMut<'_, Self>,
         property: impl Into<StyleProperty>,
@@ -284,28 +252,6 @@ impl Label {
         this.ctx.request_layout();
     }
 
-    #[doc(alias = "set_color")]
-    /// The runtime equivalent of [`with_brush`](Self::with_brush).
-    pub fn set_brush(this: &mut WidgetMut<'_, Self>, brush: impl Into<Brush>) {
-        let brush = brush.into();
-        this.widget.brush = brush;
-
-        // We need to repaint unless the disabled brush is currently being used.
-        if this.widget.disabled_brush.is_none() || this.ctx.is_disabled() {
-            this.ctx.request_paint_only();
-        }
-    }
-
-    /// The runtime equivalent of [`with_disabled_brush`](Self::with_disabled_brush).
-    pub fn set_disabled_brush(this: &mut WidgetMut<'_, Self>, brush: impl Into<Option<Brush>>) {
-        let brush = brush.into();
-        this.widget.disabled_brush = brush;
-
-        if this.ctx.is_disabled() {
-            this.ctx.request_paint_only();
-        }
-    }
-
     /// The runtime equivalent of [`with_hint`](Self::with_hint).
     pub fn set_hint(this: &mut WidgetMut<'_, Self>, hint: bool) {
         this.widget.hint = hint;
@@ -321,12 +267,15 @@ impl Widget for Label {
 
     fn register_children(&mut self, _ctx: &mut RegisterCtx<'_>) {}
 
+    fn property_changed(&mut self, ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
+        TextColor::prop_changed(ctx, property_type);
+        DisabledTextColor::prop_changed(ctx, property_type);
+    }
+
     fn update(&mut self, ctx: &mut UpdateCtx<'_>, _props: &mut PropertiesMut<'_>, event: &Update) {
         match event {
             Update::DisabledChanged(_) => {
-                if self.disabled_brush.is_some() {
-                    ctx.request_paint_only();
-                }
+                ctx.request_paint_only();
             }
             _ => {}
         }
@@ -408,21 +357,26 @@ impl Widget for Label {
         bc.constrain(label_size)
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, scene: &mut Scene) {
+    fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
         if self.line_break_mode == LineBreaking::Clip {
             let clip_rect = ctx.size().to_rect();
             scene.push_layer(BlendMode::default(), 1., Affine::IDENTITY, &clip_rect);
         }
         let transform = Affine::translate((LABEL_X_PADDING, 0.));
 
-        let brush = if ctx.is_disabled() {
-            self.disabled_brush
-                .clone()
-                .unwrap_or_else(|| self.brush.clone())
+        let text_color = if ctx.is_disabled() {
+            &props.get::<DisabledTextColor>().0
         } else {
-            self.brush.clone()
+            props.get::<TextColor>()
         };
-        render_text(scene, transform, &self.text_layout, &[brush], self.hint);
+
+        render_text(
+            scene,
+            transform,
+            &self.text_layout,
+            &[text_color.color.into()],
+            self.hint,
+        );
 
         if self.line_break_mode == LineBreaking::Clip {
             scene.pop_layer();
@@ -467,6 +421,8 @@ impl Widget for Label {
 #[cfg(test)]
 mod tests {
 
+    use masonry_core::core::Properties;
+    use masonry_testing::TestWidgetExt as _;
     use parley::style::GenericFamily;
     use parley::{FontFamily, StyleProperty};
 
@@ -488,12 +444,12 @@ mod tests {
 
     #[test]
     fn styled_label() {
-        let label = Label::new("The quick brown fox jumps over the lazy dog")
-            .with_brush(ACCENT_COLOR)
+        let label =  Label::new("The quick brown fox jumps over the lazy dog")
             .with_style(FontFamily::Generic(GenericFamily::Monospace))
             .with_style(StyleProperty::FontSize(20.0))
             .with_line_break_mode(LineBreaking::WordWrap)
-            .with_text_alignment(TextAlign::Center);
+            .with_text_alignment(TextAlign::Center)
+            .with_props(Properties::new().with(TextColor::new(ACCENT_COLOR)));
 
         let mut harness =
             TestHarness::create_with_size(default_property_set(), label, Size::new(200.0, 200.0));
@@ -529,32 +485,32 @@ mod tests {
     /// A wrapping label's text alignment should be respected, regardless of
     /// its parent's text alignment.
     fn label_text_alignment_flex() {
-        fn base_label() -> Label {
-            Label::new("Hello")
-                .with_style(StyleProperty::FontSize(20.0))
-                .with_line_break_mode(LineBreaking::WordWrap)
-        }
-        let label1 = base_label().with_text_alignment(TextAlign::Start);
-        let label2 = base_label().with_text_alignment(TextAlign::Center);
-        let label3 = base_label().with_text_alignment(TextAlign::End);
-        let label4 = base_label().with_text_alignment(TextAlign::Start);
-        let label5 = base_label().with_text_alignment(TextAlign::Center);
-        let label6 = base_label().with_text_alignment(TextAlign::End);
-        let flex = Flex::column()
-            .with_flex_child(label1, CrossAxisAlignment::Start)
-            .with_flex_child(label2, CrossAxisAlignment::Start)
-            .with_flex_child(label3, CrossAxisAlignment::Start)
-            // Text alignment start is "overwritten" by CrossAxisAlignment::Center.
-            .with_flex_child(label4, CrossAxisAlignment::Center)
-            .with_flex_child(label5, CrossAxisAlignment::Center)
-            .with_flex_child(label6, CrossAxisAlignment::Center)
-            .gap(0.0);
-
-        let mut harness =
-            TestHarness::create_with_size(default_property_set(), flex, Size::new(200.0, 200.0));
-
-        assert_render_snapshot!(harness, "label_label_alignment_flex");
+    fn base_label() -> Label {
+        Label::new("Hello")
+            .with_style(StyleProperty::FontSize(20.0))
+            .with_line_break_mode(LineBreaking::WordWrap)
     }
+    let label1 = base_label().with_text_alignment(TextAlign::Start);
+    let label2 = base_label().with_text_alignment(TextAlign::Center);
+    let label3 = base_label().with_text_alignment(TextAlign::End);
+    let label4 = base_label().with_text_alignment(TextAlign::Start);
+    let label5 = base_label().with_text_alignment(TextAlign::Center);
+    let label6 = base_label().with_text_alignment(TextAlign::End);
+    let flex = Flex::column()
+        .with_flex_child(label1, CrossAxisAlignment::Start)
+        .with_flex_child(label2, CrossAxisAlignment::Start)
+        .with_flex_child(label3, CrossAxisAlignment::Start)
+        // Text alignment start is "overwritten" by CrossAxisAlignment::Center.
+        .with_flex_child(label4, CrossAxisAlignment::Center)
+        .with_flex_child(label5, CrossAxisAlignment::Center)
+        .with_flex_child(label6, CrossAxisAlignment::Center)
+        .gap(0.0);
+
+    let mut harness =
+        TestHarness::create_with_size(default_property_set(), flex, Size::new(200.0, 200.0));
+
+    assert_render_snapshot!(harness, "label_label_alignment_flex");
+}
 
     #[test]
     fn line_break_modes() {
@@ -594,12 +550,12 @@ mod tests {
     #[test]
     fn edit_label() {
         let image_1 = {
-            let label = Label::new("The quick brown fox jumps over the lazy dog")
-                .with_brush(ACCENT_COLOR)
+            let label =  Label::new("The quick brown fox jumps over the lazy dog")
                 .with_style(FontFamily::Generic(GenericFamily::Monospace))
                 .with_style(StyleProperty::FontSize(20.0))
                 .with_line_break_mode(LineBreaking::WordWrap)
-                .with_text_alignment(TextAlign::Center);
+                .with_text_alignment(TextAlign::Center)
+                .with_props(Properties::new().with(TextColor::new(ACCENT_COLOR)));
 
             let mut harness =
                 TestHarness::create_with_size(default_property_set(), label, Size::new(50.0, 50.0));
@@ -608,17 +564,15 @@ mod tests {
         };
 
         let image_2 = {
-            let label = Label::new("Hello world")
-                .with_brush(ACCENT_COLOR)
-                .with_style(StyleProperty::FontSize(40.0));
+            let label = Label::new("Hello world").with_style(StyleProperty::FontSize(40.0));
 
             let mut harness =
                 TestHarness::create_with_size(default_property_set(), label, Size::new(50.0, 50.0));
 
             harness.edit_root_widget(|mut label| {
                 let mut label = label.downcast::<Label>();
+                label.insert_prop(TextColor::new(ACCENT_COLOR));
                 Label::set_text(&mut label, "The quick brown fox jumps over the lazy dog");
-                Label::set_brush(&mut label, ACCENT_COLOR);
                 Label::insert_style(&mut label, FontFamily::Generic(GenericFamily::Monospace));
                 Label::insert_style(&mut label, StyleProperty::FontSize(20.0));
                 Label::set_line_break_mode(&mut label, LineBreaking::WordWrap);

--- a/xilem/examples/calc.rs
+++ b/xilem/examples/calc.rs
@@ -219,7 +219,7 @@ fn app_logic(data: &mut Calculator) -> impl WidgetView<Calculator> + use<> {
             .grid_item(GridParams::new(0, 0, 4, 1)),
             // Top row
             expanded_button(
-                label("CE").brush(if data.get_current_number().is_empty() {
+                label("CE").text_color(if data.get_current_number().is_empty() {
                     palette::css::MEDIUM_VIOLET_RED
                 } else {
                     palette::css::WHITE

--- a/xilem/examples/emoji_picker.rs
+++ b/xilem/examples/emoji_picker.rs
@@ -63,15 +63,17 @@ fn picker(data: &mut EmojiPagination) -> impl WidgetView<EmojiPagination> + use<
                     },
                 ))
                 .expand_width(),
-                sized_box(prose(emoji.name).text_alignment(TextAlign::Center).brush(
-                    if data.last_selected.is_some_and(|it| it == idx) {
-                        // TODO: Ensure this selection indicator color is accessible
-                        // TODO: Expose selected state to accessibility tree
-                        palette::css::BLUE
-                    } else {
-                        Color::WHITE
-                    },
-                ))
+                sized_box(
+                    prose(emoji.name)
+                        .text_alignment(TextAlign::Center)
+                        .text_color(if data.last_selected.is_some_and(|it| it == idx) {
+                            // TODO: Ensure this selection indicator color is accessible
+                            // TODO: Expose selected state to accessibility tree
+                            palette::css::BLUE
+                        } else {
+                            Color::WHITE
+                        }),
+                )
                 .expand_width(),
             ))
             .must_fill_major_axis(true);

--- a/xilem/examples/http_cats.rs
+++ b/xilem/examples/http_cats.rs
@@ -72,7 +72,7 @@ impl HttpCats {
                         "Status code {selected_code} selected, but this was not found."
                     ))
                     .text_alignment(TextAlign::Center)
-                    .brush(palette::css::YELLOW),
+                    .text_color(palette::css::YELLOW),
                 )
             }
         } else {

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -87,7 +87,7 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> + use<> {
             flex((
                 env_using(),
                 flex_row((
-                    label("Label").brush(palette::css::REBECCA_PURPLE),
+                    label("Label").text_color(palette::css::REBECCA_PURPLE),
                     label("Bold Label").weight(FontWeight::BOLD),
                     // TODO masonry doesn't allow setting disabled manually anymore?
                     // label("Disabled label").disabled(),

--- a/xilem/examples/transforms.rs
+++ b/xilem/examples/transforms.rs
@@ -25,7 +25,7 @@ impl TransformsGame {
 
         let status = if everything_correct {
             label("Great success!")
-                .brush(Color::new([0.0, 0.0, 1.0, 1.0]))
+                .text_color(Color::new([0.0, 0.0, 1.0, 1.0]))
                 .text_size(30.0)
         } else {
             let rotation_mark = if rotation_correct { "✓" } else { "⨯" };

--- a/xilem/examples/variable_clock.rs
+++ b/xilem/examples/variable_clock.rs
@@ -121,7 +121,7 @@ impl TimeZone {
             flex_row((
                 inline_prose(self.region),
                 FlexSpacer::Flex(1.),
-                label(format!("UTC{}", self.offset)).brush(
+                label(format!("UTC{}", self.offset)).text_color(
                     if data.local_offset.is_ok_and(|it| it == self.offset) {
                         // TODO: Consider accessibility here.
                         palette::css::ORANGE

--- a/xilem/examples/variable_clock.rs
+++ b/xilem/examples/variable_clock.rs
@@ -79,7 +79,7 @@ fn local_time(data: &mut Clocks) -> impl WidgetView<Clocks> + use<> {
         (
             Some(
                 prose("Could not determine local UTC offset, using UTC")
-                    .brush(palette::css::ORANGE_RED),
+                    .text_color(palette::css::ORANGE_RED),
             ),
             UtcOffset::UTC,
         )

--- a/xilem/src/style.rs
+++ b/xilem/src/style.rs
@@ -4,6 +4,7 @@
 //! Traits used to set custom styles on views.
 
 use masonry::core::Property;
+use masonry::properties::{DisabledTextColor, TextColor};
 use vello::peniko::Color;
 
 pub use masonry::properties::types::{Gradient, GradientShape};
@@ -31,6 +32,24 @@ pub trait Style: Sized {
 
     /// Return a mutable reference to the element's property storage.
     fn properties(&mut self) -> &mut Self::Props;
+
+    /// Set the element's text color.
+    fn text_color(mut self, color: Color) -> Self
+    where
+        Self: HasProperty<TextColor>,
+    {
+        *self.property() = Some(TextColor { color });
+        self
+    }
+
+    /// Set the element's text color.
+    fn disabled_text_color(mut self, color: Color) -> Self
+    where
+        Self: HasProperty<DisabledTextColor>,
+    {
+        *self.property() = Some(DisabledTextColor(TextColor { color }));
+        self
+    }
 
     /// Set the element's background to a color/gradient.
     fn background(mut self, background: Background) -> Self

--- a/xilem/src/style.rs
+++ b/xilem/src/style.rs
@@ -42,7 +42,7 @@ pub trait Style: Sized {
         self
     }
 
-    /// Set the element's text color.
+    /// Set the element's text color when disabled.
     fn disabled_text_color(mut self, color: Color) -> Self
     where
         Self: HasProperty<DisabledTextColor>,

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -22,7 +22,7 @@ use crate::{MessageResult, Pod, PropertyTuple as _, TextAlign, View, ViewCtx, Vi
 /// use masonry::parley::fontique;
 ///
 /// label("Text example.")
-///     .brush(palette::css::RED)
+///     .text_color(palette::css::RED)
 ///     .text_alignment(TextAlign::Middle)
 ///     .text_size(24.0)
 ///     .weight(FontWeight::BOLD)

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -3,13 +3,14 @@
 
 use masonry::core::{ArcStr, StyleProperty};
 use masonry::parley::style::{FontStack, FontWeight};
+use masonry::properties::{DisabledTextColor, TextColor};
 use masonry::widgets::{
     LineBreaking, {self},
 };
-use vello::peniko::Brush;
 
 use crate::core::{DynMessage, Mut, ViewMarker};
-use crate::{Color, MessageResult, Pod, TextAlign, View, ViewCtx, ViewId};
+use crate::style::Style;
+use crate::{MessageResult, Pod, PropertyTuple as _, TextAlign, View, ViewCtx, ViewId};
 
 /// A non-interactive text element.
 /// # Example
@@ -30,12 +31,12 @@ use crate::{Color, MessageResult, Pod, TextAlign, View, ViewCtx, ViewId};
 pub fn label(label: impl Into<ArcStr>) -> Label {
     Label {
         label: label.into(),
-        text_brush: Color::WHITE.into(),
         text_alignment: TextAlign::default(),
         text_size: masonry::theme::TEXT_SIZE_NORMAL,
         weight: FontWeight::NORMAL,
         font: FontStack::List(std::borrow::Cow::Borrowed(&[])),
         line_break_mode: LineBreaking::Overflow,
+        properties: Default::default(),
     }
 }
 
@@ -45,22 +46,15 @@ pub fn label(label: impl Into<ArcStr>) -> Label {
 #[must_use = "View values do nothing unless provided to Xilem."]
 pub struct Label {
     label: ArcStr,
-    text_brush: Brush,
     text_alignment: TextAlign,
     text_size: f32,
     weight: FontWeight,
     font: FontStack<'static>,
     line_break_mode: LineBreaking, // TODO: add more attributes of `masonry::widgets::Label`
+    properties: LabelProps,
 }
 
 impl Label {
-    /// In most cases brush sets text color, but gradients and images are also supported.
-    #[doc(alias = "color")]
-    pub fn brush(mut self, brush: impl Into<Brush>) -> Self {
-        self.text_brush = brush.into();
-        self
-    }
-
     /// Sets text alignment: `Start`, `Middle`, `End` or `Justified`.
     pub fn text_alignment(mut self, text_alignment: TextAlign) -> Self {
         self.text_alignment = text_alignment;
@@ -105,22 +99,38 @@ where
     }
 }
 
+impl Style for Label {
+    type Props = LabelProps;
+
+    fn properties(&mut self) -> &mut Self::Props {
+        &mut self.properties
+    }
+}
+
+crate::declare_property_tuple!(
+    LabelProps;
+    Label;
+
+    TextColor, 0;
+    DisabledTextColor, 1;
+);
+
 impl ViewMarker for Label {}
 impl<State, Action> View<State, Action, ViewCtx> for Label {
     type Element = Pod<widgets::Label>;
     type ViewState = ();
 
     fn build(&self, ctx: &mut ViewCtx, _: &mut State) -> (Self::Element, Self::ViewState) {
-        let widget_pod = ctx.create_pod(
+        let mut pod = ctx.create_pod(
             widgets::Label::new(self.label.clone())
-                .with_brush(self.text_brush.clone())
                 .with_text_alignment(self.text_alignment)
                 .with_style(StyleProperty::FontSize(self.text_size))
                 .with_style(StyleProperty::FontWeight(self.weight))
                 .with_style(StyleProperty::FontStack(self.font.clone()))
                 .with_line_break_mode(self.line_break_mode),
         );
-        (widget_pod, ())
+        pod.properties = self.properties.build_properties();
+        (pod, ())
     }
 
     fn rebuild(
@@ -131,11 +141,10 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
         mut element: Mut<'_, Self::Element>,
         _: &mut State,
     ) {
+        self.properties
+            .rebuild_properties(&prev.properties, &mut element);
         if prev.label != self.label {
             widgets::Label::set_text(&mut element, self.label.clone());
-        }
-        if prev.text_brush != self.text_brush {
-            widgets::Label::set_brush(&mut element, self.text_brush.clone());
         }
         if prev.text_alignment != self.text_alignment {
             widgets::Label::set_text_alignment(&mut element, self.text_alignment);

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -36,7 +36,7 @@ pub fn label(label: impl Into<ArcStr>) -> Label {
         weight: FontWeight::NORMAL,
         font: FontStack::List(std::borrow::Cow::Borrowed(&[])),
         line_break_mode: LineBreaking::Overflow,
-        properties: Default::default(),
+        properties: LabelProps::default(),
     }
 }
 

--- a/xilem/src/view/prose.rs
+++ b/xilem/src/view/prose.rs
@@ -1,28 +1,26 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::core::{ArcStr, StyleProperty, WidgetPod};
+use masonry::core::{ArcStr, Properties, StyleProperty, WidgetPod};
 use masonry::parley::FontWeight;
 use masonry::properties::{DisabledTextColor, TextColor};
 use masonry::widgets::{
     LineBreaking, {self},
 };
-use vello::peniko::Brush;
 
 use crate::core::{DynMessage, Mut, ViewMarker};
-use crate::style::Style;
-use crate::{Color, MessageResult, Pod, PropertyTuple as _, TextAlign, View, ViewCtx, ViewId};
+use crate::{Color, MessageResult, Pod, TextAlign, View, ViewCtx, ViewId};
 
 /// A view which displays selectable text.
 pub fn prose(content: impl Into<ArcStr>) -> Prose {
     Prose {
         content: content.into(),
-        text_brush: Color::WHITE.into(),
+        text_color: None,
+        disabled_text_color: None,
         text_alignment: TextAlign::default(),
         text_size: masonry::theme::TEXT_SIZE_NORMAL,
         line_break_mode: LineBreaking::WordWrap,
         weight: FontWeight::NORMAL,
-        properties: Default::default(),
     }
 }
 
@@ -41,21 +39,30 @@ pub fn inline_prose(content: impl Into<ArcStr>) -> Prose {
 pub struct Prose {
     content: ArcStr,
 
-    text_brush: Brush,
+    text_color: Option<Color>,
+    disabled_text_color: Option<Color>,
     text_alignment: TextAlign,
     text_size: f32,
     line_break_mode: LineBreaking,
     weight: FontWeight,
-    properties: ProseProps,
     // TODO: disabled: bool,
     // TODO: add more attributes of `masonry::widgets::Prose`
 }
 
 impl Prose {
-    /// Set the brush used to paint the text.
-    #[doc(alias = "color")]
-    pub fn brush(mut self, brush: impl Into<Brush>) -> Self {
-        self.text_brush = brush.into();
+    /// Set the text's color.
+    ///
+    /// This overwrites the default `TextColor` property for the inner `TextArea` widget.
+    pub fn text_color(mut self, color: Color) -> Self {
+        self.text_color = Some(color);
+        self
+    }
+
+    /// Set the text's color when the text input is disabled.
+    ///
+    /// This overwrites the default `DisabledTextColor` property for the inner `TextArea` widget.
+    pub fn disabled_text_color(mut self, color: Color) -> Self {
+        self.disabled_text_color = Some(color);
         self
     }
 
@@ -89,22 +96,6 @@ fn line_break_clips(linebreaking: LineBreaking) -> bool {
     matches!(linebreaking, LineBreaking::Clip | LineBreaking::WordWrap)
 }
 
-impl Style for Prose {
-    type Props = ProseProps;
-
-    fn properties(&mut self) -> &mut Self::Props {
-        &mut self.properties
-    }
-}
-
-crate::declare_property_tuple!(
-    ProseProps;
-    Prose;
-
-    TextColor, 0;
-    DisabledTextColor, 1;
-);
-
 impl ViewMarker for Prose {}
 impl<State, Action> View<State, Action, ViewCtx> for Prose {
     type Element = Pod<widgets::Prose>;
@@ -117,8 +108,16 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
             .with_style(StyleProperty::FontWeight(self.weight))
             .with_word_wrap(self.line_break_mode == LineBreaking::WordWrap);
 
-        // TODO - Handle more elegantly
-        let text_area = WidgetPod::new_with_props(text_area, self.properties.build_properties());
+        // TODO - Replace this with properties on the Prose view
+        // once we implement property inheritance or something like it.
+        let mut props = Properties::new();
+        if let Some(color) = self.text_color {
+            props.insert(TextColor { color });
+        }
+        if let Some(color) = self.disabled_text_color {
+            props.insert(DisabledTextColor(TextColor { color }));
+        }
+        let text_area = WidgetPod::new_with_props(text_area, props);
 
         let pod = ctx.create_pod(
             widgets::Prose::from_text_area_pod(text_area)
@@ -136,8 +135,23 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
         _: &mut State,
     ) {
         let mut text_area = widgets::Prose::text_mut(&mut element);
-        self.properties
-            .rebuild_properties(&prev.properties, &mut text_area);
+
+        // TODO - Replace this with properties on the Prose view
+        if self.text_color != prev.text_color {
+            if let Some(color) = self.text_color {
+                text_area.insert_prop(TextColor { color });
+            } else {
+                text_area.remove_prop::<TextColor>();
+            }
+        }
+        if self.disabled_text_color != prev.disabled_text_color {
+            if let Some(color) = self.disabled_text_color {
+                text_area.insert_prop(DisabledTextColor(TextColor { color }));
+            } else {
+                text_area.remove_prop::<DisabledTextColor>();
+            }
+        }
+
         if prev.content != self.content {
             widgets::TextArea::reset_text(&mut text_area, &self.content);
         }

--- a/xilem/src/view/text_input.rs
+++ b/xilem/src/view/text_input.rs
@@ -8,12 +8,12 @@ use masonry::properties::{
 };
 use masonry::widgets;
 use vello::kurbo::Affine;
-use vello::peniko::Brush;
+use vello::peniko::Color;
 
 use crate::core::{DynMessage, Mut, View, ViewMarker};
 use crate::property_tuple::PropertyTuple;
 use crate::style::Style;
-use crate::{Color, InsertNewline, MessageResult, Pod, TextAlign, ViewCtx, ViewId};
+use crate::{InsertNewline, MessageResult, Pod, TextAlign, ViewCtx, ViewId};
 
 // FIXME - A major problem of the current approach (always setting the text_input contents)
 // is that if the user forgets to hook up the modify the state's contents in the callback,
@@ -31,7 +31,8 @@ where
         contents,
         on_changed: Box::new(on_changed),
         on_enter: None,
-        text_brush: Color::WHITE.into(),
+        text_color: None,
+        disabled_text_color: None,
         text_alignment: TextAlign::default(),
         insert_newline: InsertNewline::default(),
         disabled: false,
@@ -45,7 +46,8 @@ pub struct TextInput<State, Action> {
     contents: String,
     on_changed: Callback<State, Action>,
     on_enter: Option<Callback<State, Action>>,
-    text_brush: Brush,
+    text_color: Option<Color>,
+    disabled_text_color: Option<Color>,
     text_alignment: TextAlign,
     insert_newline: InsertNewline,
     disabled: bool,
@@ -54,10 +56,19 @@ pub struct TextInput<State, Action> {
 }
 
 impl<State, Action> TextInput<State, Action> {
-    /// Set the brush used to paint the text.
-    #[doc(alias = "color")]
-    pub fn brush(mut self, color: impl Into<Brush>) -> Self {
-        self.text_brush = color.into();
+    /// Set the text's color.
+    ///
+    /// This overwrites the default `TextColor` property for the inner `TextArea` widget.
+    pub fn text_color(mut self, color: Color) -> Self {
+        self.text_color = Some(color);
+        self
+    }
+
+    /// Set the text's color when the text input is disabled.
+    ///
+    /// This overwrites the default `DisabledTextColor` property for the inner `TextArea` widget.
+    pub fn disabled_text_color(mut self, color: Color) -> Self {
+        self.disabled_text_color = Some(color);
         self
     }
 
@@ -108,9 +119,6 @@ crate::declare_property_tuple!(
     BoxShadow, 4;
     CornerRadius, 5;
     Padding, 6;
-
-    TextColor, 7;
-    DisabledTextColor, 8;
 );
 
 impl<State, Action> ViewMarker for TextInput<State, Action> {}
@@ -124,13 +132,14 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for TextInput
             .with_text_alignment(self.text_alignment)
             .with_insert_newline(self.insert_newline);
 
-        // TODO - Handle more elegantly
+        // TODO - Replace this with properties on the TextInput view
+        // once we implement property inheritance or something like it.
         let mut props = Properties::new();
-        if let Some(prop) = self.properties.7 {
-            props.insert::<TextColor>(prop);
+        if let Some(color) = self.text_color {
+            props.insert(TextColor { color });
         }
-        if let Some(prop) = self.properties.8 {
-            props.insert::<DisabledTextColor>(prop);
+        if let Some(color) = self.disabled_text_color {
+            props.insert(DisabledTextColor(TextColor { color }));
         }
 
         let text_input = widgets::TextInput::from_text_area_pod(WidgetPod::new_with(
@@ -162,17 +171,17 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for TextInput
         self.properties
             .rebuild_properties(&prev.properties, &mut element);
 
-        // TODO - Handle more elegantly
-        if self.properties.7 != prev.properties.7 {
-            if let Some(prop) = self.properties.7 {
-                element.insert_prop::<TextColor>(prop);
+        // TODO - Replace this with properties on the TextInput view
+        if self.text_color != prev.text_color {
+            if let Some(color) = self.text_color {
+                element.insert_prop(TextColor { color });
             } else {
                 element.remove_prop::<TextColor>();
             }
         }
-        if self.properties.8 != prev.properties.8 {
-            if let Some(prop) = self.properties.8 {
-                element.insert_prop::<DisabledTextColor>(prop);
+        if self.disabled_text_color != prev.disabled_text_color {
+            if let Some(color) = self.disabled_text_color {
+                element.insert_prop(DisabledTextColor(TextColor { color }));
             } else {
                 element.remove_prop::<DisabledTextColor>();
             }

--- a/xilem/src/view/variable_label.rs
+++ b/xilem/src/view/variable_label.rs
@@ -4,11 +4,12 @@
 use masonry::core::ArcStr;
 use masonry::parley::style::{FontStack, FontWeight};
 use masonry::widgets;
-use vello::peniko::Brush;
+use vello::peniko::Color;
 use xilem_core::ViewPathTracker;
 
 use super::{Label, label};
 use crate::core::{DynMessage, Mut, ViewMarker};
+use crate::style::Style as _;
 use crate::{MessageResult, Pod, TextAlign, View, ViewCtx, ViewId};
 
 /// A view for displaying non-editable text, with a variable [weight](masonry::parley::style::FontWeight).
@@ -63,10 +64,10 @@ impl VariableLabel {
         self
     }
 
-    /// Set the brush used to paint the text.
-    #[doc(alias = "color")]
-    pub fn brush(mut self, brush: impl Into<Brush>) -> Self {
-        self.label = self.label.brush(brush);
+    /// Set the color used to paint the text.
+    pub fn color(mut self, color: Color) -> Self {
+        // TODO - Rewrite more elegantly
+        self.label = self.label.text_color(color);
         self
     }
 

--- a/xilem/src/view/variable_label.rs
+++ b/xilem/src/view/variable_label.rs
@@ -66,7 +66,8 @@ impl VariableLabel {
 
     /// Set the color used to paint the text.
     pub fn color(mut self, color: Color) -> Self {
-        // TODO - Rewrite more elegantly
+        // TODO - Replace this with properties on the VariableLabel view
+        // once we implement property inheritance or something like it.
         self.label = self.label.text_color(color);
         self
     }


### PR DESCRIPTION
Add these properties to Label and TextArea.
Remove with_brush/set_brush methods.
Add TextColor and DisabledTextColor properties to Label view in Xilem.
Replace `.brush()` methods in TextEdit, Prose and VariableLabel views with `.text_color()` and `.disabled_text_color()` methods which set these properties.

Making TextColor and DisabledTextColor properties also means they can now be changed app-wide with DefaultProperties.