### PR TITLE
Add WidgetTag

### DIFF
--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -14,9 +14,10 @@ use vello::Scene;
 use vello::kurbo::{Rect, Size};
 
 use crate::core::{
-    AccessEvent, BrushIndex, CursorIcon, DefaultProperties, ErasedAction, Handled, Ime, NewWidget,
-    PointerEvent, PropertiesRef, QueryCtx, ResizeDirection, TextEvent, Widget, WidgetArena,
-    WidgetArenaNode, WidgetId, WidgetMut, WidgetPod, WidgetRef, WidgetState, WindowEvent,
+    AccessEvent, BrushIndex, CursorIcon, DefaultProperties, ErasedAction, FromDynWidget, Handled,
+    Ime, NewWidget, PointerEvent, PropertiesRef, QueryCtx, ResizeDirection, TextEvent, Widget,
+    WidgetArena, WidgetArenaNode, WidgetId, WidgetMut, WidgetPod, WidgetRef, WidgetState,
+    WidgetTag, WindowEvent,
 };
 use crate::passes::accessibility::run_accessibility_pass;
 use crate::passes::anim::run_update_anim_pass;
@@ -136,6 +137,8 @@ pub(crate) struct RenderRootState {
 
     /// Scene cache for the widget tree.
     pub(crate) scene_cache: HashMap<WidgetId, (Scene, Scene)>,
+
+    pub(crate) widget_tags: HashMap<&'static str, WidgetId>,
 
     /// Whether data set in the pointer pass has been invalidated.
     pub(crate) needs_pointer_pass: bool,
@@ -317,6 +320,7 @@ impl RenderRoot {
                 is_ime_active: false,
                 last_sent_ime_area: INVALID_IME_AREA,
                 scene_cache: HashMap::new(),
+                widget_tags: HashMap::new(),
                 needs_pointer_pass: false,
                 trace: PassTracing::from_env(),
                 inspector_state: InspectorState {
@@ -536,6 +540,29 @@ impl RenderRoot {
         }
 
         let res = mutate_widget(self, id, f);
+
+        self.run_rewrite_passes();
+
+        res
+    }
+
+    /// Get a [`WidgetMut`] to the widget with the given tag.
+    ///
+    /// Because of how `WidgetMut` works, it can only be passed to a user-provided callback.
+    #[track_caller]
+    pub fn edit_widget_with_tag<R, W: Widget + FromDynWidget + ?Sized>(
+        &mut self,
+        tag: WidgetTag<W>,
+        f: impl FnOnce(WidgetMut<'_, W>) -> R,
+    ) -> R {
+        let Some(id) = self.global_state.widget_tags.get(&tag.name).copied() else {
+            panic!(
+                "Could not find widget with tag '{}' in widget tree.",
+                tag.name
+            );
+        };
+
+        let res = mutate_widget(self, id, |mut widget_mut| f(widget_mut.downcast()));
 
         self.run_rewrite_passes();
 

--- a/masonry_core/src/core/mod.rs
+++ b/masonry_core/src/core/mod.rs
@@ -17,6 +17,7 @@ mod widget_mut;
 mod widget_pod;
 mod widget_ref;
 mod widget_state;
+mod widget_tag;
 
 use anymore::AnyDebug;
 pub use axis::Axis;
@@ -37,6 +38,7 @@ pub use widget::{AllowRawMut, AsDynWidget, ChildrenIds, FromDynWidget, Widget, W
 pub use widget_mut::WidgetMut;
 pub use widget_pod::{NewWidget, WidgetOptions, WidgetPod};
 pub use widget_ref::WidgetRef;
+pub use widget_tag::WidgetTag;
 
 pub use ui_events::keyboard::{KeyboardEvent, Modifiers};
 pub use ui_events::pointer::{

--- a/masonry_core/src/core/widget_pod.rs
+++ b/masonry_core/src/core/widget_pod.rs
@@ -4,7 +4,7 @@
 use std::any::TypeId;
 use vello::kurbo::Affine;
 
-use crate::core::{Properties, Widget, WidgetId};
+use crate::core::{Properties, Widget, WidgetId, WidgetTag};
 
 /// A container for one widget in the hierarchy.
 ///
@@ -37,6 +37,8 @@ pub struct NewWidget<W: ?Sized> {
     pub options: WidgetOptions,
     /// The properties the widget will be created with.
     pub properties: Properties,
+
+    pub(crate) tag: &'static str,
 }
 
 // TODO - Remove this and merge it into NewWidget?
@@ -78,6 +80,15 @@ impl<W: Widget> NewWidget<W> {
             action_type_name: std::any::type_name::<W::Action>(),
             options: WidgetOptions::default(),
             properties: Properties::default(),
+            tag: "",
+        }
+    }
+
+    /// Create a new widget with a [`WidgetTag`].
+    pub fn new_with_tag(inner: W, tag: WidgetTag<W>) -> Self {
+        Self {
+            tag: tag.name,
+            ..Self::new(inner)
         }
     }
 
@@ -108,6 +119,7 @@ impl<W: Widget> NewWidget<W> {
             action_type_name: std::any::type_name::<W::Action>(),
             options,
             properties: props,
+            tag: "",
         }
     }
 }
@@ -126,6 +138,7 @@ impl<W: Widget + ?Sized> NewWidget<W> {
             action_type_name: self.action_type_name,
             options: self.options,
             properties: self.properties,
+            tag: self.tag,
         }
     }
 

--- a/masonry_core/src/core/widget_tag.rs
+++ b/masonry_core/src/core/widget_tag.rs
@@ -1,0 +1,30 @@
+// Copyright 2025 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::marker::PhantomData;
+
+use crate::core::Widget;
+
+/// A typed key which can be passed to a widget at construction, and then used to access that widget.
+///
+/// Unlike [`WidgetId`](crate::core::WidgetId), using this type to access a widget lets you
+/// skip downcasting.
+/// This should mostly be useful for testing.
+///
+/// You can only add one widget with a given tag to the entire widget tree.
+/// Trying to add another widget with the same tag will debug-panic or fail silently.
+/// Tags currently aren't garbage-collected even when the widget is removed from the tree.
+pub struct WidgetTag<W: Widget + ?Sized> {
+    pub(crate) name: &'static str,
+    pub(crate) _marker: PhantomData<W>,
+}
+
+impl<W: Widget> WidgetTag<W> {
+    /// Create a new tag.
+    pub const fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            _marker: PhantomData,
+        }
+    }
+}

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -133,6 +133,7 @@ fn update_widget_tree(
 
     {
         let mut ctx = RegisterCtx {
+            global_state,
             children: children.reborrow_mut(),
             #[cfg(debug_assertions)]
             registered_ids: Vec::new(),
@@ -209,6 +210,7 @@ pub(crate) fn run_update_widget_tree_pass(root: &mut RenderRoot) {
 
     if root.root.incomplete() {
         let mut ctx = RegisterCtx {
+            global_state: &mut root.global_state,
             children: root.widget_arena.nodes.roots_mut(),
             #[cfg(debug_assertions)]
             registered_ids: Vec::new(),

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -20,9 +20,9 @@ use masonry_core::app::{
     RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy, try_init_test_tracing,
 };
 use masonry_core::core::{
-    CursorIcon, DefaultProperties, ErasedAction, Handled, Ime, NewWidget, PointerButton,
-    PointerEvent, PointerId, PointerInfo, PointerState, PointerType, PointerUpdate, ScrollDelta,
-    TextEvent, Widget, WidgetId, WidgetMut, WidgetRef, WindowEvent,
+    CursorIcon, DefaultProperties, ErasedAction, FromDynWidget, Handled, Ime, NewWidget,
+    PointerButton, PointerEvent, PointerId, PointerInfo, PointerState, PointerType, PointerUpdate,
+    ScrollDelta, TextEvent, Widget, WidgetId, WidgetMut, WidgetRef, WidgetTag, WindowEvent,
 };
 use masonry_core::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
 use masonry_core::kurbo::{Point, Size, Vec2};
@@ -747,6 +747,20 @@ impl<W: Widget> TestHarness<W> {
         f: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R,
     ) -> R {
         let ret = self.render_root.edit_widget(id, f);
+        self.process_signals();
+        ret
+    }
+
+    /// Get a [`WidgetMut`] to the widget with the given tag.
+    ///
+    /// Because of how `WidgetMut` works, it can only be passed to a user-provided callback.
+    #[track_caller]
+    pub fn edit_widget_with_tag<R, W2: Widget + FromDynWidget + ?Sized>(
+        &mut self,
+        tag: WidgetTag<W2>,
+        f: impl FnOnce(WidgetMut<'_, W2>) -> R,
+    ) -> R {
+        let ret = self.render_root.edit_widget_with_tag(tag, f);
         self.process_signals();
         ret
     }


### PR DESCRIPTION
Add a new WidgetTag type, which lets you access widgets without having to store their WidgetIds and lets you skip downcasting.
Tweak the to-do-list example to demonstrate how to use those tags.

Tags are similar to Selectors back in Druid and have a similar purpose: to carry type information between places in the code.

This is a first step towards adding a more generalized query system to Masonry.