### PR TITLE
Add Length type, and have widgets use that type instead of floats.

### DIFF
--- a/masonry/screenshots/grid_with_negative_spacing.png
+++ b/masonry/screenshots/grid_with_negative_spacing.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aea53c5fe09a5e334442afc855940d36d35c0b9f62c6f03bb5a7742596f01104
-size 1301

--- a/masonry/src/properties/types/length.rs
+++ b/masonry/src/properties/types/length.rs
@@ -1,0 +1,65 @@
+// Copyright 2025 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use masonry_core::debug_panic;
+
+/// A value representing a width, height, or similar distance value.
+///
+/// Its value is always finite and non-negative.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Length {
+    value: f64,
+}
+
+impl Length {
+    /// A length of zero.
+    pub const ZERO: Self = Length { value: 0. };
+
+    /// Create a length, in logical pixels.
+    ///
+    /// # Panics
+    ///
+    /// If debug assertions are on, this will panic in these cases:
+    ///
+    /// - `value` is NaN.
+    /// - `value` is infinite.
+    /// - `value` is negative.
+    ///
+    /// If debug assertions are off, this will return zero instead of panicking.
+    pub fn px(value: f64) -> Self {
+        if value < 0. || !value.is_finite() {
+            // TODO - Make const once const formatting is allowed.
+            // (aka see you in 2030)
+            debug_panic!("Invalid length value '{value}'");
+            return Self::ZERO;
+        }
+        Self { value }
+    }
+
+    /// Create a length, in logical pixels.
+    ///
+    /// Can be called from const contexts.
+    ///
+    /// # Panics
+    ///
+    /// This will always panic if value is negative or non-finite.
+    pub const fn const_px(value: f64) -> Self {
+        if value < 0. || !value.is_finite() {
+            panic!("Invalid length value");
+        }
+        Self { value }
+    }
+
+    /// Get the value, in logical pixels.
+    pub const fn value(self) -> f64 {
+        self.value
+    }
+
+    #[doc(hidden)]
+    // TODO - Remove once pixel-snapping is merged.
+    pub fn ceil(self) -> Self {
+        Self {
+            value: self.value.ceil(),
+        }
+    }
+}

--- a/masonry/src/properties/types/mod.rs
+++ b/masonry/src/properties/types/mod.rs
@@ -13,7 +13,9 @@
 //! [`Background::Gradient`]: crate::properties::Background::Gradient
 
 mod gradient;
+mod length;
 mod unit_point;
 
 pub use gradient::*;
