### PR TITLE
Add ChildrenIds type alias to avoid spelling out SmallVec size.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,7 +2121,6 @@ dependencies = [
  "masonry_testing",
  "parley",
  "profiling",
- "smallvec",
  "tracing",
  "ui-events",
  "vello",

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -27,7 +27,6 @@ dpi.workspace = true
 masonry_core.workspace = true
 masonry_testing = { workspace = true, optional = true }
 parley.workspace = true
-smallvec.workspace = true
 tracing = { workspace = true, features = ["default"] }
 ui-events.workspace = true
 vello.workspace = true

--- a/masonry/src/doc/implementing_container_widget.md
+++ b/masonry/src/doc/implementing_container_widget.md
@@ -54,7 +54,7 @@ trait Widget {
     fn compose(&mut self, ctx: &mut ComposeCtx<'_>);
 
     fn register_children(&mut self, ctx: &mut RegisterCtx<'_>);
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]>;
+    fn children_ids(&self) -> ChildrenIds;
 }
 ```
 
@@ -178,7 +178,7 @@ Not doing so is a logical bug, and may also trigger debug assertions.
 impl Widget for VerticalStack {
     // ...
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
+    fn children_ids(&self) -> ChildrenIds {
         self.children.iter().map(|child| child.id()).collect()
     }
 }

--- a/masonry/src/doc/implementing_widget.md
+++ b/masonry/src/doc/implementing_widget.md
@@ -265,13 +265,12 @@ And last, we stub in some additional methods:
 use masonry::core::{
     RegisterCtx, Widget, WidgetId
 };
-use masonry::smallvec::SmallVec;
 
 impl Widget for ColorRectangle {
     // ...
 
     fn register_children(&mut self, _ctx: &mut RegisterCtx<'_>) {}
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
+    fn children_ids(&self) -> ChildrenIds {
         SmallVec::new()
     }
 }

--- a/masonry/src/doc/implementing_widget.md
+++ b/masonry/src/doc/implementing_widget.md
@@ -271,7 +271,7 @@ impl Widget for ColorRectangle {
 
     fn register_children(&mut self, _ctx: &mut RegisterCtx<'_>) {}
     fn children_ids(&self) -> ChildrenIds {
-        SmallVec::new()
+        ChildrenIds::new()
     }
 }
 ```

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -38,7 +38,6 @@ pub mod widgets;
 
 pub use accesskit;
 pub use parley::{Alignment as TextAlign, AlignmentOptions as TextAlignOptions};
-pub use smallvec;
 pub use vello::peniko::color::palette;
 pub use vello::{kurbo, peniko};
 pub use {cursor_icon, dpi, parley, vello};

--- a/masonry/src/widgets/align.rs
+++ b/masonry/src/widgets/align.rs
@@ -9,14 +9,13 @@
 // its computed size. See https://github.com/linebender/xilem/issues/378
 
 use accesskit::{Node, Role};
-use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Rect, Size};
 
 use crate::core::{
-    AccessCtx, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef, RegisterCtx,
-    Widget, WidgetId, WidgetPod,
+    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef,
+    RegisterCtx, Widget, WidgetId, WidgetPod,
 };
 use crate::properties::types::UnitPoint;
 use crate::util::include_screenshot;
@@ -151,8 +150,8 @@ impl Widget for Align {
     ) {
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        smallvec![self.child.id()]
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::from_slice(&[self.child.id()])
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -6,7 +6,6 @@
 use std::any::TypeId;
 
 use accesskit::{Node, Role};
-use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace, trace_span};
 use ui_events::pointer::PointerButton;
 use vello::Scene;
@@ -15,9 +14,9 @@ use vello::peniko::Color;
 
 use crate::core::keyboard::{Key, NamedKey};
 use crate::core::{
-    AccessCtx, AccessEvent, ArcStr, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
-    PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
-    WidgetMut, WidgetPod,
+    AccessCtx, AccessEvent, ArcStr, BoxConstraints, ChildrenIds, EventCtx, LayoutCtx, PaintCtx,
+    PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update, UpdateCtx, Widget,
+    WidgetId, WidgetMut, WidgetPod,
 };
 use crate::properties::{
     ActiveBackground, Background, BorderColor, BorderWidth, BoxShadow, CornerRadius,
@@ -295,8 +294,8 @@ impl Widget for Button {
         node.add_action(accesskit::Action::Click);
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        smallvec![self.label.id()]
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::from_slice(&[self.label.id()])
     }
 
     fn accepts_focus(&self) -> bool {

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -6,7 +6,6 @@
 use std::any::TypeId;
 
 use accesskit::{Node, Role, Toggled};
-use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace, trace_span};
 use ui_events::keyboard::Key;
 use vello::Scene;
@@ -14,9 +13,9 @@ use vello::kurbo::{Affine, BezPath, Cap, Dashes, Join, Size, Stroke};
 use vello::peniko::Color;
 
 use crate::core::{
-    AccessCtx, AccessEvent, ArcStr, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
-    PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
-    WidgetMut, WidgetPod,
+    AccessCtx, AccessEvent, ArcStr, BoxConstraints, ChildrenIds, EventCtx, LayoutCtx, PaintCtx,
+    PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update, UpdateCtx, Widget,
+    WidgetId, WidgetMut, WidgetPod,
 };
 use crate::properties::{
     ActiveBackground, Background, BorderColor, BorderWidth, CheckmarkColor, CheckmarkStrokeWidth,
@@ -313,8 +312,8 @@ impl Widget for Checkbox {
         }
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        smallvec![self.label.id()]
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::from_slice(&[self.label.id()])
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -7,15 +7,14 @@ use std::any::TypeId;
 
 use accesskit::{Node, Role};
 use masonry_core::core::RegisterCtx;
-use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::common::FloatExt;
 use vello::kurbo::{Affine, Line, Point, Rect, Size, Stroke, Vec2};
 
 use crate::core::{
-    AccessCtx, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef, UpdateCtx,
-    Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef,
+    UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use crate::util::{debug_panic, fill, include_screenshot, stroke};
@@ -1178,7 +1177,7 @@ impl Widget for Flex {
     ) {
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
+    fn children_ids(&self) -> ChildrenIds {
         self.children
             .iter()
             .filter_map(|child| child.widget())

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -5,14 +5,13 @@ use std::any::TypeId;
 
 use accesskit::{Node, Role};
 use masonry_core::core::UpdateCtx;
-use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Affine, Line, Point, Size, Stroke};
 
 use crate::core::{
-    AccessCtx, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef, RegisterCtx,
-    Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef,
+    RegisterCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use crate::util::{debug_panic, fill, include_screenshot, stroke};
@@ -380,7 +379,7 @@ impl Widget for Grid {
     ) {
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
+    fn children_ids(&self) -> ChildrenIds {
         self.children
             .iter()
             .map(|child| child.widget.id())

--- a/masonry/src/widgets/image.rs
+++ b/masonry/src/widgets/image.rs
@@ -5,15 +5,14 @@
 //! Please consider using SVG and the SVG widget as it scales much better.
 
 use accesskit::{Node, Role};
-use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Affine, Size};
 use vello::peniko::{BlendMode, Image as ImageBuf};
 
 use crate::core::{
-    AccessCtx, BoxConstraints, LayoutCtx, ObjectFit, PaintCtx, PropertiesMut, PropertiesRef,
-    RegisterCtx, Update, UpdateCtx, Widget, WidgetId, WidgetMut,
+    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, ObjectFit, PaintCtx, PropertiesMut,
+    PropertiesRef, RegisterCtx, Update, UpdateCtx, Widget, WidgetId, WidgetMut,
 };
 
 // TODO - Resolve name collision between masonry::Image and peniko::Image
@@ -139,8 +138,8 @@ impl Widget for Image {
         // TODO - Handle alt text and such.
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        SmallVec::new()
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::new()
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/masonry/src/widgets/indexed_stack.rs
+++ b/masonry/src/widgets/indexed_stack.rs
@@ -3,11 +3,10 @@
 
 use accesskit::{Node, Role};
 use masonry_core::core::WidgetMut;
-use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::kurbo::{Affine, Line, Point, Stroke};
 
-use crate::core::{AccessCtx, PropertiesRef, Widget, WidgetId, WidgetPod};
+use crate::core::{AccessCtx, ChildrenIds, PropertiesRef, Widget, WidgetId, WidgetPod};
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use crate::util::{debug_panic, fill, include_screenshot, stroke};
 
@@ -308,7 +307,7 @@ impl Widget for IndexedStack {
     ) {
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
+    fn children_ids(&self) -> ChildrenIds {
         self.children.iter().map(WidgetPod::id).collect()
     }
 

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -8,14 +8,13 @@ use std::mem::Discriminant;
 
 use accesskit::{Node, NodeId, Role};
 use parley::{Layout, LayoutAccessibility};
-use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Affine, Size};
 use vello::peniko::BlendMode;
 
 use crate::core::{
-    AccessCtx, ArcStr, BoxConstraints, BrushIndex, LayoutCtx, PaintCtx, PropertiesMut,
+    AccessCtx, ArcStr, BoxConstraints, BrushIndex, ChildrenIds, LayoutCtx, PaintCtx, PropertiesMut,
     PropertiesRef, RegisterCtx, StyleProperty, StyleSet, Update, UpdateCtx, Widget, WidgetId,
     WidgetMut, render_text,
 };
@@ -405,8 +404,8 @@ impl Widget for Label {
         );
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        SmallVec::new()
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::new()
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -5,15 +5,14 @@ use std::ops::Range;
 
 use accesskit::{Node, Role};
 use dpi::PhysicalPosition;
-use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Point, Rect, Size, Vec2};
 
 use crate::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, FromDynWidget, LayoutCtx,
-    PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, ScrollDelta, TextEvent,
-    Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ComposeCtx, EventCtx, FromDynWidget,
+    LayoutCtx, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, ScrollDelta,
+    TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::widgets::{Axis, ScrollBar};
 
@@ -500,12 +499,12 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
         node.set_clips_children();
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        smallvec![
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::from_slice(&[
             self.child.id(),
             self.scrollbar_vertical.id(),
             self.scrollbar_horizontal.id(),
-        ]
+        ])
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/masonry/src/widgets/progress_bar.rs
+++ b/masonry/src/widgets/progress_bar.rs
@@ -4,14 +4,13 @@
 //! A progress bar widget.
 
 use accesskit::{Node, Role};
-use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Point, Size};
 
 use crate::core::{
-    AccessCtx, ArcStr, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef,
-    RegisterCtx, Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, ArcStr, BoxConstraints, ChildrenIds, LayoutCtx, PaintCtx, PropertiesMut,
+    PropertiesRef, RegisterCtx, Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::theme;
 use crate::util::{fill, include_screenshot, stroke};
@@ -180,8 +179,8 @@ impl Widget for ProgressBar {
         }
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        smallvec![self.label.id()]
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::from_slice(&[self.label.id()])
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/masonry/src/widgets/prose.rs
+++ b/masonry/src/widgets/prose.rs
@@ -2,15 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use accesskit::{Node, Role};
-use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Point, Size};
 
 use crate::core::{
-    AccessCtx, AccessEvent, BoxConstraints, EventCtx, LayoutCtx, PaintCtx, PointerEvent,
-    PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
-    WidgetMut, WidgetPod,
+    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, EventCtx, LayoutCtx, PaintCtx,
+    PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update, UpdateCtx, Widget,
+    WidgetId, WidgetMut, WidgetPod,
 };
 use crate::util::include_screenshot;
 use crate::widgets::TextArea;
@@ -169,8 +168,8 @@ impl Widget for Prose {
     ) {
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        smallvec![self.text.id()]
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::from_slice(&[self.text.id()])
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -2,15 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use accesskit::{Node, Role};
-use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Point, Rect, Size};
 
 use crate::core::{
-    AccessCtx, AccessEvent, AllowRawMut, BoxConstraints, EventCtx, LayoutCtx, PaintCtx,
-    PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update, UpdateCtx, Widget,
-    WidgetId, WidgetMut,
+    AccessCtx, AccessEvent, AllowRawMut, BoxConstraints, ChildrenIds, EventCtx, LayoutCtx,
+    PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update,
+    UpdateCtx, Widget, WidgetId, WidgetMut,
 };
 use crate::theme;
 use crate::util::{fill_color, include_screenshot, stroke};
@@ -248,8 +247,8 @@ impl Widget for ScrollBar {
         // Use set_scroll_x/y_min/max?
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        SmallVec::new()
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::new()
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -7,14 +7,13 @@ use std::any::TypeId;
 
 use accesskit::{Node, Role};
 use masonry_core::util::fill;
-use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span, warn};
 use vello::Scene;
 use vello::kurbo::{Point, Size};
 
 use crate::core::{
-    AccessCtx, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef, RegisterCtx,
-    UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef,
+    RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use crate::util::{include_screenshot, stroke};
@@ -302,11 +301,11 @@ impl Widget for SizedBox {
     ) {
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
+    fn children_ids(&self) -> ChildrenIds {
         if let Some(child) = &self.child {
-            smallvec![child.id()]
+            ChildrenIds::from_slice(&[child.id()])
         } else {
-            smallvec![]
+            ChildrenIds::from_slice(&[])
         }
     }
 

--- a/masonry/src/widgets/spinner.rs
+++ b/masonry/src/widgets/spinner.rs
@@ -6,14 +6,13 @@
 use std::f64::consts::PI;
 
 use accesskit::{Node, Role};
-use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Affine, Cap, Line, Point, Size, Stroke, Vec2};
 
 use crate::core::{
-    AccessCtx, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef, RegisterCtx,
-    Update, UpdateCtx, Widget, WidgetId, WidgetMut,
+    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef,
+    RegisterCtx, Update, UpdateCtx, Widget, WidgetId, WidgetMut,
 };
 use crate::peniko::Color;
 use crate::theme;
@@ -151,8 +150,8 @@ impl Widget for Spinner {
     ) {
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        SmallVec::new()
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::new()
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -5,15 +5,14 @@
 
 use accesskit::{Node, Role};
 use cursor_icon::CursorIcon;
-use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span, warn};
 use vello::Scene;
 use vello::kurbo::{Line, Point, Rect, Size};
 
 use crate::core::{
-    AccessCtx, AccessEvent, BoxConstraints, EventCtx, FromDynWidget, LayoutCtx, PaintCtx,
-    PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId,
-    WidgetMut, WidgetPod,
+    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, EventCtx, FromDynWidget, LayoutCtx,
+    PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget,
+    WidgetId, WidgetMut, WidgetPod,
 };
 use crate::peniko::Color;
 use crate::theme;
@@ -599,8 +598,8 @@ where
     ) {
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        smallvec![self.child1.id(), self.child2.id()]
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::from_slice(&[self.child1.id(), self.child2.id()])
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/masonry/src/widgets/tests/lifecycle_disable.rs
+++ b/masonry/src/widgets/tests/lifecycle_disable.rs
@@ -6,8 +6,6 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
-use smallvec::smallvec;
-
 use crate::testing::{ModularWidget, TestHarness, TestWidgetExt as _, widget_ids};
 use crate::widgets::Flex;
 use crate::*;
@@ -98,7 +96,7 @@ fn disable_tree() {
                 ctx.place_child(child, Point::ZERO);
                 size
             })
-            .children_fn(|child| smallvec![child.id()])
+            .children_fn(|child| ChildrenIds::from_slice(&[child.id()]))
             .with_id(id)
     }
 

--- a/masonry/src/widgets/tests/lifecycle_focus.rs
+++ b/masonry/src/widgets/tests/lifecycle_focus.rs
@@ -6,8 +6,6 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
-use smallvec::smallvec;
-
 use crate::testing::{ModularWidget, TestHarness, TestWidgetExt as _, WrapperWidget, widget_ids};
 use crate::widgets::Flex;
 use crate::*;
@@ -182,7 +180,7 @@ fn resign_focus_on_disable() {
                 ctx.place_child(child, Point::ZERO);
                 layout
             })
-            .children_fn(|child| smallvec![child.id()])
+            .children_fn(|child| ChildrenIds::from_slice(&[child.id()]))
     }
 
     let [group_0, group_1, sub_group, focus_1, focus_2] = widget_ids();

--- a/masonry/src/widgets/tests/safety_rails.rs
+++ b/masonry/src/widgets/tests/safety_rails.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use smallvec::smallvec;
+use masonry_core::core::ChildrenIds;
 use vello::kurbo::{Point, Size};
 
 use crate::core::{PointerButton, Update, Widget, WidgetId, WidgetPod};
@@ -20,7 +20,7 @@ fn make_parent_widget<W: Widget>(child: W) -> ModularWidget<WidgetPod<W>> {
             ctx.place_child(child, Point::ZERO);
             size
         })
-        .children_fn(|child| smallvec![child.id()])
+        .children_fn(|child| ChildrenIds::from_slice(&[child.id()]))
 }
 
 #[cfg(false)]
@@ -259,9 +259,9 @@ fn check_forget_children_changed() {
         })
         .children_fn(|child| {
             if let Some(child) = child {
-                smallvec![child.as_dyn()]
+                ChildrenIds::from_slice(&[child.id()])
             } else {
-                smallvec![]
+                ChildrenIds::new()
             }
         });
 

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -8,7 +8,6 @@ use accesskit::{Node, NodeId, Role};
 use cursor_icon::CursorIcon;
 use parley::PlainEditor;
 use parley::editor::{Generation, SplitString};
