### PR TITLE
Standardize capitalization of the word "widget" in doc.

### DIFF
--- a/masonry/ARCHITECTURE.md
+++ b/masonry/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 Masonry is a framework that aims to provide the foundation for Rust GUI libraries.
 
-Developers trying to write immediate-mode GUIs, Elm-architecture GUIs, functional reactive GUIs, etc, can import Masonry and get a platform to create windows (using Winit as a backend) each with a tree of widgets. Each widget has to implement the Widget trait that Masonry provides.
+Developers trying to write immediate-mode GUIs, Elm-architecture GUIs, functional reactive GUIs, etc, can import Masonry and get a platform to create windows (using Winit as a backend) each with a tree of widgets. Each widget has to implement the `Widget` trait that Masonry provides.
 
 
 ## High-level goals
@@ -20,14 +20,14 @@ Masonry has some opinionated design goals:
 
 ### `src/core/`
 
-Most widget-related code, including the Widget trait, its context types, event types, and the WidgetRef, WidgetMut, and WidgetPod types.
+Most widget-related code, including the `Widget` trait, its context types, event types, and the `WidgetRef`, `WidgetMut`, and `WidgetPod` types.
 
 #### `src/core/widget_state.rs`
 
 Contains the WidgetState type, around which a lot of internal code is based.
 
-WidgetState is one of the most important internal types in Masonry.
-Understanding Masonry pass code will likely be easier if you read WidgetState documentation first.
+`WidgetState` is one of the most important internal types in Masonry.
+Understanding Masonry pass code will likely be easier if you read `WidgetState` documentation first.
 
 ### `src/app/`
 

--- a/masonry/src/doc/01_creating_app.md
+++ b/masonry/src/doc/01_creating_app.md
@@ -36,7 +36,7 @@ cargo add masonry_winit
 ```
 
 
-## The Widget tree
+## The widget tree
 
 Let's start with the `main()` function.
 
@@ -255,7 +255,7 @@ All the Masonry examples follow this structure:
 - A struct implementing `AppDriver` to handle user interactions.
 - A Winit window and event loop.
 
-Some examples also define custom Widgets, but you can build an interactive app with Masonry's base widget set, though it's not Masonry's intended use.
+Some examples also define custom widgets, but you can build an interactive app with Masonry's base widget set, though it's not Masonry's intended use.
 
 
 ## Higher layers

--- a/masonry/src/doc/02_implementing_widget.md
+++ b/masonry/src/doc/02_implementing_widget.md
@@ -1,4 +1,4 @@
-# Creating a new Widget
+# Creating a new widget
 
 <!-- Copyright 2024 the Xilem Authors -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
@@ -19,7 +19,7 @@ If you're building your own GUI framework on top of Masonry, or even a GUI app w
 This tutorial explains how to create a simple leaf widget.
 
 
-## The Widget trait
+## The `Widget` trait
 
 Widgets are types which implement the [`Widget`] trait:
 
@@ -371,7 +371,7 @@ impl Widget for ColorRectangle {
 Most of the methods we've listed take a `props: &mut PropertiesMut<'_>` argument.
 
 We won't cover properties in this chapter.
-See [Reading Widget Properties](crate::doc::doc_04b_widget_properties) for more info.
+See [Reading widget Properties](crate::doc::doc_04b_widget_properties) for more info.
 
 
 ## Widget mutation

--- a/masonry/src/doc/03_implementing_container_widget.md
+++ b/masonry/src/doc/03_implementing_container_widget.md
@@ -1,4 +1,4 @@
-# Creating a container Widget
+# Creating a container widget
 
 <!-- Copyright 2024 the Xilem Authors -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->

