### PR TITLE
Replace RawWrapper concept with much simpler RawCtx

### DIFF
--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -277,18 +277,10 @@ impl Widget for Button {
 
     fn accessibility(
         &mut self,
-        ctx: &mut AccessCtx<'_>,
+        _ctx: &mut AccessCtx<'_>,
         _props: &PropertiesRef<'_>,
         node: &mut Node,
     ) {
-        // IMPORTANT: We don't want to merge this code in practice, because
-        // the child label already has a 'name' property.
-        // This is more of a proof of concept of `get_raw_ref()`.
-        if false {
-            let label = ctx.get_raw_ref(&self.label);
-            let name = label.widget().text().as_ref().to_string();
-            node.set_value(name);
-        }
         node.add_action(accesskit::Action::Click);
     }
 

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -290,18 +290,10 @@ impl Widget for Checkbox {
 
     fn accessibility(
         &mut self,
-        ctx: &mut AccessCtx<'_>,
+        _ctx: &mut AccessCtx<'_>,
         _props: &PropertiesRef<'_>,
         node: &mut Node,
     ) {
-        // IMPORTANT: We don't want to merge this code in practice, because
-        // the child label already has a 'name' property.
-        // This is more of a proof of concept of `get_raw_ref()`.
-        if false {
-            let label = ctx.get_raw_ref(&self.label);
-            let name = label.widget().text().as_ref().to_string();
-            node.set_value(name);
-        }
         node.add_action(accesskit::Action::Click);
         if self.checked {
             node.set_toggled(Toggled::True);

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -271,7 +271,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
         event: &PointerEvent,
     ) {
         let portal_size = ctx.size();
-        let content_size = ctx.get_raw_ref(&mut self.child).ctx().size();
+        let content_size = ctx.child_size(&mut self.child);
 
         match *event {
             PointerEvent::Scroll { delta, .. } => {
@@ -289,10 +289,10 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
                 ctx.request_compose();
 
                 // TODO - horizontal scrolling?
-                let mut scrollbar = ctx.get_raw_mut(&mut self.scrollbar_vertical);
-                scrollbar.widget().cursor_progress =
+                let (scrollbar, mut scrollbar_ctx) = ctx.get_raw_mut(&mut self.scrollbar_vertical);
+                scrollbar.cursor_progress =
                     self.viewport_pos.y / (content_size - portal_size).height;
-                scrollbar.ctx().request_render();
+                scrollbar_ctx.request_render();
             }
             _ => (),
         }
@@ -301,11 +301,11 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
         // pointer events, then its event method has already been called by the time this runs.
         let mut scrollbar_moved = false;
         {
-            let mut scrollbar = ctx.get_raw_mut(&mut self.scrollbar_horizontal);
-            if scrollbar.widget().moved {
-                scrollbar.widget().moved = false;
+            let (scrollbar, _) = ctx.get_raw_mut(&mut self.scrollbar_horizontal);
+            if scrollbar.moved {
+                scrollbar.moved = false;
 
-                let progress = scrollbar.widget().cursor_progress;
+                let progress = scrollbar.cursor_progress;
                 self.viewport_pos = Axis::Horizontal
                     .pack(
                         progress * Axis::Horizontal.major(content_size - portal_size),
@@ -316,11 +316,11 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
             }
         }
         {
-            let mut scrollbar = ctx.get_raw_mut(&mut self.scrollbar_vertical);
-            if scrollbar.widget().moved {
-                scrollbar.widget().moved = false;
+            let (scrollbar, _) = ctx.get_raw_mut(&mut self.scrollbar_vertical);
+            if scrollbar.moved {
+                scrollbar.moved = false;
 
-                let progress = scrollbar.widget().cursor_progress;
+                let progress = scrollbar.cursor_progress;
                 self.viewport_pos = Axis::Vertical
                     .pack(
                         progress * Axis::Vertical.major(content_size - portal_size),
@@ -364,7 +364,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
         match event {
             Update::RequestPanToChild(target) => {
                 let portal_size = ctx.size();
-                let content_size = ctx.get_raw_ref(&mut self.child).ctx().size();
+                let content_size = ctx.child_size(&mut self.child);
 
                 self.pan_viewport_to_raw(portal_size, content_size, *target);
                 ctx.request_compose();
@@ -373,17 +373,18 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
                 // event in `on_pointer_event`.
                 // Because this code directly manipulates child widgets, it's hard to factor
                 // it out.
-                let mut scrollbar = ctx.get_raw_mut(&mut self.scrollbar_vertical);
-                scrollbar.widget().cursor_progress =
+                let (scrollbar, mut scrollbar_ctx) = ctx.get_raw_mut(&mut self.scrollbar_vertical);
+                scrollbar.cursor_progress =
                     self.viewport_pos.y / (content_size - portal_size).height;
-                scrollbar.ctx().request_render();
+                scrollbar_ctx.request_render();
 
-                std::mem::drop(scrollbar);
+                std::mem::drop(scrollbar_ctx);
 
-                let mut scrollbar = ctx.get_raw_mut(&mut self.scrollbar_horizontal);
-                scrollbar.widget().cursor_progress =
+                let (scrollbar, mut scrollbar_ctx) =
+                    ctx.get_raw_mut(&mut self.scrollbar_horizontal);
+                scrollbar.cursor_progress =
                     self.viewport_pos.x / (content_size - portal_size).width;
-                scrollbar.ctx().request_render();
+                scrollbar_ctx.request_render();
             }
             _ => {}
         }
@@ -428,11 +429,10 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
         );
 
         if self.scrollbar_horizontal_visible {
-            let mut scrollbar = ctx.get_raw_mut(&mut self.scrollbar_horizontal);
-            scrollbar.widget().portal_size = portal_size.width;
-            scrollbar.widget().content_size = content_size.width;
+            let (scrollbar, _) = ctx.get_raw_mut(&mut self.scrollbar_horizontal);
+            scrollbar.portal_size = portal_size.width;
+            scrollbar.content_size = content_size.width;
             // TODO - request paint for scrollbar?
-            std::mem::drop(scrollbar);
 
             let scrollbar_size = ctx.run_layout(&mut self.scrollbar_horizontal, bc);
             ctx.place_child(
@@ -443,11 +443,10 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
             ctx.skip_layout(&mut self.scrollbar_horizontal);
         }
         if self.scrollbar_vertical_visible {
-            let mut scrollbar = ctx.get_raw_mut(&mut self.scrollbar_vertical);
-            scrollbar.widget().portal_size = portal_size.height;
-            scrollbar.widget().content_size = content_size.height;
+            let (scrollbar, _) = ctx.get_raw_mut(&mut self.scrollbar_vertical);
+            scrollbar.portal_size = portal_size.height;
+            scrollbar.content_size = content_size.height;
             // TODO - request paint for scrollbar?
-            std::mem::drop(scrollbar);
 
             let scrollbar_size = ctx.run_layout(&mut self.scrollbar_vertical, bc);
             ctx.place_child(
@@ -473,30 +472,10 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
 
     fn accessibility(
         &mut self,
-        ctx: &mut AccessCtx<'_>,
+        _ctx: &mut AccessCtx<'_>,
         _props: &PropertiesRef<'_>,
         node: &mut Node,
     ) {
-        // TODO - Double check this code
-        // Not sure about these values
-        if false {
-            node.set_scroll_x(self.viewport_pos.x);
-            node.set_scroll_y(self.viewport_pos.y);
-            node.set_scroll_x_min(0.0);
-
-            let x_max = ctx
-                .get_raw_ref(&self.scrollbar_horizontal)
-                .widget()
-                .portal_size;
-            let y_max = ctx
-                .get_raw_ref(&self.scrollbar_vertical)
-                .widget()
-                .portal_size;
-            node.set_scroll_x_max(x_max);
-            node.set_scroll_y_min(0.0);
-            node.set_scroll_y_max(y_max);
-        }
-
         node.set_clips_children();
     }
 

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -118,6 +118,7 @@ pub struct ComposeCtx<'a> {
     pub(crate) widget_state: &'a mut WidgetState,
     pub(crate) widget_state_children: ArenaMutList<'a, WidgetState>,
     pub(crate) widget_children: ArenaMutList<'a, Box<dyn Widget>>,
+    pub(crate) properties_children: ArenaMutList<'a, AnyMap>,
 }
 
 /// A context passed to [`Widget::paint`] method.
@@ -135,9 +136,17 @@ pub struct AccessCtx<'a> {
     pub(crate) widget_state: &'a WidgetState,
     pub(crate) widget_state_children: ArenaMutList<'a, WidgetState>,
     pub(crate) widget_children: ArenaMutList<'a, Box<dyn Widget>>,
-    pub(crate) properties_children: ArenaMutList<'a, AnyMap>,
     pub(crate) tree_update: &'a mut TreeUpdate,
-    pub(crate) rebuild_all: bool,
+}
+
+/// A context given when calling another context's `get_raw()` method.
+pub struct RawCtx<'a> {
+    pub(crate) global_state: &'a mut RenderRootState,
+    pub(crate) parent_widget_state: &'a mut WidgetState,
+    pub(crate) widget_state: &'a mut WidgetState,
+    pub(crate) widget_state_children: ArenaMutList<'a, WidgetState>,
+    pub(crate) widget_children: ArenaMutList<'a, Box<dyn Widget>>,
+    pub(crate) properties_children: ArenaMutList<'a, AnyMap>,
 }
 
 // --- MARK: GETTERS
@@ -151,7 +160,9 @@ impl_context_method!(
     ComposeCtx<'_>,
     PaintCtx<'_>,
     AccessCtx<'_>,
+    RawCtx<'_>,
     {
+        #[allow(dead_code, reason = "Copy-pasted for some types that don't need it")]
         /// The `WidgetId` of the current widget.
         pub fn widget_id(&self) -> WidgetId {
             self.widget_state.id
@@ -189,6 +200,7 @@ impl_context_method!(
             child_state_ref.item
         }
 
+        #[allow(dead_code, reason = "Copy-pasted for some types that don't need it")]
         /// The current (local) transform of this widget.
         pub fn transform(&self) -> Affine {
             self.widget_state.transform
@@ -202,6 +214,7 @@ impl_context_method!(
     UpdateCtx<'_>,
     LayoutCtx<'_>,
     ComposeCtx<'_>,
+    RawCtx<'_>,
     {
         /// Helper method to get a mutable reference to a child widget's `WidgetState` from its `WidgetPod`.
         ///
@@ -339,6 +352,7 @@ impl_context_method!(
     ComposeCtx<'_>,
     PaintCtx<'_>,
     AccessCtx<'_>,
+    RawCtx<'_>,
     {
         /// Get the Parley contexts needed to build and paint text sections.
         ///
@@ -861,6 +875,11 @@ impl_context_method!(
         pub fn to_window(&self, widget_point: Point) -> Point {
             self.widget_state.window_transform * widget_point
         }
+
+        /// Get the given child's size.
+        pub fn child_size(&self, child: &WidgetPod<impl Widget + ?Sized>) -> Size {
+            self.get_child_state(child).size
+        }
     }
 );
 
@@ -997,8 +1016,7 @@ impl_context_method!(
 );
 
 // --- MARK: UPDATE FLAGS
-// Methods on MutateCtx, EventCtx, and UpdateCtx
-impl_context_method!(MutateCtx<'_>, EventCtx<'_>, UpdateCtx<'_>, {
+impl_context_method!(MutateCtx<'_>, EventCtx<'_>, UpdateCtx<'_>, RawCtx<'_>, {
     /// Request a [`paint`](crate::core::Widget::paint) and an [`accessibility`](crate::core::Widget::accessibility) pass.
     pub fn request_render(&mut self) {
         trace!("request_render");
@@ -1130,6 +1148,7 @@ impl_context_method!(
     UpdateCtx<'_>,
     LayoutCtx<'_>,
     ComposeCtx<'_>,
+    RawCtx<'_>,
     {
         // TODO - Remove from LayoutCtx/ComposeCtx
         /// Mark child widget as stashed.
@@ -1176,6 +1195,80 @@ impl_context_method!(
                 callback: Box::new(|mut widget_mut| f(widget_mut.downcast())),
             };
             self.global_state.mutate_callbacks.push(callback);
+        }
+
+        /// Get direct reference to the stored child, and a context handle for that child.
+        ///
+        /// This context lets you set pass flags for the child widget, which may be tricky.
+        /// In general, you should avoid setting the flags of a pass that runs before the
+        /// pass you're currently in.
+        ///
+        /// See [pass documentation](crate::doc::05_pass_system) for the pass order.
+        pub fn get_raw<Child: Widget + FromDynWidget + ?Sized>(
+            &mut self,
+            child: &mut WidgetPod<Child>,
+        ) -> (&Child, RawCtx<'_>) {
+            let child_state_mut = self
+                .widget_state_children
+                .item_mut(child.id())
+                .expect("get_raw: child not found");
+            let child_mut = self
+                .widget_children
+                .item_mut(child.id())
+                .expect("get_raw: child not found");
+            let child_properties = self
+                .properties_children
+                .item_mut(child.id())
+                .expect("get_raw: child not found");
+            let child_ctx = RawCtx {
+                global_state: self.global_state,
+                parent_widget_state: &mut self.widget_state,
+                widget_state: child_state_mut.item,
+                widget_state_children: child_state_mut.children,
+                widget_children: child_mut.children,
+                properties_children: child_properties.children,
+            };
+
+            let widget = Child::from_dyn(&mut **child_mut.item).unwrap();
+
+            (widget, child_ctx)
+        }
+
+        /// Get direct mutable reference to the stored child, and a context handle for that child.
+        ///
+        /// This context lets you set pass flags for the child widget, which may be tricky.
+        /// In general, you should avoid setting the flags of a pass that runs before the
+        /// pass you're currently in.
+        ///
+        /// See [pass documentation](crate::doc::05_pass_system) for the pass order.
+        pub fn get_raw_mut<Child: Widget + FromDynWidget + AllowRawMut + ?Sized>(
+            &mut self,
+            child: &mut WidgetPod<Child>,
+        ) -> (&mut Child, RawCtx<'_>) {
+            let child_state_mut = self
+                .widget_state_children
+                .item_mut(child.id())
+                .expect("get_raw_mut: child not found");
+            let child_mut = self
+                .widget_children
+                .item_mut(child.id())
+                .expect("get_raw_mut: child not found");
+            let child_properties = self
+                .properties_children
+                .item_mut(child.id())
+                .expect("get_raw_mut: child not found");
+            let child_ctx = RawCtx {
+                global_state: self.global_state,
+                parent_widget_state: &mut self.widget_state,
+                widget_state: child_state_mut.item,
+                widget_state_children: child_state_mut.children,
+                widget_children: child_mut.children,
+                properties_children: child_properties.children,
+            };
+
+            let widget = Child::from_dyn_mut(&mut **child_mut.item).unwrap();
+
+            (widget, child_ctx)
         }
 
         /// Submit an Action, which indicates that this widget requires something be handled
@@ -1291,6 +1384,12 @@ impl RegisterCtx<'_> {
     }
 }
 
+impl Drop for RawCtx<'_> {
+    fn drop(&mut self) {
+        self.parent_widget_state.merge_up(self.widget_state);
+    }
+}
+
 // --- MARK: DEBUG PAINT
 impl PaintCtx<'_> {
     /// Whether debug paint is enabled.
@@ -1314,213 +1413,3 @@ impl PaintCtx<'_> {
         get_debug_color(self.widget_id().to_raw())
     }
 }
-
-// --- MARK: RAW WRAPPERS
-macro_rules! impl_get_raw {
-    ($SomeCtx:tt) => {
-        impl<'s> $SomeCtx<'s> {
-            /// Get a child context and a raw shared reference to a child widget.
-            ///
-            /// The child context can be used to call context methods on behalf of the
-            /// child widget.
-            pub fn get_raw_ref<'a, 'r, Child: Widget + FromDynWidget + ?Sized>(
-                &'a mut self,
-                child: &'a mut WidgetPod<Child>,
-            ) -> RawWrapper<'r, $SomeCtx<'r>, Child>
-            where
-                'a: 'r,
-                's: 'r,
-            {
-                let child_state_mut = self
-                    .widget_state_children
-                    .item_mut(child.id())
-                    .expect("get_raw_ref: child not found");
-                let child_mut = self
-                    .widget_children
-                    .item_mut(child.id())
-                    .expect("get_raw_ref: child not found");
-                let child_properties = self
-                    .properties_children
-                    .item_mut(child.id())
-                    .expect("get_raw_ref: child not found");
-                #[allow(clippy::needless_update)]
-                let child_ctx = $SomeCtx {
-                    widget_state: child_state_mut.item,
-                    widget_state_children: child_state_mut.children,
-                    widget_children: child_mut.children,
-                    properties_children: child_properties.children,
-                    global_state: self.global_state,
-                    ..*self
-                };
-                RawWrapper {
-                    ctx: child_ctx,
-                    widget: Child::from_dyn(&**child_mut.item).unwrap(),
-                }
-            }
-
-            /// Get a raw mutable reference to a child widget.
-            ///
-            /// See documentation for [`AllowRawMut`] for more details.
-            pub fn get_raw_mut<'a, 'r, Child: Widget + FromDynWidget + AllowRawMut + ?Sized>(
-                &'a mut self,
-                child: &'a mut WidgetPod<Child>,
-            ) -> RawWrapperMut<'r, $SomeCtx<'r>, Child>
-            where
-                'a: 'r,
-                's: 'r,
-            {
-                let child_state_mut = self
-                    .widget_state_children
-                    .item_mut(child.id())
-                    .expect("get_raw_mut: child not found");
-                let child_mut = self
-                    .widget_children
-                    .item_mut(child.id())
-                    .expect("get_raw_mut: child not found");
-                let child_properties = self
-                    .properties_children
-                    .item_mut(child.id())
-                    .expect("get_raw_mut: child not found");
-                #[allow(clippy::needless_update)]
-                let child_ctx = $SomeCtx {
-                    widget_state: child_state_mut.item,
-                    widget_state_children: child_state_mut.children,
-                    widget_children: child_mut.children,
-                    properties_children: child_properties.children,
-                    global_state: self.global_state,
-                    ..*self
-                };
-                RawWrapperMut {
-                    parent_widget_state: &mut self.widget_state,
-                    ctx: child_ctx,
-                    widget: Child::from_dyn_mut(&mut **child_mut.item).unwrap(),
-                }
-            }
-        }
-    };
-}
-
-impl_get_raw!(EventCtx);
-impl_get_raw!(UpdateCtx);
-impl_get_raw!(LayoutCtx);
-
-#[allow(missing_docs, reason = "RawWrapper is likely to be reworked")]
-impl<'s> AccessCtx<'s> {
-    pub fn get_raw_ref<'a, 'r, Child: Widget + FromDynWidget + ?Sized>(
-        &'a mut self,
-        child: &'a WidgetPod<Child>,
-    ) -> RawWrapper<'r, AccessCtx<'r>, Child>
-    where
-        'a: 'r,
-        's: 'r,
-    {
-        let child_state_mut = self
-            .widget_state_children
-            .item_mut(child.id())
-            .expect("get_raw_ref: child not found");
-        let child_mut = self
-            .widget_children
-            .item_mut(child.id())
-            .expect("get_raw_ref: child not found");
-        let child_properties = self
-            .properties_children
-            .item_mut(child.id())
-            .expect("get_raw_ref: child not found");
-        let child_ctx = AccessCtx {
-            widget_state: child_state_mut.item,
-            widget_state_children: child_state_mut.children,
-            widget_children: child_mut.children,
-            properties_children: child_properties.children,
-            global_state: self.global_state,
-            tree_update: self.tree_update,
-            rebuild_all: self.rebuild_all,
-        };
-        RawWrapper {
-            ctx: child_ctx,
-            widget: Child::from_dyn(&**child_mut.item).unwrap(),
-        }
-    }
-}
-
-#[allow(missing_docs, reason = "RawWrapper is likely to be reworked")]
-pub struct RawWrapper<'a, Ctx, W: ?Sized> {
-    ctx: Ctx,
-    widget: &'a W,
-}
-
-#[allow(missing_docs, reason = "RawWrapper is likely to be reworked")]
-pub struct RawWrapperMut<'a, Ctx: IsContext, W: ?Sized> {
-    parent_widget_state: &'a mut WidgetState,
-    ctx: Ctx,
-    widget: &'a mut W,
-}
-
-#[allow(missing_docs, reason = "RawWrapper is likely to be reworked")]
-impl<Ctx, W: ?Sized> RawWrapper<'_, Ctx, W> {
-    pub fn widget(&self) -> &W {
-        self.widget
-    }
-
-    pub fn ctx(&self) -> &Ctx {
-        &self.ctx
-    }
-}
-
-#[allow(missing_docs, reason = "RawWrapper is likely to be reworked")]
-impl<Ctx: IsContext, W: ?Sized> RawWrapperMut<'_, Ctx, W> {
-    pub fn widget(&mut self) -> &mut W {
-        self.widget
-    }
-
-    pub fn ctx(&mut self) -> &mut Ctx {
-        &mut self.ctx
-    }
-}
-
-impl<Ctx: IsContext, W: ?Sized> Drop for RawWrapperMut<'_, Ctx, W> {
-    fn drop(&mut self) {
-        self.parent_widget_state
-            .merge_up(self.ctx.get_widget_state());
-    }
-}
-
-mod private {
-    #[allow(
-        unnameable_types,
-        reason = "see https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/"
-    )]
-    pub trait Sealed {}
-}
-
-// TODO - Rethink RawWrapper API
-// We're exporting a trait with a method that returns a private type.
-// It's mostly fine because the trait is sealed anyway, but it's not great for documentation.
-
-#[allow(
-    private_interfaces,
-    reason = "see https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/"
-)]
-#[allow(missing_docs, reason = "RawWrapper is likely to be reworked")]
-pub trait IsContext: private::Sealed {
-    fn get_widget_state(&mut self) -> &mut WidgetState;
-}
-
-macro_rules! impl_context_trait {
-    ($SomeCtx:tt) => {
-        impl private::Sealed for $SomeCtx<'_> {}
-
-        #[allow(
-            private_interfaces,
-            reason = "see https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/"
-        )]
-        impl IsContext for $SomeCtx<'_> {
-            fn get_widget_state(&mut self) -> &mut WidgetState {
-                self.widget_state
-            }
-        }
-    };
-}
-
-impl_context_trait!(EventCtx);
-impl_context_trait!(UpdateCtx);
-impl_context_trait!(LayoutCtx);

--- a/masonry_core/src/core/mod.rs
+++ b/masonry_core/src/core/mod.rs
@@ -19,8 +19,8 @@ mod widget_state;
 use anymore::AnyDebug;
 pub use box_constraints::BoxConstraints;
 pub use contexts::{
-    AccessCtx, ComposeCtx, EventCtx, IsContext, LayoutCtx, MutateCtx, PaintCtx, QueryCtx,
-    RawWrapper, RawWrapperMut, RegisterCtx, UpdateCtx,
+    AccessCtx, ComposeCtx, EventCtx, LayoutCtx, MutateCtx, PaintCtx, QueryCtx, RawCtx, RegisterCtx,
+    UpdateCtx,
 };
 pub use events::{AccessEvent, Ime, ResizeDirection, TextEvent, Update, WindowEvent, WindowTheme};
 pub use object_fit::ObjectFit;

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -433,7 +433,7 @@ pub fn find_widget_under_pointer<'c>(
 /// A parent widget can use [`EventCtx::get_raw_mut`], [`UpdateCtx::get_raw_mut`],
 /// or [`LayoutCtx::get_raw_mut`] to directly access a child widget. In that case,
 /// these methods return both a mutable reference to the child widget and a new
-/// context (`MutateCtx`, `EventCtx`, etc) scoped to the child. The parent is
+/// [`RawCtx`](crate::core::RawCtx) context scoped to the child. The parent is
 /// responsible for calling the context methods (eg `request_layout`,
 /// `request_accessibility_update`) for the child.
 ///

--- a/masonry_core/src/doc/05_pass_system.md
+++ b/masonry_core/src/doc/05_pass_system.md
@@ -52,7 +52,7 @@ The animation pass may be considered as a special event pass: it's not triggered
 ## Rewrite passes
 
 After an event pass, some flags may have been changed, and some values may have been invalidated and need to be recomputed.
-To address these invalidations, Masonry runs a set of **rewrite passes** over the tree:
+To address these invalidations, Masonry runs a set of **rewrite passes** over the tree, in the following order:
 
 - **mutate:** Runs callbacks with mutable access to the tree.
 - **update_widget_tree:** Updates the tree when widgets are added or removed.

--- a/masonry_core/src/passes/accessibility.rs
+++ b/masonry_core/src/passes/accessibility.rs
@@ -18,7 +18,7 @@ fn build_accessibility_tree(
     tree_update: &mut TreeUpdate,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
-    mut properties: ArenaMut<'_, AnyMap>,
+    properties: ArenaMut<'_, AnyMap>,
     rebuild_all: bool,
     scale_factor: Option<f64>,
 ) {
@@ -43,9 +43,7 @@ fn build_accessibility_tree(
             widget_state: state.item,
             widget_state_children: state.children.reborrow_mut(),
             widget_children: widget.children.reborrow_mut(),
-            properties_children: properties.children.reborrow_mut(),
             tree_update,
-            rebuild_all,
         };
         let mut node = build_access_node(&mut **widget.item, &mut ctx, scale_factor);
         let props = PropertiesRef {

--- a/masonry_core/src/passes/compose.rs
+++ b/masonry_core/src/passes/compose.rs
@@ -15,7 +15,7 @@ fn compose_widget(
     global_state: &mut RenderRootState,
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
-    properties: ArenaMut<'_, AnyMap>,
+    mut properties: ArenaMut<'_, AnyMap>,
     parent_transformed: bool,
     parent_window_transform: Affine,
 ) {
@@ -41,6 +41,7 @@ fn compose_widget(
         widget_state: state.item,
         widget_state_children: state.children.reborrow_mut(),
         widget_children: widget.children.reborrow_mut(),
+        properties_children: properties.children.reborrow_mut(),
     };
     if ctx.widget_state.request_compose {
         widget.item.compose(&mut ctx);


### PR DESCRIPTION
The main differences are:
- get_raw and get_raw_mut now both give a mutable context.
- get_raw_ and get_raw_mut are no longer included in AccessCtx.
- No need for more layers of macro copy-pasting, instead everything is in RawCtx.

Currently RawCtx is only used in Portal widget.
Places where the code was gated behind an `if false` block have been removed.