### PR TITLE
Add WidgetArenaNode type to centralize all data in a single TreeArena

### DIFF
--- a/masonry_core/src/core/mod.rs
+++ b/masonry_core/src/core/mod.rs
@@ -44,7 +44,7 @@ pub use ui_events::pointer::{
 pub use ui_events::{ScrollDelta, keyboard, pointer};
 
 pub(crate) use layout_cache::*;
-pub(crate) use widget_arena::{WidgetArena, WidgetArenaMut, WidgetArenaRef};
+pub(crate) use widget_arena::{WidgetArena, WidgetArenaNode};
 pub(crate) use widget_state::WidgetState;
 
 /// Actions are emitted by Masonry widgets when a user input needs to be handled by the application.

--- a/masonry_core/src/core/widget_arena.rs
+++ b/masonry_core/src/core/widget_arena.rs
@@ -1,39 +1,30 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use tree_arena::{ArenaMut, ArenaMutList, ArenaRef, ArenaRefList, TreeArena};
+use tree_arena::{ArenaMut, ArenaRef, TreeArena};
 
 use crate::core::{Widget, WidgetId, WidgetState};
 use crate::util::AnyMap;
 
 pub(crate) struct WidgetArena {
-    pub(crate) widgets: TreeArena<Box<dyn Widget>>,
-    pub(crate) states: TreeArena<WidgetState>,
-    pub(crate) properties: TreeArena<AnyMap>,
+    pub(crate) nodes: TreeArena<WidgetArenaNode>,
 }
 
-#[derive(Clone, Copy)]
-pub(crate) struct WidgetArenaRef<'a> {
-    pub(crate) widget_state_children: ArenaRefList<'a, WidgetState>,
-    pub(crate) widget_children: ArenaRefList<'a, Box<dyn Widget>>,
-    pub(crate) properties_children: ArenaRefList<'a, AnyMap>,
-}
-
-pub(crate) struct WidgetArenaMut<'a> {
-    pub(crate) widget_state_children: ArenaMutList<'a, WidgetState>,
-    pub(crate) widget_children: ArenaMutList<'a, Box<dyn Widget>>,
-    pub(crate) properties_children: ArenaMutList<'a, AnyMap>,
+pub(crate) struct WidgetArenaNode {
+    pub(crate) widget: Box<dyn Widget>,
+    pub(crate) state: WidgetState,
+    pub(crate) properties: AnyMap,
 }
 
 impl WidgetArena {
     pub(crate) fn has(&self, widget_id: WidgetId) -> bool {
-        self.widgets.find(widget_id).is_some()
+        self.nodes.find(widget_id).is_some()
     }
 
     #[track_caller]
     pub(crate) fn parent_of(&self, widget_id: WidgetId) -> Option<WidgetId> {
         let widget_ref = self
-            .widgets
+            .nodes
             .find(widget_id)
             .expect("parent_of: widget not found in arena");
 
@@ -42,99 +33,36 @@ impl WidgetArena {
     }
 
     #[track_caller]
-    pub(crate) fn get_all(
-        &self,
-        widget_id: WidgetId,
-    ) -> (
-        ArenaRef<'_, Box<dyn Widget>>,
-        ArenaRef<'_, WidgetState>,
-        ArenaRef<'_, AnyMap>,
-    ) {
-        let widget = self
-            .widgets
+    pub(crate) fn get_node(&self, widget_id: WidgetId) -> ArenaRef<'_, WidgetArenaNode> {
+        self.nodes
             .find(widget_id)
-            .expect("get_pair: widget not in widget tree");
-        let state = self
-            .states
-            .find(widget_id)
-            .expect("get_pair: widget state not in widget tree");
-        let properties = self
-            .properties
-            .find(widget_id)
-            .expect("get_pair: widget properties not in widget tree");
-        (widget, state, properties)
+            .expect("get_pair: widget not in widget tree")
     }
 
     #[track_caller]
-    pub(crate) fn get_all_mut(
-        &mut self,
-        widget_id: WidgetId,
-    ) -> (
-        ArenaMut<'_, Box<dyn Widget>>,
-        ArenaMut<'_, WidgetState>,
-        ArenaMut<'_, AnyMap>,
-    ) {
-        let widget = self
-            .widgets
+    pub(crate) fn get_node_mut(&mut self, widget_id: WidgetId) -> ArenaMut<'_, WidgetArenaNode> {
+        self.nodes
             .find_mut(widget_id)
-            .expect("get_pair_mut: widget not in widget tree");
-        let state = self
-            .states
-            .find_mut(widget_id)
-            .expect("get_pair_mut: widget state not in widget tree");
-        let properties = self
-            .properties
-            .find_mut(widget_id)
-            .expect("get_pair_mut: widget properties not in widget tree");
-        (widget, state, properties)
-    }
-
-    #[allow(dead_code, reason = "might be useful later")]
-    #[track_caller]
-    pub(crate) fn get_widget(&self, widget_id: WidgetId) -> ArenaRef<'_, Box<dyn Widget>> {
-        self.widgets
-            .find(widget_id)
-            .expect("get_widget: widget not in widget tree")
-    }
-
-    #[allow(dead_code, reason = "might be useful later")]
-    #[track_caller]
-    pub(crate) fn get_widget_mut(&mut self, widget_id: WidgetId) -> ArenaMut<'_, Box<dyn Widget>> {
-        self.widgets
-            .find_mut(widget_id)
-            .expect("get_widget_mut: widget not in widget tree")
+            .expect("get_pair_mut: widget not in widget tree")
     }
 
     #[track_caller]