--- a/masonry/src/doc/04b_widget_properties.md
+++ b/masonry/src/doc/04b_widget_properties.md
@@ -16,7 +16,7 @@
 
 **TODO - Add screenshots - see [#501](https://github.com/linebender/xilem/issues/501)**
 
-Throughout the previous chapters, you may have noticed that most Widget methods take a `props: &PropertiesRef<'_>` or `props: &mut PropertiesMut<'_>` argument.
+Throughout the previous chapters, you may have noticed that most widget methods take a `props: &PropertiesRef<'_>` or `props: &mut PropertiesMut<'_>` argument.
 We haven't used these arguments so far, and you can build a robust widget set without them, but they're helpful for making your widgets more customizable and modular.
 
 
@@ -37,7 +37,7 @@ if let Some(ducky) = props.get::<RubberDuck>() {
 
 ### Properties are only data
 
-Properties are a way for Widgets to store arbitrary state; they do not encode *behavior*.
+Properties are a way for widgets to store arbitrary state; they do not encode *behavior*.
 For those familiar, properties are similar to the "Component" part of ECS.
 
 In other words, adding a property to a widget will not change anything about how that widget is rendered *unless that widget has code specifically reading that property*.

--- a/masonry/src/doc/mod.rs
+++ b/masonry/src/doc/mod.rs
@@ -6,8 +6,8 @@
 //! This module includes a series of articles documenting the crate:
 //!
 //! - **Building a "To-Do List" app:** Tutorial to get started with Masonry.
-//! - **Creating a new Widget:** Introduces the Widget trait.
-//! - **Creating a container Widget:** Expands on the Widget trait for container Widgets.
+//! - **Creating a new widget:** Introduces the `Widget` trait.
+//! - **Creating a container widget:** Expands on the `Widget` trait for container widgets.
 //! - **Testing widgets in Masonry:** Describes how to test your Masonry widgets in CI.
 //! - **Masonry pass system:** Deep dive into Masonry internals.
 //! - **Concepts and definitions:** Glossary of concepts used in Masonry APIs and internals.

--- a/masonry/src/properties/box_shadow.rs
+++ b/masonry/src/properties/box_shadow.rs
@@ -20,7 +20,7 @@ use crate::core::{Property, UpdateCtx};
 // a "spread radius" value. We should implement it and add a `spread_radius` value.
 // - Corner radius: Right now take our widget's corner radii, and average them to draw a shadow with a single corner radius. Ideally we'd like to match individual values.
 
-/// The drop shadow of a Widget.
+/// The drop shadow of a widget.
 ///
 /// Will be invisible if default values are kept.
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -20,7 +20,7 @@ use crate::widgets::{Axis, ScrollBar};
 // TODO - refactor - see https://github.com/linebender/xilem/issues/366
 // TODO - rename "Portal" to "ScrollPortal"?
 // TODO - Document which cases need request_layout, request_compose and request_render
-// Conceptually, a Portal is a Widget giving a restricted view of a child widget
+// Conceptually, a Portal is a widget giving a restricted view of a child widget
 // Imagine a very large widget, and a rect that represents the part of the widget we see
 #[expect(missing_docs, reason = "TODO")]
 pub struct Portal<W: Widget + ?Sized> {

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -71,7 +71,7 @@ pub struct QueryCtx<'a> {
     pub(crate) properties_children: ArenaRefList<'a, AnyMap>,
 }
 
-/// A context provided to Widget event-handling methods.
+/// A context provided to event-handling [`Widget`] methods.
 pub struct EventCtx<'a> {
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) widget_state: &'a mut WidgetState,

--- a/masonry_core/src/core/mod.rs
+++ b/masonry_core/src/core/mod.rs
@@ -43,7 +43,7 @@ pub(crate) use widget_arena::WidgetArena;
 pub(crate) use widget_pod::CreateWidget;
 pub(crate) use widget_state::WidgetState;
 
-/// Actions are emitted by Masonry Widgets when a user input needs to be handled by the application.
+/// Actions are emitted by Masonry widgets when a user input needs to be handled by the application.
 ///
 /// The concrete action type can be accessed from this type using [`downcast`](anymore::AnyDebug#method.downcast-1).
 // N.b. We would like to use a true intra-doc link here, but it's not feasible to do so to `dyn Trait` items.

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -50,7 +50,7 @@ impl WidgetId {
     }
 }
 
-/// A trait to access a `Widget` as trait object. It is implemented for all types that implement `Widget`.
+/// A trait to access a [`Widget`] value as a trait object. It is implemented for all types that implement `Widget`.
 pub trait AsDynWidget {
     fn as_box_dyn(self: Box<Self>) -> Box<dyn Widget>;
     fn as_dyn(&self) -> &dyn Widget;
@@ -424,10 +424,10 @@ pub fn find_widget_under_pointer<'c>(
     }
 }
 
-/// Marker trait for Widgets whose parents can get a raw mutable reference to them.
+/// Marker trait for widgets whose parents can get a raw mutable reference to them.
 ///
 /// "Raw mut" means using a mutable reference (eg `&mut MyWidget`) to the data
