### PR TITLE
Refactor layout code and remove `WidgetState::synthetic`

### DIFF
--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -548,7 +548,24 @@ impl LayoutCtx<'_> {
         child: &mut WidgetPod<impl Widget + ?Sized>,
         bc: &BoxConstraints,
     ) -> Size {
-        run_layout_on(self, child, bc)
+        let id = child.id();
+        let widget = self.children.widget_children.item_mut(id).unwrap();
+        let state = self.children.widget_state_children.item_mut(id).unwrap();
+        let properties = self.children.properties_children.item_mut(id).unwrap();
+
+        let new_size = run_layout_on(
+            self.global_state,
+            self.default_properties,
+            widget,
+            state,
+            properties,
+            bc,
+        );
+
+        let state_mut = self.children.widget_state_children.item_mut(id).unwrap();
+        self.widget_state.merge_up(state_mut.item);
+
+        new_size
     }
 
     /// Set the position of a child widget, in the parent's coordinate space.

--- a/masonry_core/src/core/widget_state.rs
+++ b/masonry_core/src/core/widget_state.rs
@@ -260,30 +260,6 @@ impl WidgetState {
         }
     }
 
-    /// Create a dummy root state.
-    ///
-    /// This is useful for passes that need a parent state for the root widget.
-    pub(crate) fn synthetic(id: WidgetId, size: Size) -> Self {
-        Self {
-            size,
-            is_new: false,
-            needs_layout: false,
-            request_compose: false,
-            needs_compose: false,
-            request_paint: false,
-            needs_paint: false,
-            request_accessibility: false,
-            needs_accessibility: false,
-            request_anim: false,
-            needs_anim: false,
-            needs_update_disabled: false,
-            needs_update_stashed: false,
-            children_changed: false,
-            needs_update_focus_chain: false,
-            ..Self::new(id, "<root>", WidgetOptions::default())
-        }
-    }
-
     /// Update to incorporate state changes from a child.
     ///
     /// This method is idempotent and can be called multiple times.


### PR DESCRIPTION
Make `run_layout_on` function more modular:
- Make it not take a LayoutCtx parameter.
- Make it not propagate state to parent state.
Make run_layout_pass no longer create a fake WidgetState parent to the root.
Remove `WidgetState::synthetic()` constructor since it's no longer needed.

Otherwise, doesn't change any behavior.