-use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Affine, Point, Rect, Size};
@@ -16,8 +15,8 @@ use vello::peniko::Fill;
 
 use crate::core::keyboard::{Key, KeyState, NamedKey};
 use crate::core::{
-    AccessCtx, AccessEvent, BoxConstraints, BrushIndex, EventCtx, Ime, LayoutCtx, PaintCtx,
-    PointerButton, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx,
+    AccessCtx, AccessEvent, BoxConstraints, BrushIndex, ChildrenIds, EventCtx, Ime, LayoutCtx,
+    PaintCtx, PointerButton, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx,
     StyleProperty, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut, render_text,
 };
 use crate::properties::{DisabledTextColor, TextColor};
@@ -900,8 +899,8 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
         };
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        SmallVec::new()
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::new()
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/masonry/src/widgets/text_input.rs
+++ b/masonry/src/widgets/text_input.rs
@@ -4,15 +4,14 @@
 use std::any::TypeId;
 
 use accesskit::{Node, Role};
-use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Affine, Point, Rect, Size};
 use vello::peniko::Color;
 
 use crate::core::{
-    AccessCtx, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef, RegisterCtx,
-    Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef,
+    RegisterCtx, Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::properties::{
     Background, BorderColor, BorderWidth, BoxShadow, CornerRadius, DisabledBackground, Padding,
@@ -210,8 +209,8 @@ impl Widget for TextInput {
     ) {
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        smallvec![self.text.id()]
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::from_slice(&[self.text.id()])
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/masonry/src/widgets/variable_label.rs
+++ b/masonry/src/widgets/variable_label.rs
@@ -9,14 +9,14 @@ use std::cmp::Ordering;
 
 use accesskit::{Node, Role};
 use parley::style::FontWeight;
-use smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
 use vello::Scene;
 use vello::kurbo::{Point, Size};
 
 use crate::core::{
-    AccessCtx, ArcStr, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef,
-    RegisterCtx, StyleProperty, Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, ArcStr, BoxConstraints, ChildrenIds, LayoutCtx, PaintCtx, PropertiesMut,
+    PropertiesRef, RegisterCtx, StyleProperty, Update, UpdateCtx, Widget, WidgetId, WidgetMut,
+    WidgetPod,
 };
 use crate::widgets::Label;
 
@@ -246,8 +246,8 @@ impl Widget for VariableLabel {
     ) {
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        smallvec![self.label.id()]
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::from_slice(&[self.label.id()])
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -10,9 +10,9 @@ use vello::kurbo::{Point, Size, Vec2};
 
 use crate::core::keyboard::{Key, KeyState, NamedKey};
 use crate::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, FromDynWidget, LayoutCtx,
-    PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, ScrollDelta, TextEvent,
-    Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ComposeCtx, EventCtx, FromDynWidget,
+    LayoutCtx, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, ScrollDelta,
+    TextEvent, Update, UpdateCtx, Widget, WidgetMut, WidgetPod,
 };
 use crate::util::debug_panic;
 
@@ -954,12 +954,12 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for VirtualScroll<W> {
         node.add_child_action(accesskit::Action::ScrollIntoView);
     }
 
-    fn children_ids(&self) -> smallvec::SmallVec<[WidgetId; 16]> {
+    fn children_ids(&self) -> ChildrenIds {
         let mut items = self
             .items
             .iter()
             .map(|(index, pod)| (*index, pod.id()))
-            .collect::<smallvec::SmallVec<[(i64, WidgetId); 10]>>();
+            .collect::<Vec<_>>();
         items.sort_unstable_by_key(|(index, _)| *index);
         items.into_iter().map(|(_, id)| id).collect()
     }

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use accesskit::{Node, Role};
-use smallvec::SmallVec;
 use tracing::trace_span;
 use vello::Scene;
 use vello::kurbo::{Point, Size};
 
 use crate::core::{
-    AccessCtx, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef, RegisterCtx,
-    Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef,
+    RegisterCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::util::include_screenshot;
 
@@ -353,7 +352,7 @@ impl Widget for ZStack {
         }
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
+    fn children_ids(&self) -> ChildrenIds {
         self.children
             .iter()
             .map(|child| &child.widget)

--- a/masonry_core/src/core/mod.rs
+++ b/masonry_core/src/core/mod.rs
@@ -29,7 +29,7 @@ pub use object_fit::ObjectFit;
 pub use properties::{DefaultProperties, Properties, PropertiesMut, PropertiesRef, Property};
 pub use text::{ArcStr, BrushIndex, StyleProperty, StyleSet, render_text};
 pub use widget::find_widget_under_pointer;
-pub use widget::{AllowRawMut, AsDynWidget, FromDynWidget, Widget, WidgetId};
+pub use widget::{AllowRawMut, AsDynWidget, ChildrenIds, FromDynWidget, Widget, WidgetId};
 pub use widget_mut::WidgetMut;
 pub use widget_pod::WidgetPod;
 pub use widget_ref::WidgetRef;

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -103,7 +103,7 @@ impl FromDynWidget for dyn Widget {
 /// A collection of widget ids, to be returned from [`Widget::children_ids`].
 ///
 /// Internally, this uses a small vector optimisation, but you should treat it as an append-only `Vec<WidgetId>`.
-/// You can use `ChildrenIds::from_slice` with an array to make a list of children ids of known size, 
+/// You can use `ChildrenIds::from_slice` with an array to make a list of children ids of known size,
 /// or use `ChildrenIds::new` then `push` to it.
 /// This type also implements [`FromIterator<WidgetId>`](core::iter::FromIterator).
 // TODO: Consider making our own wrapper type here, to make future breaking changes easier.?

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -100,9 +100,13 @@ impl FromDynWidget for dyn Widget {
     }
 }
 
-/// Alias for the type returned by [`Widget::children_ids`].
+/// A collection of widget ids, to be returned from [`Widget::children_ids`].
 ///
-/// Essentially an optimization for `Vec<WidgetId>`.
+/// Internally, this uses a small vector optimisation, but you should treat it as an append-only `Vec<WidgetId>`.
+/// You can use `ChildrenIds::from_slice` with an array to make a list of children ids of known size, 
+/// or use `ChildrenIds::new` then `push` to it.
+/// This type also implements [`FromIterator<WidgetId>`](core::iter::FromIterator).
+// TODO: Consider making our own wrapper type here, to make future breaking changes easier.?
 pub type ChildrenIds = SmallVec<[WidgetId; 16]>;
 
 /// The trait implemented by all widgets.

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -100,6 +100,11 @@ impl FromDynWidget for dyn Widget {
     }
 }
 
+/// Alias for the type returned by [`Widget::children_ids`].
+///
+/// Essentially an optimization for `Vec<WidgetId>`.
+pub type ChildrenIds = SmallVec<[WidgetId; 16]>;
+
 /// The trait implemented by all widgets.
 ///
 /// For details on how to implement this trait, see the [tutorials](crate::doc).
@@ -281,7 +286,7 @@ pub trait Widget: AsDynWidget + Any {
     /// consistent. If children are added or removed, the parent widget should call
     /// `children_changed` on one of the Ctx parameters. Container widgets are
     /// responsible for visiting all their children during `layout` and `register_children`.
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]>;
+    fn children_ids(&self) -> ChildrenIds;
 
     /// Whether this widget gets pointer events and hovered status. True by default.
     ///

--- a/masonry_core/src/lib.rs
+++ b/masonry_core/src/lib.rs
@@ -31,7 +31,7 @@
 
 pub use anymore;
 pub use vello::{kurbo, peniko, peniko::color::palette};
-pub use {accesskit, cursor_icon, dpi, parley, smallvec, ui_events, vello};
+pub use {accesskit, cursor_icon, dpi, parley, ui_events, vello};
 
 // TODO - re-add #[doc(hidden)]
 pub mod doc;

--- a/masonry_core/src/passes/layout.rs
+++ b/masonry_core/src/passes/layout.rs
@@ -6,14 +6,14 @@
 //! Most of the logic for this pass happens in [`Widget::layout`] implementations.
 
 use dpi::LogicalSize;
-use smallvec::SmallVec;
 use tracing::{info_span, trace};
 use tree_arena::ArenaMut;
 use vello::kurbo::{Point, Rect, Size};
 
 use crate::app::{RenderRoot, RenderRootSignal, WindowSizePolicy};
 use crate::core::{
-    BoxConstraints, LayoutCtx, PropertiesMut, Widget, WidgetArenaMut, WidgetPod, WidgetState,
+    BoxConstraints, ChildrenIds, LayoutCtx, PropertiesMut, Widget, WidgetArenaMut, WidgetPod,
+    WidgetState,
 };
 use crate::debug_panic;
 use crate::passes::{enter_span_if, recurse_on_children};
@@ -52,7 +52,7 @@ pub(crate) fn run_layout_on<W: Widget + ?Sized>(
     let state = state.item;
     let properties = properties.item;
 
-    let mut children_ids = SmallVec::new();
+    let mut children_ids = ChildrenIds::new();
     if cfg!(debug_assertions) {
         children_ids = widget.children_ids();
 

--- a/masonry_testing/src/modular_widget.rs
+++ b/masonry_testing/src/modular_widget.rs
@@ -13,7 +13,6 @@ use masonry_core::core::{
 };
 use masonry_core::cursor_icon::CursorIcon;
 use masonry_core::kurbo::{Point, Size};
-use masonry_core::smallvec::SmallVec;
 use masonry_core::vello::Scene;
 
 pub(crate) type PointerEventFn<S> =
@@ -335,7 +334,7 @@ impl<S: 'static> Widget for ModularWidget<S> {
         if let Some(f) = self.children.as_ref() {
             f(&self.state)
         } else {
-            SmallVec::new()
+            ChildrenIds::new()
         }
     }
 

--- a/masonry_testing/src/recorder_widget.rs
+++ b/masonry_testing/src/recorder_widget.rs
@@ -15,13 +15,12 @@ use std::rc::Rc;
 
 use masonry_core::accesskit::{Node, Role};
 use masonry_core::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
+    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetRef,
 };
 use masonry_core::cursor_icon::CursorIcon;
 use masonry_core::kurbo::{Point, Size};
-use masonry_core::smallvec::SmallVec;
 use masonry_core::vello::Scene;
 
 // TODO - Re-enable doc test.
@@ -221,7 +220,7 @@ impl<W: Widget> Widget for Recorder<W> {
         self.child.accessibility(ctx, props, node);
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
+    fn children_ids(&self) -> ChildrenIds {
         self.child.children_ids()
     }
 

--- a/masonry_testing/src/wrapper_widget.rs
+++ b/masonry_testing/src/wrapper_widget.rs
@@ -5,12 +5,11 @@ use std::any::TypeId;
 
 use masonry_core::accesskit::{Node, Role};
 use masonry_core::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
+    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ComposeCtx, EventCtx, LayoutCtx, PaintCtx,
     PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update, UpdateCtx, Widget,
-    WidgetId, WidgetMut, WidgetPod,
+    WidgetMut, WidgetPod,
 };
 use masonry_core::kurbo::{Point, Size};
-use masonry_core::smallvec::{SmallVec, smallvec};
 use masonry_core::vello::Scene;
 
 /// A basic wrapper widget that can replace its child.
@@ -121,7 +120,7 @@ impl Widget for WrapperWidget {
     ) {
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        smallvec![self.child.id()]
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::from_slice(&[self.child.id()])
     }
 }

--- a/masonry_winit/examples/calc_masonry.rs
+++ b/masonry_winit/examples/calc_masonry.rs
@@ -15,16 +15,15 @@ use std::str::FromStr;
 
 use masonry::accesskit;
 use masonry::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ErasedAction, EventCtx, LayoutCtx, PaintCtx,
-    PointerEvent, Properties, PropertiesMut, PropertiesRef, RegisterCtx, StyleProperty, TextEvent,
-    Update, UpdateCtx, Widget, WidgetId, WidgetOptions, WidgetPod,
+    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ErasedAction, EventCtx, LayoutCtx,
+    PaintCtx, PointerEvent, Properties, PropertiesMut, PropertiesRef, RegisterCtx, StyleProperty,
+    TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetOptions, WidgetPod,
 };
 use masonry::dpi::LogicalSize;
 use masonry::kurbo::{Point, Size};
 use masonry::peniko::Color;
 use masonry::peniko::color::AlphaColor;
 use masonry::properties::{Background, BorderColor, BorderWidth, Padding};
-use masonry::smallvec::{SmallVec, smallvec};
 use masonry::theme::default_property_set;
 use masonry::vello::Scene;
 use masonry::widgets::{Align, CrossAxisAlignment, Flex, Label, SizedBox};
@@ -282,8 +281,8 @@ impl Widget for CalcButton {
         node.add_action(accesskit::Action::Click);
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        smallvec![self.inner.id()]
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::from_slice(&[self.inner.id()])
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/masonry_winit/examples/custom_widget.rs
+++ b/masonry_winit/examples/custom_widget.rs
@@ -10,15 +10,14 @@
 
 use masonry::accesskit::{Node, Role};
 use masonry::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ErasedAction, EventCtx, LayoutCtx, ObjectFit, PaintCtx,
-    PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Widget, WidgetId,
-    WidgetPod,
+    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ErasedAction, EventCtx, LayoutCtx,
+    ObjectFit, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent,
+    Widget, WidgetId, WidgetPod,
 };
 use masonry::kurbo::{Affine, BezPath, Point, Rect, Size, Stroke};
 use masonry::palette;
 use masonry::parley::style::{FontFamily, FontStack, GenericFamily, StyleProperty};
 use masonry::peniko::{Color, Fill, Image, ImageFormat};
-use masonry::smallvec::SmallVec;
 use masonry::theme::default_property_set;
 use masonry::vello::Scene;
 use masonry::{TextAlign, TextAlignOptions};
@@ -177,8 +176,8 @@ impl Widget for CustomWidget {
         );
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        SmallVec::new()
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::new()
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/xilem/src/any_view.rs
+++ b/xilem/src/any_view.rs
@@ -3,12 +3,11 @@
 
 use masonry::accesskit::{Node, Role};
 use masonry::core::{
-    AccessCtx, AccessEvent, BoxConstraints, EventCtx, FromDynWidget, LayoutCtx, PaintCtx,
-    PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Widget, WidgetId,
+    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, EventCtx, FromDynWidget, LayoutCtx,
+    PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Widget, WidgetId,
     WidgetMut, WidgetPod,
 };
 use masonry::kurbo::{Point, Size};
-use masonry::smallvec::{SmallVec, smallvec};
 use tracing::{Span, trace_span};
 use vello::Scene;
 
@@ -123,8 +122,8 @@ impl Widget for DynWidget {
     ) {
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
-        smallvec![self.inner.id()]
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::from_slice(&[self.inner.id()])
     }
 
     fn make_trace_span(&self, id: WidgetId) -> Span {

--- a/xilem/src/one_of.rs
+++ b/xilem/src/one_of.rs
@@ -5,12 +5,11 @@
 
 use masonry::accesskit::{Node, Role};
 use masonry::core::{
-    AccessCtx, AccessEvent, BoxConstraints, EventCtx, FromDynWidget, LayoutCtx, PaintCtx,
-    PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Widget, WidgetId,
+    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, EventCtx, FromDynWidget, LayoutCtx,
+    PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Widget,
     WidgetPod,
 };
 use masonry::kurbo::{Point, Size};
-use masonry::smallvec::{SmallVec, smallvec};
 use vello::Scene;
 
 use crate::core::Mut;
@@ -291,17 +290,17 @@ impl<
     ) {
     }
 
-    fn children_ids(&self) -> SmallVec<[WidgetId; 16]> {
+    fn children_ids(&self) -> ChildrenIds {
         match self {
-            Self::A(w) => smallvec![w.id()],
-            Self::B(w) => smallvec![w.id()],
-            Self::C(w) => smallvec![w.id()],
-            Self::D(w) => smallvec![w.id()],
-            Self::E(w) => smallvec![w.id()],
-            Self::F(w) => smallvec![w.id()],
-            Self::G(w) => smallvec![w.id()],
-            Self::H(w) => smallvec![w.id()],
-            Self::I(w) => smallvec![w.id()],
+            Self::A(w) => ChildrenIds::from_slice(&[w.id()]),
+            Self::B(w) => ChildrenIds::from_slice(&[w.id()]),
+            Self::C(w) => ChildrenIds::from_slice(&[w.id()]),
+            Self::D(w) => ChildrenIds::from_slice(&[w.id()]),
+            Self::E(w) => ChildrenIds::from_slice(&[w.id()]),
+            Self::F(w) => ChildrenIds::from_slice(&[w.id()]),
+            Self::G(w) => ChildrenIds::from_slice(&[w.id()]),
+            Self::H(w) => ChildrenIds::from_slice(&[w.id()]),
+            Self::I(w) => ChildrenIds::from_slice(&[w.id()]),
         }
     }
 }


### PR DESCRIPTION
Use type alias in various places.
Avoid referencing smallvec from widget code.

Fixes #1141.