### PR TITLE
Re-export `CursorIcon` from `masonry_core::core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,7 +2112,6 @@ version = "0.3.0"
 dependencies = [
  "accesskit",
  "assert_matches",
- "cursor-icon",
  "dpi",
  "float-cmp",
  "image",

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -22,7 +22,6 @@ testing = ["dep:masonry_testing"]
 
 [dependencies]
 accesskit.workspace = true
-cursor-icon = "1.1.0"
 dpi.workspace = true
 masonry_core.workspace = true
 masonry_testing = { workspace = true, optional = true }

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -40,7 +40,7 @@ pub use accesskit;
 pub use parley::{Alignment as TextAlign, AlignmentOptions as TextAlignOptions};
 pub use vello::peniko::color::palette;
 pub use vello::{kurbo, peniko};
-pub use {cursor_icon, dpi, parley, vello};
+pub use {dpi, parley, vello};
 
 pub use masonry_core::{app, core, util};
 #[cfg(any(feature = "testing", test))]

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -4,15 +4,14 @@
 //! A widget which splits an area in two, with a settable ratio, and optional draggable resizing.
 
 use accesskit::{Node, Role};
-use cursor_icon::CursorIcon;
 use tracing::{Span, trace_span, warn};
 use vello::Scene;
 use vello::kurbo::{Line, Point, Rect, Size};
 
 use crate::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, EventCtx, FromDynWidget, LayoutCtx,
-    NewWidget, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx,
-    TextEvent, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, CursorIcon, EventCtx, FromDynWidget,
+    LayoutCtx, NewWidget, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx,
+    RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::peniko::Color;
 use crate::theme;

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -5,7 +5,6 @@ use std::any::TypeId;
 use std::mem::Discriminant;
 
 use accesskit::{Node, NodeId, Role};
-use cursor_icon::CursorIcon;
 use parley::PlainEditor;
 use parley::editor::{Generation, SplitString};
 use tracing::{Span, trace_span};
@@ -15,9 +14,10 @@ use vello::peniko::Fill;
 
 use crate::core::keyboard::{Key, KeyState, NamedKey};
 use crate::core::{
-    AccessCtx, AccessEvent, BoxConstraints, BrushIndex, ChildrenIds, EventCtx, Ime, LayoutCtx,
-    PaintCtx, PointerButton, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx,
-    StyleProperty, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut, render_text,
+    AccessCtx, AccessEvent, BoxConstraints, BrushIndex, ChildrenIds, CursorIcon, EventCtx, Ime,
+    LayoutCtx, PaintCtx, PointerButton, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx,
+    RegisterCtx, StyleProperty, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut,
+    render_text,
 };
 use crate::properties::{DisabledTextColor, TextColor};
 use crate::theme::default_text_styles;

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use accesskit::{ActionRequest, NodeId, TreeUpdate};
-use cursor_icon::CursorIcon;
 use dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use parley::fontique::{Blob, Collection, CollectionOptions, FamilyId, FontInfo, SourceCache};
 use parley::{FontContext, LayoutContext};
@@ -15,7 +14,7 @@ use vello::Scene;
 use vello::kurbo::{Rect, Size};
 
 use crate::core::{
-    AccessEvent, BrushIndex, DefaultProperties, ErasedAction, Handled, Ime, NewWidget,
+    AccessEvent, BrushIndex, CursorIcon, DefaultProperties, ErasedAction, Handled, Ime, NewWidget,
     PointerEvent, PropertiesRef, QueryCtx, ResizeDirection, TextEvent, Widget, WidgetArena,
     WidgetArenaMut, WidgetArenaRef, WidgetId, WidgetMut, WidgetPod, WidgetRef, WidgetState,
     WindowEvent,

--- a/masonry_core/src/core/mod.rs
+++ b/masonry_core/src/core/mod.rs
@@ -34,6 +34,8 @@ pub use widget_mut::WidgetMut;
 pub use widget_pod::{NewWidget, WidgetOptions, WidgetPod};
 pub use widget_ref::WidgetRef;
 
+pub use cursor_icon::CursorIcon;
+
 pub use ui_events::keyboard::{KeyboardEvent, Modifiers};
 pub use ui_events::pointer::{
     PointerButton, PointerEvent, PointerId, PointerInfo, PointerState, PointerType, PointerUpdate,

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -7,7 +7,6 @@ use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use accesskit::{Node, Role};
-use cursor_icon::CursorIcon;
 use smallvec::SmallVec;
 use tracing::field::DisplayValue;
 use tracing::{Span, trace_span};
@@ -15,8 +14,8 @@ use vello::Scene;
 use vello::kurbo::{Point, Size};
 
 use crate::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, EventCtx, LayoutCtx, NewWidget, PaintCtx,
-    PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
+    AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, CursorIcon, EventCtx, LayoutCtx, NewWidget,
+    PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update,
     UpdateCtx, WidgetRef,
 };
 

--- a/masonry_core/src/lib.rs
+++ b/masonry_core/src/lib.rs
@@ -31,7 +31,7 @@
 
 pub use anymore;
 pub use vello::{kurbo, peniko, peniko::color::palette};
-pub use {accesskit, cursor_icon, dpi, parley, ui_events, vello};
+pub use {accesskit, dpi, parley, ui_events, vello};
 
 // TODO - re-add #[doc(hidden)]
 pub mod doc;

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -3,16 +3,15 @@
 
 use std::collections::HashSet;
 
-use cursor_icon::CursorIcon;
 use tracing::{info_span, trace};
 use tree_arena::ArenaMut;
 use ui_events::pointer::PointerType;
 
 use crate::app::{RenderRoot, RenderRootSignal, RenderRootState};
 use crate::core::{
-    DefaultProperties, Ime, PointerEvent, PointerInfo, PropertiesMut, PropertiesRef, QueryCtx,
-    RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetArenaMut, WidgetArenaRef, WidgetId,
-    WidgetState,
+    CursorIcon, DefaultProperties, Ime, PointerEvent, PointerInfo, PropertiesMut, PropertiesRef,
+    QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetArenaMut, WidgetArenaRef,
+    WidgetId, WidgetState,
 };
 use crate::passes::event::{run_on_pointer_event_pass, run_on_text_event_pass};
 use crate::passes::{enter_span, enter_span_if, merge_state_up, recurse_on_children};

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -19,11 +19,10 @@ use masonry_core::app::{
     RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy, try_init_test_tracing,
 };
 use masonry_core::core::{
-    DefaultProperties, ErasedAction, Handled, Ime, NewWidget, PointerButton, PointerEvent,
-    PointerId, PointerInfo, PointerState, PointerType, PointerUpdate, ScrollDelta, TextEvent,
-    Widget, WidgetId, WidgetMut, WidgetRef, WindowEvent,
+    CursorIcon, DefaultProperties, ErasedAction, Handled, Ime, NewWidget, PointerButton,
+    PointerEvent, PointerId, PointerInfo, PointerState, PointerType, PointerUpdate, ScrollDelta,
+    TextEvent, Widget, WidgetId, WidgetMut, WidgetRef, WindowEvent,
 };
-use masonry_core::cursor_icon::CursorIcon;
 use masonry_core::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
 use masonry_core::kurbo::{Point, Size, Vec2};
 use masonry_core::peniko::{Blob, Color};

--- a/masonry_testing/src/modular_widget.rs
+++ b/masonry_testing/src/modular_widget.rs
@@ -7,11 +7,11 @@ use tracing::trace_span;
 
 use masonry_core::accesskit::{Node, Role};
 use masonry_core::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ComposeCtx, EventCtx, LayoutCtx,
-    NewWidget, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx,
-    TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetRef, find_widget_under_pointer,
+    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ComposeCtx, CursorIcon, EventCtx,
+    LayoutCtx, NewWidget, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx,
+    RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetRef,
+    find_widget_under_pointer,
 };
-use masonry_core::cursor_icon::CursorIcon;
 use masonry_core::kurbo::{Point, Size};
 use masonry_core::vello::Scene;
 

--- a/masonry_testing/src/recorder_widget.rs
+++ b/masonry_testing/src/recorder_widget.rs
@@ -15,11 +15,10 @@ use std::rc::Rc;
 
 use masonry_core::accesskit::{Node, Role};
 use masonry_core::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ComposeCtx, EventCtx, LayoutCtx,
-    NewWidget, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx,
-    TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetRef,
+    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ComposeCtx, CursorIcon, EventCtx,
+    LayoutCtx, NewWidget, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, QueryCtx,
+    RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetRef,
 };
-use masonry_core::cursor_icon::CursorIcon;
 use masonry_core::kurbo::{Point, Size};
 use masonry_core::vello::Scene;
 


### PR DESCRIPTION
Instead of re-exporting `cursor_icon` from `masonry_core` and `masonry`, we can re-export the single type that matters (`CursorIcon`) from `masonry_core::core` / `masonry::core`.