### PR TITLE
Add a `Prop` view to compose properties of widgets

### DIFF
--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -23,7 +23,7 @@ use crate::core::{
 use crate::debug_panic;
 use crate::passes::layout::{place_widget, run_layout_on};
 use crate::peniko::Color;
-use crate::util::get_debug_color;
+use crate::util::{AnySet, get_debug_color};
 
 // Note - Most methods defined in this file revolve around `WidgetState` fields.
 // Consider reading `WidgetState` documentation (especially the documented naming scheme)
@@ -245,6 +245,7 @@ impl MutateCtx<'_> {
             properties: PropertiesMut {
                 map: &mut node_mut.item.properties,
                 default_map: self.properties.default_map,
+                changed: &mut node_mut.item.changed_properties,
             },
             children: node_mut.children,
             default_properties: self.default_properties,
@@ -1443,6 +1444,7 @@ impl RegisterCtx<'_> {
             widget: widget.as_box_dyn(),
             state,
             properties: properties.map,
+            changed_properties: AnySet::default(),
         };
         self.children.insert(id, node);
     }

--- a/masonry_core/src/core/properties.rs
+++ b/masonry_core/src/core/properties.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::default::Default;
 
 use crate::core::Widget;
-use crate::util::AnyMap;
+use crate::util::{AnyMap, AnySet};
 
 /// A marker trait that indicates that a type is intended to be used as a widget's property.
 ///
@@ -17,7 +17,7 @@ use crate::util::AnyMap;
 /// as a property.
 /// That information is deliberately not encoded in the type system.
 /// We might change that in a future version.
-pub trait Property: Default + Send + Sync + 'static {
+pub trait Property: Default + Clone + Send + Sync + 'static {
     /// A static reference to a default value.
     ///
     /// Should be the same as [`Default::default()`].
@@ -55,6 +55,7 @@ pub struct PropertiesRef<'a> {
 pub struct PropertiesMut<'a> {
     pub(crate) map: &'a mut AnyMap,
     pub(crate) default_map: &'a AnyMap,
+    pub(crate) changed: &'a mut AnySet,
 }
 
 // TODO - Better document local vs default properties.
@@ -196,6 +197,7 @@ impl PropertiesMut<'_> {
     ///
     /// [`WidgetMut::insert_prop`]: crate::core::WidgetMut::insert_prop
     pub fn insert<P: Property>(&mut self, value: P) -> Option<P> {
+        self.changed.insert(TypeId::of::<P>());
         self.map.insert(value)
     }
 
@@ -207,7 +209,17 @@ impl PropertiesMut<'_> {
     ///
     /// [`WidgetMut::remove_prop`]: crate::core::WidgetMut::remove_prop
     pub fn remove<P: Property>(&mut self) -> Option<P> {
+        self.changed.insert(TypeId::of::<P>());
         self.map.remove::<P>()
+    }
+
+    /// Whether the property `P` has been modified in this pass.
+    ///
+    /// If you're using a `WidgetMut`, call [`WidgetMut::prop_has_changed`] instead.
+    ///
+    /// [`WidgetMut::prop_has_changed`]: crate::core::WidgetMut::prop_has_changed
+    pub fn has_changed<P: Property>(&self) -> bool {
+        self.changed.contains(&TypeId::of::<P>())
     }
 
     /// Get a `PropertiesMut` for the same underlying properties with a shorter lifetime.
@@ -215,6 +227,7 @@ impl PropertiesMut<'_> {
         PropertiesMut {
             map: &mut *self.map,
             default_map: self.default_map,
+            changed: &mut *self.changed,
         }
     }
 }

--- a/masonry_core/src/core/widget_arena.rs
+++ b/masonry_core/src/core/widget_arena.rs
@@ -4,7 +4,7 @@
 use tree_arena::{ArenaMut, ArenaRef, TreeArena};
 
 use crate::core::{Widget, WidgetId, WidgetState};
