### PR TITLE
Avoid drawing a stroke for zero stroke width

### DIFF
--- a/masonry_core/src/util.rs
+++ b/masonry_core/src/util.rs
@@ -85,6 +85,11 @@ pub fn stroke<'b>(
     brush: impl Into<BrushRef<'b>>,
     stroke_width: f64,
 ) {
+    // Avoid drawing when the stroke width is zero.
+    if stroke_width == 0.0 {
+        return;
+    }
+
     // Using Join::Miter avoids rounding corners when a widget has a wide border.
     let style = Stroke {
         width: stroke_width,


### PR DESCRIPTION
If you create a `text_input` and set the border width to zero using `.border_width(0.0)`, it simply fills the entire area with the border color, and if focused, with a white color. Currently, a workaround for this is to use some epsilon (e.g., 0.00001 as the border width), but ideally we should just be able to use `0.0`, and in that case we shouldn't be drawing any strokes anyway.

This PR simply adds a check to see if `stroke_width` is equal to zero, and turns the `masonry::util::stroke` function into a no-op, but maybe there is a more logical spot to do this.