### PR TITLE
DRAFT: Add layer system to Masonry

### DIFF
--- a/masonry/screenshots/text_input_selection.png
+++ b/masonry/screenshots/text_input_selection.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f9a50d9b69fe0ddae5eaa58770d1e429da18fab35c80f67c91bf6a6923c671b5
-size 1643
+oid sha256:03aa080a0ff2319a5a881149b8ccc20d25b5857a57179fe201f93771572ab9cd
+size 1629

--- a/masonry/src/widgets/indexed_stack.rs
+++ b/masonry/src/widgets/indexed_stack.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 the Xilem Authors
+// Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::any::TypeId;

--- a/masonry_core/src/app/layer_stack.rs
+++ b/masonry_core/src/app/layer_stack.rs
@@ -1,0 +1,166 @@
+// Copyright 2025 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::any::TypeId;
+
+use accesskit::{Node, Role};
+use tracing::{Span, trace_span};
+use vello::Scene;
+use vello::kurbo::{Point, Size};
+
+use crate::core::{
+    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, NoAction, PaintCtx,
+    PropertiesMut, PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+};
+use crate::util::debug_panic;
+
+/// A widget representing the top-level stack of visible layers owned by [`RenderRoot`](crate::app::RenderRoot).
+///
+/// This stack must always have at least one child, representing the "base layer",
+/// e.g. most of the stuff drawn in the app.
+///
+/// Other layers can represent tooltips, menus, dialogs, etc.
+/// They have an associated position and are drawn on top of the base layer.
+pub(crate) struct LayerStack {
+    layers: Vec<Layer>,
+}
+
+struct Layer {
+    widget: WidgetPod<dyn Widget>,
+    pos: Point,
+}
+
+// --- MARK: IMPL LAYER_STACK
+impl LayerStack {
+    /// Create a stack with the provided base layer.
+    pub(crate) fn new(root: NewWidget<impl Widget + ?Sized>) -> Self {
+        let layer = Layer {
+            widget: root.erased().to_pod(),
+            pos: Point::ZERO,
+        };
+        Self {
+            layers: vec![layer],
+        }
+    }
+
+    /// Returns the number of layers, including the base layer.
+    #[expect(dead_code, reason = "Might be useful later")]
+    pub(crate) fn layer_count(&self) -> usize {
+        self.layers.len()
+    }
+
+    /// The [`WidgetId`] of the root widget of the given layer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `idx` is out of bounds.
+    pub(crate) fn layer_id(&self, idx: usize) -> WidgetId {
+        self.layers[idx].widget.id()
+    }
+}
+
+// --- MARK: IMPL WIDGETMUT
+impl LayerStack {
+    /// Add a new layer at the end of the stack, with the given widget as its root, at the given position.
+    pub(crate) fn add_layer(
+        this: &mut WidgetMut<'_, Self>,
+        root: NewWidget<impl Widget + ?Sized>,
+        pos: Point,
+    ) {
+        let layer = Layer {
+            widget: root.erased().to_pod(),
+            pos,
+        };
+        this.widget.layers.push(layer);
+        this.ctx.children_changed();
+        this.ctx.request_layout();
+    }
+
+    /// Get a mutable reference to the root widget of the layer at `idx`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `idx` is out of bounds.
+    #[expect(dead_code, reason = "Might be useful later")]
+    pub(crate) fn layer_root_mut<'t>(
+        this: &'t mut WidgetMut<'_, Self>,
+        idx: usize,
+    ) -> WidgetMut<'t, dyn Widget> {
+        let layer = &mut this.widget.layers[idx].widget;
+        this.ctx.get_mut(layer)
+    }
+
+    /// Removes the layer at the given index.
+    ///
+    /// The base layer cannot be removed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is zero or out of bounds.
+    pub(crate) fn remove_layer(this: &mut WidgetMut<'_, Self>, idx: usize) {
+        if idx == 0 {
+            debug_panic!("Cannot remove initial layer");
+            return;
+        }
+        let child = this.widget.layers.remove(idx).widget;
+        this.ctx.remove_child(child);
+    }
+}
+
+// --- MARK: IMPL WIDGET
+impl Widget for LayerStack {
+    type Action = NoAction;
+
+    fn register_children(&mut self, ctx: &mut RegisterCtx<'_>) {
+        for layer in self.layers.iter_mut() {
+            ctx.register_child(&mut layer.widget);
+        }
+    }
+
+    fn property_changed(&mut self, _ctx: &mut UpdateCtx<'_>, _property_type: TypeId) {}
+
+    fn layout(
+        &mut self,
+        ctx: &mut LayoutCtx<'_>,
+        _props: &mut PropertiesMut<'_>,
+        bc: &BoxConstraints,
+    ) -> Size {
+        // First child is the base layer.
+        // Its position is always the origin.
+        let Some(base_layer) = self.layers.first_mut() else {
+            debug_panic!("Missing first layer");
+            return Size::ZERO;
+        };
+        let size = ctx.run_layout(&mut base_layer.widget, bc);
+        ctx.place_child(&mut base_layer.widget, Point::ORIGIN);
+
+        for layer in &mut self.layers[1..] {
+            let _ = ctx.run_layout(&mut layer.widget, bc);
+            ctx.place_child(&mut layer.widget, layer.pos);
+        }
+
+        size
+    }
+
+    fn paint(&mut self, _ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, _scene: &mut Scene) {}
+
+    fn accessibility_role(&self) -> Role {
+        Role::GenericContainer
+    }
+
+    fn accessibility(
+        &mut self,
+        _ctx: &mut AccessCtx<'_>,
+        _props: &PropertiesRef<'_>,
+        _node: &mut Node,
+    ) {
+    }
+
+    fn children_ids(&self) -> ChildrenIds {
+        self.layers.iter().map(|child| child.widget.id()).collect()
+    }
+
+    fn make_trace_span(&self, id: WidgetId) -> Span {
+        trace_span!("LayerStack", id = id.trace())
+    }
+}

--- a/masonry_core/src/app/mod.rs
+++ b/masonry_core/src/app/mod.rs
@@ -3,6 +3,7 @@
 
 //! Types needed for running a Masonry app.
 
+mod layer_stack;
 mod render_root;
 mod tracing_backend;
 

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -11,8 +12,9 @@ use parley::{FontContext, LayoutContext};
 use tracing::{info_span, warn};
 use tree_arena::{ArenaMut, TreeArena};
 use vello::Scene;
-use vello::kurbo::{Rect, Size};
+use vello::kurbo::{Point, Rect, Size};
 
+use crate::app::layer_stack::LayerStack;
 use crate::core::{
     AccessEvent, BrushIndex, CursorIcon, DefaultProperties, ErasedAction, FromDynWidget, Handled,
     Ime, NewWidget, PointerEvent, PropertiesRef, QueryCtx, ResizeDirection, TextEvent, Widget,
@@ -48,8 +50,8 @@ const INVALID_IME_AREA: Rect = Rect::new(f64::NAN, f64::NAN, f64::NAN, f64::NAN)
 ///
 /// This is also the type that owns the widget tree.
 pub struct RenderRoot {
-    /// Root of the widget tree.
-    pub(crate) root: WidgetPod<dyn Widget>,
+    /// WidgetPod handle for the layer stack, which holds the root widget of each layer.
+    pub(crate) layer_stack: WidgetPod<LayerStack>,
 
     /// The accessibility pass creates a wrapper node for the app with `Role::Window`.
     ///
@@ -289,8 +291,10 @@ impl RenderRoot {
         } = options;
         let debug_paint = std::env::var("MASONRY_DEBUG_PAINT").is_ok_and(|it| !it.is_empty());
 
+        let layer_stack = WidgetPod::new(LayerStack::new(root_widget));
+
         let mut root = Self {
-            root: root_widget.erased().to_pod(),
+            layer_stack,
             window_node_id: WidgetId::next().into(),
             size_policy,
             size: PhysicalSize::new(0, 0),
@@ -352,12 +356,29 @@ impl RenderRoot {
         root
     }
 
+    pub(crate) fn root_id(&self) -> WidgetId {
+        self.layer_stack.id()
+    }
+
+    /// `WidgetId` of the given layer's root widget.
+    pub(crate) fn layer_root_id(&self, layer_idx: usize) -> WidgetId {
+        let node_ref = self
+            .widget_arena
+            .nodes
+            .find(self.root_id())
+            .expect("root widget not in widget tree");
+        let widget = &*node_ref.item.widget;
+
+        let stack = (widget as &dyn Any).downcast_ref::<LayerStack>().unwrap();
+        stack.layer_id(layer_idx)
+    }
+
     pub(crate) fn root_state(&self) -> &WidgetState {
         &self
             .widget_arena
             .nodes
             .roots()
-            .into_item(self.root.id())
+            .into_item(self.root_id())
             .expect("root widget not in widget tree")
             .item
             .state
@@ -368,7 +389,7 @@ impl RenderRoot {
             .widget_arena
             .nodes
             .roots_mut()
-            .into_item_mut(self.root.id())
+            .into_item_mut(self.layer_stack.id())
             .expect("root widget not in widget tree")
             .item
             .state
@@ -478,10 +499,10 @@ impl RenderRoot {
     }
 
     // --- MARK: ACCESS WIDGETS
-    /// Get a [`WidgetRef`] to the root widget.
-    pub fn get_root_widget(&self) -> WidgetRef<'_, dyn Widget> {
-        self.get_widget(self.root.id())
-            .expect("root widget not in widget tree")
+    /// Get a [`WidgetRef`] to the root widget of the given [layer](crate::doc::masonry_concepts#layer).
+    pub fn get_layer_root(&self, layer_idx: usize) -> WidgetRef<'_, dyn Widget> {
+        self.get_widget(self.layer_root_id(layer_idx))
+            .expect("layer root not in widget tree")
     }
 
     /// Get a [`WidgetRef`] to a specific widget.
@@ -522,11 +543,32 @@ impl RenderRoot {
         self.widget_arena.has(id)
     }
 
-    /// Get a [`WidgetMut`] to the root widget.
+    /// Get a [`WidgetMut`] to the root widget of the [base layer](crate::doc::masonry_concepts#layers).
     ///
     /// Because of how `WidgetMut` works, it can only be passed to a user-provided callback.
-    pub fn edit_root_widget<R>(&mut self, f: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R) -> R {
-        let res = mutate_widget(self, self.root.id(), f);
+    pub fn edit_base_layer<R>(&mut self, f: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R) -> R {
+        let layer_id = self.layer_root_id(0);
+        let res = mutate_widget(self, layer_id, f);
+
+        self.run_rewrite_passes();
+
+        res
+    }
+
+    /// Get a [`WidgetMut`] to the root widget of the given [layer](crate::doc::masonry_concepts#layer).
+    ///
+    /// Because of how `WidgetMut` works, it can only be passed to a user-provided callback.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `idx` is out of bounds.
+    pub fn edit_layer<R>(
+        &mut self,
+        layer_idx: usize,
+        f: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R,
+    ) -> R {
+        let layer_id = self.layer_root_id(layer_idx);
+        let res = mutate_widget(self, layer_id, f);
 
         self.run_rewrite_passes();
 
@@ -578,6 +620,36 @@ impl RenderRoot {
         self.run_rewrite_passes();
 
         res
+    }
+
+    /// Add a new layer at the end of the stack, with the given widget as its root, at the given position.
+    pub fn add_layer(&mut self, root: NewWidget<impl Widget + ?Sized>, pos: Point) {
+        let _ = mutate_widget(self, self.root_id(), |mut layer_stack| {
+            let mut layer_stack = layer_stack.downcast::<LayerStack>();
+            LayerStack::add_layer(&mut layer_stack, root, pos);
+        });
+
+        self.run_rewrite_passes();
+    }
+
+    /// Removes the layer at the given index.
+    ///
+    /// The base layer cannot be removed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is zero or out of bounds.
+    pub fn remove_layer(&mut self, idx: usize) {
+        if idx == 0 {
+            debug_panic!("Cannot remove initial layer");
+            return;
+        }
+        let _ = mutate_widget(self, self.root_id(), |mut layer_stack| {
+            let mut layer_stack = layer_stack.downcast::<LayerStack>();
+            LayerStack::remove_layer(&mut layer_stack, idx);
+        });
+
+        self.run_rewrite_passes();
     }
 
     pub(crate) fn get_kurbo_size(&self) -> Size {
@@ -676,7 +748,7 @@ impl RenderRoot {
             });
         }
 
-        let root_node = self.widget_arena.get_node_mut(self.root.id());
+        let root_node = self.widget_arena.get_node_mut(self.root_id());
         request_render_all_in(root_node);
         self.global_state
             .emit_signal(RenderRootSignal::RequestRedraw);

--- a/masonry_core/src/doc/masonry_concepts.md
+++ b/masonry_core/src/doc/masonry_concepts.md
@@ -137,12 +137,24 @@ The bounding rects of the widget tree form a kind of "bounding volume hierarchy"
 
 <!-- TODO - Add section about clip paths and pointer detection. -->
 
-
-## Layout rect
+### Layout rect
 
 Previous versions of Masonry had a concept of a widget's "layout rect", composed of its self-declared size and the position attributed by its parent.
 
 However, given that widgets can have arbitrary transforms, the concept of an axis-aligned layout rect doesn't really make sense anymore.
+
+
+## Layers
+
+A Masonry application is composed of layers.
+
+Layers are top-level items in a [`RenderRoot`], drawn on top of each other.
+
+There is always at least one layer, called the "base layer".
+It's the one in which almost all content (buttons, texts, images) will be drawn.
+
+Other layers can represent tooltips, menus, dialogs, etc.
+They are created with a pre-set position and are drawn on top of the base layer.
 
 
 ## Safety rails

--- a/masonry_core/src/passes/accessibility.rs
+++ b/masonry_core/src/passes/accessibility.rs
@@ -159,7 +159,7 @@ pub(crate) fn run_accessibility_pass(root: &mut RenderRoot, scale_factor: f64) -
             .unwrap_or(root.window_node_id),
     };
 
-    let root_node = root.widget_arena.get_node_mut(root.root.id());
+    let root_node = root.widget_arena.get_node_mut(root.root_id());
 
     if root.rebuild_access_tree {
         debug!("Running ACCESSIBILITY pass with rebuild_all");
@@ -177,7 +177,7 @@ pub(crate) fn run_accessibility_pass(root: &mut RenderRoot, scale_factor: f64) -
     // TODO: make root node type customizable to support Dialog/AlertDialog roles
     // (should go hand in hand with introducing support for modal windows?)
     let mut window_node = Node::new(Role::Window);
-    window_node.set_children(vec![root.root.id().into()]);
+    window_node.set_children(vec![root.root_id().into()]);
     tree_update.nodes.push((root.window_node_id, window_node));
 
     tree_update

--- a/masonry_core/src/passes/anim.rs
+++ b/masonry_core/src/passes/anim.rs
@@ -67,7 +67,7 @@ fn update_anim_for_widget(
 pub(crate) fn run_update_anim_pass(root: &mut RenderRoot, elapsed_ns: u64) {
     let _span = info_span!("update_anim").entered();
 
-    let root_node = root.widget_arena.get_node_mut(root.root.id());
+    let root_node = root.widget_arena.get_node_mut(root.root_id());
     update_anim_for_widget(
         &mut root.global_state,
         &root.default_properties,

--- a/masonry_core/src/passes/compose.rs
+++ b/masonry_core/src/passes/compose.rs
@@ -88,7 +88,7 @@ pub(crate) fn run_compose_pass(root: &mut RenderRoot) {
         root.global_state.needs_pointer_pass = true;
     }
 
-    let root_node = root.widget_arena.get_node_mut(root.root.id());
+    let root_node = root.widget_arena.get_node_mut(root.root_id());
     compose_widget(
         &mut root.global_state,
         &root.default_properties,

--- a/masonry_core/src/passes/event.rs
+++ b/masonry_core/src/passes/event.rs
@@ -30,7 +30,8 @@ fn get_pointer_target(
         // TODO - Apply scale
         let pointer_pos = (pointer_pos.x, pointer_pos.y).into();
         return root
-            .get_root_widget()
+            .get_widget(root.root_id())
+            .expect("root widget not in widget tree")
             .find_widget_under_pointer(pointer_pos)
             .map(|widget| widget.id());
     }
@@ -251,16 +252,16 @@ pub(crate) fn run_on_text_event_pass(root: &mut RenderRoot, event: &TextEvent) -
     }
 
     let target = root.global_state.focused_widget.or_else(|| {
-        // In case no widget is focused target the root widget only child.
+        // In case no widget is focused, we target the only child of the root widget of the base layer.
         // We're targeting the child instead of the root widget to accommodate
         // Xilem, which wraps the main widget in another widget so that it can be swapped
         // (since the root widget cannot be swapped).
-        let root_widget_children = root.get_root_widget().children();
+        let root_widget_children = root.get_layer_root(0).children();
         if root_widget_children.len() == 1 {
             Some(root_widget_children[0].id())
         } else {
             tracing::warn!(
-                widget_id = root.root.id().trace(),
+                widget_id = root.get_layer_root(0).id().trace(),
                 "text event without focused widget dropped because root widget doesn't have exactly one child"
             );
             None

--- a/masonry_core/src/passes/layout.rs
+++ b/masonry_core/src/passes/layout.rs
@@ -237,7 +237,7 @@ pub(crate) fn run_layout_pass(root: &mut RenderRoot) {
         WindowSizePolicy::Content => BoxConstraints::UNBOUNDED,
     };
 
-    let mut root_node = root.widget_arena.get_node_mut(root.root.id());
+    let mut root_node = root.widget_arena.get_node_mut(root.root_id());
 
     let size = run_layout_on(
         &mut root.global_state,

--- a/masonry_core/src/passes/paint.rs
+++ b/masonry_core/src/passes/paint.rs
@@ -144,7 +144,7 @@ pub(crate) fn run_paint_pass(root: &mut RenderRoot) -> Scene {
     // https://github.com/linebender/xilem/issues/524
     let mut complete_scene = Scene::new();
 
-    let root_node = root.widget_arena.get_node_mut(root.root.id());
+    let root_node = root.widget_arena.get_node_mut(root.root_id());
 
     // TODO - This is a bit of a hack until we refactor widget tree mutation.
     // This should be removed once remove_child is exclusive to MutateCtx.

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -208,17 +208,18 @@ fn update_widget_tree(
 pub(crate) fn run_update_widget_tree_pass(root: &mut RenderRoot) {
     let _span = info_span!("update_new_widgets").entered();
 
-    if root.root.incomplete() {
+    // REROOT
+    if root.layer_stack.incomplete() {
         let mut ctx = RegisterCtx {
             global_state: &mut root.global_state,
             children: root.widget_arena.nodes.roots_mut(),
             #[cfg(debug_assertions)]
             registered_ids: Vec::new(),
         };
-        ctx.register_child(&mut root.root);
+        ctx.register_child(&mut root.layer_stack);
     }
 
-    let root_node = root.widget_arena.get_node_mut(root.root.id());
+    let root_node = root.widget_arena.get_node_mut(root.root_id());
     update_widget_tree(&mut root.global_state, &root.default_properties, root_node);
 }
 
@@ -286,7 +287,7 @@ pub(crate) fn run_update_disabled_pass(root: &mut RenderRoot) {
         root.global_state.needs_pointer_pass = true;
     }
 
-    let root_node = root.widget_arena.get_node_mut(root.root.id());
+    let root_node = root.widget_arena.get_node_mut(root.root_id());
     update_disabled_for_widget(
         &mut root.global_state,
         &root.default_properties,
@@ -366,7 +367,7 @@ fn update_stashed_for_widget(
 pub(crate) fn run_update_stashed_pass(root: &mut RenderRoot) {
     let _span = info_span!("update_stashed").entered();
 
-    let root_node = root.widget_arena.get_node_mut(root.root.id());
+    let root_node = root.widget_arena.get_node_mut(root.root_id());
     update_stashed_for_widget(
         &mut root.global_state,
         &root.default_properties,
@@ -438,7 +439,7 @@ pub(crate) fn run_update_focus_chain_pass(root: &mut RenderRoot) {
     let _span = info_span!("update_focus_chain").entered();
     let mut dummy_focus_chain = Vec::new();
 
-    let root_node = root.widget_arena.get_node_mut(root.root.id());
+    let root_node = root.widget_arena.get_node_mut(root.root_id());
     update_focus_chain_for_widget(&mut root.global_state, root_node, &mut dummy_focus_chain);
 }
 
@@ -640,7 +641,8 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
     if root.global_state.inspector_state.is_picking_widget {
         if let Some(pos) = pointer_pos {
             root.global_state.inspector_state.hovered_widget = root
-                .get_root_widget()
+                .get_widget(root.root_id())
+                .expect("root widget not in widget tree")
                 .find_widget_under_pointer(pos)
                 .map(|widget| widget.id());
         }
@@ -733,7 +735,8 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
 
     // -- UPDATE HOVERED --
     let mut next_hovered_widget = if let Some(pos) = pointer_pos {
-        root.get_root_widget()
+        root.get_widget(root.root_id())
+            .expect("root widget not in widget tree")
             .find_widget_under_pointer(pos)
             .map(|widget| widget.id())
     } else {

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -598,7 +598,7 @@ impl<W: Widget> TestHarness<W> {
         }
         if self
             .render_root
-            .get_root_widget()
+            .get_layer_root(0)
             .find_widget_under_pointer(widget_center)
             .map(|w| w.id())
             != Some(id)
@@ -674,12 +674,12 @@ impl<W: Widget> TestHarness<W> {
 
     /// Return a [`WidgetRef`] to the root widget.
     pub fn root_widget(&self) -> WidgetRef<'_, W> {
-        self.render_root.get_root_widget().downcast().unwrap()
+        self.render_root.get_layer_root(0).downcast().unwrap()
     }
 
     /// Return the [`WidgetId`] of the root widget.
     pub fn root_id(&self) -> WidgetId {
-        self.render_root.get_root_widget().id()
+        self.render_root.get_layer_root(0).id()
     }
 
     /// Return a [`WidgetRef`] to the widget with the given id.
@@ -717,7 +717,7 @@ impl<W: Widget> TestHarness<W> {
     /// Return a [`WidgetRef`] to the [focused widget](masonry_core::doc::masonry_concepts#text-focus).
     pub fn focused_widget(&self) -> Option<WidgetRef<'_, dyn Widget>> {
         self.render_root
-            .get_root_widget()
+            .get_layer_root(0)
             .find_widget_by_id(self.render_root.focused_widget()?)
     }
 
@@ -745,14 +745,14 @@ impl<W: Widget> TestHarness<W> {
             }
         }
 
-        inspect(self.render_root.get_root_widget(), &f);
+        inspect(self.render_root.get_layer_root(0), &f);
     }
 
     /// Get a [`WidgetMut`] to the root widget.
     ///
     /// Because of how `WidgetMut` works, it can only be passed to a user-provided callback.
     pub fn edit_root_widget<R>(&mut self, f: impl FnOnce(WidgetMut<'_, W>) -> R) -> R {
-        let ret = self.render_root.edit_root_widget(|mut root| {
+        let ret = self.render_root.edit_base_layer(|mut root| {
             let root = root.downcast::<W>();
             f(root)
         });

--- a/masonry_winit/examples/calc_masonry.rs
+++ b/masonry_winit/examples/calc_masonry.rs
@@ -171,7 +171,7 @@ impl AppDriver for CalcState {
             CalcAction::None => (),
         }
 
-        ctx.render_root(window_id).edit_root_widget(|mut root| {
+        ctx.render_root(window_id).edit_base_layer(|mut root| {
             let mut grid = root.downcast();
             let mut flex = Grid::child_mut(&mut grid, 0);
             let mut flex = flex.downcast();

--- a/masonry_winit/examples/grid_masonry.rs
+++ b/masonry_winit/examples/grid_masonry.rs
@@ -42,7 +42,7 @@ impl AppDriver for Driver {
                 _ => 0.5,
             };
 
-            ctx.render_root(window_id).edit_root_widget(|mut root| {
+            ctx.render_root(window_id).edit_base_layer(|mut root| {
                 let mut grid = root.downcast::<Grid>();
                 Grid::set_spacing(&mut grid, self.grid_spacing);
             });

--- a/masonry_winit/examples/virtual_fizzbuzz.rs
+++ b/masonry_winit/examples/virtual_fizzbuzz.rs
@@ -53,7 +53,7 @@ impl AppDriver for Driver {
             let action = action
                 .downcast::<VirtualScrollAction>()
                 .expect("Only expected Virtual Scroll actions");
-            ctx.render_root(window_id).edit_root_widget(|mut root| {
+            ctx.render_root(window_id).edit_base_layer(|mut root| {
                 let mut scroll = root.downcast::<VirtualScroll<ScrollContents>>();
                 // We need to tell the `VirtualScroll` which request this is associated with
                 // This is so that the controller knows which actions have been handled.

--- a/xilem/src/window_view.rs
+++ b/xilem/src/window_view.rs
@@ -71,7 +71,7 @@ where
         (_, render_root): Mut<'_, Self::Element>,
         app_state: &mut State,
     ) {
-        render_root.edit_root_widget(|mut root| {
+        render_root.edit_base_layer(|mut root| {
             self.root_widget_view
                 .teardown(view_state, ctx, root.downcast(), app_state);
         });
@@ -84,7 +84,7 @@ where
         (_, render_root): Mut<'_, Self::Element>,
         app_state: &mut State,
     ) -> xilem_core::MessageResult<()> {
-        render_root.edit_root_widget(|mut root| {
+        render_root.edit_base_layer(|mut root| {
             self.root_widget_view
                 .message(view_state, message, root.downcast(), app_state)
         })
@@ -103,7 +103,7 @@ where
         render_root: &mut RenderRoot,
         app_state: &mut State,
     ) {
-        render_root.edit_root_widget(|mut root| {
+        render_root.edit_base_layer(|mut root| {
             self.root_widget_view.rebuild(
                 &prev.root_widget_view,
                 root_widget_view_state,


### PR DESCRIPTION
This adds a very rudimentary layer system to Masonry.

This is still a draft.
A more complete version would add a few RenderRootSignal variants for adding new layers.

Also, adding a layer stack kind of muddies the concept of a "root widget", and the APIs and doc don't really account for that. I'd like to fix that before a merge.