### PR TITLE
Remove detail sections of MSRV notices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,18 +166,6 @@ This version of Xilem has been verified to compile with **Rust 1.88** and later.
 Future versions of Xilem might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
 
-<details>
-<summary>Click here if compiling fails.</summary>
-
-As time has passed, some of Xilem's dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
-
-```sh
-# Use the problematic dependency's name and version
-cargo update -p package_name --precise 0.1.1
-```
-</details>
-
 ## Community
 
 Discussion of Xilem development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#xilem channel](https://xi.zulipchat.com/#narrow/stream/354396-xilem).

--- a/masonry/README.md
+++ b/masonry/README.md
@@ -38,18 +38,6 @@ This version of Masonry has been verified to compile with **Rust 1.88** and late
 Future versions of Masonry might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
 
-<details>
-<summary>Click here if compiling fails.</summary>
-
-As time has passed, some of Masonry's dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
-
-```sh
-# Use the problematic dependency's name and version
-cargo update -p package_name --precise 0.1.1
-```
-</details>
-
 ## Community
 
 Discussion of Masonry development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#masonry channel](https://xi.zulipchat.com/#narrow/stream/317477-masonry).

--- a/masonry_winit/README.md
+++ b/masonry_winit/README.md
@@ -145,18 +145,6 @@ This version of Masonry Winit has been verified to compile with **Rust 1.88** an
 Future versions of Masonry Winit might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
 
-<details>
-<summary>Click here if compiling fails.</summary>
-
-As time has passed, some of Masonry Winit's dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
-
-```sh
-# Use the problematic dependency's name and version
-cargo update -p package_name --precise 0.1.1
-```
-</details>
-
 ## Community
 
 Discussion of Masonry Winit development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#masonry channel](https://xi.zulipchat.com/#narrow/stream/317477-masonry).

--- a/placehero/README.md
+++ b/placehero/README.md
@@ -34,19 +34,6 @@ This version of Placehero has been verified to compile with **Rust 1.88** and la
 Future versions of Placehero might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
 
-<details>
-<summary>Click here if compiling fails.</summary>
-
-As time has passed, some of Placehero's dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
-
-```sh
-# Use the problematic dependency's name and version
-cargo update -p package_name --precise 0.1.1
-```
-
-</details>
-
 ## Community
 
 Discussion of Placehero development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#xilem channel](https://xi.zulipchat.com/#narrow/stream/354396-xilem).

--- a/tree_arena/README.md
+++ b/tree_arena/README.md
@@ -97,18 +97,6 @@ This version of Tree Arena has been verified to compile with **Rust 1.88** and l
 Future versions of Tree Arena might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
 
-<details>
-<summary>Click here if compiling fails.</summary>
-
-As time has passed, some of Tree Arena's dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
-
-```sh
-# Use the problematic dependency's name and version
-cargo update -p package_name --precise 0.1.1
-```
-</details>
-
 ## Community
 
 Discussion of Tree Arena development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#masonry channel](https://xi.zulipchat.com/#narrow/stream/317477-masonry).

--- a/xilem/README.md
+++ b/xilem/README.md
@@ -156,18 +156,6 @@ This version of Xilem has been verified to compile with **Rust 1.88** and later.
 Future versions of Xilem might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
 
-<details>
-<summary>Click here if compiling fails.</summary>
-
-As time has passed, some of Xilem's dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
-
-```sh
-# Use the problematic dependency's name and version
-cargo update -p package_name --precise 0.1.1
-```
-</details>
-
 ## Community
 
 Discussion of Xilem development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#xilem channel](https://xi.zulipchat.com/#narrow/stream/354396-xilem).

--- a/xilem_core/README.md
+++ b/xilem_core/README.md
@@ -71,9 +71,6 @@ This version of Xilem Core has been verified to compile with **Rust 1.88** and l
 Future versions of Xilem Core might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
 
-<!-- We hide these elements when viewing in Rustdoc, because they're not expected to be present in crate level docs -->
-<div class="rustdoc-hidden">
-
 ## Community
 
 Discussion of Xilem Core development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#xilem channel](https://xi.zulipchat.com/#narrow/stream/354396-xilem).
@@ -85,8 +82,6 @@ The [Rust code of conduct] applies.
 ## License
 
 Licensed under the Apache License, Version 2.0 ([LICENSE] or <http://www.apache.org/licenses/LICENSE-2.0>)
-
-</div>
 
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
 

--- a/xilem_core/README.md
+++ b/xilem_core/README.md
@@ -71,19 +71,6 @@ This version of Xilem Core has been verified to compile with **Rust 1.88** and l
 Future versions of Xilem Core might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
 
-<details>
-<summary>Click here if compiling fails.</summary>
-
-As time has passed, some of Xilem Core's dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
-
-```sh
-# Use the problematic dependency's name and version
-cargo update -p package_name --precise 0.1.1
-```
-
-</details>
-
 <!-- We hide these elements when viewing in Rustdoc, because they're not expected to be present in crate level docs -->
 <div class="rustdoc-hidden">
 

--- a/xilem_web/README.md
+++ b/xilem_web/README.md
@@ -57,18 +57,6 @@ This version of Xilem Web has been verified to compile with **Rust 1.88** and la
 Future versions of Xilem Web might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.
 
-<details>
-<summary>Click here if compiling fails.</summary>
-
-As time has passed, some of Xilem Web's dependencies could have released versions with a higher Rust requirement.
-If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
-
-```sh
-# Use the problematic dependency's name and version
-cargo update -p package_name --precise 0.1.1
-```
-</details>
-
 <!-- We hide these elements when viewing in Rustdoc, because they're not expected to be present in crate level docs -->
 <div class="rustdoc-hidden">
 


### PR DESCRIPTION
See [#linebender > Should we mention MSRVs in our crate READMEs?](https://xi.zulipchat.com/#narrow/channel/419691-linebender/topic/Should.20we.20mention.20MSRVs.20in.20our.20crate.20READMEs.3F/with/523325015) for rationale.

Also removes extra `<div class="rustdoc-hidden">` tag, which isn't needed when we use `cargo rdme`.