### PR TITLE
Implement tests to check that widgets can handle a size of zero

### DIFF
--- a/masonry_core/src/core/object_fit.rs
+++ b/masonry_core/src/core/object_fit.rs
@@ -32,6 +32,10 @@ impl ObjectFit {
     /// This takes some properties of a widget and an object fit and returns an affine matrix
     /// used to position and scale the image in the widget.
     pub fn affine_to_fill(self, parent: Size, fit_box: Size) -> Affine {
+        if fit_box.width == 0. || fit_box.height == 0. {
+            return Affine::IDENTITY;
+        }
+
         let raw_scalex = parent.width / fit_box.width;
         let raw_scaley = parent.height / fit_box.height;
 

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -192,6 +192,13 @@ macro_rules! assert_failing_render_snapshot {
 }
 
 impl TestHarnessParams {
+    /// Default test param values.
+    pub const DEFAULT: Self = Self {
+        window_size: Self::DEFAULT_SIZE,
+        background_color: Self::DEFAULT_BACKGROUND_COLOR,
+        scale_factor: 1.0,
+    };
+
     /// Default canvas size for tests.
     pub const DEFAULT_SIZE: Size = Size::new(400., 400.);
 
@@ -201,11 +208,7 @@ impl TestHarnessParams {
 
 impl Default for TestHarnessParams {
     fn default() -> Self {
-        Self {
-            window_size: Self::DEFAULT_SIZE,
-            background_color: Self::DEFAULT_BACKGROUND_COLOR,
-            scale_factor: 1.0,
-        }
+        Self::DEFAULT
     }
 }
 
@@ -406,6 +409,11 @@ impl TestHarness {
 
         // TODO - fix window_size
         let (width, height) = (self.window_size.width, self.window_size.height);
+
+        // Avoid having a zero-sized image
+        let width = width.max(1);
+        let height = height.max(1);
+
         let render_params = vello::RenderParams {
             base_color: self.background_color,
             width,

--- a/masonry_winit/examples/calc_masonry.rs
+++ b/masonry_winit/examples/calc_masonry.rs
@@ -235,7 +235,8 @@ fn digit_button(digit: u8) -> NewWidget<Button> {
     )
 }
 
-fn build_calc() -> NewWidget<impl Widget> {
+/// Build the widget tree
+pub fn build_calc() -> NewWidget<impl Widget> {
     let display = Label::new(String::new()).with_style(StyleProperty::FontSize(32.));
     let display = Flex::column()
         .with_flex_spacer(1.)

--- a/masonry_winit/examples/custom_widget.rs
+++ b/masonry_winit/examples/custom_widget.rs
@@ -11,8 +11,8 @@
 use masonry::accesskit::{Node, Role};
 use masonry::core::{
     AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ErasedAction, EventCtx, LayoutCtx,
-    NewWidget, ObjectFit, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx,
-    TextEvent, Widget, WidgetId,
+    NewWidget, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent,
+    Widget, WidgetId,
 };
 use masonry::kurbo::{Affine, BezPath, Point, Rect, Size, Stroke};
 use masonry::palette;
@@ -38,7 +38,9 @@ impl AppDriver for Driver {
     }
 }
 
-struct CustomWidget(String);
+/// A widget with a custom implementation of the Widget trait.
+#[derive(Debug)]
+pub struct CustomWidget(pub String);
 
 impl Widget for CustomWidget {
     fn on_pointer_event(
@@ -156,8 +158,7 @@ impl Widget for CustomWidget {
         // Let's burn some CPU to make a (partially transparent) image buffer
         let image_data = make_image_data(256, 256);
         let image_data = Image::new(image_data.into(), ImageFormat::Rgba8, 256, 256);
-        let transform = ObjectFit::Fill.affine_to_fill(ctx.size(), size);
-        scene.draw_image(&image_data, transform);
+        scene.draw_image(&image_data, Affine::IDENTITY);
     }
 
     fn accessibility_role(&self) -> Role {

--- a/masonry_winit/examples/grid_masonry.rs
+++ b/masonry_winit/examples/grid_masonry.rs
@@ -56,7 +56,8 @@ fn grid_button(params: GridParams) -> Button {
     ))
 }
 
-fn make_grid(grid_spacing: f64) -> Grid {
+/// Create a grid with a bunch of buttons
+pub fn make_grid(grid_spacing: f64) -> Grid {
     let label = Prose::from_text_area(
         TextArea::new_immutable("Change spacing by right and left clicking on the buttons")
             .with_style(StyleProperty::FontSize(14.0))

--- a/masonry_winit/examples/simple_image.rs
+++ b/masonry_winit/examples/simple_image.rs
@@ -29,7 +29,8 @@ impl AppDriver for Driver {
     }
 }
 
-fn make_image() -> Image {
+/// Return an image with hardcoded data
+pub fn make_image() -> Image {
     let image_bytes = include_bytes!("./assets/PicWithAlpha.png");
     let image_data = image::load_from_memory(image_bytes).unwrap().to_rgba8();
     let (width, height) = image_data.dimensions();

--- a/masonry_winit/examples/to_do_list.rs
+++ b/masonry_winit/examples/to_do_list.rs
@@ -57,7 +57,8 @@ impl AppDriver for Driver {
     }
 }
 
-fn make_widget_tree() -> impl Widget {
+/// Return initial to-do-list without items.
+pub fn make_widget_tree() -> impl Widget {
     Portal::new(
         Flex::column()
             .with_child(NewWidget::new_with_props(

--- a/masonry_winit/tests/examples.rs
+++ b/masonry_winit/tests/examples.rs
@@ -17,3 +17,71 @@ pub mod others {
     pub mod simple_image;
     pub mod to_do_list;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use masonry::core::Widget;
+    use masonry::kurbo::Size;
+    use masonry::theme::default_property_set;
+    use masonry_testing::{TestHarness, TestHarnessParams};
+
+    // A series of tests to check that various widgets (the ones used in examples)
+    // can handle being laid out and painted with a size of zero.
+
+    const PARAMS_ZERO_SIZE: TestHarnessParams = {
+        let mut params = TestHarnessParams::DEFAULT;
+        params.window_size = Size::ZERO;
+        params
+    };
+
+    #[test]
+    fn zero_size_calc_masonry() {
+        let mut harness = TestHarness::create_with(
+            default_property_set(),
+            others::calc_masonry::build_calc(),
+            PARAMS_ZERO_SIZE,
+        );
+        let _ = harness.render();
+    }
+
+    #[test]
+    fn zero_size_custom_widget() {
+        let mut harness = TestHarness::create_with(
+            default_property_set(),
+            others::custom_widget::CustomWidget("Foobar".to_string()).with_auto_id(),
+            PARAMS_ZERO_SIZE,
+        );
+        let _ = harness.render();
+    }
+
+    #[test]
+    fn zero_size_grid_masonry() {
+        let mut harness = TestHarness::create_with(
+            default_property_set(),
+            others::grid_masonry::make_grid(1.0).with_auto_id(),
+            PARAMS_ZERO_SIZE,
+        );
+        let _ = harness.render();
+    }
+
+    #[test]
+    fn zero_size_simple_image() {
+        let mut harness = TestHarness::create_with(
+            default_property_set(),
+            others::simple_image::make_image().with_auto_id(),
+            PARAMS_ZERO_SIZE,
+        );
+        let _ = harness.render();
+    }
+
+    #[test]
+    fn zero_size_to_do_list() {
+        let mut harness = TestHarness::create_with(
+            default_property_set(),
+            others::to_do_list::make_widget_tree().with_auto_id(),
+            PARAMS_ZERO_SIZE,
+        );
+        let _ = harness.render();
+    }
+}


### PR DESCRIPTION
The tests re-use the examples, since they already use a variety of widgets.

Tweak harness renderer code to not give wgpu a size of zero in those cases.

Fix some problems that came up.