-    pub(crate) fn get_state(&mut self, widget_id: WidgetId) -> ArenaRef<'_, WidgetState> {
-        self.states
+    pub(crate) fn get_state(&mut self, widget_id: WidgetId) -> &WidgetState {
+        &self
+            .nodes
             .find(widget_id)
             .expect("get_state: widget state not in widget tree")
+            .item
+            .state
     }
 
     #[track_caller]
-    pub(crate) fn get_state_mut(&mut self, widget_id: WidgetId) -> ArenaMut<'_, WidgetState> {
-        self.states
+    pub(crate) fn get_state_mut(&mut self, widget_id: WidgetId) -> &mut WidgetState {
+        &mut self
+            .nodes
             .find_mut(widget_id)
             .expect("get_state_mut: widget state not in widget tree")
-    }
-}
-
-impl<'a> WidgetArenaMut<'a> {
-    #[allow(unused, reason = "May be used later")]
-    pub(crate) fn reborrow(&self) -> WidgetArenaRef<'_> {
-        WidgetArenaRef {
-            widget_state_children: self.widget_state_children.reborrow(),
-            widget_children: self.widget_children.reborrow(),
-            properties_children: self.properties_children.reborrow(),
-        }
-    }
-
-    pub(crate) fn reborrow_mut(&mut self) -> WidgetArenaMut<'_> {
-        WidgetArenaMut {
-            widget_state_children: self.widget_state_children.reborrow_mut(),
-            widget_children: self.widget_children.reborrow_mut(),
-            properties_children: self.properties_children.reborrow_mut(),
-        }
+            .item
+            .state
     }
 }

--- a/masonry_core/src/core/widget_ref.rs
+++ b/masonry_core/src/core/widget_ref.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 use smallvec::SmallVec;
 use vello::kurbo::Point;
 
-use crate::core::{PropertiesRef, Property, QueryCtx, Widget, WidgetArenaRef, WidgetId};
+use crate::core::{PropertiesRef, Property, QueryCtx, Widget, WidgetId};
 
 /// A rich reference to a [`Widget`].
 ///
