### PR TITLE
Add type parameter to TestHarness

### DIFF
--- a/masonry/src/doc/color_rectangle.rs
+++ b/masonry/src/doc/color_rectangle.rs
@@ -279,15 +279,13 @@ mod tests {
 
     #[test]
     fn edit_rect() {
+        const RED: Color = Color::from_rgb8(u8::MAX, 0, 0);
         const BLUE: Color = Color::from_rgb8(0, 0, u8::MAX);
-        let [rect_id] = widget_ids();
-        let widget = ColorRectangle::new(Size::new(20.0, 20.0), BLUE).with_id(rect_id);
+        let widget = ColorRectangle::new(Size::new(20.0, 20.0), BLUE);
 
         let mut harness = TestHarness::create(default_property_set(), widget);
 
-        harness.edit_widget(rect_id, |mut rect| {
-            const RED: Color = Color::from_rgb8(u8::MAX, 0, 0);
-            let mut rect = rect.downcast::<ColorRectangle>();
+        harness.edit_root_widget(|mut rect| {
             ColorRectangle::set_size(&mut rect, Size::new(50.0, 50.0));
             ColorRectangle::set_color(&mut rect, RED);
         });

--- a/masonry/src/doc/testing_widget.md
+++ b/masonry/src/doc/testing_widget.md
@@ -142,15 +142,15 @@ Let's add a test that changes a rectangle's color, then checks its visual appear
 
     #[test]
     fn edit_rect() {
-        let [rect_id] = widget_ids();
-        let widget = ColorRectangle::new(Size::new(20.0, 20.0), Color::BLUE).with_id(rect_id);
+        const RED: Color = Color::from_rgb8(u8::MAX, 0, 0);
+        const BLUE: Color = Color::from_rgb8(0, 0, u8::MAX);
+        let widget = ColorRectangle::new(Size::new(20.0, 20.0), BLUE);
 
-        let mut harness = TestHarness::create(widget);
+        let mut harness = TestHarness::create(default_property_set(), widget);
 
-        harness.edit_widget(rect_id |mut rect| {
-            let mut rect = rect.downcast::<ColorRectangle>();
-            ColorRectangle::set_color(&mut rect, Size::new(50.0, 50.0));
-            ColorRectangle::set_size(&mut rect, Color::RED);
+        harness.edit_root_widget(|mut rect| {
+            ColorRectangle::set_size(&mut rect, Size::new(50.0, 50.0));
+            ColorRectangle::set_color(&mut rect, RED);
         });
 
         assert_render_snapshot!(harness, "rect_big_red_rectangle");

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -309,15 +309,15 @@ impl Widget for Button {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
+    use masonry_testing::TestHarnessParams;
+
     use super::*;
     use crate::core::keyboard::NamedKey;
     use crate::core::{PointerButton, Properties, StyleProperty};
     use crate::properties::TextColor;
-    use crate::testing::{
-        TestHarness, TestWidgetExt, WrapperWidget, assert_render_snapshot, widget_ids,
-    };
+    use crate::testing::{TestHarness, TestWidgetExt, assert_render_snapshot, widget_ids};
     use crate::theme::{ACCENT_COLOR, default_property_set};
-    use crate::widgets::{Grid, GridParams, SizedBox};
+    use crate::widgets::{Grid, GridParams};
 
     #[test]
     fn simple_button() {
@@ -433,20 +433,15 @@ mod tests {
             .with_child(Button::new("B").with_auto_id(), GridParams::new(1, 0, 1, 1))
             .with_child(Button::new("C").with_auto_id(), GridParams::new(0, 1, 1, 1))
             .with_child(Button::new("D").with_auto_id(), GridParams::new(1, 1, 1, 1));
+        let root_widget =
+            NewWidget::new_with_props(grid, Properties::new().with(Padding::all(20.0)));
 
-        let root_widget = SizedBox::new(grid.with_auto_id())
-            .with_props(Properties::new().with(Padding::all(20.0)));
-
-        let window_size = Size::new(300.0, 300.0);
+        let mut test_params = TestHarnessParams::default();
+        test_params.window_size = Size::new(300.0, 300.0);
         let mut harness =
-            TestHarness::create_with_size(default_property_set(), root_widget, window_size);
+            TestHarness::create_with(default_property_set(), root_widget, test_params);
 
-        harness.edit_root_widget(|mut root| {
-            let mut sized_box = WrapperWidget::child_mut(&mut root);
-            let mut sized_box = sized_box.downcast::<SizedBox>();
-            let mut grid = SizedBox::child_mut(&mut sized_box).unwrap();
-            let mut grid = grid.downcast::<Grid>();
-
+        harness.edit_root_widget(|mut grid| {
             {
                 let mut button = Grid::child_mut(&mut grid, 0);
                 let mut button = button.downcast::<Button>();

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -387,7 +387,6 @@ mod tests {
             );
 
             harness.edit_root_widget(|mut button| {
-                let mut button = button.downcast::<Button>();
                 Button::set_text(&mut button, "The quick brown fox jumps over the lazy dog");
 
                 let mut label = Button::label_mut(&mut button);
@@ -412,8 +411,6 @@ mod tests {
             TestHarness::create_with_size(default_property_set(), button, window_size);
 
         harness.edit_root_widget(|mut button| {
-            let mut button = button.downcast::<Button>();
-
             button.insert_prop(BorderColor { color: red });
             button.insert_prop(BorderWidth { width: 5.0 });
             button.insert_prop(CornerRadius { radius: 20.0 });
@@ -445,7 +442,6 @@ mod tests {
             TestHarness::create_with_size(default_property_set(), root_widget, window_size);
 
         harness.edit_root_widget(|mut root| {
-            let mut root = root.downcast::<WrapperWidget>();
             let mut sized_box = WrapperWidget::child_mut(&mut root);
             let mut sized_box = sized_box.downcast::<SizedBox>();
             let mut grid = SizedBox::child_mut(&mut sized_box).unwrap();

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -396,7 +396,6 @@ mod tests {
             );
 
             harness.edit_root_widget(|mut checkbox| {
-                let mut checkbox = checkbox.downcast::<Checkbox>();
                 Checkbox::set_checked(&mut checkbox, true);
                 Checkbox::set_text(
                     &mut checkbox,

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -1216,31 +1216,26 @@ mod tests {
             TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Start);
         });
         assert_render_snapshot!(harness, "flex_row_cross_axis_start");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Center);
         });
         assert_render_snapshot!(harness, "flex_row_cross_axis_center");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::End);
         });
         assert_render_snapshot!(harness, "flex_row_cross_axis_end");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Baseline);
         });
         assert_render_snapshot!(harness, "flex_row_cross_axis_baseline");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Fill);
         });
         assert_render_snapshot!(harness, "flex_row_cross_axis_fill");
@@ -1264,37 +1259,31 @@ mod tests {
         // MAIN AXIS ALIGNMENT
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::Start);
         });
         assert_render_snapshot!(harness, "flex_row_main_axis_start");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::Center);
         });
         assert_render_snapshot!(harness, "flex_row_main_axis_center");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::End);
         });
         assert_render_snapshot!(harness, "flex_row_main_axis_end");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::SpaceBetween);
         });
         assert_render_snapshot!(harness, "flex_row_main_axis_spaceBetween");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::SpaceEvenly);
         });
         assert_render_snapshot!(harness, "flex_row_main_axis_spaceEvenly");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::SpaceAround);
         });
         assert_render_snapshot!(harness, "flex_row_main_axis_spaceAround");
