### PR TITLE
Rewrite SizedBox setter methods

### DIFF
--- a/masonry/src/tests/event.rs
+++ b/masonry/src/tests/event.rs
@@ -133,7 +133,7 @@ fn pointer_capture_suppresses_neighbors() {
     let target = create_capture_target();
     let target = NewWidget::new_with_tag(target, target_tag);
 
-    let other = SizedBox::empty().width(10.px()).height(10.px());
+    let other = SizedBox::empty().size(10.px(), 10.px());
     let other = NewWidget::new_with_tag(other.record(), other_tag);
 
     let parent = Flex::column()
@@ -236,7 +236,7 @@ fn click_anchors_focus() {
 
     let parent = Flex::column()
         .with_child(NewWidget::new_with_tag(
-            SizedBox::empty().width(5.px()).height(5.px()),
+            SizedBox::empty().size(5.px(), 5.px()),
             other,
         ))
         .with_child(NewWidget::new(Button::with_text("")))

--- a/masonry/src/tests/layout.rs
+++ b/masonry/src/tests/layout.rs
@@ -144,8 +144,8 @@ fn skip_layout_when_cached() {
 
     harness.flush_records_of(button_tag);
     harness.edit_widget_with_tag(sibling_tag, |mut sized_box| {
-        SizedBox::set_width(&mut sized_box, 30.0);
-        SizedBox::set_height(&mut sized_box, 30.0);
+        SizedBox::set_width(&mut sized_box, 30.px());
+        SizedBox::set_height(&mut sized_box, 30.px());
     });
 
     // The button did not request layout and its input constraints are the same:

--- a/masonry/src/tests/layout.rs
+++ b/masonry/src/tests/layout.rs
@@ -156,10 +156,7 @@ fn skip_layout_when_cached() {
 #[test]
 fn pixel_snapping() {
     let child_tag = WidgetTag::new("child");
-    let child = NewWidget::new_with_tag(
-        SizedBox::empty().width(10.3.px()).height(10.3.px()),
-        child_tag,
-    );
+    let child = NewWidget::new_with_tag(SizedBox::empty().size(10.3.px(), 10.3.px()), child_tag);
     let pos = Point::new(5.1, 5.3);
     let parent = ModularWidget::new_parent(child).layout_fn(move |child, ctx, _, bc| {
         let size = ctx.run_layout(child, &bc.loosen());

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -74,6 +74,13 @@ impl SizedBox {
         self
     }
 
+    /// Set container's width and height.
+    pub fn size(mut self, width: Length, height: Length) -> Self {
+        self.width = Some(width.value());
+        self.height = Some(height.value());
+        self
+    }
+
     /// Expand container to fit the parent.
     ///
     /// Only call this method if you want your widget to occupy all available
@@ -143,14 +150,21 @@ impl SizedBox {
     }
 
     /// Set container's width.
-    pub fn set_width(this: &mut WidgetMut<'_, Self>, width: f64) {
-        this.widget.width = Some(width);
+    pub fn set_width(this: &mut WidgetMut<'_, Self>, width: Length) {
+        this.widget.width = Some(width.value());
         this.ctx.request_layout();
     }
 
     /// Set container's height.
-    pub fn set_height(this: &mut WidgetMut<'_, Self>, height: f64) {
-        this.widget.height = Some(height);
+    pub fn set_height(this: &mut WidgetMut<'_, Self>, height: Length) {
+        this.widget.height = Some(height.value());
+        this.ctx.request_layout();
+    }
+
+    /// Set container's width and height.
+    pub fn set_size(this: &mut WidgetMut<'_, Self>, width: Length, height: Length) {
+        this.widget.width = Some(width.value());
+        this.widget.height = Some(height.value());
         this.ctx.request_layout();
     }
 
@@ -163,6 +177,18 @@ impl SizedBox {
     /// Unset container's height.
     pub fn unset_height(this: &mut WidgetMut<'_, Self>) {
         this.widget.height = None;
+        this.ctx.request_layout();
+    }
+
+    /// Set the width directly. Intended for toolkits abstracting over `SizedBox`
+    pub fn set_raw_width(this: &mut WidgetMut<'_, Self>, value: Option<f64>) {
+        this.widget.width = value;
+        this.ctx.request_layout();
+    }
+
+    /// Set the height directly. Intended for toolkits abstracting over `SizedBox`
+    pub fn set_raw_height(this: &mut WidgetMut<'_, Self>, value: Option<f64>) {
+        this.widget.height = value;
         this.ctx.request_layout();
     }
 

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -76,8 +76,8 @@ impl SizedBox {
 
     /// Set container's width and height.
     pub fn size(mut self, width: Length, height: Length) -> Self {
-        self.width = Some(width.value());
-        self.height = Some(height.value());
+        self.width = Some(width.get());
+        self.height = Some(height.get());
         self
     }
 
@@ -151,20 +151,20 @@ impl SizedBox {
 
     /// Set container's width.
     pub fn set_width(this: &mut WidgetMut<'_, Self>, width: Length) {
-        this.widget.width = Some(width.value());
+        this.widget.width = Some(width.get());
         this.ctx.request_layout();
     }
 
     /// Set container's height.
     pub fn set_height(this: &mut WidgetMut<'_, Self>, height: Length) {
-        this.widget.height = Some(height.value());
+        this.widget.height = Some(height.get());
         this.ctx.request_layout();
     }
 
     /// Set container's width and height.
     pub fn set_size(this: &mut WidgetMut<'_, Self>, width: Length, height: Length) {
-        this.widget.width = Some(width.value());
-        this.widget.height = Some(height.value());
+        this.widget.width = Some(width.get());
+        this.widget.height = Some(height.get());
         this.ctx.request_layout();
     }
 

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -113,13 +113,17 @@ impl SizedBox {
         self
     }
 
-    /// Set the width directly. Intended for toolkits abstracting over `SizedBox`
+    /// Set the width directly. Intended for toolkits abstracting over `SizedBox`.
+    ///
+    /// If `Some`, the value should be non-negative and not NaN.
     pub fn raw_width(mut self, value: Option<f64>) -> Self {
         self.width = value;
         self
     }
 
-    /// Set the height directly. Intended for toolkits abstracting over `SizedBox`
+    /// Set the height directly. Intended for toolkits abstracting over `SizedBox`.
+    ///
+    /// If `Some`, the value should be non-negative and not NaN.
     pub fn raw_height(mut self, value: Option<f64>) -> Self {
         self.height = value;
         self
@@ -180,13 +184,17 @@ impl SizedBox {
         this.ctx.request_layout();
     }
 
-    /// Set the width directly. Intended for toolkits abstracting over `SizedBox`
+    /// Set the width directly. Intended for toolkits abstracting over `SizedBox`.
+    ///
+    /// If `Some`, the value should be non-negative and not NaN.
     pub fn set_raw_width(this: &mut WidgetMut<'_, Self>, value: Option<f64>) {
         this.widget.width = value;
         this.ctx.request_layout();
     }
 
-    /// Set the height directly. Intended for toolkits abstracting over `SizedBox`
+    /// Set the height directly. Intended for toolkits abstracting over `SizedBox`.
+    ///
+    /// If `Some`, the value should be non-negative and not NaN.
     pub fn set_raw_height(this: &mut WidgetMut<'_, Self>, value: Option<f64>) {
         this.widget.height = value;
         this.ctx.request_layout();

--- a/masonry/src/widgets/tests/layout.rs
+++ b/masonry/src/widgets/tests/layout.rs
@@ -22,11 +22,11 @@ fn layout_simple() {
         .with_child(
             Flex::row()
                 .with_child(NewWidget::new_with_id(
-                    SizedBox::empty().width(box_side).height(box_side),
+                    SizedBox::empty().size(box_side, box_side),
                     id_1,
                 ))
                 .with_child(NewWidget::new_with_id(
-                    SizedBox::empty().width(box_side).height(box_side),
+                    SizedBox::empty().size(box_side, box_side),
                     id_2,
                 ))
                 .with_flex_spacer(1.0)

--- a/masonry/src/widgets/tests/status_change.rs
+++ b/masonry/src/widgets/tests/status_change.rs
@@ -54,7 +54,7 @@ fn propagate_hovered() {
 
     let widget = Flex::column()
         .with_child(NewWidget::new_with_id(
-            SizedBox::empty().width(10.px()).height(10.px()),
+            SizedBox::empty().size(10.px(), 10.px()),
             empty,
         ))
         .with_child(NewWidget::new_with_id(
@@ -240,11 +240,11 @@ fn get_pointer_events_while_active() {
 
     let widget = Flex::column()
         .with_child(NewWidget::new_with_id(
-            SizedBox::empty().width(10.px()).height(10.px()),
+            SizedBox::empty().size(10.px(), 10.px()),
             empty,
         ))
         .with_child(NewWidget::new_with_id(
-            SizedBox::empty().width(10.px()).height(10.px()),
+            SizedBox::empty().size(10.px(), 10.px()),
             empty_2,
         ))
         .with_child(NewWidget::new_with_id(
@@ -324,7 +324,7 @@ fn automatically_lose_pointer_on_pointer_lost() {
 
     let widget = Flex::column()
         .with_child(NewWidget::new_with_id(
-            SizedBox::empty().width(10.px()).height(10.px()),
+            SizedBox::empty().size(10.px(), 10.px()),
             empty,
         ))
         .with_child(NewWidget::new_with_id(

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -152,16 +152,10 @@ where
         self.properties
             .rebuild_properties(&prev.properties, &mut element);
         if self.width != prev.width {
-            match self.width {
-                Some(width) => widgets::SizedBox::set_width(&mut element, width),
-                None => widgets::SizedBox::unset_width(&mut element),
-            }
+            widgets::SizedBox::set_raw_width(&mut element, self.width);
         }
         if self.height != prev.height {
-            match self.height {
-                Some(height) => widgets::SizedBox::set_height(&mut element, height),
-                None => widgets::SizedBox::unset_height(&mut element),
-            }
+            widgets::SizedBox::set_raw_height(&mut element, self.height);
         }
         {
             let mut child = widgets::SizedBox::child_mut(&mut element)


### PR DESCRIPTION
Have `SizedBox::set_width()` and `SizedBox::set_height()` take a `Length`
Add `SizedBox::set_raw_width()` and `SizedBox::set_raw_height()` for use in Xilem

Add `SizedBox::size()`
Add `SizedBox::set_size()`

Follow-up to #1250.