### PR TITLE
Add `access_tree_active` flag

### DIFF
--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -70,12 +70,6 @@ pub struct RenderRoot {
     /// State passed to context types.
     pub(crate) global_state: RenderRootState,
 
-    /// Whether the next accessibility pass should rebuild the entire access tree.
-    ///
-    /// TODO - Add `access_tree_active` to detect when you don't need to update the
-    // access tree
-    pub(crate) rebuild_access_tree: bool,
-
     /// The widget tree; stores widgets and their states.
     pub(crate) widget_arena: WidgetArena,
     pub(crate) debug_paint: bool,
@@ -140,6 +134,9 @@ pub(crate) struct RenderRootState {
     /// Pass tracing configuration, used to skip tracing to limit overhead.
     pub(crate) trace: PassTracing,
     pub(crate) inspector_state: InspectorState,
+
+    /// Whether the next accessibility pass tree should be updated during `render()`.
+    pub(crate) access_tree_active: bool,
 
     /// DPI scale factor.
     ///
@@ -302,6 +299,7 @@ impl RenderRoot {
                     is_picking_widget: false,
                     hovered_widget: None,
                 },
+                access_tree_active: false,
                 scale_factor,
             },
             widget_arena: WidgetArena {
@@ -309,7 +307,6 @@ impl RenderRoot {
                 states: TreeArena::new(),
                 properties: TreeArena::new(),
             },
-            rebuild_access_tree: true,
             debug_paint,
         };
 
@@ -369,10 +366,14 @@ impl RenderRoot {
 
                 Handled::Yes
             }
-            WindowEvent::RebuildAccessTree => {
-                self.rebuild_access_tree = true;
+            WindowEvent::EnableAccessTree => {
+                self.global_state.access_tree_active = true;
                 self.global_state
                     .emit_signal(RenderRootSignal::RequestRedraw);
+                Handled::Yes
+            }
+            WindowEvent::DisableAccessTree => {
+                self.global_state.access_tree_active = false;
                 Handled::Yes
             }
         }
@@ -436,12 +437,15 @@ impl RenderRoot {
     ///
     /// Returns an update to the accessibility tree and a Vello scene representing
     /// the widget tree's current state.
-    pub fn redraw(&mut self) -> (Scene, TreeUpdate) {
+    pub fn redraw(&mut self) -> (Scene, Option<TreeUpdate>) {
         self.run_rewrite_passes();
+
+        let access_tree_active = self.global_state.access_tree_active;
 
         // TODO - Handle invalidation regions
         let scene = run_paint_pass(self);
-        let tree_update = run_accessibility_pass(self, self.global_state.scale_factor);
+        let tree_update = access_tree_active
+            .then(|| run_accessibility_pass(self, self.global_state.scale_factor));
         (scene, tree_update)
     }
 
@@ -594,9 +598,9 @@ impl RenderRoot {
         }
 
         // We request a redraw if either the render tree or the accessibility
-        // tree needs to be rebuilt. Usually both happen at the same time.
+        // tree needs to be rebuilt. Usually both are rebuilt at the same time.
         // A redraw will trigger a rebuild of the accessibility tree.
-        if self.root_state().needs_paint || self.root_state().needs_accessibility {
+        if self.root_state().needs_paint || self.needs_accessibility() {
             self.global_state
                 .emit_signal(RenderRootSignal::RequestRedraw);
         }
@@ -726,6 +730,13 @@ impl RenderRoot {
     /// Returns true if the widget tree is waiting for an animation frame.
     pub fn needs_anim(&self) -> bool {
         self.root_state().needs_anim
+    }
+
+    /// Returns true if the accessibility tree needs to be rebuilt.
+    ///
+    /// This will be inhibited if `access_tree_active` is false.
+    pub fn needs_accessibility(&self) -> bool {
+        self.global_state.access_tree_active && self.root_state().needs_accessibility
     }
 
     /// Returns `true` if something requires a rewrite pass or a re-render.

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -137,7 +137,6 @@ pub struct AccessCtx<'a> {
     pub(crate) widget_children: ArenaMutList<'a, Box<dyn Widget>>,
     pub(crate) properties_children: ArenaMutList<'a, AnyMap>,
     pub(crate) tree_update: &'a mut TreeUpdate,
-    pub(crate) rebuild_all: bool,
 }
 
 // --- MARK: GETTERS
@@ -1439,7 +1438,6 @@ impl<'s> AccessCtx<'s> {
             properties_children: child_properties.children,
             global_state: self.global_state,
             tree_update: self.tree_update,
-            rebuild_all: self.rebuild_all,
         };
         RawWrapper {
             ctx: child_ctx,

--- a/masonry_core/src/core/events.rs
+++ b/masonry_core/src/core/events.rs
@@ -22,8 +22,10 @@ pub enum WindowEvent {
     Resize(PhysicalSize<u32>),
     /// The animation frame requested by this window must run.
     AnimFrame(Duration),
-    /// The accessibility tree must be rebuilt.
-    RebuildAccessTree,
+    /// The accessibility tree must be updated when rendering the app.
+    EnableAccessTree,
+    /// The accessibility tree is no longer updated when rendering the app.
+    DisableAccessTree,
 }
 
 // TODO - Clipboard Paste?

--- a/masonry_core/src/passes/accessibility.rs
+++ b/masonry_core/src/passes/accessibility.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use accesskit::{Node, NodeId, Role, Tree, TreeUpdate};
-use tracing::{debug, info_span, trace};
+use tracing::{info_span, trace};
 use tree_arena::ArenaMut;
 use vello::kurbo::Rect;
 
@@ -19,17 +19,16 @@ fn build_accessibility_tree(
     mut widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
     mut properties: ArenaMut<'_, AnyMap>,
-    rebuild_all: bool,
     scale_factor: Option<f64>,
 ) {
     let _span = enter_span_if(global_state.trace.access, state.reborrow());
     let id = state.item.id;
 
-    if !rebuild_all && !state.item.needs_accessibility {
+    if !state.item.needs_accessibility {
         return;
     }
 
-    if (rebuild_all || state.item.request_accessibility) && !state.item.is_stashed {
+    if state.item.request_accessibility && !state.item.is_stashed {
         if global_state.trace.access {
             trace!(
                 "Building accessibility node for widget '{}' {}",
@@ -45,7 +44,6 @@ fn build_accessibility_tree(
             widget_children: widget.children.reborrow_mut(),
             properties_children: properties.children.reborrow_mut(),
             tree_update,
-            rebuild_all,
         };
         let mut node = build_access_node(&mut **widget.item, &mut ctx, scale_factor);
         let props = PropertiesRef {
@@ -81,7 +79,6 @@ fn build_accessibility_tree(
                 widget,
                 state.reborrow_mut(),
                 properties,
-                rebuild_all,
                 None,
             );
             parent_state.merge_up(state.item);
@@ -189,9 +186,6 @@ pub(crate) fn run_accessibility_pass(root: &mut RenderRoot, scale_factor: f64) -
         (widget, state, properties)
     };
 
-    if root.rebuild_access_tree {
-        debug!("Running ACCESSIBILITY pass with rebuild_all");
-    }
     build_accessibility_tree(
         &mut root.global_state,
         &root.default_properties,
@@ -199,10 +193,8 @@ pub(crate) fn run_accessibility_pass(root: &mut RenderRoot, scale_factor: f64) -
         root_widget,
         root_state,
         root_properties,
-        root.rebuild_access_tree,
         Some(scale_factor),
     );
-    root.rebuild_access_tree = false;
 
     // TODO: make root node type customizable to support Dialog/AlertDialog roles
     // (should go hand in hand with introducing support for modal windows?)

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -299,6 +299,7 @@ impl TestHarness {
             title: String::new(),
         };
         harness.process_window_event(WindowEvent::Resize(window_size));
+        harness.process_window_event(WindowEvent::EnableAccessTree);
 
         harness
     }
@@ -379,6 +380,7 @@ impl TestHarness {
     /// The returned image contains a bitmap (an array of pixels) as an 8-bits-per-channel RGB image.
     pub fn render(&mut self) -> RgbaImage {
         let (scene, tree_update) = self.render_root.redraw();
+        let tree_update = tree_update.unwrap();
         if let Some(access_tree) = &mut self.access_tree {
             access_tree.update_and_process_changes(tree_update, &mut NoOpTreeChangeHandler);
         } else {

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -643,7 +643,9 @@ impl MasonryState<'_> {
                     error!("Suspended inside event");
                     return;
                 };
-                accesskit_adapter.update_if_active(|| tree_update);
+                if let Some(tree_update) = tree_update {
+                    accesskit_adapter.update_if_active(|| tree_update);
+                }
             }
             WinitWindowEvent::CloseRequested => {
                 app_driver.on_close_requested(window.id, &mut DriverCtx::new(self, event_loop));
@@ -712,12 +714,16 @@ impl MasonryState<'_> {
                     accesskit_winit::WindowEvent::InitialTreeRequested => {
                         state
                             .render_root
-                            .handle_window_event(WindowEvent::RebuildAccessTree);
+                            .handle_window_event(WindowEvent::EnableAccessTree);
                     }
                     accesskit_winit::WindowEvent::ActionRequested(action_request) => {
                         state.render_root.handle_access_event(action_request);
                     }
-                    accesskit_winit::WindowEvent::AccessibilityDeactivated => {}
+                    accesskit_winit::WindowEvent::AccessibilityDeactivated => {
+                        state
+                            .render_root
+                            .handle_window_event(WindowEvent::DisableAccessTree);
+                    }
                 }
             }
             // TODO - Not sure what the use-case for this is.
@@ -858,7 +864,9 @@ impl MasonryState<'_> {
                 ..
             } = &mut window.state
             {
-                accesskit_adapter.update_if_active(|| tree_update);
+                if let Some(tree_update) = tree_update {
+                    accesskit_adapter.update_if_active(|| tree_update);
+                }
                 handle.set_visible(true);
             };
         }


### PR DESCRIPTION
Change how accessibility updates are handled to a "ignore updates if tree isn't built" model.