### PR TITLE
Add `TestHarness::scroll_into_view` method.

### DIFF
--- a/masonry/screenshots/portal_scrolled_button_into_view.png
+++ b/masonry/screenshots/portal_scrolled_button_into_view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2251f287d54a3af30e7c0179472afc49ca9107824d49dd5e81e0302d5f1a6c0
+size 1372

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -593,6 +593,24 @@ mod tests {
         assert_render_snapshot!(harness, "portal_button_list_scroll_to_item_13");
     }
 
+    #[test]
+    fn scroll_into_view() {
+        let [button_id] = widget_ids();
+
+        let widget = Portal::new(
+            Flex::column()
+                .with_spacer(500.0)
+                .with_child_id(Button::new("Fully visible"), button_id)
+                .with_spacer(500.0),
+        );
+
+        let mut harness =
+            TestHarness::create_with_size(default_property_set(), widget, Size::new(200., 200.));
+
+        harness.scroll_into_view(button_id);
+        assert_render_snapshot!(harness, "portal_scrolled_button_into_view");
+    }
+
     // Helper function for panning tests
     fn make_range(repr: &str) -> Range<f64> {
         let repr = &repr[repr.find('_').unwrap()..];

--- a/masonry_core/src/passes/event.rs
+++ b/masonry_core/src/passes/event.rs
@@ -361,6 +361,14 @@ pub(crate) fn run_on_access_event_pass(
                 handled = Handled::Yes;
             }
         }
+        accesskit::Action::ScrollIntoView if !handled.is_handled() => {
+            let widget_state = root.widget_arena.get_state(target);
+            let rect = widget_state.item.layout_rect();
+            root.global_state
+                .scroll_request_targets
+                .push((target, rect));
+            handled = Handled::Yes;
+        }
         _ => {}
     }
 

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, mpsc};
 
 use image::{DynamicImage, ImageFormat, ImageReader, Rgba, RgbaImage};
+use masonry_core::accesskit::{Action, ActionRequest};
 use masonry_core::anymore::AnyDebug;
 use oxipng::{Options, optimize_from_memory};
 use tracing::debug;
@@ -574,6 +575,23 @@ impl TestHarness {
         }
 
         self.mouse_move(widget_center);
+    }
+
+    /// Try to get the target widget into the viewport.
+    ///
+    /// This will send an accesskit [`ScrollIntoView`] action to the widget,
+    /// which will usually send [`RequestPanToChild`] events to the widget's parents.
+    /// If the widget is hidden because it's "scrolled away", this should make it visible again.
+    ///
+    /// [`RequestPanToChild`]: masonry_core::core::Update::RequestPanToChild
+    /// [`ScrollIntoView`]: masonry_core::accesskit::Action::ScrollIntoView
+    #[track_caller]
+    pub fn scroll_into_view(&mut self, id: WidgetId) {
+        self.render_root.handle_access_event(ActionRequest {
+            action: Action::ScrollIntoView,
+            target: id.to_raw().into(),
+            data: None,
+        });
     }
 
     // TODO - Handle complicated IME


### PR DESCRIPTION
This may be useful in cases where the user wants the harness to click something that would otherwise be scrolled away.