-use crate::util::AnyMap;
+use crate::util::{AnyMap, AnySet};
 
 pub(crate) struct WidgetArena {
     pub(crate) nodes: TreeArena<WidgetArenaNode>,
@@ -14,6 +14,7 @@ pub(crate) struct WidgetArenaNode {
     pub(crate) widget: Box<dyn Widget>,
     pub(crate) state: WidgetState,
     pub(crate) properties: AnyMap,
+    pub(crate) changed_properties: AnySet,
 }
 
 impl WidgetArena {

--- a/masonry_core/src/core/widget_mut.rs
+++ b/masonry_core/src/core/widget_mut.rs
@@ -58,6 +58,11 @@ impl<W: Widget + ?Sized> WidgetMut<'_, W> {
         self.ctx.properties.contains::<T>()
     }
 
+    /// Whether the property `P` of this widget has been modified in this pass.
+    pub fn prop_has_changed<P: Property>(&self) -> bool {
+        self.ctx.properties.has_changed::<P>()
+    }
+
     /// Get value of property `T`.
     ///
     /// If the widget has an entry for `P`, returns that entry.

--- a/masonry_core/src/passes/anim.rs
+++ b/masonry_core/src/passes/anim.rs
@@ -19,6 +19,7 @@ fn update_anim_for_widget(
     let widget = &mut *node.item.widget;
     let state = &mut node.item.state;
     let properties = &mut node.item.properties;
+    let changed_properties = &mut node.item.changed_properties;
     let id = state.id;
     let _span = enter_span_if(global_state.trace.anim, state);
 
@@ -41,6 +42,7 @@ fn update_anim_for_widget(
         let mut props = PropertiesMut {
             map: properties,
             default_map: default_properties.for_widget(widget.type_id()),
+            changed: changed_properties,
         };
         widget.on_anim_frame(&mut ctx, &mut props, elapsed_ns);
     }

--- a/masonry_core/src/passes/event.rs
+++ b/masonry_core/src/passes/event.rs
@@ -114,6 +114,7 @@ fn run_event_pass<E>(
             let mut props = PropertiesMut {
                 map: &mut node.item.properties,
                 default_map: root.default_properties.for_widget(widget.type_id()),
+                changed: &mut node.item.changed_properties,
             };
             pass_fn(widget, &mut ctx, &mut props, event);
             is_handled = ctx.is_handled;

--- a/masonry_core/src/passes/layout.rs
+++ b/masonry_core/src/passes/layout.rs
@@ -34,6 +34,7 @@ pub(crate) fn run_layout_on(
     let widget = &mut *node.item.widget;
     let state = &mut node.item.state;
     let properties = &mut node.item.properties;
+    let changed_properties = &mut node.item.changed_properties;
     let id = state.id;
     let trace = global_state.trace.layout;
     let _span = enter_span_if(trace, state);
@@ -114,6 +115,7 @@ pub(crate) fn run_layout_on(
         let mut props = PropertiesMut {
             map: properties,
             default_map: default_properties.for_widget(widget.type_id()),
+            changed: changed_properties,
         };
         widget.layout(&mut ctx, &mut props, bc)
     };

--- a/masonry_core/src/passes/mutate.rs
+++ b/masonry_core/src/passes/mutate.rs
@@ -19,12 +19,16 @@ pub(crate) fn mutate_widget<R>(
     let widget = &mut *node.item.widget;
     let state = &mut node.item.state;
     let properties = &mut node.item.properties;
+    let changed_properties = &mut node.item.changed_properties;
     let id = state.id;
 
     let _span = info_span!("mutate_widget", name = widget.short_type_name()).entered();
 
+    changed_properties.clear();
+
     // NOTE - we can set parent_widget_state to None here, because the loop below will merge the
     // states up to the root.
+
     let root_widget = WidgetMut {
         ctx: MutateCtx {
             global_state: &mut root.global_state,
@@ -33,6 +37,7 @@ pub(crate) fn mutate_widget<R>(
             properties: PropertiesMut {
                 map: properties,
                 default_map: root.default_properties.for_widget(widget.type_id()),
+                changed: changed_properties,
             },
             children,
             default_properties: &root.default_properties,

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -55,6 +55,7 @@ fn run_targeted_update_pass(
         let widget = &mut *node.item.widget;
         let state = &mut node.item.state;
         let properties = &mut node.item.properties;
+        let changed_properties = &mut node.item.changed_properties;
 
         let mut ctx = UpdateCtx {
             global_state: &mut root.global_state,
@@ -65,6 +66,7 @@ fn run_targeted_update_pass(
         let mut props = PropertiesMut {
             map: properties,
             default_map: root.default_properties.for_widget(widget.type_id()),
+            changed: changed_properties,
         };
         pass_fn(widget, &mut ctx, &mut props);
 
@@ -91,6 +93,7 @@ fn run_single_update_pass(
     let widget = &mut *node.item.widget;
     let state = &mut node.item.state;
     let properties = &mut node.item.properties;
+    let changed_properties = &mut node.item.changed_properties;
 
     let mut ctx = UpdateCtx {
         global_state: &mut root.global_state,
@@ -101,6 +104,7 @@ fn run_single_update_pass(
     let mut props = PropertiesMut {
         map: properties,
         default_map: root.default_properties.for_widget(widget.type_id()),
+        changed: changed_properties,
     };
     pass_fn(widget, &mut ctx, &mut props);
 
@@ -121,6 +125,7 @@ fn update_widget_tree(
     let widget = &mut *node.item.widget;
     let state = &mut node.item.state;
     let properties = &mut node.item.properties;
+    let changed_properties = &mut node.item.changed_properties;
     let id = state.id;
 
     let trace = global_state.trace.update_tree;
@@ -183,6 +188,7 @@ fn update_widget_tree(
         let mut props = PropertiesMut {
             map: properties,
             default_map: default_properties.for_widget(widget.type_id()),
+            changed: changed_properties,
         };
         widget.update(&mut ctx, &mut props, &Update::WidgetAdded);
         if trace {
@@ -237,6 +243,7 @@ fn update_disabled_for_widget(
     let widget = &mut *node.item.widget;
     let state = &mut node.item.state;
     let properties = &mut node.item.properties;
+    let changed_properties = &mut node.item.changed_properties;
     let id = state.id;
 
     let _span = enter_span(state);
@@ -256,12 +263,15 @@ fn update_disabled_for_widget(
         let mut props = PropertiesMut {
             map: properties,
             default_map: default_properties.for_widget(widget.type_id()),
+            changed: changed_properties,
         };
         widget.update(&mut ctx, &mut props, &Update::DisabledChanged(disabled));
         state.is_disabled = disabled;
         state.needs_update_focus_chain = true;
         state.request_accessibility = true;
         state.needs_accessibility = true;
+        // TODO: Do something with the changed information?
+        props.changed.clear();
     }
 
     state.needs_update_disabled = false;
@@ -313,6 +323,7 @@ fn update_stashed_for_widget(
     let widget = &mut *node.item.widget;
     let state = &mut node.item.state;
     let properties = &mut node.item.properties;
+    let changed_properties = &mut node.item.changed_properties;
     let id = state.id;
 
     let _span = enter_span(state);
@@ -332,6 +343,7 @@ fn update_stashed_for_widget(
         let mut props = PropertiesMut {
             map: properties,
             default_map: default_properties.for_widget(widget.type_id()),
+            changed: changed_properties,
         };
         widget.update(&mut ctx, &mut props, &Update::StashedChanged(stashed));
         state.is_stashed = stashed;

--- a/masonry_core/src/util.rs
+++ b/masonry_core/src/util.rs
@@ -38,6 +38,10 @@ pub use crate::debug_panic;
 // ---
 
 pub(crate) type AnyMap = anymap3::Map<dyn Any + Send + Sync>;
+pub(crate) type AnySet = std::collections::HashSet<
+    std::any::TypeId,
+    std::hash::BuildHasherDefault<anymap3::TypeIdHasher>,
+>;
 
 // --- MARK: PAINT HELPERS
 

--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -8,9 +8,10 @@
 
 use std::time::Duration;
 
+use vello::peniko::color::AlphaColor;
 use winit::error::EventLoopError;
 use xilem::core::{Resource, fork, provides, run_once, with_context, without_elements};
-use xilem::style::Style as _;
+use xilem::style::{Background, BorderWidth, Style as _};
 use xilem::tokio::time;
 use xilem::view::{
     Axis, FlexExt as _, FlexSpacer, PointerButton, button, button_any_pointer, checkbox, flex,
@@ -81,6 +82,10 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> + use<> {
         }
     });
 
+    let background = (data.count * 4)
+        .clamp(0, u8::MAX.into())
+        .try_into()
+        .unwrap();
     provides(
         |_: &mut AppData| SomeContext(120),
         fork(
@@ -89,6 +94,11 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> + use<> {
                 flex_row((
                     label("Label").text_color(palette::css::REBECCA_PURPLE),
                     label("Bold Label").weight(FontWeight::BOLD),
+                    button("Styled button", |data: &mut AppData| data.count += 1)
+                        .prop(BorderWidth::all(4.0))
+                        .prop(Background::Color(AlphaColor::from_rgb8(background, 0, 0)))
+                        // Test property override
+                        .prop(Background::Color(AlphaColor::from_rgb8(0, background, 0))),
                     // TODO masonry doesn't allow setting disabled manually anymore?
                     // label("Disabled label").disabled(),
                 )),

--- a/xilem/src/view/mod.rs
+++ b/xilem/src/view/mod.rs
@@ -47,6 +47,9 @@ pub use variable_label::*;
 mod progress_bar;
 pub use progress_bar::*;
 
+mod prop;
+pub use prop::*;
+
 mod prose;
 pub use prose::*;
 

--- a/xilem/src/view/prop.rs
+++ b/xilem/src/view/prop.rs
@@ -1,0 +1,101 @@
+// Copyright 2025 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::cmp::PartialEq;
+use std::marker::PhantomData;
+
+use masonry::core::Property;
+use xilem_core::{MessageContext, Mut};
+
+use crate::core::{View, ViewMarker};
+use crate::style::{HasProperty, Style};
+use crate::{Pod, ViewCtx, WidgetView};
+
+/// The view for [`property`].
+pub struct Prop<P, V, State, Action> {
+    pub(crate) property: P,
+    pub(crate) child: V,
+    pub(crate) phantom: PhantomData<(State, Action)>,
+}
+
+// TODO: (likely) Remove
+impl<P, V: Style, State, Action> Style for Prop<P, V, State, Action> {
+    type Props = V::Props;
+
+    fn properties(&mut self) -> &mut Self::Props {
+        self.child.properties()
+    }
+}
+
+// TODO: (likely) Remove
+impl<P: Property, Pe: Property, V: HasProperty<Pe>, State, Action> HasProperty<Pe>
+    for Prop<P, V, State, Action>
+{
+    fn property(&mut self) -> &mut Option<Pe> {
+        self.child.property()
+    }
+}
+
+impl<P, V, State, Action> ViewMarker for Prop<P, V, State, Action> {}
+impl<P, Child, State, Action> View<State, Action, ViewCtx> for Prop<P, Child, State, Action>
+where
+    P: Property + PartialEq,
+    Child: WidgetView<State, Action>,
+    // TODO implement this on the element/widget
+    // Child::Widget: HasProperty<P>,
+    State: 'static,
+    Action: 'static,
+{
+    type Element = Pod<Child::Widget>;
+    type ViewState = Child::ViewState;
+
+    fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
+        let (mut child_pod, child_state) = self.child.build(ctx, app_state);
+        child_pod
+            .new_widget
+            .properties
+            .insert(self.property.clone());
+        (child_pod, child_state)
+    }
+
+    fn rebuild(
+        &self,
+        prev: &Self,
+        view_state: &mut Self::ViewState,
+        ctx: &mut ViewCtx,
+        mut element: Mut<'_, Self::Element>,
+        app_state: &mut State,
+    ) {
+        self.child.rebuild(
+            &prev.child,
+            view_state,
+            ctx,
+            element.reborrow_mut(),
+            app_state,
+        );
+        // If a child view changed the property, we know we're out of date.
+        if self.property != prev.property || element.prop_has_changed::<P>() {
+            element.insert_prop(self.property.clone());
+        }
+    }
+
+    fn teardown(
+        &self,
+        view_state: &mut Self::ViewState,
+        ctx: &mut ViewCtx,
+        element: Mut<'_, Self::Element>,
+        app_state: &mut State,
+    ) {
+        self.child.teardown(view_state, ctx, element, app_state);
+    }
+
+    fn message(
+        &self,
+        view_state: &mut Self::ViewState,
+        message: &mut MessageContext,
+        element: Mut<'_, Self::Element>,
+        app_state: &mut State,
+    ) -> xilem_core::MessageResult<Action> {
+        self.child.message(view_state, message, element, app_state)
+    }
+}

--- a/xilem/src/widget_view.rs
+++ b/xilem/src/widget_view.rs
@@ -3,10 +3,11 @@
 
 use masonry::kurbo::Affine;
 
-use masonry::core::{FromDynWidget, Widget};
+use masonry::core::{FromDynWidget, Property, Widget};
 
 use crate::core::{View, ViewSequence};
-use crate::view::{Transformed, transformed};
+use crate::style::{HasProperty, Style};
+use crate::view::{Prop, Transformed, transformed};
 use crate::{AnyWidgetView, Pod, ViewCtx};
 
 #[expect(missing_docs, reason = "TODO - Document these items")]
@@ -45,6 +46,21 @@ pub trait WidgetView<State, Action = ()>:
         Self: Sized,
     {
         transformed(self).transform(by)
+    }
+
+    // TODO: Remove
+    /// This is a temporary test for composing properties, this won't be the final API
+    fn prop<P: Property>(self, property: P) -> Prop<P, Self, State, Action>
+    where
+        Self: Sized + Style,
+        // TODO: implement this bound on the Element of the view instead (likely directly in masonry).
+        Self: HasProperty<P>,
+    {
+        Prop {
+            property,
+            child: self,
+            phantom: std::marker::PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
This is the first and minimal implementation to get a composable `Prop` view working (see mason example), this is very far from being done.
In it's current form, it should serve as a base for discussion for this controversial direction, and includes the first of (likely) two controversial changes, by adding `changed_properties` in masonry (apart from the obvious goal of composing properties with views instead of having all properties on the widget views).

The likely second controversial change (that takes a lot more effort) would be to transfer `HasProperty` to masonry (as marker trait) and implement it directly on the widgets instead of the *views* of the widgets. Motivation for this, is my experience of developing xilem_web, where we first had a similar case on the views, but having it on the element (as it is now) is a lot cleaner and more idiomatic (e.g. being compatible with xilem_core views).

That can obviously also be done in xilem, but I think there's value of having it in masonry instead.
I'd like to include this as well here in this PR, to avoid churning code (and cleanup of the xilem side of this PR).

See [#xilem > Refactor property system to use a composition property view](https://xi.zulipchat.com/#narrow/channel/354396-xilem/topic/Refactor.20property.20system.20to.20use.20a.20composition.20property.20view) for prior discussion