+pub use length::*;
 pub use unit_point::UnitPoint;

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -313,6 +313,7 @@ mod tests {
     use crate::core::keyboard::NamedKey;
     use crate::core::{PointerButton, Properties, StyleProperty};
     use crate::properties::TextColor;
+    use crate::properties::types::Length;
     use crate::testing::{TestHarness, TestWidgetExt, assert_render_snapshot, widget_ids};
     use crate::theme::{ACCENT_COLOR, default_property_set};
     use crate::widgets::{Grid, GridParams};
@@ -426,7 +427,7 @@ mod tests {
         use crate::palette::css::ORANGE;
 
         let grid = Grid::with_dimensions(2, 2)
-            .with_spacing(40.0)
+            .with_spacing(Length::px(40.0))
             .with_child(Button::new("A").with_auto_id(), GridParams::new(0, 0, 1, 1))
             .with_child(Button::new("B").with_auto_id(), GridParams::new(1, 0, 1, 1))
             .with_child(Button::new("C").with_auto_id(), GridParams::new(0, 1, 1, 1))

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -15,6 +15,7 @@ use crate::core::{
     AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, PaintCtx, PropertiesMut,
     PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
+use crate::properties::types::Length;
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use crate::util::{debug_panic, fill, include_screenshot, stroke};
 
@@ -29,7 +30,7 @@ pub struct Flex {
     main_alignment: MainAxisAlignment,
     fill_major_axis: bool,
     children: Vec<Child>,
-    gap: f64,
+    gap: Length,
 }
 
 /// Optional parameters for an item in a [`Flex`] container (row or column).
@@ -114,7 +115,7 @@ enum Child {
         alignment: Option<CrossAxisAlignment>,
         flex: f64,
     },
-    FixedSpacer(f64, f64),
+    FixedSpacer(Length, f64),
     FlexedSpacer(f64, f64),
 }
 
@@ -128,7 +129,7 @@ impl Flex {
             cross_alignment: CrossAxisAlignment::Center,
             main_alignment: MainAxisAlignment::Start,
             fill_major_axis: false,
-            gap: crate::theme::WIDGET_PADDING,
+            gap: Length::px(crate::theme::WIDGET_PADDING),
         }
     }
 
@@ -172,17 +173,9 @@ impl Flex {
     /// Equivalent to the css [gap] property.
     /// This gap is also present between spacers.
     ///
-    /// ## Panics
-    ///
-    /// If `gap` is not a non-negative finite value.
-    ///
     /// [gap]: https://developer.mozilla.org/en-US/docs/Web/CSS/gap
     // TODO: Semantics - should this include fixed spacers?
-    pub fn with_gap(mut self, mut gap: f64) -> Self {
-        if !gap.is_finite() || gap < 0.0 {
-            debug_panic!("Invalid gap value '{gap}', expected a non-negative finite value.");
-            gap = 0.0;
-        }
+    pub fn with_gap(mut self, gap: Length) -> Self {
         self.gap = gap;
         self
     }
@@ -214,12 +207,7 @@ impl Flex {
     /// Builder-style method for adding a fixed-size spacer to the container.
     ///
     /// A good default size is [`WIDGET_PADDING`](crate::theme::WIDGET_PADDING).
-    pub fn with_spacer(mut self, mut len: f64) -> Self {
-        if len < 0.0 {
-            tracing::warn!("with_spacer called with negative length: {}", len);
-        }
-        len = len.clamp(0.0, f64::MAX);
-
+    pub fn with_spacer(mut self, len: Length) -> Self {
         let new_child = Child::FixedSpacer(len, 0.0);
         self.children.push(new_child);
         self
@@ -282,15 +270,7 @@ impl Flex {
     /// This gap is also present between spacers.
     ///
     /// [gap]: https://developer.mozilla.org/en-US/docs/Web/CSS/gap
-    ///
-    /// ## Panics
-    ///
-    /// If `gap` is not a non-negative finite value.
-    pub fn set_gap(this: &mut WidgetMut<'_, Self>, mut gap: f64) {
-        if !gap.is_finite() || gap < 0.0 {
-            debug_panic!("Invalid gap value '{gap}', expected a non-negative finite value.");
-            gap = 0.0;
-        }
+    pub fn set_gap(this: &mut WidgetMut<'_, Self>, gap: Length) {
         this.widget.gap = gap;
         this.ctx.request_layout();
     }
@@ -325,12 +305,7 @@ impl Flex {
     /// Add an empty spacer widget with the given size.
     ///
     /// A good default size is [`WIDGET_PADDING`](crate::theme::WIDGET_PADDING).
-    pub fn add_spacer(this: &mut WidgetMut<'_, Self>, mut len: f64) {
-        if len < 0.0 {
-            tracing::warn!("add_spacer called with negative length: {}", len);
-        }
-        len = len.clamp(0.0, f64::MAX);
-
+    pub fn add_spacer(this: &mut WidgetMut<'_, Self>, len: Length) {
         let new_child = Child::FixedSpacer(len, 0.0);
         this.widget.children.push(new_child);
         this.ctx.request_layout();
@@ -387,16 +362,7 @@ impl Flex {
     /// Insert an empty spacer widget with the given size at the given index.
     ///
     /// A good default size is [`WIDGET_PADDING`](crate::theme::WIDGET_PADDING).
-    ///
-    /// # Panics
-    ///
-    /// Panics if the index is larger than the number of children.
-    pub fn insert_spacer(this: &mut WidgetMut<'_, Self>, idx: usize, mut len: f64) {
-        if len < 0.0 {
-            tracing::warn!("add_spacer called with negative length: {}", len);
-        }
-        len = len.clamp(0.0, f64::MAX);
-
+    pub fn insert_spacer(this: &mut WidgetMut<'_, Self>, idx: usize, len: Length) {
         let new_child = Child::FixedSpacer(len, 0.0);
         this.widget.children.insert(idx, new_child);
         this.ctx.request_layout();
@@ -465,7 +431,7 @@ impl Flex {
         params: impl Into<FlexParams>,
     ) {
         let child = &mut this.widget.children[idx];
-        let child_val = std::mem::replace(child, Child::FixedSpacer(0.0, 0.0));
+        let child_val = std::mem::replace(child, Child::FixedSpacer(Length::ZERO, 0.0));
         let widget = match child_val {
             Child::Fixed { widget, .. } | Child::Flex { widget, .. } => widget,
             _ => {
@@ -501,7 +467,7 @@ impl Flex {
     /// # Panics
     ///
     /// Panics if the element at `idx` is not a spacer.
-    pub fn update_spacer_fixed(this: &mut WidgetMut<'_, Self>, idx: usize, len: f64) {
+    pub fn update_spacer_fixed(this: &mut WidgetMut<'_, Self>, idx: usize, len: Length) {
         let child = &mut this.widget.children[idx];
 
         match *child {
@@ -843,7 +809,7 @@ impl Widget for Flex {
 
         let gap = self.gap;
         // The gaps are only between the items, so 2 children means 1 gap.
-        let total_gap = self.children.len().saturating_sub(1) as f64 * gap;
+        let total_gap = self.children.len().saturating_sub(1) as f64 * gap.value();
         // Measure non-flex children.
         let mut major_non_flex = total_gap;
         // We start with a small value to avoid divide-by-zero errors.
@@ -880,7 +846,7 @@ impl Widget for Flex {
                     max_below_baseline = max_below_baseline.max(baseline_offset);
                 }
                 Child::FixedSpacer(kv, calculated_size) => {
-                    *calculated_size = *kv;
+                    *calculated_size = kv.value();
                     if *calculated_size < 0.0 {
                         tracing::warn!("Length provided to fixed spacer was less than 0");
                     }
@@ -1003,12 +969,12 @@ impl Widget for Flex {
                     ctx.place_child(widget, child_pos);
                     major += self.direction.major(child_size).expand();
                     major += spacing.next().unwrap_or(0.);
-                    major += gap;
+                    major += gap.value();
                 }
                 Child::FlexedSpacer(_, calculated_size)
                 | Child::FixedSpacer(_, calculated_size) => {
                     major += *calculated_size;
-                    major += gap;
+                    major += gap.value();
                 }
             }
         }
@@ -1021,7 +987,7 @@ impl Widget for Flex {
             // If we have at least one child, the last child added `gap` to `major`, which means that `major` is
             // not the total size of the flex in the major axis, it's instead where the "next widget" will be placed.
             // However, for the rest of this value, we need the total size of the widget in the major axis.
-            major -= gap;
+            major -= gap.value();
         }
 
         if flex_sum > MIN_FLEX_SUM {
@@ -1415,7 +1381,7 @@ mod tests {
                 // -> acdx
                 Flex::add_flex_child(&mut flex, Label::new("y").with_auto_id(), 2.0);
                 // -> acdxy
-                Flex::add_spacer(&mut flex, 5.0);
+                Flex::add_spacer(&mut flex, Length::px(5.0));
                 // -> acdxy_
                 Flex::add_flex_spacer(&mut flex, 1.0);
                 // -> acdxy__
@@ -1423,7 +1389,7 @@ mod tests {
                 // -> acidxy__
                 Flex::insert_flex_child(&mut flex, 2, Label::new("j").with_auto_id(), 2.0);
                 // -> acjidxy__
-                Flex::insert_spacer(&mut flex, 2, 5.0);
+                Flex::insert_spacer(&mut flex, 2, Length::px(5.0));
                 // -> ac_jidxy__
                 Flex::insert_flex_spacer(&mut flex, 2, 1.0);
                 // -> ac__jidxy__
@@ -1437,13 +1403,13 @@ mod tests {
                 .with_child(Label::new("a").with_auto_id())
                 .with_child(Label::new("c").with_auto_id())
                 .with_flex_spacer(1.0)
-                .with_spacer(5.0)
+                .with_spacer(Length::px(5.0))
                 .with_flex_child(Label::new("j").with_auto_id(), 2.0)
                 .with_child(Label::new("i").with_auto_id())
                 .with_child(Label::new("d").with_auto_id())
                 .with_child(Label::new("x").with_auto_id())
                 .with_flex_child(Label::new("y").with_auto_id(), 2.0)
-                .with_spacer(5.0)
+                .with_spacer(Length::px(5.0))
                 .with_flex_spacer(1.0);
 
             let window_size = Size::new(200.0, 150.0);
@@ -1461,7 +1427,7 @@ mod tests {
         let widget = Flex::column()
             .with_child(Label::new("hello").with_auto_id())
             .with_child(Label::new("world").with_auto_id())
-            .with_spacer(1.0);
+            .with_spacer(Length::px(1.0));
 
         let window_size = Size::new(200.0, 150.0);
         let mut harness =

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -12,6 +12,7 @@ use crate::core::{
     AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, PaintCtx, PropertiesMut,
     PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
+use crate::properties::types::Length;
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use crate::util::{debug_panic, fill, include_screenshot, stroke};
 
@@ -22,7 +23,7 @@ pub struct Grid {
     children: Vec<Child>,
     grid_width: i32,
     grid_height: i32,
-    grid_spacing: f64,
+    grid_spacing: Length,
 }
 
 struct Child {
@@ -54,12 +55,12 @@ impl Grid {
             children: Vec::new(),
             grid_width: width,
             grid_height: height,
-            grid_spacing: 0.0,
+            grid_spacing: Length::ZERO,
         }
     }
 
     /// Builder-style method for setting the spacing between grid items.
-    pub fn with_spacing(mut self, spacing: f64) -> Self {
+    pub fn with_spacing(mut self, spacing: Length) -> Self {
         self.grid_spacing = spacing;
         self
     }
@@ -173,7 +174,7 @@ impl Grid {
     }
 
     /// Set the spacing between grid items.
-    pub fn set_spacing(this: &mut WidgetMut<'_, Self>, spacing: f64) {
+    pub fn set_spacing(this: &mut WidgetMut<'_, Self>, spacing: Length) {
         this.widget.grid_spacing = spacing;
         this.ctx.request_layout();
     }
@@ -273,12 +274,13 @@ impl Widget for Grid {
                 total_size
             );
         }
-        let width_unit = (total_size.width + self.grid_spacing) / (self.grid_width as f64);
-        let height_unit = (total_size.height + self.grid_spacing) / (self.grid_height as f64);
+        let gap = self.grid_spacing.value();
+        let width_unit = (total_size.width + gap) / (self.grid_width as f64);
+        let height_unit = (total_size.height + gap) / (self.grid_height as f64);
         for child in &mut self.children {
             let cell_size = Size::new(
-                (child.width as f64 * width_unit - self.grid_spacing).max(0.0),
-                (child.height as f64 * height_unit - self.grid_spacing).max(0.0),
+                (child.width as f64 * width_unit - gap).max(0.0),
+                (child.height as f64 * height_unit - gap).max(0.0),
             );
             let child_bc = BoxConstraints::new(cell_size, cell_size);
             let _ = ctx.run_layout(&mut child.widget, &child_bc);
@@ -404,15 +406,9 @@ mod tests {
 
         // Change the spacing
         harness.edit_root_widget(|mut grid| {
-            Grid::set_spacing(&mut grid, 7.0);
+            Grid::set_spacing(&mut grid, Length::px(7.0));
         });
         assert_render_snapshot!(harness, "grid_with_changed_spacing");
-
-        // Make the spacing negative
-        harness.edit_root_widget(|mut grid| {
-            Grid::set_spacing(&mut grid, -4.0);
-        });
-        assert_render_snapshot!(harness, "grid_with_negative_spacing");
     }
 
     #[test]

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -427,6 +427,7 @@ mod tests {
 
     use super::*;
     use crate::core::Properties;
+    use crate::properties::types::Length;
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::{ACCENT_COLOR, default_property_set};
     use crate::widgets::{CrossAxisAlignment, Flex, SizedBox};
@@ -503,7 +504,7 @@ mod tests {
             .with_flex_child(label4.with_auto_id(), CrossAxisAlignment::Center)
             .with_flex_child(label5.with_auto_id(), CrossAxisAlignment::Center)
             .with_flex_child(label6.with_auto_id(), CrossAxisAlignment::Center)
-            .with_gap(0.0);
+            .with_gap(Length::ZERO);
 
         let mut harness =
             TestHarness::create_with_size(default_property_set(), flex, Size::new(200.0, 200.0));
@@ -521,27 +522,27 @@ mod tests {
                         .with_line_break_mode(LineBreaking::WordWrap)
                         .with_auto_id(),
                 )
-                .width(180.0)
+                .width(Length::px(180.0))
                 .with_auto_id(),
             )
-            .with_spacer(20.0)
+            .with_spacer(Length::px(20.0))
             .with_child(
                 SizedBox::new(
                     Label::new("The quick brown fox jumps over the lazy dog")
                         .with_line_break_mode(LineBreaking::Clip)
                         .with_auto_id(),
                 )
-                .width(180.0)
+                .width(Length::px(180.0))
                 .with_auto_id(),
             )
-            .with_spacer(20.0)
+            .with_spacer(Length::px(20.0))
             .with_child(
                 SizedBox::new(
                     Label::new("The quick brown fox jumps over the lazy dog")
                         .with_line_break_mode(LineBreaking::Overflow)
                         .with_auto_id(),
                 )
-                .width(180.0)
+                .width(Length::px(180.0))
                 .with_auto_id(),
             )
             .with_flex_spacer(1.0);

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -505,14 +505,15 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::properties::types::Length;
     use crate::testing::{TestHarness, assert_render_snapshot, widget_ids};
     use crate::theme::default_property_set;
     use crate::widgets::{Button, Flex, SizedBox};
 
     fn button(text: &'static str) -> impl Widget {
         SizedBox::new(Button::new(text).with_auto_id())
-            .width(70.0)
-            .height(40.0)
+            .width(Length::px(70.0))
+            .height(Length::px(40.0))
     }
 
     #[test]
@@ -522,33 +523,33 @@ mod tests {
         let widget = Portal::new(NewWidget::new(
             Flex::column()
                 .with_child(button("Item 1").with_auto_id())
-                .with_spacer(10.0)
+                .with_spacer(Length::px(10.0))
                 .with_child(button("Item 2").with_auto_id())
-                .with_spacer(10.0)
+                .with_spacer(Length::px(10.0))
                 .with_child(NewWidget::new_with_id(button("Item 3"), item_3_id))
-                .with_spacer(10.0)
+                .with_spacer(Length::px(10.0))
                 .with_child(button("Item 4").with_auto_id())
-                .with_spacer(10.0)
+                .with_spacer(Length::px(10.0))
                 .with_child(button("Item 5").with_auto_id())
-                .with_spacer(10.0)
+                .with_spacer(Length::px(10.0))
                 .with_child(button("Item 6").with_auto_id())
-                .with_spacer(10.0)
+                .with_spacer(Length::px(10.0))
                 .with_child(button("Item 7").with_auto_id())
-                .with_spacer(10.0)
+                .with_spacer(Length::px(10.0))
                 .with_child(button("Item 8").with_auto_id())
-                .with_spacer(10.0)
+                .with_spacer(Length::px(10.0))
                 .with_child(button("Item 9").with_auto_id())
-                .with_spacer(10.0)
+                .with_spacer(Length::px(10.0))
                 .with_child(button("Item 10").with_auto_id())
-                .with_spacer(10.0)
+                .with_spacer(Length::px(10.0))
                 .with_child(button("Item 11").with_auto_id())
-                .with_spacer(10.0)
+                .with_spacer(Length::px(10.0))
                 .with_child(button("Item 12").with_auto_id())
-                .with_spacer(10.0)
+                .with_spacer(Length::px(10.0))
                 .with_child(NewWidget::new_with_id(button("Item 13"), item_13_id))
-                .with_spacer(10.0)
+                .with_spacer(Length::px(10.0))
                 .with_child(button("Item 14").with_auto_id())
-                .with_spacer(10.0),
+                .with_spacer(Length::px(10.0)),
         ));
 
         let mut harness =
@@ -583,12 +584,12 @@ mod tests {
 
         let widget = Portal::new(
             Flex::column()
-                .with_spacer(500.0)
+                .with_spacer(Length::px(500.0))
                 .with_child(NewWidget::new_with_id(
                     Button::new("Fully visible"),
                     button_id,
                 ))
-                .with_spacer(500.0)
+                .with_spacer(Length::px(500.0))
                 .with_auto_id(),
         );
 

--- a/masonry/src/widgets/prose.rs
+++ b/masonry/src/widgets/prose.rs
@@ -184,6 +184,7 @@ mod tests {
 
     use super::*;
     use crate::TextAlign;
+    use crate::properties::types::Length;
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::default_property_set;
     use crate::widgets::{CrossAxisAlignment, Flex, SizedBox, TextArea};
@@ -202,7 +203,7 @@ mod tests {
 
         let root_widget = Flex::row().with_child(
             SizedBox::new(prose.with_auto_id())
-                .width(60.)
+                .width(Length::px(60.))
                 .with_auto_id(),
         );
 
@@ -242,7 +243,7 @@ mod tests {
             .with_flex_child(prose4.with_auto_id(), CrossAxisAlignment::Center)
             .with_flex_child(prose5.with_auto_id(), CrossAxisAlignment::Center)
             .with_flex_child(prose6.with_auto_id(), CrossAxisAlignment::Center)
-            .with_gap(0.0);
+            .with_gap(Length::ZERO);
 
         let mut harness =
             TestHarness::create_with_size(default_property_set(), flex, Size::new(200.0, 120.0));

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -14,6 +14,7 @@ use crate::core::{
     AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, PaintCtx, PropertiesMut,
     PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
+use crate::properties::types::Length;
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use crate::util::{fill, include_screenshot, stroke};
 
@@ -59,14 +60,14 @@ impl SizedBox {
     }
 
     /// Set container's width.
-    pub fn width(mut self, width: f64) -> Self {
-        self.width = Some(width);
+    pub fn width(mut self, width: Length) -> Self {
+        self.width = Some(width.value());
         self
     }
 
     /// Set container's height.
-    pub fn height(mut self, height: f64) -> Self {
-        self.height = Some(height);
+    pub fn height(mut self, height: Length) -> Self {
+        self.height = Some(height.value());
         self
     }
 
@@ -79,6 +80,8 @@ impl SizedBox {
     /// [`expand_height`]: Self::expand_height
     /// [`expand_width`]: Self::expand_width
     pub fn expand(mut self) -> Self {
+        // TODO - Using infinity in layout is a code smell.
+        // Rewor these methods.
         self.width = Some(f64::INFINITY);
         self.height = Some(f64::INFINITY);
         self
@@ -320,7 +323,7 @@ mod tests {
 
     #[test]
     fn no_width() {
-        let expand = SizedBox::new(Label::new("hello!").with_auto_id()).height(200.);
+        let expand = SizedBox::new(Label::new("hello!").with_auto_id()).height(Length::px(200.));
         let bc = BoxConstraints::tight(Size::new(400., 400.)).loosen();
         let child_bc = expand.child_constraints(&bc);
         assert_eq!(child_bc.min(), Size::new(0., 200.,));
@@ -335,8 +338,8 @@ mod tests {
         box_props.insert(CornerRadius::all(5.0));
 
         let widget = SizedBox::empty()
-            .width(20.0)
-            .height(20.0)
+            .width(Length::px(20.0))
+            .height(Length::px(20.0))
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -370,8 +373,8 @@ mod tests {
         box_props.insert(CornerRadius::all(5.0));
 
         let widget = SizedBox::new(Label::new("hello").with_auto_id())
-            .width(20.0)
-            .height(20.0)
+            .width(Length::px(20.0))
+            .height(Length::px(20.0))
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -404,8 +407,8 @@ mod tests {
         box_props.insert(Background::Color(palette::css::PLUM));
 
         let widget = SizedBox::new(Label::new("hello").with_auto_id())
-            .width(20.0)
-            .height(20.0)
+            .width(Length::px(20.0))
+            .height(Length::px(20.0))
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -432,8 +435,8 @@ mod tests {
         box_props.insert(CornerRadius::all(10.0));
 
         let widget = SizedBox::empty()
-            .width(20.)
-            .height(20.)
+            .width(Length::px(20.))
+            .height(Length::px(20.))
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -460,8 +463,8 @@ mod tests {
         box_props.insert(CornerRadius::all(10.0));
 
         let widget = SizedBox::empty()
-            .width(20.)
-            .height(20.)
+            .width(Length::px(20.))
+            .height(Length::px(20.))
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -488,8 +491,8 @@ mod tests {
         box_props.insert(CornerRadius::all(10.0));
 
         let widget = SizedBox::empty()
-            .width(20.)
-            .height(20.)
+            .width(Length::px(20.))
+            .height(Length::px(20.))
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -508,8 +511,8 @@ mod tests {
         box_props.insert(Padding::all(25.));
 
         let widget = SizedBox::new(Label::new("hello").with_auto_id())
-            .width(20.0)
-            .height(20.0)
+            .width(Length::px(20.0))
+            .height(Length::px(20.0))
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -535,8 +538,8 @@ mod tests {
         box_props.insert(BorderWidth::all(5.2));
 
         let widget = SizedBox::empty()
-            .width(20.0)
-            .height(20.0)
+            .width(Length::px(20.0))
+            .height(Length::px(20.0))
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -558,8 +561,8 @@ mod tests {
         box_props.insert(Padding::all(0.2));
 
         let widget = SizedBox::new(Label::new("hello").with_auto_id())
-            .width(20.0)
-            .height(20.0)
+            .width(Length::px(20.0))
+            .height(Length::px(20.0))
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -14,6 +14,7 @@ use crate::core::{
     RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::peniko::Color;
+use crate::properties::types::Length;
 use crate::theme;
 use crate::util::{fill_color, include_screenshot, stroke};
 use crate::widgets::flex::Axis;
@@ -29,9 +30,9 @@ where
     split_axis: Axis,
     split_point_chosen: f64,
     split_point_effective: f64,
-    min_size: (f64, f64), // Integers only
-    bar_size: f64,        // Integers only
-    min_bar_area: f64,    // Integers only
+    min_size: (Length, Length), // Integers only
+    bar_size: Length,           // Integers only
+    min_bar_area: Length,       // Integers only
     solid: bool,
     draggable: bool,
     /// Offset from the split point (bar center) to the actual mouse position when the
@@ -50,9 +51,9 @@ impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
             split_axis: Axis::Horizontal,
             split_point_chosen: 0.5,
             split_point_effective: 0.5,
-            min_size: (0.0, 0.0),
-            bar_size: 6.0,
-            min_bar_area: 6.0,
+            min_size: (Length::ZERO, Length::ZERO),
+            bar_size: Length::px(6.0),
+            min_bar_area: Length::px(6.0),
             solid: false,
             draggable: true,
             click_offset: 0.0,
@@ -87,22 +88,17 @@ impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
 
     /// Builder-style method to set the minimum size for both sides of the split axis.
     ///
-    /// The value must be greater than or equal to `0.0`.
     /// The value will be rounded up to the nearest integer.
-    pub fn min_size(mut self, first: f64, second: f64) -> Self {
-        assert!(first >= 0.0, "minimum size must be 0.0 or greater");
-        assert!(second >= 0.0, "minimum size must be 0.0 or greater");
+    pub fn min_size(mut self, first: Length, second: Length) -> Self {
         self.min_size = (first.ceil(), second.ceil());
         self
     }
 
     /// Builder-style method to set the size of the splitter bar.
     ///
-    /// The value must be positive or zero.
     /// The value will be rounded up to the nearest integer.
     /// The default splitter bar size is `6.0`.
-    pub fn bar_size(mut self, bar_size: f64) -> Self {
-        assert!(bar_size >= 0.0, "bar_size must be 0.0 or greater");
+    pub fn bar_size(mut self, bar_size: Length) -> Self {
         self.bar_size = bar_size.ceil();
         self
     }
@@ -116,11 +112,9 @@ impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
     /// This can be useful when you want to use a very narrow visual splitter bar,
     /// but don't want to sacrifice user experience by making it hard to click on.
     ///
-    /// The value must be positive or zero.
     /// The value will be rounded up to the nearest integer.
     /// The default minimum splitter bar area is `6.0`.
-    pub fn min_bar_area(mut self, min_bar_area: f64) -> Self {
-        assert!(min_bar_area >= 0.0, "min_bar_area must be 0.0 or greater");
+    pub fn min_bar_area(mut self, min_bar_area: Length) -> Self {
         self.min_bar_area = min_bar_area.ceil();
         self
     }
@@ -145,13 +139,13 @@ impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
     /// Returns the size of the splitter bar area.
     #[inline]
     fn bar_area(&self) -> f64 {
-        self.bar_size.max(self.min_bar_area)
+        self.bar_size.value().max(self.min_bar_area.value())
     }
 
     /// Returns the padding size added to each side of the splitter bar.
     #[inline]
     fn bar_padding(&self) -> f64 {
-        (self.bar_area() - self.bar_size) / 2.0
+        (self.bar_area() - self.bar_size.value()) / 2.0
     }
 
     /// Returns the position of the split point (split bar center).
@@ -204,7 +198,9 @@ impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
     fn split_side_limits(&self, size: Size) -> (f64, f64) {
         let split_axis_size = self.split_axis.major(size);
 
-        let (mut min_limit, min_second) = self.min_size;
+        let (min_limit, min_second) = self.min_size;
+        let mut min_limit = min_limit.value();
+        let min_second = min_second.value();
         let mut max_limit = (split_axis_size - min_second).max(0.0);
 
         if min_limit > max_limit {
@@ -255,7 +251,7 @@ impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
         let size = ctx.size();
         // Set the line width to a third of the splitter bar size,
         // because we'll paint two equal lines at the edges.
-        let line_width = (self.bar_size / 3.0).floor();
+        let line_width = (self.bar_size.value() / 3.0).floor();
         let line_midpoint = line_width / 2.0;
         let (edge1, edge2) = self.bar_edges(size);
         let padding = self.bar_padding();
@@ -326,22 +322,17 @@ where
 
     /// Set the minimum size for both sides of the split axis.
     ///
-    /// The value must be greater than or equal to `0.0`.
     /// The value will be rounded up to the nearest integer.
-    pub fn set_min_size(this: &mut WidgetMut<'_, Self>, first: f64, second: f64) {
-        assert!(first >= 0.0, "minimum size must be 0.0 or greater");
-        assert!(second >= 0.0, "minimum size must be 0.0 or greater");
+    pub fn set_min_size(this: &mut WidgetMut<'_, Self>, first: Length, second: Length) {
         this.widget.min_size = (first.ceil(), second.ceil());
         this.ctx.request_layout();
     }
 
     /// Set the size of the splitter bar.
     ///
-    /// The value must be positive or zero.
     /// The value will be rounded up to the nearest integer.
     /// The default splitter bar size is `6.0`.
-    pub fn set_bar_size(this: &mut WidgetMut<'_, Self>, bar_size: f64) {
-        assert!(bar_size >= 0.0, "bar_size must be 0.0 or greater");
+    pub fn set_bar_size(this: &mut WidgetMut<'_, Self>, bar_size: Length) {
         this.widget.bar_size = bar_size.ceil();
         this.ctx.request_layout();
     }
@@ -355,11 +346,9 @@ where
     /// This can be useful when you want to use a very narrow visual splitter bar,
     /// but don't want to sacrifice user experience by making it hard to click on.
     ///
-    /// The value must be positive or zero.
     /// The value will be rounded up to the nearest integer.
     /// The default minimum splitter bar area is `6.0`.
-    pub fn set_min_bar_area(this: &mut WidgetMut<'_, Self>, min_bar_area: f64) {
-        assert!(min_bar_area >= 0.0, "min_bar_area must be 0.0 or greater");
+    pub fn set_min_bar_area(this: &mut WidgetMut<'_, Self>, min_bar_area: Length) {
         this.widget.min_bar_area = min_bar_area.ceil();
         this.ctx.request_layout();
     }
@@ -648,8 +637,8 @@ mod tests {
                 Label::new("World").with_auto_id(),
             )
             .split_point(0.3)
-            .min_size(40.0, 10.0)
-            .bar_size(12.0)
+            .min_size(Length::px(40.0), Length::px(10.0))
+            .bar_size(Length::px(12.0))
             .draggable(true)
             .solid_bar(true);
 
@@ -676,8 +665,8 @@ mod tests {
 
             harness.edit_root_widget(|mut splitter| {
                 Split::set_split_point(&mut splitter, 0.3);
-                Split::set_min_size(&mut splitter, 40.0, 10.0);
-                Split::set_bar_size(&mut splitter, 12.0);
+                Split::set_min_size(&mut splitter, Length::px(40.0), Length::px(10.0));
+                Split::set_bar_size(&mut splitter, Length::px(12.0));
                 Split::set_draggable(&mut splitter, true);
                 Split::set_bar_solid(&mut splitter, true);
             });

--- a/masonry/src/widgets/tests/layout.rs
+++ b/masonry/src/widgets/tests/layout.rs
@@ -6,6 +6,7 @@
 use vello::kurbo::{Insets, Size};
 
 use crate::core::{NewWidget, Widget as _};
+use crate::properties::types::Length;
 use crate::testing::{ModularWidget, TestHarness, TestWidgetExt, widget_ids};
 use crate::theme::default_property_set;
 use crate::widgets::{Flex, SizedBox};
@@ -15,16 +16,17 @@ fn layout_simple() {
     const BOX_WIDTH: f64 = 50.;
 
     let [id_1, id_2] = widget_ids();
+    let box_side = Length::px(BOX_WIDTH);
 
     let widget = Flex::column()
         .with_child(
             Flex::row()
                 .with_child(NewWidget::new_with_id(
-                    SizedBox::empty().width(BOX_WIDTH).height(BOX_WIDTH),
+                    SizedBox::empty().width(box_side).height(box_side),
                     id_1,
                 ))
                 .with_child(NewWidget::new_with_id(
-                    SizedBox::empty().width(BOX_WIDTH).height(BOX_WIDTH),
+                    SizedBox::empty().width(box_side).height(box_side),
                     id_2,
                 ))
                 .with_flex_spacer(1.0)

--- a/masonry/src/widgets/tests/status_change.rs
+++ b/masonry/src/widgets/tests/status_change.rs
@@ -6,6 +6,7 @@ use masonry_core::core::Widget;
 use vello::kurbo::Vec2;
 
 use crate::core::{NewWidget, PointerButton, PointerEvent, Update, WidgetId};
+use crate::properties::types::Length;
 use crate::testing::{
     PRIMARY_MOUSE, Record, Recording, TestHarness, TestWidgetExt as _, widget_ids,
 };
@@ -53,17 +54,19 @@ fn propagate_hovered() {
 
     let widget = Flex::column()
         .with_child(NewWidget::new_with_id(
-            SizedBox::empty().width(10.0).height(10.0),
+            SizedBox::empty()
+                .width(Length::px(10.0))
+                .height(Length::px(10.0)),
             empty,
         ))
         .with_child(NewWidget::new_with_id(
             Flex::column()
-                .with_spacer(100.0)
+                .with_spacer(Length::px(100.0))
                 .with_child(NewWidget::new_with_id(
                     Button::new("hovered").record(&button_rec),
                     button,
                 ))
-                .with_spacer(10.0)
+                .with_spacer(Length::px(10.0))
                 .record(&padding_rec),
             pad,
         ))
@@ -237,11 +240,15 @@ fn get_pointer_events_while_active() {
 
     let widget = Flex::column()
         .with_child(NewWidget::new_with_id(
-            SizedBox::empty().width(10.0).height(10.0),
+            SizedBox::empty()
+                .width(Length::px(10.0))
+                .height(Length::px(10.0)),
             empty,
         ))
         .with_child(NewWidget::new_with_id(
-            SizedBox::empty().width(10.0).height(10.0),
+            SizedBox::empty()
+                .width(Length::px(10.0))
+                .height(Length::px(10.0)),
             empty_2,
         ))
         .with_child(NewWidget::new_with_id(
@@ -321,7 +328,9 @@ fn automatically_lose_pointer_on_pointer_lost() {
 
     let widget = Flex::column()
         .with_child(NewWidget::new_with_id(
-            SizedBox::empty().width(10.0).height(10.0),
+            SizedBox::empty()
+                .width(Length::px(10.0))
+                .height(Length::px(10.0)),
             empty,
         ))
         .with_child(NewWidget::new_with_id(

--- a/masonry/src/widgets/tests/transforms.rs
+++ b/masonry/src/widgets/tests/transforms.rs
@@ -9,7 +9,7 @@ use vello::kurbo::{Affine, Vec2};
 use vello::peniko::color::palette;
 
 use crate::core::{NewWidget, PointerButton, Properties, Widget, WidgetOptions};
-use crate::properties::types::UnitPoint;
+use crate::properties::types::{Length, UnitPoint};
 use crate::properties::{Background, BorderColor, BorderWidth};
 use crate::testing::{TestHarness, TestWidgetExt, assert_render_snapshot};
 use crate::theme::default_property_set;
@@ -22,8 +22,8 @@ fn blue_box(inner: impl Widget) -> impl Widget {
     box_props.insert(BorderWidth::all(2.0));
 
     SizedBox::new(inner.with_auto_id())
-        .width(200.)
-        .height(100.)
+        .width(Length::px(200.))
+        .height(Length::px(100.))
         .with_props(box_props)
 }
 

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -221,6 +221,7 @@ mod tests {
 
     use super::*;
     use crate::core::Properties;
+    use crate::properties::types::Length;
     use crate::properties::{Background, BorderColor, BorderWidth};
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::default_property_set;
@@ -242,8 +243,8 @@ mod tests {
             .with_child(
                 NewWidget::new_with_props(
                     SizedBox::new(Label::new("Background").with_auto_id())
-                        .width(200.)
-                        .height(100.),
+                        .width(Length::px(200.))
+                        .height(Length::px(100.)),
                     bg_props,
                 ),
                 ChildAlignment::ParentAligned,

--- a/masonry_winit/examples/calc_masonry.rs
+++ b/masonry_winit/examples/calc_masonry.rs
@@ -19,6 +19,7 @@ use masonry::core::{
 use masonry::dpi::LogicalSize;
 use masonry::peniko::Color;
 use masonry::peniko::color::AlphaColor;
+use masonry::properties::types::Length;
 use masonry::properties::{
     ActiveBackground, Background, BorderColor, BorderWidth, HoveredBorderColor, Padding,
 };
@@ -249,7 +250,7 @@ pub fn build_calc() -> NewWidget<impl Widget> {
     }
 
     let root_widget = Grid::with_dimensions(4, 6)
-        .with_spacing(1.0)
+        .with_spacing(Length::px(1.0))
         .with_child(display.with_auto_id(), GridParams::new(0, 0, 4, 1))
         .with_child(
             op_button_with_label('c', "CE".to_string()),

--- a/masonry_winit/examples/grid_masonry.rs
+++ b/masonry_winit/examples/grid_masonry.rs
@@ -12,6 +12,7 @@ use masonry::core::{
 };
 use masonry::dpi::LogicalSize;
 use masonry::peniko::Color;
+use masonry::properties::types::Length;
 use masonry::properties::{BorderColor, BorderWidth};
 use masonry::theme::default_property_set;
 use masonry::widgets::{Button, ButtonPress, Grid, GridParams, Prose, SizedBox, TextArea};
@@ -43,7 +44,7 @@ impl AppDriver for Driver {
 
             ctx.render_root(window_id).edit_root_widget(|mut root| {
                 let mut grid = root.downcast::<Grid>();
-                Grid::set_spacing(&mut grid, self.grid_spacing);
+                Grid::set_spacing(&mut grid, Length::px(self.grid_spacing));
             });
         }
     }
@@ -123,7 +124,7 @@ pub fn make_grid(grid_spacing: f64) -> Grid {
 
     // Arrange widgets in a 4 by 4 grid.
     let mut main_widget = Grid::with_dimensions(4, 4)
-        .with_spacing(grid_spacing)
+        .with_spacing(Length::px(grid_spacing))
         .with_child(label.with_auto_id(), GridParams::new(1, 0, 1, 1));
     for button_input in button_inputs {
         let button = grid_button(button_input);

--- a/masonry_winit/examples/hello_masonry.rs
+++ b/masonry_winit/examples/hello_masonry.rs
@@ -10,6 +10,7 @@
 use masonry::core::{ErasedAction, NewWidget, StyleProperty, Widget as _, WidgetId};
 use masonry::dpi::LogicalSize;
 use masonry::parley::style::FontWeight;
+use masonry::properties::types::Length;
 use masonry::theme::default_property_set;
 use masonry::widgets::{Button, ButtonPress, Flex, Label};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
@@ -50,7 +51,7 @@ fn main() {
     // Arrange the two widgets vertically, with some padding
     let main_widget = Flex::column()
         .with_child(label.with_auto_id())
-        .with_spacer(VERTICAL_WIDGET_SPACING)
+        .with_spacer(Length::px(VERTICAL_WIDGET_SPACING))
         .with_child(button.with_auto_id());
 
     let window_size = LogicalSize::new(400.0, 400.0);

--- a/masonry_winit/examples/to_do_list.rs
+++ b/masonry_winit/examples/to_do_list.rs
@@ -10,6 +10,7 @@
 use masonry::core::{ErasedAction, NewWidget, Properties, Widget, WidgetId};
 use masonry::dpi::LogicalSize;
 use masonry::properties::Padding;
+use masonry::properties::types::Length;
 use masonry::theme::default_property_set;
 use masonry::widgets::{Button, ButtonPress, Flex, Label, Portal, TextAction, TextArea, TextInput};
 use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
@@ -67,7 +68,7 @@ pub fn make_widget_tree() -> impl Widget {
                     .with_child(Button::new("Add task").with_auto_id()),
                 Properties::new().with(Padding::all(WIDGET_SPACING)),
             ))
-            .with_spacer(WIDGET_SPACING)
+            .with_spacer(Length::px(WIDGET_SPACING))
             .with_auto_id(),
     )
 }

--- a/masonry_winit/src/lib.rs
+++ b/masonry_winit/src/lib.rs
@@ -19,6 +19,7 @@
 //! ```rust
 //! use masonry::core::{ErasedAction, NewWidget, Widget, WidgetId, WidgetPod};
 //! use masonry::dpi::LogicalSize;
+//! use masonry::properties::types::Length;
 //! use masonry::theme::default_property_set;
 //! use masonry::widgets::{Button, ButtonPress, Flex, Label, Portal, TextAction, TextInput};
 //! use masonry_winit::app::{AppDriver, DriverCtx, WindowId};
@@ -67,7 +68,7 @@
 //!                     .with_flex_child(TextInput::new("").with_auto_id(), 1.0)
 //!                     .with_child(Button::new("Add task").with_auto_id()),
 //!             ))
-//!             .with_spacer(WIDGET_SPACING)
+//!             .with_spacer(Length::px(WIDGET_SPACING))
 //!             .with_auto_id(),
 //!     );
 //!

--- a/placehero/src/avatars.rs
+++ b/placehero/src/avatars.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use xilem::core::one_of::Either;
 use xilem::core::{MessageProxy, NoElement, View};
+use xilem::masonry::properties::types::Length;
 use xilem::palette::css;
 use xilem::style::{Gradient, Style};
 use xilem::tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
@@ -73,7 +74,11 @@ impl Avatars {
         let height = 50.;
         if let Some(maybe_image) = self.icons.get(url) {
             if let Some(image_) = maybe_image {
-                return Either::A(sized_box(image(image_)).width(width).height(height));
+                return Either::A(
+                    sized_box(image(image_))
+                        .width(Length::px(width))
+                        .height(Length::px(height)),
+                );
             }
         } else if let Some(requester) = self.requester.as_ref() {
             drop(requester.send(AvatarRequest {
@@ -92,8 +97,8 @@ impl Avatars {
                     )
                     .with_stops([css::YELLOW, css::LIME]),
                 )
-                .width(width)
-                .height(height)
+                .width(Length::px(width))
+                .height(Length::px(height))
                 .padding(4.0),
         )
     }

--- a/placehero/src/components.rs
+++ b/placehero/src/components.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use megalodon::entities::Status;
+use xilem::masonry::properties::types::Length;
 use xilem::view::{
     CrossAxisAlignment, FlexExt, FlexSequence, FlexSpacer, MainAxisAlignment, button, flex,
     flex_row, inline_prose, label, prose,
@@ -44,7 +45,7 @@ fn base_status(avatars: &mut Avatars, status: &Status) -> impl FlexSequence<Plac
                     .flex(CrossAxisAlignment::Start),
             ))
             .main_axis_alignment(MainAxisAlignment::Start)
-            .gap(1.),
+            .gap(Length::px(1.)),
             FlexSpacer::Flex(1.0),
             inline_prose(status.created_at.format("%Y-%m-%d %H:%M:%S").to_string())
                 .text_alignment(TextAlign::End),

--- a/placehero/src/components/thread.rs
+++ b/placehero/src/components/thread.rs
@@ -3,6 +3,7 @@
 
 use megalodon::entities::{Context, Status};
 use xilem::WidgetView;
+use xilem::masonry::properties::types::Length;
 use xilem::palette::css;
 use xilem::style::{Padding, Style};
 use xilem::view::{CrossAxisAlignment, FlexExt, flex, flex_row, label, portal, sized_box};
@@ -66,8 +67,8 @@ fn thread_ancestor(avatars: &mut Avatars, status: &Status) -> impl WidgetView<Pl
         flex_row((
             // An awful left-side border.
             sized_box(flex(()))
-                .width(3.)
-                .height(50.)
+                .width(Length::px(3.))
+                .height(Length::px(50.))
                 .background_color(css::WHITE)
                 .flex(CrossAxisAlignment::Start),
             flex(base_status(avatars, status)).flex(1.0),

--- a/xilem/examples/calc.rs
+++ b/xilem/examples/calc.rs
@@ -4,6 +4,7 @@
 //! A simple calculator example
 #![expect(clippy::cast_possible_truncation, reason = "Deferred: Noisy")]
 
+use masonry::properties::types::Length;
 use masonry::widgets::{CrossAxisAlignment, GridParams, MainAxisAlignment};
 use winit::dpi::LogicalSize;
 use winit::error::EventLoopError;
@@ -199,7 +200,7 @@ fn num_row(nums: [&'static str; 3], row: i32) -> impl GridSequence<Calculator> {
 }
 
 const DISPLAY_FONT_SIZE: f32 = 30.;
-const GRID_GAP: f64 = 2.;
+const GRID_GAP: Length = Length::const_px(2.);
 fn app_logic(data: &mut Calculator) -> impl WidgetView<Calculator> + use<> {
     grid(
         (
@@ -257,7 +258,7 @@ pub fn centered_flex_row<State, Seq: FlexSequence<State>>(sequence: Seq) -> Flex
         .direction(Axis::Horizontal)
         .cross_axis_alignment(CrossAxisAlignment::Center)
         .main_axis_alignment(MainAxisAlignment::Start)
-        .gap(5.)
+        .gap(Length::px(5.))
 }
 
 /// Returns a label intended to be used in the calculator's top display.

--- a/xilem/examples/emoji_picker.rs
+++ b/xilem/examples/emoji_picker.rs
@@ -3,6 +3,7 @@
 
 //! A simple emoji picker.
 
+use masonry::properties::types::Length;
 use winit::error::EventLoopError;
 use xilem::core::map_state;
 use xilem::style::Style as _;
@@ -15,7 +16,7 @@ use xilem::{
 
 fn app_logic(data: &mut EmojiPagination) -> impl WidgetView<EmojiPagination> + use<> {
     flex((
-        FlexSpacer::Fixed(50.), // Padding because of the info bar on Android
+        FlexSpacer::Fixed(Length::px(50.)), // Padding because of the info bar on Android
         flex_row((
             // TODO: Expose that this is a "zoom out" button accessibly
             button("🔍-", |data: &mut EmojiPagination| {
@@ -37,7 +38,7 @@ fn app_logic(data: &mut EmojiPagination) -> impl WidgetView<EmojiPagination> + u
         ),
         data.last_selected
             .map(|idx| label(format!("Selected: {}", data.emoji[idx].display)).text_size(40.)),
-        FlexSpacer::Fixed(10.),
+        FlexSpacer::Fixed(Length::px(10.)),
     ))
     .direction(Axis::Vertical)
     .must_fill_major_axis(true)
@@ -86,7 +87,7 @@ fn picker(data: &mut EmojiPagination) -> impl WidgetView<EmojiPagination> + use<
         data.size.try_into().unwrap(),
         data.size.try_into().unwrap(),
     )
-    .spacing(10.0)
+    .spacing(Length::px(10.0))
     .padding(20.0)
 }
 

--- a/xilem/examples/external_event_loop.rs
+++ b/xilem/examples/external_event_loop.rs
@@ -6,6 +6,7 @@
 //! accessing raw events from winit.
 //! Support for more custom embeddings would be welcome, but needs more design work
 
+use masonry::properties::types::Length;
 use masonry::theme::default_property_set;
 use masonry::widgets::{CrossAxisAlignment, MainAxisAlignment};
 use masonry_winit::app::{AppDriver, MasonryUserEvent};
@@ -21,7 +22,9 @@ fn big_button(
     label: impl Into<Label>,
     callback: impl Fn(&mut i32) + Send + Sync + 'static,
 ) -> impl WidgetView<i32> {
-    sized_box(button(label, callback)).width(40.).height(40.)
+    sized_box(button(label, callback))
+        .width(Length::px(40.))
+        .height(Length::px(40.))
 }
 
 fn app_logic(data: &mut i32) -> impl WidgetView<i32> + use<> {

--- a/xilem/examples/flex.rs
+++ b/xilem/examples/flex.rs
@@ -3,6 +3,7 @@
 
 //! Flex properties can be set in Xilem.
 
+use masonry::properties::types::Length;
 use masonry::widgets::{CrossAxisAlignment, MainAxisAlignment};
 use winit::error::EventLoopError;
 use xilem::view::{FlexExt as _, FlexSpacer, Label, button, flex_row, label, sized_box};
@@ -13,12 +14,14 @@ fn big_button(
     label: impl Into<Label>,
     callback: impl Fn(&mut i32) + Send + Sync + 'static,
 ) -> impl WidgetView<i32> {
-    sized_box(button(label, callback)).width(40.).height(40.)
+    sized_box(button(label, callback))
+        .width(Length::px(40.))
+        .height(Length::px(40.))
 }
 
 fn app_logic(data: &mut i32) -> impl WidgetView<i32> + use<> {
     flex_row((
-        FlexSpacer::Fixed(30.0),
+        FlexSpacer::Fixed(Length::px(30.0)),
         big_button("-", |data| {
             *data -= 1;
         }),
@@ -28,7 +31,7 @@ fn app_logic(data: &mut i32) -> impl WidgetView<i32> + use<> {
         big_button("+", |data| {
             *data += 1;
         }),
-        FlexSpacer::Fixed(30.0),
+        FlexSpacer::Fixed(Length::px(30.0)),
     ))
     .cross_axis_alignment(CrossAxisAlignment::Center)
     .main_axis_alignment(MainAxisAlignment::Center)

--- a/xilem/examples/http_cats.rs
+++ b/xilem/examples/http_cats.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 use masonry::properties::Padding;
-use masonry::properties::types::UnitPoint;
+use masonry::properties::types::{Length, UnitPoint};
 use masonry::widgets::LineBreaking;
 use tokio::sync::mpsc::UnboundedSender;
 use vello::peniko::{Blob, Image};
@@ -88,7 +88,7 @@ impl HttpCats {
         fork(
             flex((
                 // Add padding to the top for Android. Still a horrible hack
-                FlexSpacer::Fixed(40.),
+                FlexSpacer::Fixed(Length::px(40.)),
                 split(left_column, portal(sized_box(info_area).expand_width())).split_point(0.4),
             ))
             .must_fill_major_axis(true),
@@ -167,7 +167,7 @@ impl Status {
 
                 state.selected_code = Some(code);
             }),
-            FlexSpacer::Fixed(masonry::theme::SCROLLBAR_WIDTH),
+            FlexSpacer::Fixed(Length::px(masonry::theme::SCROLLBAR_WIDTH)),
         ))
     }
 
@@ -177,7 +177,11 @@ impl Status {
                 prose("Failed to start fetching image. This is a bug!")
                     .text_alignment(TextAlign::Center),
             ),
-            ImageState::Pending => OneOf3::B(sized_box(spinner()).width(80.).height(80.)),
+            ImageState::Pending => OneOf3::B(
+                sized_box(spinner())
+                    .width(Length::px(80.))
+                    .height(Length::px(80.)),
+            ),
             // TODO: Alt text?
             ImageState::Available(image_data) => {
                 let attribution = sized_box(
@@ -207,7 +211,7 @@ impl Status {
             prose(self.message)
                 .text_size(20.)
                 .text_alignment(TextAlign::Center),
-            FlexSpacer::Fixed(10.),
+            FlexSpacer::Fixed(Length::px(10.)),
             image,
         ))
         .main_axis_alignment(xilem::view::MainAxisAlignment::Start)

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -8,6 +8,7 @@
 
 use std::time::Duration;
 
+use masonry::properties::types::Length;
 use winit::error::EventLoopError;
 use xilem::core::{Resource, fork, provides, run_once, with_context, without_elements};
 use xilem::style::Style as _;
@@ -64,7 +65,7 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> + use<> {
                 if data.active {
                     FlexSpacer::Flex(x as f64)
                 } else {
-                    FlexSpacer::Fixed((count - x) as f64)
+                    FlexSpacer::Fixed(Length::px((count - x) as f64))
                 },
             )
         })
@@ -77,7 +78,7 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> + use<> {
             })
             .into_any_flex()
         } else {
-            FlexSpacer::Fixed(10.0 * c.0 as f64).into_any_flex()
+            FlexSpacer::Fixed(Length::px(10.0 * c.0 as f64)).into_any_flex()
         }
     });
 

--- a/xilem/examples/state_machine.rs
+++ b/xilem/examples/state_machine.rs
@@ -3,6 +3,7 @@
 
 //! A state machine to detect whether the button was pressed an even or an odd number of times.
 
+use masonry::properties::types::Length;
 use winit::error::EventLoopError;
 use xilem::core::one_of::{OneOf, OneOf3};
 use xilem::style::Style as _;
@@ -67,7 +68,9 @@ fn app_logic(app_data: &mut StateMachine) -> impl WidgetView<StateMachine> + use
         prose(&*app_data.history),
         label(format!("Current state: {:?}", app_data.state)),
         // TODO: Make `spinner` not need a `sized_box` to appear.
-        sized_box(spinner()).height(40.).width(40.),
+        sized_box(spinner())
+            .height(Length::px(40.))
+            .width(Length::px(40.)),
         state_machine(app_data),
         // TODO: When we have a canvas widget, visualise the entire state machine here.
     ))

--- a/xilem/examples/stopwatch.rs
+++ b/xilem/examples/stopwatch.rs
@@ -7,6 +7,7 @@ use std::ops::{Add, Sub};
 use std::time::{Duration, SystemTime};
 
 use masonry::dpi::LogicalSize;
+use masonry::properties::types::Length;
 use masonry::widgets::{CrossAxisAlignment, MainAxisAlignment};
 use masonry_winit::app::{EventLoop, EventLoopBuilder};
 use tokio::time;
@@ -108,10 +109,10 @@ fn get_formatted_duration(dur: Duration) -> String {
 fn app_logic(data: &mut Stopwatch) -> impl WidgetView<Stopwatch> + use<> {
     fork(
         flex((
-            FlexSpacer::Fixed(5.0),
+            FlexSpacer::Fixed(Length::px(5.0)),
             label(get_formatted_duration(data.displayed_duration)).text_size(70.0),
             flex_row((lap_reset_button(data), start_stop_button(data))),
-            FlexSpacer::Fixed(1.0),
+            FlexSpacer::Fixed(Length::px(1.0)),
             laps_section(data),
             label(data.displayed_error.as_ref()),
         )),

--- a/xilem/examples/variable_clock.rs
+++ b/xilem/examples/variable_clock.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use masonry::properties::types::Length;
 use time::error::IndeterminateOffset;
 use time::macros::format_description;
 use time::{OffsetDateTime, UtcOffset};
@@ -41,7 +42,7 @@ struct TimeZone {
 fn app_logic(data: &mut Clocks) -> impl WidgetView<Clocks> + use<> {
     let view = flex((
         // HACK: We add a spacer at the top for Android. See https://github.com/rust-windowing/winit/issues/2308
-        FlexSpacer::Fixed(40.),
+        FlexSpacer::Fixed(Length::px(40.)),
         local_time(data),
         controls(),
         portal(flex(
@@ -154,7 +155,7 @@ impl TimeZone {
             )),
         )))
         .expand_width()
-        .height(72.)
+        .height(Length::px(72.))
     }
 }
 

--- a/xilem/examples/virtual_cats.rs
+++ b/xilem/examples/virtual_cats.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use masonry::core::ArcStr;
 use masonry::properties::Padding;
-use masonry::properties::types::UnitPoint;
+use masonry::properties::types::{Length, UnitPoint};
 use vello::peniko::{Blob, Image};
 use winit::dpi::LogicalSize;
 use winit::error::EventLoopError;
@@ -116,7 +116,11 @@ impl VirtualCats {
                 attribution.alignment(UnitPoint::TOP_RIGHT),
             )))
         } else {
-            Either::B(sized_box(spinner()).width(80.).height(80.))
+            Either::B(
+                sized_box(spinner())
+                    .width(Length::px(80.))
+                    .height(Length::px(80.)),
+            )
         };
         fork(flex((prose(item.message.clone()), img)), task)
     }

--- a/xilem/examples/widgets.rs
+++ b/xilem/examples/widgets.rs
@@ -4,6 +4,7 @@
 //! A widget gallery for xilem/masonry
 
 use masonry::dpi::LogicalSize;
+use masonry::properties::types::Length;
 use masonry_winit::app::{EventLoop, EventLoopBuilder};
 use winit::error::EventLoopError;
 use xilem::style::Style as _;
@@ -68,8 +69,8 @@ fn border_box<State: 'static, Action: 'static>(
         FlexSpacer::Flex(1.),
     )))
     .border(Color::WHITE, 2.)
-    .width(450.)
-    .height(200.)
+    .width(Length::px(450.))
+    .height(Length::px(200.))
 }
 
 /// Top-level view
@@ -99,7 +100,7 @@ fn app_logic(data: &mut WidgetGallery) -> impl WidgetView<WidgetGallery> + use<>
             ))
             .active(data.tab as usize),
         ))
-        .gap(SPACER_WIDTH),
+        .gap(Length::px(SPACER_WIDTH)),
     )
     .padding(SPACER_WIDTH)
 }

--- a/xilem/src/view/flex.rs
+++ b/xilem/src/view/flex.rs
@@ -6,6 +6,7 @@ use std::marker::PhantomData;
 use crate::style::Style;
 
 use masonry::core::{FromDynWidget, Widget, WidgetMut};
+use masonry::properties::types::Length;
 use masonry::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use masonry::widgets::{self};
 pub use masonry::widgets::{Axis, CrossAxisAlignment, FlexParams, MainAxisAlignment};
@@ -67,7 +68,7 @@ pub fn flex<State, Action, Seq: FlexSequence<State, Action>>(
         cross_axis_alignment: CrossAxisAlignment::Center,
         main_axis_alignment: MainAxisAlignment::Start,
         fill_major_axis: false,
-        gap: masonry::theme::WIDGET_PADDING,
+        gap: Length::px(masonry::theme::WIDGET_PADDING),
         properties: FlexProps::default(),
         phantom: PhantomData,
     }
@@ -93,7 +94,7 @@ pub struct Flex<Seq, State, Action = ()> {
     cross_axis_alignment: CrossAxisAlignment,
     main_axis_alignment: MainAxisAlignment,
     fill_major_axis: bool,
-    gap: f64,
+    gap: Length,
     properties: FlexProps,
     phantom: PhantomData<fn() -> (State, Action)>,
 }
@@ -128,20 +129,11 @@ impl<Seq, State, Action> Flex<Seq, State, Action> {
     ///
     /// Leave unset to use the default spacing which is [`WIDGET_PADDING`].
     ///
-    /// ## Panics
-    ///
-    /// If `gap` is not a non-negative finite value.
-    ///
     /// [gap]: https://developer.mozilla.org/en-US/docs/Web/CSS/gap
     /// [`WIDGET_PADDING`]: masonry::theme::WIDGET_PADDING
     #[track_caller]
-    pub fn gap(mut self, gap: f64) -> Self {
-        if gap.is_finite() && gap >= 0.0 {
-            self.gap = gap;
-        } else {
-            // TODO: Don't panic here, for future editor scenarios.
-            panic!("Invalid `gap` {gap}, expected a non-negative finite value.")
-        }
+    pub fn gap(mut self, gap: Length) -> Self {
+        self.gap = gap;
         self
     }
 }
@@ -260,7 +252,7 @@ pub enum FlexElement {
     /// Child widget.
     Child(Pod<dyn Widget>, FlexParams),
     /// Child spacer with fixed size.
-    FixedSpacer(f64),
+    FixedSpacer(Length),
     /// Child spacer with flex size.
     FlexSpacer(f64),
 }
@@ -600,7 +592,7 @@ where
 #[derive(Copy, Clone, PartialEq)]
 #[expect(missing_docs, reason = "TODO - Need to document units used.")]
 pub enum FlexSpacer {
-    Fixed(f64),
+    Fixed(Length),
     Flex(f64),
 }
 

--- a/xilem/src/view/grid.rs
+++ b/xilem/src/view/grid.rs
@@ -6,6 +6,7 @@ use std::marker::PhantomData;
 use crate::style::Style;
 
 use masonry::core::{FromDynWidget, Widget, WidgetMut};
+use masonry::properties::types::Length;
 use masonry::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use masonry::widgets;
 
@@ -55,7 +56,7 @@ pub fn grid<State, Action, Seq: GridSequence<State, Action>>(
 ) -> Grid<Seq, State, Action> {
     Grid {
         sequence,
-        spacing: 0.0,
+        spacing: Length::ZERO,
         height,
         width,
         properties: GridProps::default(),
@@ -69,7 +70,7 @@ pub fn grid<State, Action, Seq: GridSequence<State, Action>>(
 #[must_use = "View values do nothing unless provided to Xilem."]
 pub struct Grid<Seq, State, Action = ()> {
     sequence: Seq,
-    spacing: f64,
+    spacing: Length,
     width: i32,
     height: i32,
     properties: GridProps,
@@ -83,12 +84,8 @@ pub struct Grid<Seq, State, Action = ()> {
 impl<Seq, State, Action> Grid<Seq, State, Action> {
     /// Set the spacing (both vertical and horizontal) between grid items.
     #[track_caller]
-    pub fn spacing(mut self, spacing: f64) -> Self {
-        if spacing.is_finite() && spacing >= 0.0 {
-            self.spacing = spacing;
-        } else {
-            panic!("Invalid `spacing` {spacing}; expected a non-negative finite value.")
-        }
+    pub fn spacing(mut self, spacing: Length) -> Self {
+        self.spacing = spacing;
         self
     }
 }

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+use masonry::properties::types::Length;
 use masonry::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use std::marker::PhantomData;
 
@@ -59,14 +60,14 @@ pub struct SizedBox<V, State, Action = ()> {
 
 impl<V, State, Action> SizedBox<V, State, Action> {
     /// Set container's width.
-    pub fn width(mut self, width: f64) -> Self {
-        self.width = Some(width);
+    pub fn width(mut self, width: Length) -> Self {
+        self.width = Some(width.value());
         self
     }
 
     /// Set container's height.
-    pub fn height(mut self, height: f64) -> Self {
-        self.height = Some(height);
+    pub fn height(mut self, height: Length) -> Self {
+        self.height = Some(height.value());
         self
     }
 

--- a/xilem/src/view/split.rs
+++ b/xilem/src/view/split.rs
@@ -3,7 +3,10 @@
 
 use std::marker::PhantomData;
 
-use masonry::widgets::{self, Axis};
+use masonry::{
+    properties::types::Length,
+    widgets::{self, Axis},
+};
 use xilem_core::{DynMessage, MessageResult, View, ViewId, ViewMarker, ViewPathTracker};
 
 use crate::{Pod, ViewCtx, WidgetView};
@@ -47,9 +50,9 @@ where
     Split {
         split_axis: Axis::Horizontal,
         split_point: 0.5,
-        min_size: (0.0, 0.0),
-        bar_size: 6.0,
-        min_bar_area: 6.0,
+        min_size: (Length::ZERO, Length::ZERO),
+        bar_size: Length::px(6.0),
+        min_bar_area: Length::px(6.0),
         solid_bar: false,
         draggable: true,
         child1,
@@ -65,9 +68,9 @@ where
 pub struct Split<ChildA, ChildB, State, Action = ()> {
     split_axis: Axis,
     split_point: f64,
-    min_size: (f64, f64), // Integers only
-    bar_size: f64,        // Integers only
-    min_bar_area: f64,    // Integers only
+    min_size: (Length, Length), // Integers only
+    bar_size: Length,           // Integers only
+    min_bar_area: Length,       // Integers only
     solid_bar: bool,
     draggable: bool,
     child1: ChildA,
@@ -103,23 +106,18 @@ impl<ChildA, ChildB, State, Action> Split<ChildA, ChildB, State, Action> {
 
     /// Set the minimum size for both sides of the split axis in logical pixels.
     ///
-    /// The value must be greater than or equal to `0.0`.
     /// The value will be rounded up to the nearest integer.
-    pub fn min_size(mut self, first: f64, second: f64) -> Self {
-        assert!(first >= 0.0);
-        assert!(second >= 0.0);
+    pub fn min_size(mut self, first: Length, second: Length) -> Self {
         self.min_size = (first.ceil(), second.ceil());
         self
     }
 
     /// Set the size of the splitter bar in logical pixels.
     ///
-    /// The value must be positive or zero.
     /// The value will be rounded up to the nearest integer.
     /// The default splitter bar size is `6.0`.
     #[track_caller]
-    pub fn bar_size(mut self, bar_size: f64) -> Self {
-        assert!(bar_size >= 0.0, "bar_size must be 0.0 or greater!");
+    pub fn bar_size(mut self, bar_size: Length) -> Self {
         self.bar_size = bar_size.ceil();
         self
     }
@@ -133,12 +131,10 @@ impl<ChildA, ChildB, State, Action> Split<ChildA, ChildB, State, Action> {
     /// This can be useful when you want to use a very narrow visual splitter bar,
     /// but don't want to sacrifice user experience by making it hard to click on.
     ///
-    /// The value must be positive or zero.
     /// The value will be rounded up to the nearest integer.
     /// The default minimum splitter bar area is `6.0`.
     #[track_caller]
-    pub fn min_bar_area(mut self, min_bar_area: f64) -> Self {
-        assert!(min_bar_area >= 0.0, "min_bar_area must be 0.0 or greater!");
+    pub fn min_bar_area(mut self, min_bar_area: Length) -> Self {
         self.min_bar_area = min_bar_area.ceil();
         self
     }


### PR DESCRIPTION
See [#masonry > Plan for scale factor, dpi, and layout units](https://xi.zulipchat.com/#narrow/channel/317477-masonry/topic/Plan.20for.20scale.20factor.2C.20dpi.2C.20and.20layout.20units) for rationale.

This PR adds a Length newtype which guarantees its value is always finite and non-negative.
Using a newtype should also make it easier to handle unit conversion in the future.

I don't really like this PR as it stands (especially not the added verbosity), so I'm keeping it as draft now.
I'd like to merge #1245 and a few others before getting back to this one.