### PR TITLE
Introduce "focus fallback" mechanism

### DIFF
--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -101,6 +101,9 @@ pub(crate) struct RenderRootState {
     /// This is used to pick the focused widget on Tab events.
     pub(crate) focus_anchor: Option<WidgetId>,
 
+    /// Widget which will get text events if no widget is focused.
+    pub(crate) focus_fallback: Option<WidgetId>,
+
     /// Whether the window is focused.
     pub(crate) window_focused: bool,
 
@@ -309,6 +312,7 @@ impl RenderRoot {
                 focused_path: Vec::new(),
                 next_focused_widget: None,
                 focus_anchor: None,
+                focus_fallback: None,
                 window_focused: true,
                 scroll_request_targets: Vec::new(),
                 hovered_path: Vec::new(),
@@ -765,6 +769,19 @@ impl RenderRoot {
         self.global_state.next_focused_widget = id;
         self.global_state.focus_anchor = id;
         self.run_rewrite_passes();
+        true
+    }
+
+    /// Sets the [focus fallback](crate::doc::masonry_concepts#focus-fallback).
+    ///
+    /// Returns false if the widget is not found in the tree or can't be focused.
+    pub fn set_focus_fallback(&mut self, id: Option<WidgetId>) -> bool {
+        if let Some(id) = id
+            && !self.is_still_interactive(id)
+        {
+            return false;
+        }
+        self.global_state.focus_fallback = id;
         true
     }
 

--- a/masonry_core/src/doc/masonry_concepts.md
+++ b/masonry_core/src/doc/masonry_concepts.md
@@ -92,6 +92,14 @@ Active focus is the default one; inactive focus is when the window your app runs
 
 In that case, we still mark the widget as focused, but with a different color to signal that e.g. typing on the keyboard won't actually affect it.
 
+### Focus fallback
+
+Masonry drivers have the option to give set a widget as the "focus fallback".
+
+In that case, if no widget is focused, text events will get to the fallback widget instead.
+
+The focus fallback isn't considered as "focused" and will not get [`FocusChanged`] events or be visually marked as focused.
+
 
 ## Disabled
 

--- a/masonry_core/src/passes/event.rs
+++ b/masonry_core/src/passes/event.rs
@@ -263,23 +263,11 @@ pub(crate) fn run_on_text_event_pass(root: &mut RenderRoot, event: &TextEvent) -
     }
 
     let target = root.global_state.focused_widget.or_else(|| {
-        // In case no widget is focused target the root widget only child.
-        // We're targeting the child instead of the root widget to accommodate
-        // Xilem, which wraps the main widget in another widget so that it can be swapped
-        // (since the root widget cannot be swapped).
-        let root_widget_children = root.get_root_widget().children();
-        if root_widget_children.len() == 1 {
-            let only_child = root_widget_children[0].id();
-            if root.is_still_interactive(only_child) {
-                Some(only_child)
-            } else {
-                None
-            }
+        if let Some(focus_fallback) = root.global_state.focus_fallback
+            && root.is_still_interactive(focus_fallback)
+        {
+            Some(focus_fallback)
         } else {
-            tracing::warn!(
-                widget_id = root.root.id().trace(),
-                "text event without focused widget dropped because root widget doesn't have exactly one child"
-            );
             None
         }
     });

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -541,6 +541,12 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
         root.global_state.focus_anchor = None;
     }
 
+    if let Some(id) = root.global_state.focus_fallback {
+        if !root.is_still_interactive(id) {
+            root.global_state.focus_fallback = None;
+        }
+    }
+
     let prev_focused = root.global_state.focused_widget;
     let was_ime_active = root.global_state.is_ime_active;
 

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -541,10 +541,10 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
         root.global_state.focus_anchor = None;
     }
 
