### PR TITLE
Add accessibility test for Node children

### DIFF
--- a/masonry/src/doc/color_rectangle.rs
+++ b/masonry/src/doc/color_rectangle.rs
@@ -126,6 +126,7 @@ impl Widget for ColorRectangle {
         _interval: u64,
     ) {
     }
+    #[cfg(false)] // We show two `update` implementations; check that both parse.
     fn update(
         &mut self,
         _ctx: &mut UpdateCtx<'_>,
@@ -188,7 +189,8 @@ impl Widget for ColorRectangle {
     // ---
 
     // Second implementation from "Creating a new widget" tutorial.
-    // We use this one in the trait, so that hovering is detected in our unit tests.
+    // We use these methods in the trait, so that hovering is detected in our unit tests.
+
     fn paint(&mut self, ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, scene: &mut Scene) {
         let rect = ctx.size().to_rect();
         let color = if ctx.is_hovered() {
@@ -203,6 +205,15 @@ impl Widget for ColorRectangle {
             Some(Affine::IDENTITY),
             &rect,
         );
+    }
+
+    fn update(&mut self, ctx: &mut UpdateCtx<'_>, _props: &mut PropertiesMut<'_>, event: &Update) {
+        match event {
+            Update::HoveredChanged(_) => {
+                ctx.request_render();
+            }
+            _ => {}
+        }
     }
 }
 

--- a/masonry/src/tests/anim.rs
+++ b/masonry/src/tests/anim.rs
@@ -16,7 +16,6 @@ fn needs_anim_flag() {
     let grandparent = NewWidget::new(ModularWidget::new_parent(parent));
 
     let mut harness = TestHarness::create(default_property_set(), grandparent);
-    harness.animate_ms(0);
     harness.flush_records_of(target_tag);
     harness.flush_records_of(parent_tag);
 

--- a/masonry/src/widgets/tests/snapshots/masonry__widgets__tests__lifecycle_basic__app_creation.snap
+++ b/masonry/src/widgets/tests/snapshots/masonry__widgets__tests__lifecycle_basic__app_creation.snap
@@ -16,4 +16,10 @@ expression: record
         400.0W×400.0H,
     ),
     Compose,
+    AnimFrame(
+        0,
+    ),
+    Paint,
+    PostPaint,
+    Accessibility,
 ]

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -1182,8 +1182,9 @@ impl_context_method!(
             // (rather than set imperatively), so it is likely to be set as part of passes.
             // Therefore, we avoid re-running the update_stashed_pass in most cases.
             if child_state.is_explicitly_stashed != stashed {
-                child_state.needs_update_stashed = true;
                 child_state.is_explicitly_stashed = stashed;
+                child_state.needs_update_stashed = true;
+                self.widget_state.needs_update_stashed = true;
             }
         }
 

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -544,3 +544,15 @@ impl Display for WidgetId {
         write!(f, "#{}", self.0)
     }
 }
+
+impl PartialEq<accesskit::NodeId> for WidgetId {
+    fn eq(&self, other: &accesskit::NodeId) -> bool {
+        self.to_raw() == other.0
+    }
+}
+
+impl PartialEq<WidgetId> for accesskit::NodeId {
+    fn eq(&self, other: &WidgetId) -> bool {
+        self.0 == other.to_raw()
+    }
+}

--- a/masonry_core/src/passes/accessibility.rs
+++ b/masonry_core/src/passes/accessibility.rs
@@ -126,7 +126,7 @@ fn build_access_node(
     if ctx.widget_state.clip_path.is_some() {
         node.set_clips_children();
     }
-    if ctx.accepts_focus() && !ctx.is_disabled() && !ctx.is_stashed() {
+    if ctx.accepts_focus() && !ctx.is_disabled() {
         node.add_action(accesskit::Action::Focus);
     }
     if ctx.is_focus_target() {


### PR DESCRIPTION
Follow-up to https://github.com/linebender/xilem/pull/711.

Fix `ColorRectangle` impl.
Add `access_node_children` test which checks that accessibility Node are set with the right children.
Run more early passes when creating TestHarness.
Add TestHarness getters for accessibility nodes.
Add new ModularWidget helper method.