### PR TITLE
Remove focus chain and refactor tab-focus

### DIFF
--- a/masonry/screenshots/text_input_selection.png
+++ b/masonry/screenshots/text_input_selection.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f9a50d9b69fe0ddae5eaa58770d1e429da18fab35c80f67c91bf6a6923c671b5
-size 1643
+oid sha256:03aa080a0ff2319a5a881149b8ccc20d25b5857a57179fe201f93771572ab9cd
+size 1629

--- a/masonry/src/widgets/tests/lifecycle_focus.rs
+++ b/masonry/src/widgets/tests/lifecycle_focus.rs
@@ -43,23 +43,7 @@ impl FocusTaker {
     }
 }
 
-#[cfg(false)]
-/// Check that a focus chain is correctly built initially..
-#[test]
-fn build_focus_chain() {
-    let [id_1, id_2, id_3, id_4] = widget_ids();
-
-    let widget = Flex::column()
-        .with_child_id(FocusTaker::new(), id_1)
-        .with_child_id(FocusTaker::new(), id_2)
-        .with_child_id(FocusTaker::new(), id_3)
-        .with_child_id(FocusTaker::new(), id_4);
-
-    let harness = TestHarness::create(widgets);
-
-    // verify that we start out with four widgets registered for focus
-    assert_eq!(harness.window().focus_chain(), &[id_1, id_2, id_3, id_4]);
-}
+// TODO - Add tests for descendant_is_focusable
 
 #[cfg(false)]
 /// Check that focus changes trigger on_status_change

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -98,10 +98,10 @@ pub(crate) struct RenderRootState {
     /// Widget that will be focused once the `update_focus` pass is run.
     pub(crate) next_focused_widget: Option<WidgetId>,
 
-    /// Most recently clicked widget.
+    /// Most recently clicked/focused widget.
     ///
     /// This is used to pick the focused widget on Tab events.
-    pub(crate) most_recently_clicked_widget: Option<WidgetId>,
+    pub(crate) focus_anchor: Option<WidgetId>,
 
     /// Whether the window is focused.
     pub(crate) window_focused: bool,
@@ -284,7 +284,7 @@ impl RenderRoot {
                 focused_widget: None,
                 focused_path: Vec::new(),
                 next_focused_widget: None,
-                most_recently_clicked_widget: None,
+                focus_anchor: None,
                 window_focused: true,
                 scroll_request_targets: Vec::new(),
                 hovered_path: Vec::new(),
@@ -675,44 +675,6 @@ impl RenderRoot {
         self.global_state.next_focused_widget = id;
         self.run_rewrite_passes();
         true
-    }
-
-    pub(crate) fn widget_from_focus_chain(&mut self, forward: bool) -> Option<WidgetId> {
-        let focused_widget = self
-            .global_state
-            .focused_widget
-            .or(self.global_state.most_recently_clicked_widget);
-        let focused_idx = focused_widget.and_then(|focused_widget| {
-            self.focus_chain()
-                .iter()
-                // Find where the focused widget is in the focus chain
-                .position(|id| id == &focused_widget)
-        });
-
-        if let Some(idx) = focused_idx {
-            // Return the id that's next to it in the focus chain
-            let len = self.focus_chain().len();
-            let new_idx = if forward {
-                (idx + 1) % len
-            } else {
-                (idx + len - 1) % len
-            };
-            Some(self.focus_chain()[new_idx])
-        } else {
-            // If no widget is currently focused or the
-            // currently focused widget isn't in the focus chain,
-            // then we'll just return the first/last entry of the chain, if any.
-            if forward {
-                self.focus_chain().first().copied()
-            } else {
-                self.focus_chain().last().copied()
-            }
-        }
-    }
-
-    // TODO - Store in RenderRootState
-    pub(crate) fn focus_chain(&mut self) -> &[WidgetId] {
-        &self.root_state().focus_chain
     }
 
     /// Returns true if the widget tree is waiting for an animation frame.

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -1100,7 +1100,7 @@ impl_context_method!(MutateCtx<'_>, EventCtx<'_>, UpdateCtx<'_>, {
     pub fn children_changed(&mut self) {
         trace!("children_changed");
         self.widget_state.children_changed = true;
-        self.widget_state.needs_update_focus_chain = true;
+        self.widget_state.needs_update_focusable = true;
         self.request_layout();
     }
 
@@ -1127,6 +1127,11 @@ impl_context_method!(MutateCtx<'_>, EventCtx<'_>, UpdateCtx<'_>, {
             .remove(id)
             .expect("remove_child: child not found");
         self.global_state.scenes.remove(&child.id());
+
+        // If we remove the focus anchor, its parent becomes the anchor.
+        if self.global_state.focus_anchor == Some(id) {
+            self.global_state.focus_anchor = Some(self.widget_state.id);
+        }
 
         self.children_changed();
     }

--- a/masonry_core/src/core/widget_state.rs
+++ b/masonry_core/src/core/widget_state.rs
@@ -156,9 +156,10 @@ pub(crate) struct WidgetState {
     /// This widget or a descendant changed its `is_explicitly_stashed` value
     pub(crate) needs_update_stashed: bool,
 
-    pub(crate) needs_update_focus_chain: bool,
-
-    pub(crate) focus_chain: Vec<WidgetId>,
+    /// This widget or a descendant has `accepts_focus == true`
+    pub(crate) descendant_is_focusable: bool,
+    /// A focusable widget was added, removed, stashed, disabled, etc.
+    pub(crate) needs_update_focusable: bool,
 
     pub(crate) children_changed: bool,
 
@@ -238,9 +239,9 @@ impl WidgetState {
             needs_anim: true,
             needs_update_disabled: true,
             needs_update_stashed: true,
-            focus_chain: Vec::new(),
             children_changed: true,
-            needs_update_focus_chain: true,
+            descendant_is_focusable: false,
+            needs_update_focusable: true,
             #[cfg(debug_assertions)]
             widget_name,
             window_transform: Affine::IDENTITY,
@@ -265,7 +266,7 @@ impl WidgetState {
         self.needs_accessibility |= child_state.needs_accessibility;
         self.needs_update_disabled |= child_state.needs_update_disabled;
         self.children_changed |= child_state.children_changed;
-        self.needs_update_focus_chain |= child_state.needs_update_focus_chain;
+        self.needs_update_focusable |= child_state.needs_update_focusable;
         self.needs_update_stashed |= child_state.needs_update_stashed;
     }
 

--- a/masonry_core/src/doc/masonry_concepts.md
+++ b/masonry_core/src/doc/masonry_concepts.md
@@ -112,11 +112,14 @@ A widget is considered "interactive" if it can still get text and/or pointer eve
 Stashed and disabled widget are non-interactive.
 
 
-## Focus chain
+## Focus anchor
 
-Masonry stores an array of all the ids of widgets which can be focused.
+When the user presses `Tab` or `Shift+Tab`, Masonry will look for the closest sibling of the focus anchor which accepts focus, and focus it.
 
-This array is called the focus chain, and is used by Masonry to move focus when the user presses `Tab` or `Shift+Tab`.
+The focus anchor is generally either the focused widget, or the most recently clicked widget.
+If the focus anchor is removed from the tree, its parent becomes the anchor.
+
+This behavior exists so that when the user clicks somewhere and then presses `Tab`, the focused widget is more likely to be close to whatever the user clicked.
 
 
 ## Properties / Props

--- a/masonry_core/src/doc/pass_system.md
+++ b/masonry_core/src/doc/pass_system.md
@@ -120,9 +120,9 @@ This pass is ran when widgets are [stashed] or un-stashed.
 
 It's very similar to the "update disabled" pass, and takes care of propagating stashed flags.
 
-#### "Update focus chain" pass
+#### "Update focusable" pass
 
-This pass rebuilds the [focus chain] whenever it might be out of date.
+This pass updates flags used to determine whether a widget has any descendant accepting focus.
 
 It runs whenever a widget that accepts tab focus is added, removed, enabled, disabled, stashed or unstashed.
 This makes sure that tab-browsing always lands on the right widget.

--- a/masonry_core/src/passes/event.rs
+++ b/masonry_core/src/passes/event.rs
@@ -12,6 +12,7 @@ use crate::core::{
 };
 use crate::debug_panic;
 use crate::dpi::{LogicalPosition, PhysicalPosition};
+use crate::passes::update::find_next_in_focus_chain;
 use crate::passes::{enter_span, merge_state_up};
 
 // --- MARK: HELPERS
@@ -189,7 +190,7 @@ pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEv
     if matches!(event, PointerEvent::Down { .. }) {
         if let Some(target_widget_id) = target_widget_id {
             // The next tab event assign focus around this widget.
-            root.global_state.most_recently_clicked_widget = Some(target_widget_id);
+            root.global_state.focus_anchor = Some(target_widget_id);
 
             // If we click outside of the focused widget, we clear the focus.
             if let Some(focused_widget) = root.global_state.focused_widget {
@@ -292,7 +293,7 @@ pub(crate) fn run_on_text_event_pass(root: &mut RenderRoot, event: &TextEvent) -
             && handled == Handled::No
         {
             let forward = !key.modifiers.shift();
-            let next_focused_widget = root.widget_from_focus_chain(forward);
+            let next_focused_widget = find_next_in_focus_chain(root, forward);
             root.global_state.next_focused_widget = next_focused_widget;
             handled = Handled::Yes;
         }

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 
 use cursor_icon::CursorIcon;
 use tracing::{info_span, trace};
@@ -293,7 +293,7 @@ fn update_disabled_for_widget(
         };
         widget.update(&mut ctx, &mut props, &Update::DisabledChanged(disabled));
         state.is_disabled = disabled;
-        state.needs_update_focus_chain = true;
+        state.needs_update_focusable = true;
         state.request_accessibility = true;
         state.needs_accessibility = true;
     }
@@ -378,7 +378,7 @@ fn update_stashed_for_widget(
         };
         widget.update(&mut ctx, &mut props, &Update::StashedChanged(stashed));
         state.is_stashed = stashed;
-        state.needs_update_focus_chain = true;
+        state.needs_update_focusable = true;
 
         // Items may have been changed while they were stashed in ways that require a
         // relayout and a re-render.
@@ -424,21 +424,12 @@ pub(crate) fn run_update_stashed_pass(root: &mut RenderRoot) {
 
 // ----------------
 
-// --- MARK: FOCUS CHAIN
+// --- MARK: FOCUSABLE
 
-// TODO https://github.com/linebender/xilem/issues/376 - Some implicit invariants:
-// - A widget only receives BuildFocusChain if none of its parents are hidden.
-
-// TODO - This logic was copy-pasted from WidgetPod code and may need to be refactored.
-// It doesn't quite behave like other update passes (for instance, some code runs after
-// recurse_on_children), and some design decisions inherited from Druid should be reconsidered.
-/// See the [passes documentation](../doc/05_pass_system.md#update-passes).
-fn update_focus_chain_for_widget(
-    global_state: &mut RenderRootState,
+fn update_focusable_for_widget(
     widget: ArenaMut<'_, Box<dyn Widget>>,
     mut state: ArenaMut<'_, WidgetState>,
     properties: ArenaMut<'_, AnyMap>,
-    parent_focus_chain: &mut Vec<WidgetId>,
 ) {
     let _span = enter_span(state.reborrow());
     let id = state.item.id;
@@ -451,56 +442,119 @@ fn update_focus_chain_for_widget(
     let widget = &mut **widget.item;
     let state = state.item;
 
-    // Replace has_focused to check if the value changed in the meantime
-    state.has_focus_target = global_state.focused_widget == Some(id);
-    let had_focus = state.has_focus_target;
+    if !state.needs_update_focusable {
+        return;
+    }
 
-    if state.needs_update_focus_chain {
-        state.focus_chain.clear();
-        if state.accepts_focus {
-            state.focus_chain.push(id);
+    state.descendant_is_focusable = false;
+
+    if state.accepts_focus {
+        state.descendant_is_focusable = true;
+    }
+
+    let parent_state = &mut *state;
+    recurse_on_children(id, widget, children, |widget, mut state, properties| {
+        update_focusable_for_widget(widget, state.reborrow_mut(), properties);
+
+        if state.item.descendant_is_focusable {
+            parent_state.descendant_is_focusable = true;
         }
-        state.needs_update_focus_chain = false;
+    });
 
-        let parent_state = &mut *state;
-        recurse_on_children(id, widget, children, |widget, mut state, properties| {
-            update_focus_chain_for_widget(
-                global_state,
-                widget,
-                state.reborrow_mut(),
-                properties,
-                &mut parent_state.focus_chain,
-            );
-            parent_state.merge_up(state.item);
-        });
-    }
-
-    if !state.is_disabled && !state.is_stashed {
-        parent_focus_chain.extend(&state.focus_chain);
-    }
-
-    // had_focus is the old focus value. state.has_focused was replaced with parent_ctx.is_focused().
-    // Therefore if had_focus is true but state.has_focused is false then the widget which is
-    // currently focused is not part of the functional tree anymore and should resign the focus.
-    if had_focus && !state.has_focus_target {
-        // Not sure about this logic, might remove
-        global_state.next_focused_widget = None;
-    }
-    state.has_focus_target = had_focus;
+    state.needs_update_focusable = false;
 }
 
 pub(crate) fn run_update_focus_chain_pass(root: &mut RenderRoot) {
     let _span = info_span!("update_focus_chain").entered();
-    let mut dummy_focus_chain = Vec::new();
 
     let (root_widget, root_state, root_properties) = root.widget_arena.get_all_mut(root.root.id());
-    update_focus_chain_for_widget(
-        &mut root.global_state,
-        root_widget,
-        root_state,
-        root_properties,
-        &mut dummy_focus_chain,
-    );
+    update_focusable_for_widget(root_widget, root_state, root_properties);
+}
+
+pub(crate) fn find_next_in_focus_chain(root: &mut RenderRoot, forward: bool) -> Option<WidgetId> {
+    let focus_anchor = root.global_state.focus_anchor;
+
+    // If the anchor isn't already focused, try to find its first focusable descendant.
+    if focus_anchor != root.global_state.focused_widget
+        && let Some(focus_anchor) = focus_anchor
+    {
+        if let Some(found) = find_first_focusable(root, focus_anchor, forward) {
+            return Some(found);
+        }
+    }
+
+    // Else find its first ancestor with a `descendant_is_focusable == true` sibling
+    let mut anchor_path = VecDeque::from(get_id_path(root, focus_anchor));
+    while let Some(anchor) = anchor_path.pop_front() {
+        if let Some(sibling) = find_next_focusable_sibling(root, anchor, forward) {
+            return find_first_focusable(root, sibling, forward);
+        }
+    }
+
+    // Else start from the root
+    find_first_focusable(root, root.root.id(), forward)
+}
+
+fn find_next_focusable_sibling(
+    root: &mut RenderRoot,
+    anchor: WidgetId,
+    forward: bool,
+) -> Option<WidgetId> {
+    let parent_id = root.widget_arena.parent_of(anchor)?;
+    let parent_widget = root.widget_arena.get_widget(parent_id);
+    let siblings = parent_widget.item.children_ids();
+
+    let anchor_idx = siblings.iter().position(|id| *id == anchor).unwrap();
+
+    if forward {
+        siblings[anchor_idx + 1..]
+            .iter()
+            .find(|id| {
+                root.widget_arena
+                    .get_state(**id)
+                    .item
+                    .descendant_is_focusable
+            })
+            .copied()
+    } else {
+        siblings[..anchor_idx]
+            .iter()
+            .rev()
+            .find(|id| {
+                root.widget_arena
+                    .get_state(**id)
+                    .item
+                    .descendant_is_focusable
+            })
+            .copied()
+    }
+}
+
+fn find_first_focusable(root: &mut RenderRoot, node: WidgetId, forward: bool) -> Option<WidgetId> {
+    let (widget, state, _) = root.widget_arena.get_all(node);
+
+    if !state.item.descendant_is_focusable {
+        return None;
+    }
+    if state.item.accepts_focus {
+        return Some(node);
+    }
+
+    if forward {
+        for child in widget.item.children_ids() {
+            if let Some(found) = find_first_focusable(root, child, forward) {
+                return Some(found);
+            }
+        }
+    } else {
+        for child in widget.item.children_ids().into_iter().rev() {
+            if let Some(found) = find_first_focusable(root, child, forward) {
+                return Some(found);
+            }
+        }
+    }
+
+    None
 }
 
 // ----------------
@@ -652,6 +706,8 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
             if widget_state.accepts_text_input {
                 root.global_state.emit_signal(RenderRootSignal::StartIme);
             }
+
+            root.global_state.focus_anchor = Some(next_focused);
         } else {
             root.global_state.is_ime_active = false;
         }


### PR DESCRIPTION
The new behavior has a few advantages:
- Avoids building and storing O(N) arrays of WidgetIds per-widget.
- When the user clicks somewhere and then presses `Tab`, the focused widget is more likely to be close to whatever the user clicked.
- Overall more reliable than the old focus code.

Incidentally fixes a bug where a textbox sometimes woulnd't be shown as focused.