### PR TITLE
Prevent adding nodes to focus chain when stashed

### DIFF
--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -467,7 +467,7 @@ fn update_focus_chain_for_widget(
         );
     }
 
-    if !state.item.is_disabled {
+    if !state.item.is_disabled && !state.item.is_stashed {
         parent_focus_chain.extend(&state.item.focus_chain);
     }
 


### PR DESCRIPTION
This appears to fix the issue in #1175. I'm not very familiar with the accessibility system, but from what I understand the issue was that stashed nodes were being included in the focus chain used by `update_focus`. However, when they would be focused, that was failing in some way (likely due to them being marked as hidden in the accessibility tree, again due to being stashed). This caused the `update_focus` logic to break in strange ways, including periodically failing to focus on anything when `tab` or `shift-tab` is pressed.

I checked the branch in #1179 since it looks related, but the tab selection issue persists on that branch as well.

### Testing

I did not find any regressions in the other examples during my testing, but I'm not sure how to properly test this change.