### PR TITLE
Add a nix flake to support development on NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ sudo apt-get install clang libwayland-dev libxkbcommon-x11-dev libvulkan-dev
 
 There's a Nix flake in `docs/` which may be used for developing on NixOS:
 
+> [!INFO]
+> 
+> This flake is provided as a starting point, and we do not routinely validate its correctness.
+> We do not require contributors to ensure that this accurately reflects the build requirements, as we expect most contributors (and indeed many maintainers) will not be using NixOS.
+> If it is out of date, please let us know by opening an issue or PR.
+
 ```sh
 # For all crates within this repo
 nix develop ./docs

--- a/README.md
+++ b/README.md
@@ -145,6 +145,17 @@ To install the remaining packages on Debian or Ubuntu, run:
 sudo apt-get install clang libwayland-dev libxkbcommon-x11-dev libvulkan-dev
 ```
 
+There's a Nix flake in `docs/` which may be used for developing on NixOS:
+
+```sh
+# For all crates within this repo
+nix develop ./docs
+# For a specific crate
+nix develop ./docs#xilem
+nix develop ./docs#masonry
+nix develop ./docs#xilem_web
+```
+
 ## Recommended Cargo Config
 
 The Xilem repository includes a lot of projects and examples, most of them pulling a lot of dependencies.

--- a/docs/flake.lock
+++ b/docs/flake.lock
@@ -1,0 +1,95 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753013524,
+        "narHash": "sha256-/M85flsZkTdNInYcdblXwhXaTfM93nKReEKcwaMbm48=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f0faa55136e9e16987814d6f432322df76411ed3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1752979888,
+        "narHash": "sha256-qRRP3QavbwW0o+LOh31QNEfCgPlzK5SKlWALUJL6T7E=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "95719de18aefa63a624bf75a1ff98744b089ec12",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/docs/flake.nix
+++ b/docs/flake.nix
@@ -1,0 +1,58 @@
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    nixpkgs.url = "github:nixos/nixpkgs";
+  };
+
+  outputs = { nixpkgs, flake-utils, rust-overlay, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; overlays = [ rust-overlay.overlays.default ]; };
+        msrvRustVersion = (pkgs.lib.importTOML ../Cargo.toml).workspace.package.rust-version;
+        # The rust-version in Cargo.toml is usually something like "1.88" but we need the full semantic version "1.88.0"
+        rustOverlayVersion = if builtins.length (builtins.split "\\." msrvRustVersion) == 3 then "${msrvRustVersion}.0" else msrvRustVersion;
+        rustToolchain = pkgs.rust-bin.stable."${rustOverlayVersion}".default.override {
+          extensions = [ "rustfmt" "rust-analyzer" "rust-src" ];
+          targets = [ "x86_64-unknown-linux-gnu" "wasm32-unknown-unknown" "x86_64-pc-windows-gnu" "aarch64-linux-android" ];
+        };
+
+        commonPackages = [
+          # comment this out if you want to use your system rust toolchain
+          rustToolchain
+        ];
+        masonryPackages = with pkgs; commonPackages ++ [
+          pkg-config
+
+          fontconfig
+
+          libxkbcommon
+          xorg.libxcb
+          xorg.libX11
+          xorg.libXcursor
+          xorg.libXi
+          xorg.libXrandr
+          xorg.libXxf86vm
+
+          vulkan-loader
+
+          wayland
+          wayland-protocols
+          wayland-scanner
+        ];
+
+        webPackages = commonPackages ++ [ pkgs.trunk ];
+
+        mkDevShell = packages: pkgs.mkShell {
+          inherit packages;
+          LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath packages}";
+        };
+      in
+      {
+        devShells.default = mkDevShell (masonryPackages ++ webPackages);
+
+        devShells.xilem_web = mkDevShell webPackages;
+        devShells.xilem = mkDevShell masonryPackages;
+        devShells.masonry = mkDevShell masonryPackages;
+      });
+}


### PR DESCRIPTION
Adds a basic nix flake with `devShells` that uses a rust environment to run on various targets, using the MSRV `rust-version` specified in the root `Cargo.toml`.

Fixes #66