### PR TITLE
Cache RenderContext and VelloRenderer in TestHarness

### DIFF
--- a/masonry/screenshots/portal_button_list_no_scroll.png
+++ b/masonry/screenshots/portal_button_list_no_scroll.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9505d150179d95f69dd7a68887c893495fd6b2e3239b28ad1b3e5520a5fb6e58
+size 2299

--- a/masonry/screenshots/portal_button_list_scroll_to_item_13.png
+++ b/masonry/screenshots/portal_button_list_scroll_to_item_13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9660536caa97bfdaee97ff987e7cf1dfe19afd3a8ac57d49c0e2e70ff88e834e
+size 2573

--- a/masonry/screenshots/portal_button_list_scroll_to_item_3.png
+++ b/masonry/screenshots/portal_button_list_scroll_to_item_3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f037f58f4a31f968ba9034244837701a70e877796b84bbfafb8f404d0f905f06
+size 2509

--- a/masonry/screenshots/portal_button_list_scrolled.png
+++ b/masonry/screenshots/portal_button_list_scrolled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f037f58f4a31f968ba9034244837701a70e877796b84bbfafb8f404d0f905f06
+size 2509

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -515,9 +515,7 @@ mod tests {
             .height(40.0)
     }
 
-    // TODO - This test takes too long right now
     #[test]
-    #[ignore]
     fn button_list() {
         let [item_3_id, item_13_id] = widget_ids();
 


### PR DESCRIPTION
Constructing those types take a lot of time.
Caching them between render calls lets us considerably speed up tests with multiple snapshots. (Still doesn't help with single-snapshot tests.)

Re-enable a multi-screenshot test that was taking too long.