### PR TITLE
Add rudimentary clipboard support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +748,20 @@ dependencies = [
  "log",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "copypasta"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6811e17f81fe246ef2bc553f76b6ee6ab41a694845df1d37e52a92b7bbd38a"
+dependencies = [
+ "clipboard-win",
+ "objc2 0.5.2",
+ "objc2-app-kit",
+ "objc2-foundation 0.2.2",
+ "smithay-clipboard",
+ "x11-clipboard",
 ]
 
 [[package]]
@@ -990,6 +1013,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "euclid"
@@ -2172,6 +2201,7 @@ name = "masonry_winit"
 version = "0.3.0"
 dependencies = [
  "accesskit_winit",
+ "copypasta",
  "image",
  "masonry",
  "masonry_core",
@@ -3770,6 +3800,17 @@ dependencies = [
  "wayland-protocols-wlr",
  "wayland-scanner",
  "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc8216eec463674a0e90f29e0ae41a4db573ec5b56b1c6c1c71615d249b6d846"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit",
+ "wayland-backend",
 ]
 
 [[package]]
@@ -5582,6 +5623,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x11-clipboard"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662d74b3d77e396b8e5beb00b9cad6a9eccf40b2ef68cc858784b14c41d535a3"
+dependencies = [
+ "libc",
+ "x11rb",
 ]
 
 [[package]]

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -210,6 +210,8 @@ pub enum RenderRootSignal {
     EndIme,
     /// The IME area has been moved.
     ImeMoved(LogicalPosition<f64>, LogicalSize<f64>),
+    /// A user interaction has sent something to the clipboard.
+    ClipboardStore(String),
     /// The window needs to be redrawn.
     RequestRedraw,
     /// The window should be redrawn for an animation frame. Currently this isn't really different from `RequestRedraw`.

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -1239,6 +1239,15 @@ impl_context_method!(
             self.widget_state.ime_area = None;
         }
 
+        /// Set the contents of the platform clipboard.
+        ///
+        /// For example, text widgets should call this for "cut" and "copy" user interactions.
+        pub fn set_clipboard(&mut self, contents: String) {
+            trace!("set_clipboard");
+            self.global_state
+                .emit_signal(RenderRootSignal::ClipboardStore(contents));
+        }
+
         /// Start a window drag.
         ///
         /// Moves the window with the left mouse button until the button is released.

--- a/masonry_core/src/core/events.rs
+++ b/masonry_core/src/core/events.rs
@@ -33,7 +33,9 @@ pub enum TextEvent {
     Ime(Ime),
     /// The window took or lost focus.
     WindowFocusChange(bool),
-    // TODO - Add ClipboardPaste variant.
+    // TODO - Handle rich text copy-pasting
+    /// The user pasted content in
+    ClipboardPaste(String),
 }
 
 /// An accessibility event.
@@ -206,6 +208,7 @@ impl TextEvent {
             Self::Ime(Ime::Preedit(s, _)) if s.is_empty() => "Ime::Preedit(\"\")",
             Self::Ime(Ime::Preedit(_, _)) => "Ime::Preedit(\"...\")",
             Self::WindowFocusChange(_) => "WindowFocusChange",
+            Self::ClipboardPaste(_) => "ClipboardPaste",
         }
     }
 }

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -136,6 +136,7 @@ pub struct TestHarness {
     action_queue: VecDeque<(ErasedAction, WidgetId)>,
     has_ime_session: bool,
     ime_rect: (LogicalPosition<f64>, LogicalSize<f64>),
+    clipboard: String,
     title: String,
 }
 
@@ -293,6 +294,7 @@ impl TestHarness {
             action_queue: VecDeque::new(),
             has_ime_session: false,
             ime_rect: Default::default(),
+            clipboard: String::new(),
             title: String::new(),
         };
         harness.process_window_event(WindowEvent::Resize(window_size));
@@ -345,6 +347,9 @@ impl TestHarness {
                 }
                 RenderRootSignal::ImeMoved(position, size) => {
                     self.ime_rect = (position, size);
+                }
+                RenderRootSignal::ClipboardStore(text) => {
+                    self.clipboard = text;
                 }
                 RenderRootSignal::RequestRedraw => (),
                 RenderRootSignal::RequestAnimFrame => (),
@@ -756,6 +761,13 @@ impl TestHarness {
     /// This is usually the layout rectangle of the focused widget.
     pub fn ime_rect(&self) -> (LogicalPosition<f64>, LogicalSize<f64>) {
         self.ime_rect
+    }
+
+    /// Returns the contents of the emulated clipboard.
+    ///
+    /// This is an empty string by default.
+    pub fn clipboard_contents(&self) -> String {
+        self.clipboard.clone()
     }
 
     /// Return the size of the simulated window.

--- a/masonry_winit/Cargo.toml
+++ b/masonry_winit/Cargo.toml
@@ -32,6 +32,7 @@ ui-events-winit.workspace = true
 pollster = "0.4.0"
 accesskit_winit.workspace = true
 wgpu-profiler = { optional = true, version = "0.22.0", default-features = false }
+copypasta = "0.10.2"
 
 [dev-dependencies]
 image = { workspace = true, features = ["png"] }


### PR DESCRIPTION
This only supports copy-pasting strings, not rich text. And the way Ctrl+C is detected is somewhat dubious.

But it does effectively add clipboard support to Masonry apps.