### PR TITLE
Make a bunch of property functions const

### DIFF
--- a/masonry/src/properties/border_color.rs
+++ b/masonry/src/properties/border_color.rs
@@ -24,7 +24,7 @@ impl Property for BorderColor {
 
 impl BorderColor {
     /// Create new `BorderColor` with given value.
-    pub fn new(color: AlphaColor<Srgb>) -> Self {
+    pub const fn new(color: AlphaColor<Srgb>) -> Self {
         Self { color }
     }
 }

--- a/masonry/src/properties/border_width.rs
+++ b/masonry/src/properties/border_width.rs
@@ -27,7 +27,7 @@ impl Property for BorderWidth {
 
 impl BorderWidth {
     /// Create new `BorderWidth` with given value.
-    pub fn all(width: f64) -> Self {
+    pub const fn all(width: f64) -> Self {
         Self { width }
     }
 

--- a/masonry/src/properties/box_shadow.rs
+++ b/masonry/src/properties/box_shadow.rs
@@ -66,7 +66,7 @@ impl BoxShadow {
     }
 
     /// Builder method to change the shadow's blur radius.
-    pub fn blur(self, blur_radius: f64) -> Self {
+    pub const fn blur(self, blur_radius: f64) -> Self {
         Self {
             blur_radius,
             ..self
@@ -85,7 +85,7 @@ impl BoxShadow {
     /// Returns `false` if the shadow can be safely treated as non-existent.
     ///
     /// May have false positives.
-    pub fn is_visible(&self) -> bool {
+    pub const fn is_visible(&self) -> bool {
         let alpha = self.color.components[3];
         alpha != 0.0
     }

--- a/masonry/src/properties/corner_radius.rs
+++ b/masonry/src/properties/corner_radius.rs
@@ -21,7 +21,7 @@ impl Property for CornerRadius {
 
 impl CornerRadius {
     /// Create new `CornerRadius` with given value.
-    pub fn all(radius: f64) -> Self {
+    pub const fn all(radius: f64) -> Self {
         Self { radius }
     }
 

--- a/masonry/src/properties/text_color.rs
+++ b/masonry/src/properties/text_color.rs
@@ -34,7 +34,7 @@ impl Property for TextColor {
 
 impl TextColor {
     /// Create new `TextColor` with given value.
-    pub fn new(color: AlphaColor<Srgb>) -> Self {
+    pub const fn new(color: AlphaColor<Srgb>) -> Self {
         Self { color }
     }
 }

--- a/masonry/src/properties/types/unit_point.rs
+++ b/masonry/src/properties/types/unit_point.rs
@@ -41,7 +41,7 @@ impl UnitPoint {
     }
 
     /// Given a rectangle, resolve the point within the rectangle.
-    pub fn resolve(self, rect: Rect) -> Point {
+    pub const fn resolve(self, rect: Rect) -> Point {
         Point::new(
             rect.x0 + self.u * (rect.x1 - rect.x0),
             rect.y0 + self.v * (rect.y1 - rect.y0),


### PR DESCRIPTION
For no particular reason.
Some of the property constructors cannot be made const because they use trait methods.