@@ -117,34 +117,17 @@ impl<'w, W: Widget + ?Sized> WidgetRef<'w, W> {
             .children_ids()
             .iter()
             .map(|&id| {
-                let Some(state_ref) = self.ctx.children.widget_state_children.into_item(id) else {
-                    panic!(
-                        "Error in '{}' #{parent_id}: child #{id} has not been added to tree",
-                        self.widget.short_type_name()
-                    );
-                };
-                let Some(widget_ref) = self.ctx.children.widget_children.into_item(id) else {
-                    panic!(
-                        "Error in '{}' #{parent_id}: child #{id} has not been added to tree",
-                        self.widget.short_type_name()
-                    );
-                };
-                let Some(properties_ref) = self.ctx.children.properties_children.into_item(id)
-                else {
+                let Some(node_ref) = self.ctx.children.into_item(id) else {
                     panic!(
                         "Error in '{}' #{parent_id}: child #{id} has not been added to tree",
                         self.widget.short_type_name()
                     );
                 };
 
-                let children = WidgetArenaRef {
-                    widget_children: widget_ref.children,
-                    widget_state_children: state_ref.children,
-                    properties_children: properties_ref.children,
-                };
-                let widget = &**widget_ref.item;
-                let state = state_ref.item;
-                let properties = properties_ref.item;
+                let children = node_ref.children;
+                let widget = &*node_ref.item.widget;
+                let state = &node_ref.item.state;
+                let properties = &node_ref.item.properties;
 
                 let ctx = QueryCtx {
                     global_state: self.ctx.global_state,

--- a/masonry_core/src/passes/layout.rs
+++ b/masonry_core/src/passes/layout.rs
@@ -12,13 +12,10 @@ use vello::kurbo::{Rect, Size};
 
 use crate::app::RenderRootState;
 use crate::app::{RenderRoot, RenderRootSignal, WindowSizePolicy};
-use crate::core::DefaultProperties;
-use crate::core::{
-    BoxConstraints, ChildrenIds, LayoutCtx, PropertiesMut, Widget, WidgetArenaMut, WidgetState,
-};
+use crate::core::{BoxConstraints, ChildrenIds, LayoutCtx, PropertiesMut};
+use crate::core::{DefaultProperties, WidgetArenaNode};
 use crate::debug_panic;
 use crate::passes::{enter_span_if, recurse_on_children};
-use crate::util::AnyMap;
 
 // --- MARK: RUN LAYOUT
 /// Run [`Widget::layout`] method on the given widget.
@@ -26,25 +23,16 @@ use crate::util::AnyMap;
 pub(crate) fn run_layout_on(
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
-    widget: ArenaMut<'_, Box<dyn Widget>>,
-    mut state: ArenaMut<'_, WidgetState>,
-    properties: ArenaMut<'_, AnyMap>,
+    node: ArenaMut<'_, WidgetArenaNode>,
     bc: &BoxConstraints,
 ) -> Size {
-    let trace = global_state.trace.layout;
-    let _span = enter_span_if(trace, state.reborrow());
-
-    let mut children = WidgetArenaMut {
-        widget_children: widget.children,
-        widget_state_children: state.children,
-        properties_children: properties.children,
-    };
-
-    let widget = &mut **widget.item;
-    let state = state.item;
-    let properties = properties.item;
-
+    let mut children = node.children;
+    let widget = &mut *node.item.widget;
+    let state = &mut node.item.state;
+    let properties = &mut node.item.properties;
     let id = state.id;
+    let trace = global_state.trace.layout;
+    let _span = enter_span_if(trace, state);
 
     // This checks reads `is_explicitly_stashed` instead of `is_stashed` because the latter may be outdated.
     // A widget's `is_explicitly_stashed` flag is controlled by its direct parent.
@@ -92,11 +80,7 @@ pub(crate) fn run_layout_on(
         // We forcefully set request_layout to true for all children.
         // This is used below to check that widget.layout(..) visited all of them.
         for child_id in widget.children_ids() {
-            let child_state = children
-                .widget_state_children
-                .item_mut(child_id)
-                .unwrap()
-                .item;
+            let child_state = &mut children.item_mut(child_id).unwrap().item.state;
             if !child_state.is_explicitly_stashed {
                 child_state.request_layout = true;
             }
@@ -105,16 +89,11 @@ pub(crate) fn run_layout_on(
 
     // If children are stashed, the layout pass will not recurse over them.
     // We reset need_layout and request_layout to false directly instead.
-    recurse_on_children(
-        id,
-        widget,
-        children.reborrow_mut(),
-        |widget, state, properties| {
-            if state.item.is_explicitly_stashed {
-                clear_layout_flags(widget, state, properties);
-            }
-        },
-    );
+    recurse_on_children(id, widget, children.reborrow_mut(), |node| {
+        if node.item.state.is_explicitly_stashed {
+            clear_layout_flags(node);
+        }
+    });
 
     state.local_paint_rect = Rect::ZERO;
 
@@ -150,11 +129,7 @@ pub(crate) fn run_layout_on(
     {
         let name = widget.short_type_name();
         for child_id in widget.children_ids() {
-            let child_state = children
-                .widget_state_children
-                .item_mut(child_id)
-                .unwrap()
-                .item;
+            let child_state = &children.item(child_id).unwrap().item.state;
 
             if child_state.is_explicitly_stashed {
                 continue;
@@ -204,26 +179,17 @@ pub(crate) fn run_layout_on(
 // --- MARK: CLEAR LAYOUT
 // This function is called on stashed widgets and their children
 // to set all layout flags to false.
-fn clear_layout_flags(
-    widget: ArenaMut<'_, Box<dyn Widget>>,
-    state: ArenaMut<'_, WidgetState>,
-    properties: ArenaMut<'_, AnyMap>,
-) {
-    let children = WidgetArenaMut {
-        widget_children: widget.children,
-        widget_state_children: state.children,
-        properties_children: properties.children,
-    };
-
-    let widget = &mut **widget.item;
-    let state = state.item;
+fn clear_layout_flags(node: ArenaMut<'_, WidgetArenaNode>) {
+    let children = node.children;
+    let widget = &mut *node.item.widget;
+    let state = &mut node.item.state;
+    let id = state.id;
 
     state.needs_layout = false;
     state.request_layout = false;
 
-    let id = state.id;
-    recurse_on_children(id, widget, children, |widget, state, properties| {
-        clear_layout_flags(widget, state, properties);
+    recurse_on_children(id, widget, children, |node| {
+        clear_layout_flags(node);
     });
 }
 
@@ -243,35 +209,15 @@ pub(crate) fn run_layout_pass(root: &mut RenderRoot) {
         WindowSizePolicy::Content => BoxConstraints::UNBOUNDED,
     };
 
-    let (root_widget, mut root_state, root_properties) = {
-        let widget_id = root.root.id();
-        let widget = root
-            .widget_arena
-            .widgets
-            .find_mut(widget_id)
-            .expect("run_layout_pass: root not in widget tree");
-        let state = root
-            .widget_arena
-            .states
-            .find_mut(widget_id)
-            .expect("run_layout_pass: root state not in widget tree");
-        let properties = root
-            .widget_arena
-            .properties
-            .find_mut(widget_id)
-            .expect("run_layout_pass: root properties not in widget tree");
-        (widget, state, properties)
-    };
+    let mut root_node = root.widget_arena.get_node_mut(root.root.id());
 
     let size = run_layout_on(
         &mut root.global_state,
         &root.default_properties,
-        root_widget,
-        root_state.reborrow_mut(),
-        root_properties,
+        root_node.reborrow_mut(),
         &bc,
     );
-    root_state.item.is_expecting_place_child_call = false;
+    root_node.item.state.is_expecting_place_child_call = false;
 
     if let WindowSizePolicy::Content = root.size_policy {
         let new_size =

--- a/masonry_core/src/passes/mutate.rs
+++ b/masonry_core/src/passes/mutate.rs
@@ -4,7 +4,7 @@
 use tracing::info_span;
 
 use crate::app::RenderRoot;
-use crate::core::{MutateCtx, PropertiesMut, Widget, WidgetArenaMut, WidgetId, WidgetMut};
+use crate::core::{MutateCtx, PropertiesMut, Widget, WidgetId, WidgetMut};
 use crate::passes::merge_state_up;
 
 pub(crate) fn mutate_widget<R>(
@@ -14,15 +14,12 @@ pub(crate) fn mutate_widget<R>(
 ) -> R {
     // TODO - This panics if id can't be found.
     // Should it return Option instead?
-    let (widget_mut, state_mut, properties_mut) = root.widget_arena.get_all_mut(id);
-    let children = WidgetArenaMut {
-        widget_children: widget_mut.children,
-        widget_state_children: state_mut.children,
-        properties_children: properties_mut.children,
-    };
-    let widget = &mut **widget_mut.item;
-    let state = state_mut.item;
-    let properties = properties_mut.item;
+    let node = root.widget_arena.get_node_mut(id);
+    let children = node.children;
+    let widget = &mut *node.item.widget;
+    let state = &mut node.item.state;
+    let properties = &mut node.item.properties;
+    let id = state.id;
 
     let _span = info_span!("mutate_widget", name = widget.short_type_name()).entered();
 


### PR DESCRIPTION
This reduces code duplication (a lot of code no longer has to be copy-pasted three times).
This is especially important for the upcoming widget refactor, which will add more code for each arena.