@@ -1303,7 +1292,6 @@ mod tests {
         // TODO - This doesn't seem to do anything?
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_must_fill_main_axis(&mut flex, true);
         });
         assert_render_snapshot!(harness, "flex_row_fill_main_axis");
@@ -1325,31 +1313,26 @@ mod tests {
             TestHarness::create_with_size(default_property_set(), widget, window_size);
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Start);
         });
         assert_render_snapshot!(harness, "flex_col_cross_axis_start");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Center);
         });
         assert_render_snapshot!(harness, "flex_col_cross_axis_center");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::End);
         });
         assert_render_snapshot!(harness, "flex_col_cross_axis_end");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Baseline);
         });
         assert_render_snapshot!(harness, "flex_col_cross_axis_baseline");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_cross_axis_alignment(&mut flex, CrossAxisAlignment::Fill);
         });
         assert_render_snapshot!(harness, "flex_col_cross_axis_fill");
@@ -1373,37 +1356,31 @@ mod tests {
         // MAIN AXIS ALIGNMENT
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::Start);
         });
         assert_render_snapshot!(harness, "flex_col_main_axis_start");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::Center);
         });
         assert_render_snapshot!(harness, "flex_col_main_axis_center");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::End);
         });
         assert_render_snapshot!(harness, "flex_col_main_axis_end");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::SpaceBetween);
         });
         assert_render_snapshot!(harness, "flex_col_main_axis_spaceBetween");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::SpaceEvenly);
         });
         assert_render_snapshot!(harness, "flex_col_main_axis_spaceEvenly");
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_main_axis_alignment(&mut flex, MainAxisAlignment::SpaceAround);
         });
         assert_render_snapshot!(harness, "flex_col_main_axis_spaceAround");