-/// structure, instead of going through the Widget trait methods
+/// structure, instead of going through the [`Widget`] trait methods
 /// (`on_text_event`, `update`, `layout`, etc) or through `WidgetMut`.
 ///
 /// A parent widget can use [`EventCtx::get_raw_mut`], [`UpdateCtx::get_raw_mut`],

--- a/masonry_core/src/core/widget_mut.rs
+++ b/masonry_core/src/core/widget_mut.rs
@@ -98,7 +98,7 @@ impl<W: Widget + ?Sized> WidgetMut<'_, W> {
         self.ctx.set_transform(transform);
     }
 
-    /// Attempt to downcast to `WidgetMut` of concrete Widget type.
+    /// Attempt to downcast to `WidgetMut` of concrete widget type.
     pub fn try_downcast<W2: Widget + FromDynWidget + ?Sized>(
         &mut self,
     ) -> Option<WidgetMut<'_, W2>> {
@@ -108,7 +108,7 @@ impl<W: Widget + ?Sized> WidgetMut<'_, W> {
         })
     }
 
-    /// Downcasts to `WidgetMut` of concrete Widget type.
+    /// Downcasts to `WidgetMut` of concrete widget type.
     ///
     /// ## Panics
     ///

--- a/masonry_core/src/core/widget_ref.rs
+++ b/masonry_core/src/core/widget_ref.rs
@@ -102,7 +102,7 @@ impl<'w, W: Widget + ?Sized> WidgetRef<'w, W> {
         self.ctx.properties.get::<T>()
     }
 
