### PR TITLE
Add layout caching to Masonry and remove `skip_layout()` method.

### DIFF
--- a/masonry/src/widgets/indexed_stack.rs
+++ b/masonry/src/widgets/indexed_stack.rs
@@ -221,9 +221,7 @@ impl Widget for IndexedStack {
                 ctx.place_child(child, origin);
             } else {
                 // TODO: move set_stashed to a different layout pass when possible,
-                // and remove skip_layout.
                 ctx.set_stashed(child, true);
-                ctx.skip_layout(child);
             }
         }
 

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -411,14 +411,9 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
             !self.constrain_vertical && portal_size.height < content_size.height;
 
         ctx.set_stashed(
-            &mut self.scrollbar_vertical,
-            !self.scrollbar_vertical_visible,
-        );
-        ctx.set_stashed(
             &mut self.scrollbar_horizontal,
             !self.scrollbar_horizontal_visible,
         );
-
         if self.scrollbar_horizontal_visible {
             let mut scrollbar = ctx.get_raw_mut(&mut self.scrollbar_horizontal);
             scrollbar.widget().portal_size = portal_size.width;
@@ -431,9 +426,12 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
                 &mut self.scrollbar_horizontal,
                 Point::new(0.0, portal_size.height - scrollbar_size.height),
             );
-        } else {
-            ctx.skip_layout(&mut self.scrollbar_horizontal);
         }
+
+        ctx.set_stashed(
+            &mut self.scrollbar_vertical,
+            !self.scrollbar_vertical_visible,
+        );
         if self.scrollbar_vertical_visible {
             let mut scrollbar = ctx.get_raw_mut(&mut self.scrollbar_vertical);
             scrollbar.widget().portal_size = portal_size.height;
@@ -446,8 +444,6 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
                 &mut self.scrollbar_vertical,
                 Point::new(portal_size.width - scrollbar_size.width, 0.0),
             );
-        } else {
-            ctx.skip_layout(&mut self.scrollbar_vertical);
         }
 
         portal_size

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -635,7 +635,6 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for VirtualScroll<W> {
                 // is nearly impossible to handle correctly without using this method; in particular, if a
                 // driver is delayed in being called (such as if layout is run twice in the passes loop).
                 ctx.set_stashed(child, true);
-                ctx.skip_layout(child);
                 continue;
             }
             first_item = first_item.map(|it| it.min(*idx)).or(Some(*idx));

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -715,14 +715,6 @@ impl LayoutCtx<'_> {
         self.get_child_state(child).size
     }
 
-    /// Skips running the layout pass and calling [`LayoutCtx::place_child`] on the child.
-    ///
-    /// This may be removed in the future. Currently it's useful for
-    /// stashed children and children whose layout is cached.
-    pub fn skip_layout(&mut self, child: &mut WidgetPod<impl Widget + ?Sized>) {
-        self.get_child_state_mut(child).request_layout = false;
-    }
-
     /// Gives the widget a clip path.
     ///
     /// A widget's clip path will have two effects:

--- a/masonry_core/src/core/layout_cache.rs
+++ b/masonry_core/src/core/layout_cache.rs
@@ -1,0 +1,16 @@
+// Copyright 2025 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::core::BoxConstraints;
+
+/// A struct that holds everything Masonry might want to cache per-widget between layout passes.
+#[derive(Clone, Debug)]
+pub(crate) struct LayoutCache {
+    pub(crate) old_bc: Option<BoxConstraints>,
+}
+
+impl LayoutCache {
+    pub(crate) fn empty() -> Self {
+        Self { old_bc: None }
+    }
+}

--- a/masonry_core/src/core/mod.rs
+++ b/masonry_core/src/core/mod.rs
@@ -6,6 +6,7 @@
 mod box_constraints;
 mod contexts;
 mod events;
+mod layout_cache;
 mod object_fit;
 mod properties;
 mod text;
@@ -40,6 +41,7 @@ pub use ui_events::pointer::{
 };
 pub use ui_events::{ScrollDelta, keyboard, pointer};
 
+pub(crate) use layout_cache::*;
 pub(crate) use widget_arena::{WidgetArena, WidgetArenaMut, WidgetArenaRef};
 pub(crate) use widget_state::WidgetState;
 

--- a/masonry_core/src/core/widget_state.rs
+++ b/masonry_core/src/core/widget_state.rs
@@ -4,7 +4,7 @@
 use tracing::Span;
 use vello::kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
 
-use crate::core::{WidgetId, WidgetOptions};
+use crate::core::{LayoutCache, WidgetId, WidgetOptions};
 
 // TODO - Reduce WidgetState size.
 // See https://github.com/linebender/xilem/issues/706
@@ -88,6 +88,8 @@ pub(crate) struct WidgetState {
     /// the baseline. Widgets that contain text or controls that expect to be
     /// laid out alongside text can set this as appropriate.
     pub(crate) baseline_offset: f64,
+    /// Data cached from previous layout passes.
+    pub(crate) layout_cache: LayoutCache,
 
     /// Tracks whether widget gets pointer events.
     /// Should be immutable after `WidgetAdded` event.
@@ -208,6 +210,7 @@ impl WidgetState {
             is_expecting_place_child_call: false,
             paint_insets: Insets::ZERO,
             local_paint_rect: Rect::ZERO,
+            layout_cache: LayoutCache::empty(),
             accepts_pointer_interaction: true,
             accepts_focus: false,
             accepts_text_input: false,


### PR DESCRIPTION
Remove caching code from `Flex`.
Fix how layout handles stashing flags.

`skip_layout()` was used for stashed widgets (no longer necessary) and layout caching, which we now handle at the Masonry level.