@@ -1412,7 +1389,6 @@ mod tests {
         // TODO - This doesn't seem to do anything?
 
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
             Flex::set_must_fill_main_axis(&mut flex, true);
         });
         assert_render_snapshot!(harness, "flex_col_fill_main_axis");
@@ -1433,8 +1409,6 @@ mod tests {
                 TestHarness::create_with_size(default_property_set(), widget, window_size);
 
             harness.edit_root_widget(|mut flex| {
-                let mut flex = flex.downcast::<Flex>();
-
                 Flex::remove_child(&mut flex, 1);
                 // -> acd
                 Flex::add_child(&mut flex, Label::new("x").with_auto_id());
@@ -1493,8 +1467,6 @@ mod tests {
         let mut harness =
             TestHarness::create_with_size(default_property_set(), widget, window_size);
         harness.edit_root_widget(|mut flex| {
-            let mut flex = flex.downcast::<Flex>();
-
             let mut child = Flex::child_mut(&mut flex, 1).unwrap();
             assert_eq!(
                 child

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -363,20 +363,17 @@ mod tests {
 
         // Expand it to a 4x4 grid
         harness.edit_root_widget(|mut grid| {
-            let mut grid = grid.downcast::<Grid>();
             Grid::set_width(&mut grid, 4);
         });
         assert_render_snapshot!(harness, "grid_expanded_4x1");
 
         harness.edit_root_widget(|mut grid| {
-            let mut grid = grid.downcast::<Grid>();
             Grid::set_height(&mut grid, 4);
         });
         assert_render_snapshot!(harness, "grid_expanded_4x4");
 
         // Add a widget that takes up more than one horizontal cell
         harness.edit_root_widget(|mut grid| {
-            let mut grid = grid.downcast::<Grid>();
             Grid::add_child(
                 &mut grid,
                 button::Button::new("B").with_auto_id(),
@@ -387,7 +384,6 @@ mod tests {
 
         // Add a widget that takes up more than one vertical cell
         harness.edit_root_widget(|mut grid| {
-            let mut grid = grid.downcast::<Grid>();
             Grid::add_child(
                 &mut grid,
                 button::Button::new("C").with_auto_id(),
@@ -398,7 +394,6 @@ mod tests {
 
         // Add a widget that takes up more than one horizontal and vertical cell
         harness.edit_root_widget(|mut grid| {
-            let mut grid = grid.downcast::<Grid>();
             Grid::add_child(
                 &mut grid,
                 button::Button::new("D").with_auto_id(),
@@ -409,14 +404,12 @@ mod tests {
 
         // Change the spacing
         harness.edit_root_widget(|mut grid| {
-            let mut grid = grid.downcast::<Grid>();
             Grid::set_spacing(&mut grid, 7.0);
         });
         assert_render_snapshot!(harness, "grid_with_changed_spacing");
 
         // Make the spacing negative
         harness.edit_root_widget(|mut grid| {
-            let mut grid = grid.downcast::<Grid>();
             Grid::set_spacing(&mut grid, -4.0);
         });
         assert_render_snapshot!(harness, "grid_with_negative_spacing");
@@ -436,14 +429,12 @@ mod tests {
 
         // Now remove the widget
         harness.edit_root_widget(|mut grid| {
-            let mut grid = grid.downcast::<Grid>();
             Grid::remove_child(&mut grid, 0);
         });
         assert_render_snapshot!(harness, "grid_2x2_with_removed_widget");
 
         // Add it back
         harness.edit_root_widget(|mut grid| {
-            let mut grid = grid.downcast::<Grid>();
             Grid::add_child(
                 &mut grid,
                 button::Button::new("A").with_auto_id(),
@@ -454,14 +445,12 @@ mod tests {
 
         // Change the grid params to position it on the other corner
         harness.edit_root_widget(|mut grid| {
-            let mut grid = grid.downcast::<Grid>();
             Grid::update_child_grid_params(&mut grid, 0, GridParams::new(1, 1, 1, 1));
         });
         assert_render_snapshot!(harness, "grid_moved_2x2_1");
 
         // Now make it take up the entire grid
         harness.edit_root_widget(|mut grid| {
-            let mut grid = grid.downcast::<Grid>();
             Grid::update_child_grid_params(&mut grid, 0, GridParams::new(0, 0, 2, 2));
         });
         assert_render_snapshot!(harness, "grid_moved_2x2_2");
@@ -481,7 +470,6 @@ mod tests {
 
         // Order sets the draw order, so draw a widget over A by adding it after
         harness.edit_root_widget(|mut grid| {
-            let mut grid = grid.downcast::<Grid>();
             Grid::add_child(
                 &mut grid,
                 button::Button::new("B").with_auto_id(),
@@ -493,7 +481,6 @@ mod tests {
         // Draw a widget under the others by putting it at index 0
         // Make it wide enough to see it stick out, with half of it under A and B.
         harness.edit_root_widget(|mut grid| {
-            let mut grid = grid.downcast::<Grid>();
             Grid::insert_grid_child_at(
                 &mut grid,
                 0,

--- a/masonry/src/widgets/image.rs
+++ b/masonry/src/widgets/image.rs
@@ -227,7 +227,6 @@ mod tests {
             );
 
             harness.edit_root_widget(|mut image| {
-                let mut image = image.downcast::<Image>();
                 Image::set_image_data(&mut image, image_data);
             });
 

--- a/masonry/src/widgets/indexed_stack.rs
+++ b/masonry/src/widgets/indexed_stack.rs
@@ -298,13 +298,11 @@ mod tests {
         assert_render_snapshot!(harness, "indexed_stack_empty");
 
         harness.edit_root_widget(|mut stack| {
-            let mut stack = stack.downcast::<IndexedStack>();
             IndexedStack::add_child(&mut stack, button::Button::new("A").with_auto_id());
         });
         assert_render_snapshot!(harness, "indexed_stack_single");
 
         harness.edit_root_widget(|mut stack| {
-            let mut stack = stack.downcast::<IndexedStack>();
             IndexedStack::add_child(&mut stack, button::Button::new("B").with_auto_id());
             IndexedStack::add_child(&mut stack, button::Button::new("C").with_auto_id());
             IndexedStack::add_child(&mut stack, button::Button::new("D").with_auto_id());
@@ -312,7 +310,6 @@ mod tests {
         assert_render_snapshot!(harness, "indexed_stack_single"); // the active child should not change
 
         harness.edit_root_widget(|mut stack| {
-            let mut stack = stack.downcast::<IndexedStack>();
             IndexedStack::set_active_child(&mut stack, 2);
         });
         assert_render_snapshot!(harness, "indexed_stack_many_2");
@@ -333,35 +330,30 @@ mod tests {
 
         // Remove the first (inactive) widget
         harness.edit_root_widget(|mut stack| {
-            let mut stack = stack.downcast::<IndexedStack>();
             IndexedStack::remove_child(&mut stack, 0);
         });
         assert_render_snapshot!(harness, "indexed_stack_initial_builder"); // Should not be changed
 
         // Now remove the active widget
         harness.edit_root_widget(|mut stack| {
-            let mut stack = stack.downcast::<IndexedStack>();
             IndexedStack::remove_child(&mut stack, 0);
         });
         assert_render_snapshot!(harness, "indexed_stack_builder_removed_widget");
 
         // Add another widget at the end
         harness.edit_root_widget(|mut stack| {
-            let mut stack = stack.downcast::<IndexedStack>();
             IndexedStack::add_child(&mut stack, button::Button::new("D").with_auto_id());
         });
         assert_render_snapshot!(harness, "indexed_stack_builder_removed_widget"); // Should not change
 
         // Make it active
         harness.edit_root_widget(|mut stack| {
-            let mut stack = stack.downcast::<IndexedStack>();
             IndexedStack::set_active_child(&mut stack, 1);
         });
         assert_render_snapshot!(harness, "indexed_stack_builder_new_widget");
 
         // Insert back the first two at the start
         harness.edit_root_widget(|mut stack| {
-            let mut stack = stack.downcast::<IndexedStack>();
             IndexedStack::insert_child(&mut stack, 0, button::Button::new("A").with_auto_id());
             IndexedStack::insert_child(&mut stack, 1, button::Button::new("B").with_auto_id());
         });
@@ -369,7 +361,6 @@ mod tests {
 
         // Reset original active index
         harness.edit_root_widget(|mut stack| {
-            let mut stack = stack.downcast::<IndexedStack>();
             IndexedStack::set_active_child(&mut stack, 1);
         });
         assert_render_snapshot!(harness, "indexed_stack_initial_builder");

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -575,7 +575,6 @@ mod tests {
                 TestHarness::create_with_size(default_property_set(), label, Size::new(50.0, 50.0));
 
             harness.edit_root_widget(|mut label| {
-                let mut label = label.downcast::<Label>();
                 label.insert_prop(TextColor::new(ACCENT_COLOR));
                 Label::set_text(&mut label, "The quick brown fox jumps over the lazy dog");
                 Label::insert_style(&mut label, FontFamily::Generic(GenericFamily::Monospace));

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -559,7 +559,6 @@ mod tests {
         assert_render_snapshot!(harness, "portal_button_list_no_scroll");
 
         harness.edit_root_widget(|mut portal| {
-            let mut portal = portal.downcast::<Portal<Flex>>();
             Portal::set_viewport_pos(&mut portal, Point::new(0.0, 130.0))
         });
 
@@ -567,7 +566,6 @@ mod tests {
 
         let item_3_rect = harness.get_widget(item_3_id).ctx().local_layout_rect();
         harness.edit_root_widget(|mut portal| {
-            let mut portal = portal.downcast::<Portal<Flex>>();
             Portal::pan_viewport_to(&mut portal, item_3_rect);
         });
 
@@ -575,7 +573,6 @@ mod tests {
 
         let item_13_rect = harness.get_widget(item_13_id).ctx().local_layout_rect();
         harness.edit_root_widget(|mut portal| {
-            let mut portal = portal.downcast::<Portal<Flex>>();
             Portal::pan_viewport_to(&mut portal, item_13_rect);
         });
 

--- a/masonry/src/widgets/progress_bar.rs
+++ b/masonry/src/widgets/progress_bar.rs
@@ -288,8 +288,7 @@ mod tests {
             let mut harness =
                 TestHarness::create_with_size(default_property_set(), bar, Size::new(60.0, 20.0));
 
-            harness.edit_root_widget(|mut label| {
-                let mut bar = label.downcast::<ProgressBar>();
+            harness.edit_root_widget(|mut bar| {
                 ProgressBar::set_progress(&mut bar, Some(0.5));
             });
 

--- a/masonry/src/widgets/spinner.rs
+++ b/masonry/src/widgets/spinner.rs
@@ -206,7 +206,6 @@ mod tests {
             );
 
             harness.edit_root_widget(|mut spinner| {
-                let mut spinner = spinner.downcast::<Spinner>();
                 Spinner::set_color(&mut spinner, palette::css::PURPLE);
             });
 

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -675,8 +675,6 @@ mod tests {
             );
 
             harness.edit_root_widget(|mut splitter| {
-                let mut splitter = splitter.downcast::<Split<Label, Label>>();
-
                 Split::set_split_point(&mut splitter, 0.3);
                 Split::set_min_size(&mut splitter, 40.0, 10.0);
                 Split::set_bar_size(&mut splitter, 12.0);

--- a/masonry/src/widgets/tests/ime_focused.rs
+++ b/masonry/src/widgets/tests/ime_focused.rs
@@ -31,7 +31,6 @@ fn ime_on_remove() {
     let ime_area_size = harness.ime_rect().1;
     assert!(ime_area_size.width > 0. && ime_area_size.height > 0.);
     harness.edit_root_widget(|mut widget| {
-        let mut widget = widget.downcast::<Flex>();
         Flex::remove_child(&mut widget, 0);
     });
 }

--- a/masonry/src/widgets/tests/status_change.rs
+++ b/masonry/src/widgets/tests/status_change.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use assert_matches::assert_matches;
+use masonry_core::core::Widget;
 use vello::kurbo::Vec2;
 
 use crate::core::{NewWidget, PointerButton, PointerEvent, Update, WidgetId};
@@ -23,11 +24,11 @@ fn next_pointer_event(recording: &Recording) -> Option<PointerEvent> {
     None
 }
 
-fn is_hovered(harness: &TestHarness, id: WidgetId) -> bool {
+fn is_hovered(harness: &TestHarness<impl Widget>, id: WidgetId) -> bool {
     harness.get_widget(id).ctx().is_hovered()
 }
 
-fn has_hovered(harness: &TestHarness, id: WidgetId) -> bool {
+fn has_hovered(harness: &TestHarness<impl Widget>, id: WidgetId) -> bool {
     harness.get_widget(id).ctx().has_hovered()
 }
 

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -971,8 +971,7 @@ mod tests {
                 );
             }
 
-            harness.edit_root_widget(|mut root| {
-                let mut area = root.downcast::<TextArea<false>>();
+            harness.edit_root_widget(|mut area| {
                 TextArea::set_word_wrap(&mut area, true);
             });
 
@@ -1006,7 +1005,6 @@ mod tests {
                 TestHarness::create_with_size(default_property_set(), area, Size::new(200.0, 20.0));
 
             harness.edit_root_widget(|mut root| {
-                let mut root = root.downcast::<WrapperWidget>();
                 let mut area = WrapperWidget::child_mut(&mut root);
                 let mut area = area.downcast::<TextArea<false>>();
                 TextArea::reset_text(&mut area, "Test string");
@@ -1021,7 +1019,6 @@ mod tests {
             );
 
             harness.edit_root_widget(|mut root| {
-                let mut root = root.downcast::<WrapperWidget>();
                 let mut area = WrapperWidget::child_mut(&mut root);
                 let mut area = area.downcast::<TextArea<false>>();
                 area.insert_prop(TextColor::new(palette::css::BROWN));

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -938,7 +938,7 @@ mod tests {
 
     use super::*;
     use crate::core::{KeyboardEvent, Modifiers, Properties};
-    use crate::testing::{TestHarness, TestWidgetExt, widget_ids};
+    use crate::testing::TestHarness;
     use crate::theme::default_property_set;
     // Tests of alignment happen in Prose.
 
@@ -1082,12 +1082,11 @@ mod tests {
             },
         ];
         for scenario in scenarios {
-            let [text_id] = widget_ids();
-            let area = TextArea::new_editable("hello world")
-                .with_insert_newline(scenario.insert_newline)
-                .with_id(text_id);
+            let area =
+                TextArea::new_editable("hello world").with_insert_newline(scenario.insert_newline);
 
             let mut harness = TestHarness::create(default_property_set(), area);
+            let text_id = harness.root_widget().id();
 
             harness.focus_on(Some(text_id));
             harness.process_text_event(TextEvent::Keyboard(KeyboardEvent {
@@ -1096,8 +1095,7 @@ mod tests {
                 ..Default::default()
             }));
 
-            let widget = harness.try_get_widget(text_id).unwrap();
-            let area = widget.downcast::<TextArea<true>>().unwrap();
+            let area = harness.root_widget();
             let text = area.text().to_string();
             let (action, widget_id) = harness.pop_action::<TextAction>().unwrap();
             assert_eq!(widget_id, text_id);

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -932,7 +932,8 @@ pub enum InsertNewline {
 
 #[cfg(test)]
 mod tests {
-    use masonry_testing::WrapperWidget;
+    use masonry_core::core::NewWidget;
+    use masonry_testing::TestHarnessParams;
     use vello::kurbo::Size;
 
     use super::*;
@@ -987,26 +988,29 @@ mod tests {
 
     #[test]
     fn edit_textarea() {
-        let base_target = {
-            let area = TextArea::new_immutable("Test string")
-                .with_props(Properties::new().with(TextColor::new(palette::css::AZURE)));
+        let mut test_params = TestHarnessParams::default();
+        test_params.window_size = Size::new(200.0, 20.0);
 
-            let mut harness =
-                TestHarness::create_with_size(default_property_set(), area, Size::new(200.0, 20.0));
+        let base_target = {
+            let area = NewWidget::new_with_props(
+                TextArea::new_immutable("Test string"),
+                Properties::new().with(TextColor::new(palette::css::AZURE)),
+            );
+
+            let mut harness = TestHarness::create_with(default_property_set(), area, test_params);
 
             harness.render()
         };
 
         {
-            let area = TextArea::new_immutable("Different string")
-                .with_props(Properties::new().with(TextColor::new(palette::css::AZURE)));
+            let area = NewWidget::new_with_props(
+                TextArea::new_immutable("Different string"),
+                Properties::new().with(TextColor::new(palette::css::AZURE)),
+            );
 
-            let mut harness =
-                TestHarness::create_with_size(default_property_set(), area, Size::new(200.0, 20.0));
+            let mut harness = TestHarness::create_with(default_property_set(), area, test_params);
 
-            harness.edit_root_widget(|mut root| {
-                let mut area = WrapperWidget::child_mut(&mut root);
-                let mut area = area.downcast::<TextArea<false>>();
+            harness.edit_root_widget(|mut area| {
                 TextArea::reset_text(&mut area, "Test string");
             });
 
@@ -1018,9 +1022,7 @@ mod tests {
                 "Updating the text should match with base text"
             );
 
-            harness.edit_root_widget(|mut root| {
-                let mut area = WrapperWidget::child_mut(&mut root);
-                let mut area = area.downcast::<TextArea<false>>();
+            harness.edit_root_widget(|mut area| {
                 area.insert_prop(TextColor::new(palette::css::BROWN));
             });
 

--- a/masonry/src/widgets/text_input.rs
+++ b/masonry/src/widgets/text_input.rs
@@ -243,7 +243,6 @@ mod tests {
 
         let mut text_area_id = None;
         harness.edit_root_widget(|mut text_input| {
-            let mut text_input = text_input.downcast::<TextInput>();
             let mut text_input = TextInput::text_mut(&mut text_input);
             text_area_id = Some(text_input.ctx.widget_id());
 

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -1280,10 +1280,7 @@ mod tests {
         let original_range;
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
         {
-            let widget = harness
-                .root_widget()
-                .downcast::<VirtualScroll<ScrollContents>>()
-                .unwrap();
+            let widget = harness.root_widget();
             assert_eq!(
                 widget.anchor_index, MIN,
                 "Virtual Scroll controller should lock anchor to be within active range"
@@ -1302,10 +1299,7 @@ mod tests {
         });
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
         {
-            let widget = harness
-                .root_widget()
-                .downcast::<VirtualScroll<ScrollContents>>()
-                .unwrap();
+            let widget = harness.root_widget();
             assert_ne!(widget.anchor_index, MIN);
             assert_ne!(widget.active_range, original_range);
         }
@@ -1316,10 +1310,7 @@ mod tests {
         });
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
         {
-            let widget = harness
-                .root_widget()
-                .downcast::<VirtualScroll<ScrollContents>>()
-                .unwrap();
+            let widget = harness.root_widget();
             assert_eq!(widget.anchor_index, MIN);
             assert_eq!(widget.scroll_offset_from_anchor, 0.0);
         }
@@ -1364,10 +1355,7 @@ mod tests {
         let original_scroll;
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
         {
-            let widget = harness
-                .root_widget()
-                .downcast::<VirtualScroll<ScrollContents>>()
-                .unwrap();
+            let widget = harness.root_widget();
             assert_eq!(
                 widget.anchor_index,
                 MAX - 1,
@@ -1387,10 +1375,7 @@ mod tests {
         });
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
         {
-            let widget = harness
-                .root_widget()
-                .downcast::<VirtualScroll<ScrollContents>>()
-                .unwrap();
+            let widget = harness.root_widget();
             assert_ne!(widget.anchor_index, MAX);
             assert_ne!(widget.active_range, original_range);
         }
@@ -1401,10 +1386,7 @@ mod tests {
         });
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
         {
-            let widget = harness
-                .root_widget()
-                .downcast::<VirtualScroll<ScrollContents>>()
-                .unwrap();
+            let widget = harness.root_widget();
             assert_eq!(widget.anchor_index, MAX - 1);
             assert_eq!(
                 widget.scroll_offset_from_anchor, original_scroll,

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -1092,8 +1092,7 @@ mod tests {
 
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
         assert_render_snapshot!(harness, "virtual_scroll_basic");
-        harness.edit_widget(virtual_scroll_id, |mut portal| {
-            let mut scroll = portal.downcast::<VirtualScroll<ScrollContents>>();
+        harness.edit_root_widget(|mut scroll| {
             VirtualScroll::overwrite_anchor(&mut scroll, 100);
         });
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
@@ -1140,8 +1139,7 @@ mod tests {
         }
 
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
-        harness.edit_widget(virtual_scroll_id, |mut portal| {
-            let mut scroll = portal.downcast::<VirtualScroll<ScrollContents>>();
+        harness.edit_root_widget(|mut scroll| {
             VirtualScroll::overwrite_anchor(&mut scroll, 100);
         });
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
@@ -1186,8 +1184,7 @@ mod tests {
         }
 
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
-        harness.edit_widget(virtual_scroll_id, |mut portal| {
-            let mut scroll = portal.downcast::<VirtualScroll<ScrollContents>>();
+        harness.edit_root_widget(|mut scroll| {
             VirtualScroll::overwrite_anchor(&mut scroll, 200);
         });
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
@@ -1232,8 +1229,7 @@ mod tests {
         }
 
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
-        harness.edit_widget(virtual_scroll_id, |mut portal| {
-            let mut scroll = portal.downcast::<VirtualScroll<ScrollContents>>();
+        harness.edit_root_widget(|mut scroll| {
             VirtualScroll::overwrite_anchor(&mut scroll, 200);
         });
         drive_to_fixpoint::<ScrollContents>(&mut harness, virtual_scroll_id, driver);
@@ -1418,7 +1414,7 @@ mod tests {
     }
 
     fn drive_to_fixpoint<T: Widget + FromDynWidget + ?Sized>(
-        harness: &mut TestHarness,
+        harness: &mut TestHarness<VirtualScroll<T>>,
         virtual_scroll_id: WidgetId,
         mut f: impl FnMut(VirtualScrollAction, WidgetMut<'_, VirtualScroll<T>>),
     ) {
@@ -1445,8 +1441,7 @@ mod tests {
                 "Shouldn't have sent an update if tUsehe target hasn't changed"
             );
 
-            harness.edit_widget(virtual_scroll_id, |mut portal| {
-                let scroll = portal.downcast::<VirtualScroll<T>>();
+            harness.edit_root_widget(|scroll| {
                 f(action, scroll);
             });
         }

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -274,7 +274,6 @@ mod tests {
 
         for (align, name) in all_cases {
             harness.edit_root_widget(|mut zstack| {
-                let mut zstack = zstack.downcast::<ZStack>();
                 ZStack::set_alignment(&mut zstack, align);
             });
             assert_render_snapshot!(harness, &format!("zstack_alignment_{name}"));


### PR DESCRIPTION
This lets us skip downcast calls around edit_root_widget and root_widget (though we don't really use the latter).