-    /// Attempt to downcast to `WidgetRef` of concrete Widget type.
+    /// Attempt to downcast to `WidgetRef` of concrete widget type.
     pub fn downcast<W2: Widget>(&self) -> Option<WidgetRef<'w, W2>> {
         Some(WidgetRef {
             ctx: self.ctx,

--- a/masonry_core/src/doc/05_pass_system.md
+++ b/masonry_core/src/doc/05_pass_system.md
@@ -65,7 +65,7 @@ To address these invalidations, Masonry runs a set of **rewrite passes** over th
 - **compose:** Assigns transforms to widgets.
 - **update_pointer:** Updates the hovered status of widgets and the current cursor icon.
 
-The layout and compose passes have methods with matching names in the Widget trait.
+The layout and compose passes have methods with matching names in the [`Widget`] trait.
 The update_xxx passes call the widgets' update method.
 
 By default, each of these passes completes without doing any work, unless pass-dependent invalidation flags are set.
@@ -175,6 +175,7 @@ They can access the layout of children if they have already been laid out.
 - [`RegisterCtx`] can't do anything except register children.
 - [`QueryCtx`] provides read-only information about the widget.
 
+[`Widget`]: crate::core::Widget
 [`LayoutCtx::place_child`]: crate::core::LayoutCtx::place_child
 [`LayoutCtx::run_layout`]: crate::core::LayoutCtx::run_layout
 [`WidgetMut`]: crate::core::WidgetMut

--- a/masonry_core/src/doc/06_masonry_concepts.md
+++ b/masonry_core/src/doc/06_masonry_concepts.md
@@ -43,7 +43,7 @@ Conversely, no other widget can get events from the pointer (outside of bubbling
 - The "hovered" status of other widgets won't be updated even if the pointer is over them.
 The hovered status of the capturing widget will be updated, meaning a widget that captured a pointer can still lose the "hovered" status.
 - The pointer's cursor icon will be updated as if the pointer stayed over the capturing widget.
-- If the widget loses pointer capture for some reason (e.g. the pointer is disconnected), the Widget will get a [`Cancel`] event.
+- If the widget loses pointer capture for some reason (e.g. the pointer is disconnected), the widget will get a [`Cancel`] event.
 
 Masonry should guarantee that pointers can only be captured by one widget at a time.
 Masonry should force the widget to lose pointer capture when some events occur; not just "mouse leave", but also `Tab` being pressed, the window losing focus, the widget being disabled, etc.

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -753,7 +753,7 @@ impl TestHarness {
 
     /// Method used by [`assert_render_snapshot`] and [`assert_failing_render_snapshot`]. Use these macros, not this method.
     ///
-    /// Renders the current Widget tree to a pixmap, and compares the pixmap against the
+    /// Renders the current widget tree to a pixmap, and compares the pixmap against the
     /// snapshot stored in `<CRATE ROOT>/screenshots/<test_name>.png`.
     ///
     /// * `manifest_dir`: directory where `Cargo.toml` can be found.

--- a/masonry_testing/src/modular_widget.rs
+++ b/masonry_testing/src/modular_widget.rs
@@ -86,7 +86,7 @@ impl<S> ModularWidget<S> {
 
 /// Builder methods.
 ///
-/// Each method takes a flag which is then returned by the matching Widget method.
+/// Each method takes a flag which is then returned by the matching [`Widget`] method.
 impl<S> ModularWidget<S> {
     /// See [`Widget::accepts_pointer_interaction`]
     pub fn accepts_pointer_interaction(mut self, flag: bool) -> Self {
@@ -109,7 +109,7 @@ impl<S> ModularWidget<S> {
 
 /// Builder methods.
 ///
-/// Each method takes a callback that matches the behavior of the matching Widget method.
+/// Each method takes a callback that matches the behavior of the matching [`Widget`] method.
 impl<S> ModularWidget<S> {
     /// See [`Widget::on_pointer_event`]
     pub fn pointer_event_fn(

--- a/masonry_testing/src/recorder_widget.rs
+++ b/masonry_testing/src/recorder_widget.rs
@@ -59,7 +59,7 @@ pub struct Recording(Rc<RefCell<VecDeque<Record>>>);
 
 /// A recording of a method call on a widget.
 ///
-/// Each member of the enum corresponds to one of the methods on `Widget`.
+/// Each member of the enum corresponds to one of the [`Widget`] trait methods.
 #[derive(Debug, Clone)]
 pub enum Record {
     /// Pointer event.

--- a/masonry_winit/examples/calc_masonry.rs
+++ b/masonry_winit/examples/calc_masonry.rs
@@ -52,7 +52,7 @@ enum CalcAction {
     Op(char),
 }
 
-/// A custom Widget which acts like a button.
+/// A custom widget which acts like a button.
 ///
 /// Emits the [`CalcAction`] action when pressed.
 struct CalcButton {

--- a/tree_arena/src/tree_arena_safe.rs
+++ b/tree_arena/src/tree_arena_safe.rs
@@ -420,7 +420,7 @@ impl<'arena, T> ArenaMutList<'arena, T> {
             .map(|child| child.arena_mut(self.parent_id, self.parents_map.parents_map))
     }
 
-    // TODO - Remove the child_id argument once creation of Widgets is figured out.
+    // TODO - Remove the child_id argument once creation of widgets is figured out.
     // Return the id instead.
     // TODO - Add #[must_use]
     /// Insert a child into the tree under the common parent of this list's items.

--- a/tree_arena/src/tree_arena_unsafe.rs
+++ b/tree_arena/src/tree_arena_unsafe.rs
@@ -546,7 +546,7 @@ impl<'arena, T> ArenaMutList<'arena, T> {
         }
     }
 
-    // TODO - Remove the child_id argument once creation of Widgets is figured out.
+    // TODO - Remove the child_id argument once creation of widgets is figured out.
     // Return the id instead.
     // TODO - Add #[must_use]
     /// Insert a child into the tree under the common parent of this list's items.

--- a/xilem/examples/widgets.rs
+++ b/xilem/examples/widgets.rs
@@ -118,7 +118,7 @@ fn run(event_loop: EventLoopBuilder) -> Result<(), EventLoopError> {
     let app = Xilem::new_simple(
         data,
         app_logic,
-        WindowOptions::new("Xilem Widgets")
+        WindowOptions::new("Xilem widgets")
             .with_min_inner_size(min_window_size)
             .with_initial_inner_size(window_size),
     );

--- a/xilem/src/pod.rs
+++ b/xilem/src/pod.rs
@@ -14,7 +14,7 @@ use crate::core::{Mut, SuperElement, ViewElement};
 /// This exists for two reasons:
 /// 1) The nearest equivalent type in Masonry, [`WidgetPod`], can't have
 ///    [Xilem Core](xilem_core) traits implemented on it due to Rust's orphan rules.
-/// 2) `WidgetPod` is also used during a Widget's lifetime to contain its children,
+/// 2) `WidgetPod` is also used during a widget's lifetime to contain its children,
 ///    and so might not actually own the underlying widget value.
 ///    When creating widgets in Xilem, layered views all want access to the - using
 ///    `WidgetPod` for this purpose would require fallible unwrapping.


### PR DESCRIPTION
Avoid capitalizing it as "Widget" unless explicitly referring to the trait.