-    if let Some(id) = root.global_state.focus_fallback {
-        if !root.is_still_interactive(id) {
-            root.global_state.focus_fallback = None;
-        }
+    if let Some(id) = root.global_state.focus_fallback
+        && !root.is_still_interactive(id)
+    {
+        root.global_state.focus_fallback = None;
     }
 
     let prev_focused = root.global_state.focused_widget;

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -729,6 +729,16 @@ impl<W: Widget> TestHarness<W> {
         self.process_signals();
     }
 
+    /// Sets the [focus fallback](crate::doc::masonry_concepts#focus-fallback).
+    pub fn set_focus_fallback(&mut self, id: Option<WidgetId>) {
+        if let Some(id) = id {
+            let Some(_) = self.render_root.get_widget(id) else {
+                panic!("Cannot set widget {id} as focus fallback: widget not found in tree");
+            };
+        }
+        let _ = self.render_root.set_focus_fallback(id);
+    }
+
     /// Run an animation pass on the widget tree.
     pub fn animate_ms(&mut self, ms: u64) {
         self.render_root

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -729,7 +729,7 @@ impl<W: Widget> TestHarness<W> {
         self.process_signals();
     }
 
-    /// Sets the [focus fallback](crate::doc::masonry_concepts#focus-fallback).
+    /// Sets the [focus fallback](masonry_core::doc::masonry_concepts#focus-fallback).
     pub fn set_focus_fallback(&mut self, id: Option<WidgetId>) {
         if let Some(id) = id {
             let Some(_) = self.render_root.get_widget(id) else {

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -863,7 +863,8 @@ impl MasonryState<'_> {
         self.is_suspended
     }
 
-    // TODO: remove (currently only exists to call register_fonts, font context should be moved out of render root)
+    // TODO: Remove this method.
+    // It's currently used to call register_fonts and set_focus_fallback.
     pub fn roots(&mut self) -> impl Iterator<Item = &mut RenderRoot> {
         self.windows
             .values_mut()

--- a/xilem/src/any_view.rs
+++ b/xilem/src/any_view.rs
@@ -67,6 +67,10 @@ impl DynWidget {
         let old_widget = std::mem::replace(&mut this.widget.inner, widget.to_pod());
         this.ctx.remove_child(old_widget);
     }
+
+    pub(crate) fn inner_id(&self) -> WidgetId {
+        self.inner.id()
+    }
 }
 
 /// Forward all events to the child widget.

--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -14,6 +14,7 @@ use masonry_winit::app::{
 };
 use winit::window::WindowAttributes;
 
+use crate::any_view::DynWidget;
 use crate::core::{
     AnyViewState, DynMessage, MessageContext, MessageResult, ProxyError, RawProxy, SendMessage,
     View, ViewId, ViewPathTracker,
@@ -338,6 +339,11 @@ where
         let fonts = std::mem::take(&mut self.fonts);
 
         for root in state.roots() {
+            if let Some(root_widget) = root.get_root_widget().downcast::<DynWidget>() {
+                let fallback = root_widget.inner().inner_id();
+                root.set_focus_fallback(Some(fallback));
+            }
+
             // Register all provided fonts
             for font in &fonts {
                 // We currently don't do anything with the resulting family information,

--- a/xilem/src/window_view.rs
+++ b/xilem/src/window_view.rs
@@ -103,15 +103,19 @@ where
         render_root: &mut RenderRoot,
         app_state: &mut State,
     ) {
+        let mut root_id = None;
         render_root.edit_root_widget(|mut root| {
+            let mut root = root.downcast();
             self.root_widget_view.rebuild(
                 &prev.root_widget_view,
                 root_widget_view_state,
                 ctx,
-                root.downcast(),
+                root.reborrow_mut(),
                 app_state,
             );
+            root_id = Some(root.widget.inner_id());
         });
+        render_root.set_focus_fallback(root_id);
         if cfg!(debug_assertions) && !render_root.needs_rewrite_passes() {
             tracing::debug!("Widget tree didn't change as result of rebuild");
         }


### PR DESCRIPTION
This introduces an explicit fallback mechanism, for text events rather than the undocumented "only child of root" method we currently use.