### PR TITLE
Suppress doc in web examples

### DIFF
--- a/xilem_web/web_examples/counter/Cargo.toml
+++ b/xilem_web/web_examples/counter/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 name = "counter"
 test = false
 doctest = false
+doc = false
 bench = false
 
 [lints]

--- a/xilem_web/web_examples/counter_custom_element/Cargo.toml
+++ b/xilem_web/web_examples/counter_custom_element/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 name = "counter_custom_element"
 test = false
 doctest = false
+doc = false
 bench = false
 
 [lints]

--- a/xilem_web/web_examples/elm/Cargo.toml
+++ b/xilem_web/web_examples/elm/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 name = "elm"
 test = false
 doctest = false
+doc = false
 bench = false
 
 [lints]

--- a/xilem_web/web_examples/fetch/Cargo.toml
+++ b/xilem_web/web_examples/fetch/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 name = "fetch"
 test = false
 doctest = false
+doc = false
 bench = false
 
 [lints]

--- a/xilem_web/web_examples/mathml_svg/Cargo.toml
+++ b/xilem_web/web_examples/mathml_svg/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 name = "mathml_svg"
 test = false
 doctest = false
+doc = false
 bench = false
 
 [lints]

--- a/xilem_web/web_examples/raw_dom_access/Cargo.toml
+++ b/xilem_web/web_examples/raw_dom_access/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 name = "raw_dom_access"
 test = false
 doctest = false
+doc = false
 bench = false
 
 [dependencies]

--- a/xilem_web/web_examples/spawn_tasks/Cargo.toml
+++ b/xilem_web/web_examples/spawn_tasks/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 name = "spawn_tasks"
 test = false
 doctest = false
+doc = false
 bench = false
 
 [lints]

--- a/xilem_web/web_examples/svgdraw/Cargo.toml
+++ b/xilem_web/web_examples/svgdraw/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 name = "svgdraw"
 test = false
 doctest = false
+doc = false
 bench = false
 
 [lints]

--- a/xilem_web/web_examples/svgtoy/Cargo.toml
+++ b/xilem_web/web_examples/svgtoy/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 name = "svgtoy"
 test = false
 doctest = false
+doc = false
 bench = false
 
 [lints]

--- a/xilem_web/web_examples/todomvc/Cargo.toml
+++ b/xilem_web/web_examples/todomvc/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 name = "todomvc"
 test = false
 doctest = false
+doc = false
 bench = false
 
 [lints]


### PR DESCRIPTION
Building was doc was fairly useless given that all items in the examples are private.