### PR TITLE
Add `Widget::post_paint()` method

### DIFF
--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -135,9 +135,7 @@ pub(crate) struct RenderRootState {
     pub(crate) last_sent_ime_area: Rect,
 
     /// Scene cache for the widget tree.
-    pub(crate) scenes: HashMap<WidgetId, Scene>,
-    /// Second scene cache, used for `post_paint()` calls.
-    pub(crate) postfix_scenes: HashMap<WidgetId, Scene>,
+    pub(crate) scene_cache: HashMap<WidgetId, (Scene, Scene)>,
 
     /// Whether data set in the pointer pass has been invalidated.
     pub(crate) needs_pointer_pass: bool,
@@ -318,8 +316,7 @@ impl RenderRoot {
                 mutate_callbacks: Vec::new(),
                 is_ime_active: false,
                 last_sent_ime_area: INVALID_IME_AREA,
-                scenes: HashMap::new(),
-                postfix_scenes: HashMap::new(),
+                scene_cache: HashMap::new(),
                 needs_pointer_pass: false,
                 trace: PassTracing::from_env(),
                 inspector_state: InspectorState {

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -136,6 +136,8 @@ pub(crate) struct RenderRootState {
 
     /// Scene cache for the widget tree.
     pub(crate) scenes: HashMap<WidgetId, Scene>,
+    /// Second scene cache, used for `post_paint()` calls.
+    pub(crate) postfix_scenes: HashMap<WidgetId, Scene>,
 
     /// Whether data set in the pointer pass has been invalidated.
     pub(crate) needs_pointer_pass: bool,
@@ -317,6 +319,7 @@ impl RenderRoot {
                 is_ime_active: false,
                 last_sent_ime_area: INVALID_IME_AREA,
                 scenes: HashMap::new(),
+                postfix_scenes: HashMap::new(),
                 needs_pointer_pass: false,
                 trace: PassTracing::from_env(),
                 inspector_state: InspectorState {

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -1085,8 +1085,7 @@ impl_context_method!(MutateCtx<'_>, EventCtx<'_>, UpdateCtx<'_>, RawCtx<'_>, {
             .children
             .remove(id)
             .expect("remove_child: child not found");
-        self.global_state.scenes.remove(&child.id());
-        self.global_state.postfix_scenes.remove(&child.id());
+        self.global_state.scene_cache.remove(&child.id());
 
         self.children_changed();
     }

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -1000,18 +1000,27 @@ impl_context_method!(MutateCtx<'_>, EventCtx<'_>, UpdateCtx<'_>, RawCtx<'_>, {
     pub fn request_render(&mut self) {
         trace!("request_render");
         self.widget_state.request_paint = true;
+        self.widget_state.request_post_paint = true;
         self.widget_state.needs_paint = true;
         self.widget_state.needs_accessibility = true;
         self.widget_state.request_accessibility = true;
     }
 
-    /// Request a [`paint`](crate::core::Widget::paint) pass.
+    /// Request a paint pass, specifically for the [`paint`](crate::core::Widget::paint) method.
     ///
-    /// Unlike [`request_render`](Self::request_render), this does not request an [`accessibility`](crate::core::Widget::accessibility) pass.
-    /// Use `request_render` unless you're sure an accessibility pass is not needed.
+    /// Unlike [`request_render`](Self::request_render), this does not request an [`accessibility`](crate::core::Widget::accessibility) pass or a call to [`post_paint`](crate::core::Widget::post_paint).
+    ///
+    /// Use `request_render` unless you're sure neither is needed.
     pub fn request_paint_only(&mut self) {
-        trace!("request_paint");
+        trace!("request_paint_only");
         self.widget_state.request_paint = true;
+        self.widget_state.needs_paint = true;
+    }
+
+    /// Request a paint pass for the [`post_paint`](crate::core::Widget::post_paint) method.
+    pub fn request_post_paint(&mut self) {
+        trace!("request_post_paint");
+        self.widget_state.request_post_paint = true;
         self.widget_state.needs_paint = true;
     }
 

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -1086,6 +1086,7 @@ impl_context_method!(MutateCtx<'_>, EventCtx<'_>, UpdateCtx<'_>, RawCtx<'_>, {
             .remove(id)
             .expect("remove_child: child not found");
         self.global_state.scenes.remove(&child.id());
+        self.global_state.postfix_scenes.remove(&child.id());
 
         self.children_changed();
     }

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -257,10 +257,16 @@ pub trait Widget: AsDynWidget + Any {
     /// Paint the widget appearance.
     ///
     /// Container widgets can paint a background before recursing to their
-    /// children, or annotations (for example, scrollbars) by painting
-    /// afterwards. In addition, they can apply masks and transforms on
-    /// the render context, which is especially useful for scrolling.
+    /// children. To draw on top of children, see [`Widget::post_paint`].
     fn paint(&mut self, ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, scene: &mut Scene);
+
+    // TODO - Implement that method in some widgets.
+    // Shadows would be a good use case.
+    /// Second paint method, which paints on top of the widget's children.
+    ///
+    /// This method paints outside of the clip defined in [`LayoutCtx::set_clip_path`].
+    fn post_paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
+    }
 
     /// Return what kind of "thing" the widget fundamentally is.
     fn accessibility_role(&self) -> Role;

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -260,8 +260,6 @@ pub trait Widget: AsDynWidget + Any {
     /// children. To draw on top of children, see [`Widget::post_paint`].
     fn paint(&mut self, ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, scene: &mut Scene);
 
-    // TODO - Implement that method in some widgets.
-    // Shadows would be a good use case.
     /// Second paint method, which paints on top of the widget's children.
     ///
     /// This method is not constrained by the clip defined in [`LayoutCtx::set_clip_path`], and can paint things outside the clip.

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -264,7 +264,7 @@ pub trait Widget: AsDynWidget + Any {
     // Shadows would be a good use case.
     /// Second paint method, which paints on top of the widget's children.
     ///
-    /// This method paints outside of the clip defined in [`LayoutCtx::set_clip_path`].
+    /// This method is not constrained by the clip defined in [`LayoutCtx::set_clip_path`], and can paint things outside the clip.
     fn post_paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
     }
 

--- a/masonry_core/src/core/widget_state.rs
+++ b/masonry_core/src/core/widget_state.rs
@@ -133,21 +133,21 @@ pub(crate) struct WidgetState {
     /// This widget or a descendant explicitly requested layout
     pub(crate) needs_layout: bool,
 
-    /// The compose method must be called on this widget
+    /// The `compose` method must be called on this widget
     pub(crate) request_compose: bool,
-    /// The compose method must be called on this widget or a descendant
+    /// The `compose` method must be called on this widget or a descendant
     pub(crate) needs_compose: bool,
 
-    /// The paint method must be called on this widget
+    /// The `paint` method must be called on this widget
     pub(crate) request_paint: bool,
-    /// The post_paint method must be called on this widget
+    /// The `post_paint` method must be called on this widget
     pub(crate) request_post_paint: bool,
     /// A painting method must be called on this widget or a descendant
     pub(crate) needs_paint: bool,
 
-    /// The accessibility method must be called on this widget
+    /// The `accessibility` method must be called on this widget
     pub(crate) request_accessibility: bool,
-    /// The accessibility method must be called on this widget or a descendant
+    /// The `accessibility` method must be called on this widget or a descendant
     pub(crate) needs_accessibility: bool,
 
     /// An animation must run on this widget

--- a/masonry_core/src/core/widget_state.rs
+++ b/masonry_core/src/core/widget_state.rs
@@ -140,6 +140,8 @@ pub(crate) struct WidgetState {
 
     /// The paint method must be called on this widget
     pub(crate) request_paint: bool,
+    /// The paint method must be called on this widget
+    pub(crate) request_post_paint: bool,
     /// The paint method must be called on this widget or a descendant
     pub(crate) needs_paint: bool,
 
@@ -233,6 +235,7 @@ impl WidgetState {
             request_compose: true,
             needs_compose: true,
             request_paint: true,
+            request_post_paint: true,
             needs_paint: true,
             request_accessibility: true,
             needs_accessibility: true,

--- a/masonry_core/src/core/widget_state.rs
+++ b/masonry_core/src/core/widget_state.rs
@@ -140,9 +140,9 @@ pub(crate) struct WidgetState {
 
     /// The paint method must be called on this widget
     pub(crate) request_paint: bool,
-    /// The paint method must be called on this widget
+    /// The post_paint method must be called on this widget
     pub(crate) request_post_paint: bool,
-    /// The paint method must be called on this widget or a descendant
+    /// A painting method must be called on this widget or a descendant
     pub(crate) needs_paint: bool,
 
     /// The accessibility method must be called on this widget

--- a/masonry_core/src/passes/layout.rs
+++ b/masonry_core/src/passes/layout.rs
@@ -67,6 +67,7 @@ pub(crate) fn run_layout_on(
     state.needs_compose = true;
     state.needs_accessibility = true;
     state.request_paint = true;
+    state.request_post_paint = true;
     state.request_compose = true;
     state.request_accessibility = true;
 

--- a/masonry_core/src/passes/paint.rs
+++ b/masonry_core/src/passes/paint.rs
@@ -73,7 +73,8 @@ fn paint_widget(
     let has_clip = state.clip_path.is_some();
     if !is_stashed {
         let transform = state.window_transform;
-        let scene = scenes.get(&id).unwrap();
+        // let scene = scenes.get(&id).unwrap();
+        let scene = scenes.entry(id).or_default();
 
         if let Some(clip) = state.clip_path {
             complete_scene.push_layer(Mix::Clip, 1., transform, &clip);
@@ -117,7 +118,8 @@ fn paint_widget(
             complete_scene.pop_layer();
         }
 
-        let postfix_scene = postfix_scenes.get(&id).unwrap();
+        // let postfix_scene = postfix_scenes.get(&id).unwrap();
+        let postfix_scene = postfix_scenes.entry(id).or_default();
         complete_scene.append(postfix_scene, Some(transform));
     }
 }

--- a/masonry_core/src/passes/paint.rs
+++ b/masonry_core/src/passes/paint.rs
@@ -76,7 +76,12 @@ fn paint_widget(
     let has_clip = state.clip_path.is_some();
     if !is_stashed {
         let transform = state.window_transform;
-        let scene = &mut scene_cache.entry(id).or_default().0;
+        let Some((scene, _)) = &mut scene_cache.get(&id) else {
+            debug_panic!(
+                "Error in paint pass: scene should have been cached earlier in this function."
+            );
+            return;
+        };
 
         if let Some(clip) = state.clip_path {
             complete_scene.push_layer(Mix::Clip, 1., transform, &clip);
@@ -119,7 +124,13 @@ fn paint_widget(
             complete_scene.pop_layer();
         }
 
-        let postfix_scene = &mut scene_cache.entry(id).or_default().1;
+        let Some((_, postfix_scene)) = &mut scene_cache.get(&id) else {
+            debug_panic!(
+                "Error in paint pass: scene should have been cached earlier in this function."
+            );
+            return;
+        };
+
         complete_scene.append(postfix_scene, Some(transform));
     }
 }

--- a/masonry_testing/src/modular_widget.rs
+++ b/masonry_testing/src/modular_widget.rs
@@ -52,6 +52,7 @@ pub struct ModularWidget<S> {
     layout: Option<Box<LayoutFn<S>>>,
     compose: Option<Box<ComposeFn<S>>>,
     paint: Option<Box<PaintFn<S>>>,
+    post_paint: Option<Box<PaintFn<S>>>,
     role: Option<Box<RoleFn<S>>>,
     access: Option<Box<AccessFn<S>>>,
     children: Option<Box<ChildrenFn<S>>>,
@@ -78,6 +79,7 @@ impl<S> ModularWidget<S> {
             layout: None,
             compose: None,
             paint: None,
+            post_paint: None,
             role: None,
             access: None,
             children: None,
@@ -197,6 +199,15 @@ impl<S> ModularWidget<S> {
         f: impl FnMut(&mut S, &mut PaintCtx<'_>, &PropertiesRef<'_>, &mut Scene) + 'static,
     ) -> Self {
         self.paint = Some(Box::new(f));
+        self
+    }
+
+    /// See [`Widget::post_paint`]
+    pub fn post_paint_fn(
+        mut self,
+        f: impl FnMut(&mut S, &mut PaintCtx<'_>, &PropertiesRef<'_>, &mut Scene) + 'static,
+    ) -> Self {
+        self.post_paint = Some(Box::new(f));
         self
     }
 
@@ -326,6 +337,12 @@ impl<S: 'static> Widget for ModularWidget<S> {
 
     fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
         if let Some(f) = self.paint.as_mut() {
+            f(&mut self.state, ctx, props, scene);
+        }
+    }
+
+    fn post_paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
+        if let Some(f) = self.post_paint.as_mut() {
             f(&mut self.state, ctx, props, scene);
         }
     }

--- a/masonry_testing/src/recorder_widget.rs
+++ b/masonry_testing/src/recorder_widget.rs
@@ -80,6 +80,8 @@ pub enum Record {
     Compose,
     /// Paint.
     Paint,
+    /// Paint after children.
+    PostPaint,
     /// Accessibility.
     Access,
 }
@@ -203,6 +205,11 @@ impl<W: Widget> Widget for Recorder<W> {
     fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
         self.recording.push(Record::Paint);
         self.child.paint(ctx, props, scene);
+    }
+
+    fn post_paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
+        self.recording.push(Record::PostPaint);
+        self.child.post_paint(ctx, props, scene);
     }
 
     fn accessibility_role(&self) -> Role {


### PR DESCRIPTION
Adds a new `post_paint()` method which paints content after children have been painted, and outside of the clip rect.

This will be useful for painting web-standards-accurate shadows, and other things which don't really fit our current painting model.

It's still missing some work; for instance, we should consider letting some widgets declare a shape which is considered "above" the widget's children when processing pointer events.