### PR TITLE
Add new gradient types

### DIFF
--- a/masonry/screenshots/sized_box_radial_gradient_background.png
+++ b/masonry/screenshots/sized_box_radial_gradient_background.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:409263aec7a6b5dee1d0df8ef61b37cca21bafa923735a755bd87272182b2296
+size 3086

--- a/masonry/screenshots/sized_box_sweep_gradient_background.png
+++ b/masonry/screenshots/sized_box_sweep_gradient_background.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fde377d8a4bfa210134225d1dc68f11109aa1565f319ddc68d098899ac975c3
+size 3103

--- a/masonry/src/properties/types/gradient.rs
+++ b/masonry/src/properties/types/gradient.rs
@@ -99,7 +99,7 @@ pub struct Gradient {
 pub enum RadialGradientShape {
     /// A circle defined based on the box size.
     CircleTo(RadialGradientExtent),
-    /// A circle with a fixed radius.
+    /// A circle with a fixed radius in logical pixels.
     FixedCircle(f64),
     // TODO - Add following and remove #[non_exhaustive]:
     // EllipseTo(RadialGradientExtent),

--- a/masonry/src/properties/types/gradient.rs
+++ b/masonry/src/properties/types/gradient.rs
@@ -5,6 +5,7 @@ use vello::kurbo::{Point, Rect};
 
 use crate::peniko::color::{ColorSpaceTag, HueDirection};
 use crate::peniko::{ColorStops, ColorStopsSource, Extend};
+use crate::properties::types::UnitPoint;
 
 /// Properties for the supported [`Gradient`] types.
 ///
@@ -13,6 +14,7 @@ use crate::peniko::{ColorStops, ColorStopsSource, Extend};
 /// "The gradient goes from point A to point B", we declare things like
 /// "The gradient has angle X", and A and B are computed dynamically from widget layout.
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum GradientShape {
     /// Gradient that transitions between two or more colors along a line.
     ///
@@ -24,6 +26,18 @@ pub enum GradientShape {
         /// Zero points upwards and positive angles represent clockwise rotation.
         angle: f64,
     },
+    /// Gradient that transitions between two or more colors that radiate from an origin.
+    ///
+    /// This is interpreted like [`radial-gradient()`] in CSS.
+    ///
+    /// [`radial-gradient()`]: https://drafts.csswg.org/css-images-3/#radial-gradient-syntax
+    Radial {
+        /// The center of the gradient, relative to the widget's bounding box.
+        center: UnitPoint,
+        /// The shape and size of the gradient.
+        shape: RadialGradientShape,
+    },
+    // TODO - Add Sweep shape
 }
 
 /// Definition of a gradient that transitions between two or more colors.
@@ -54,7 +68,60 @@ pub struct Gradient {
     pub stops: ColorStops,
 }
 
+/// An enum for different ways a radial gradient can be sized and shaped.
+///
+/// Matches the `radial-shape` and `radial-extent` parameters
+/// of the [`radial-gradient()`] syntax.
+///
+/// Defaults to `CircleTo(FarthestCorner)`.
+///
+/// [`radial-gradient()`]: https://drafts.csswg.org/css-images-3/#radial-gradient-syntax
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RadialGradientShape {
+    /// A circle defined based on the box size.
+    CircleTo(RadialGradientExtent),
+    /// A circle with a fixed radius.
+    FixedCircle(f64),
+    // TODO - Add following and remove #[non_exhaustive]:
+    // EllipseTo(RadialGradientExtent),
+    // FixedEllipse(f64),
+    // EllipsePercentage(f64),
+}
+
+/// An enum for different ways a radial gradient can be sized based on the surrounding box.
+///
+/// Matches the `radial-extent` parameter of the [`radial-gradient()`] syntax.
+///
+/// [`radial-gradient()`]: https://drafts.csswg.org/css-images-3/#radial-gradient-syntax
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RadialGradientExtent {
+    /// Interpreted like CSS `closest-corner` size.
+    ClosestCorner,
+    /// Interpreted like CSS `closest-side` size.
+    ClosestSide,
+    /// Interpreted like CSS `farthest-side` size.
+    FarthestSide,
+    /// Interpreted like CSS `farthest-corner` size.
+    FarthestCorner,
+}
+
+// ---
+
 impl Gradient {
+    /// Creates a gradient with the given shape.
+    ///
+    /// See also [`Self::new_linear`], [`Self::new_radial`], [`Self::new_radial_with`].
+    pub fn new(shape: GradientShape) -> Self {
+        Self {
+            shape,
+            extend: Extend::default(),
+            interpolation_cs: ColorSpaceTag::Srgb,
+            hue_direction: HueDirection::default(),
+            stops: ColorStops::default(),
+        }
+    }
+
     /// Creates a [`Linear`](GradientShape::Linear) gradient.
     ///
     /// `angle` is in radians, with zero pointing upwards, and higher values rotating the gradient clockwise.
@@ -64,13 +131,23 @@ impl Gradient {
     /// for an `angle` of [`π/2`](core::f32::consts::FRAC_PI_2) (90°), the first
     /// stop will be aligned with the left edge.
     pub fn new_linear(angle: f64) -> Self {
-        Self {
-            shape: GradientShape::Linear { angle },
-            extend: Extend::default(),
-            interpolation_cs: ColorSpaceTag::Srgb,
-            hue_direction: HueDirection::default(),
-            stops: ColorStops::default(),
-        }
+        let shape = GradientShape::Linear { angle };
+        Self::new(shape)
+    }
+
+    /// Creates a circular [`Radial`](GradientShape::Radial) gradient extending to the farthest corner.
+    ///
+    /// See also [`Self::new_radial_with`].
+    pub fn new_radial(center: UnitPoint) -> Self {
+        let shape = RadialGradientShape::CircleTo(RadialGradientExtent::FarthestCorner);
+        let shape = GradientShape::Radial { center, shape };
+        Self::new(shape)
+    }
+
+    /// Creates a [`Radial`](GradientShape::Radial) gradient.
+    pub fn new_radial_with(center: UnitPoint, shape: RadialGradientShape) -> Self {
+        let shape = GradientShape::Radial { center, shape };
+        Self::new(shape)
     }
 
     /// Builder method to set color stops on the gradient.
@@ -101,6 +178,9 @@ impl GradientShape {
     pub fn get_peniko_kind_for_rect(&self, rect: Rect) -> crate::peniko::GradientKind {
         match self {
             Self::Linear { angle } => Self::get_peniko_linear_for_rect(*angle, rect),
+            Self::Radial { center, shape } => {
+                Self::get_peniko_radial_for_rect(*center, *shape, rect)
+            }
         }
     }
 
@@ -122,5 +202,64 @@ impl GradientShape {
         let end = Point::new(center.x + x, center.y + y);
 
         crate::peniko::GradientKind::Linear { start, end }
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "no other way to go from f64 to f32"
+    )]
+    fn get_peniko_radial_for_rect(
+        center: UnitPoint,
+        shape: RadialGradientShape,
+        rect: Rect,
+    ) -> crate::peniko::GradientKind {
+        let center = center.resolve(rect);
+        let radius = Self::get_gradient_radius(rect, center, shape);
+
+        crate::peniko::GradientKind::Radial {
+            start_center: center,
+            start_radius: 0.,
+            end_center: center,
+            end_radius: radius as f32,
+        }
+    }
+
+    fn get_gradient_radius(rect: Rect, center: Point, shape: RadialGradientShape) -> f64 {
+        let center_offset = center - rect.origin();
+
+        let dist_to_sides = [
+            f64::abs(center_offset.x),
+            f64::abs(center_offset.y),
+            f64::abs(rect.size().width - center_offset.x),
+            f64::abs(rect.size().height - center_offset.y),
+        ];
+        let dist_to_corners = [
+            center.distance(Point::new(rect.x0, rect.y0)),
+            center.distance(Point::new(rect.x1, rect.y0)),
+            center.distance(Point::new(rect.x0, rect.y1)),
+            center.distance(Point::new(rect.x1, rect.y1)),
+        ];
+
+        match shape {
+            RadialGradientShape::CircleTo(RadialGradientExtent::ClosestCorner) => {
+                dist_to_corners.into_iter().reduce(f64::min).unwrap()
+            }
+            RadialGradientShape::CircleTo(RadialGradientExtent::ClosestSide) => {
+                dist_to_sides.into_iter().reduce(f64::min).unwrap()
+            }
+            RadialGradientShape::CircleTo(RadialGradientExtent::FarthestSide) => {
+                dist_to_sides.into_iter().reduce(f64::max).unwrap()
+            }
+            RadialGradientShape::CircleTo(RadialGradientExtent::FarthestCorner) => {
+                dist_to_corners.into_iter().reduce(f64::max).unwrap()
+            }
+            RadialGradientShape::FixedCircle(radius) => radius,
+        }
+    }
+}
+
+impl Default for RadialGradientShape {
+    fn default() -> Self {
+        Self::CircleTo(RadialGradientExtent::FarthestCorner)
     }
 }

--- a/masonry/src/properties/types/gradient.rs
+++ b/masonry/src/properties/types/gradient.rs
@@ -43,16 +43,17 @@ pub enum GradientShape {
     /// point.
     ///
     /// This is similar to [`conic-gradient()`] in CSS **but the values are interpreted differently**.
+    /// (Specifically, angle zero points to the right and positive angles rotate counter-clockwise.)
     ///
     /// [`conic-gradient()`]: https://drafts.csswg.org/css-images-4/#conic-gradient-syntax
     Sweep {
         /// The center of the gradient, relative to the widget's bounding box.
         center: UnitPoint,
         /// Start angle of the sweep, in radians.
-        /// Zero points upwards and positive angles represent clockwise rotation.
+        /// Zero points to the right and positive angles represent counter-clockwise rotation.
         start_angle: f64,
         /// End angle of the sweep, in radians.
-        /// Zero points upwards and positive angles represent clockwise rotation.
+        /// Zero points to the right and positive angles represent counter-clockwise rotation.
         end_angle: f64,
     },
 }

--- a/masonry/src/properties/types/gradient.rs
+++ b/masonry/src/properties/types/gradient.rs
@@ -176,7 +176,7 @@ impl Gradient {
     /// [conic gradients](https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/conic-gradient#composition_of_a_conic_gradient).
     /// We may change how these values are interpreted in the future.
     ///
-    /// See also [`Self::new_sweep_full`].
+    /// See also [`Self::new_full_sweep`].
     pub fn new_sweep(center: UnitPoint, start_angle: f64, end_angle: f64) -> Self {
         let shape = GradientShape::Sweep {
             center,

--- a/masonry/src/properties/types/gradient.rs
+++ b/masonry/src/properties/types/gradient.rs
@@ -42,7 +42,7 @@ pub enum GradientShape {
     /// Gradient that transitions between two or more colors that rotate around a center
     /// point.
     ///
-    /// This is similar to [`conic-gradient()`] in CSS **but the values are intepreted differently**.
+    /// This is similar to [`conic-gradient()`] in CSS **but the values are interpreted differently**.
     ///
     /// [`conic-gradient()`]: https://drafts.csswg.org/css-images-4/#conic-gradient-syntax
     Sweep {

--- a/masonry/src/properties/types/gradient.rs
+++ b/masonry/src/properties/types/gradient.rs
@@ -111,7 +111,7 @@ pub enum RadialGradientShape {
 ///
 /// Matches the `radial-extent` parameter of the [`radial-gradient()`] syntax.
 ///
-/// [`radial-gradient()`]: https://drafts.csswg.org/css-images-3/#radial-gradient-syntax
+/// [`radial-gradient()`]: https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/radial-gradient#size
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum RadialGradientExtent {
     /// Interpreted like CSS `closest-corner` size.

--- a/masonry/src/properties/types/mod.rs
+++ b/masonry/src/properties/types/mod.rs
@@ -15,5 +15,5 @@
 mod gradient;
 mod unit_point;
 
-pub use gradient::{Gradient, GradientShape};
+pub use gradient::*;
 pub use unit_point::UnitPoint;

--- a/masonry/src/properties/types/unit_point.rs
+++ b/masonry/src/properties/types/unit_point.rs
@@ -3,7 +3,7 @@
 
 use vello::kurbo::{Point, Rect};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 /// A point with coordinates in the range [0.0, 1.0].
 ///
 /// This is useful for specifying points in a normalized space, such as a gradient.

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -322,7 +322,7 @@ mod tests {
 
     use super::*;
     use crate::palette;
-    use crate::properties::types::Gradient;
+    use crate::properties::types::{Gradient, UnitPoint};
     use crate::testing::{
         TestHarness, TestWidgetExt, assert_failing_render_snapshot, assert_render_snapshot,
     };
@@ -464,7 +464,33 @@ mod tests {
         assert_render_snapshot!(harness, "sized_box_empty_box_with_gradient_background");
     }
 
-    // TODO - Test other gradient types.
+    #[test]
+    fn radial_gradient_background() {
+        let mut box_props = Properties::new();
+
+        let gradient = Gradient::new_radial(UnitPoint::CENTER).with_stops([
+            palette::css::WHITE,
+            palette::css::BLACK,
+            palette::css::RED,
+            palette::css::GREEN,
+            palette::css::WHITE,
+        ]);
+        box_props.insert(Background::Gradient(gradient));
+        box_props.insert(BorderColor::new(palette::css::LIGHT_SKY_BLUE));
+        box_props.insert(BorderWidth::all(5.0));
+        box_props.insert(CornerRadius::all(10.0));
+
+        let widget = SizedBox::empty()
+            .width(20.)
+            .height(20.)
+            .with_props(box_props);
+
+        let window_size = Size::new(100.0, 100.0);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
+
+        assert_render_snapshot!(harness, "sized_box_radial_gradient_background");
+    }
 
     #[test]
     fn label_box_with_padding_and_background() {

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -493,6 +493,34 @@ mod tests {
     }
 
     #[test]
+    fn sweep_gradient_background() {
+        let mut box_props = Properties::new();
+
+        let gradient = Gradient::new_full_sweep(UnitPoint::CENTER, 0.).with_stops([
+            palette::css::WHITE,
+            palette::css::BLACK,
+            palette::css::RED,
+            palette::css::GREEN,
+            palette::css::WHITE,
+        ]);
+        box_props.insert(Background::Gradient(gradient));
+        box_props.insert(BorderColor::new(palette::css::LIGHT_SKY_BLUE));
+        box_props.insert(BorderWidth::all(5.0));
+        box_props.insert(CornerRadius::all(10.0));
+
+        let widget = SizedBox::empty()
+            .width(20.)
+            .height(20.)
+            .with_props(box_props);
+
+        let window_size = Size::new(100.0, 100.0);
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, window_size);
+
+        assert_render_snapshot!(harness, "sized_box_sweep_gradient_background");
+    }
+
+    #[test]
     fn label_box_with_padding_and_background() {
         let mut box_props = Properties::new();
         box_props.insert(Background::Color(palette::css::PLUM));


### PR DESCRIPTION
Add `GradientShape::Radial` variant.
Add `GradientShape::Sweep` variant.

Add new `Gradient` constructors.
Add screenshot tests for new gradients.

This PR adds a lot of TODOs, but implementing gradients in a way that closely matches the CSS spec is just hard.
It still covers many common use-cases, and as such it's worth merging this before figuring out the full solution.