### PR TITLE
Add status flags test and fix problems it uncovered

### DIFF
--- a/masonry/src/tests/update.rs
+++ b/masonry/src/tests/update.rs
@@ -735,7 +735,7 @@ fn status_flag_update_order() {
     let parent3 = NewWidget::new(make_reporter_parent(parent2, sender3, 3));
 
     let mut harness = TestHarness::create(default_property_set(), parent3);
-    let parent1_id = harness.get_widget_with_tag(parent1_tag).id();
+    let parent1_id = harness.get_widget(parent1_tag).id();
     // Flush initial events
     let _ = receiver.try_iter().count();
 
@@ -750,8 +750,8 @@ fn status_flag_update_order() {
             ("HoveredChanged(true)".into(), 1)
         ]
     );
-    assert!(harness.get_widget_with_tag(parent1_tag).ctx().is_hovered());
-    assert!(harness.get_widget_with_tag(parent1_tag).ctx().has_hovered());
+    assert!(harness.get_widget(parent1_tag).ctx().is_hovered());
+    assert!(harness.get_widget(parent1_tag).ctx().has_hovered());
 
     harness.mouse_button_press(PointerButton::Primary);
     let events: Vec<_> = receiver.try_iter().collect();
@@ -764,8 +764,8 @@ fn status_flag_update_order() {
             ("ActiveChanged(true)".into(), 1)
         ]
     );
-    assert!(harness.get_widget_with_tag(parent1_tag).ctx().is_active());
-    assert!(harness.get_widget_with_tag(parent1_tag).ctx().has_active());
+    assert!(harness.get_widget(parent1_tag).ctx().is_active());
+    assert!(harness.get_widget(parent1_tag).ctx().has_active());
 
     harness.mouse_button_release(PointerButton::Primary);
     let events: Vec<_> = receiver.try_iter().collect();
@@ -778,8 +778,8 @@ fn status_flag_update_order() {
             ("ActiveChanged(false)".into(), 1)
         ]
     );
-    assert!(!harness.get_widget_with_tag(parent1_tag).ctx().is_active());
-    assert!(!harness.get_widget_with_tag(parent1_tag).ctx().has_active());
+    assert!(!harness.get_widget(parent1_tag).ctx().is_active());
+    assert!(!harness.get_widget(parent1_tag).ctx().has_active());
 
     harness.mouse_move((-10., -10.));
     let events: Vec<_> = receiver.try_iter().collect();
@@ -792,8 +792,8 @@ fn status_flag_update_order() {
             ("HoveredChanged(false)".into(), 1)
         ]
     );
-    assert!(!harness.get_widget_with_tag(parent1_tag).ctx().is_hovered());
-    assert!(!harness.get_widget_with_tag(parent1_tag).ctx().has_hovered());
+    assert!(!harness.get_widget(parent1_tag).ctx().is_hovered());
+    assert!(!harness.get_widget(parent1_tag).ctx().has_hovered());
 
     harness.focus_on(Some(parent1_id));
     let events: Vec<_> = receiver.try_iter().collect();
@@ -806,18 +806,8 @@ fn status_flag_update_order() {
             ("FocusChanged(true)".into(), 1)
         ]
     );
-    assert!(
-        harness
-            .get_widget_with_tag(parent1_tag)
-            .ctx()
-            .is_focus_target()
-    );
-    assert!(
-        harness
-            .get_widget_with_tag(parent1_tag)
-            .ctx()
-            .has_focus_target()
-    );
+    assert!(harness.get_widget(parent1_tag).ctx().is_focus_target());
+    assert!(harness.get_widget(parent1_tag).ctx().has_focus_target());
 
     harness.focus_on(None);
     let events: Vec<_> = receiver.try_iter().collect();
@@ -830,16 +820,6 @@ fn status_flag_update_order() {
             ("FocusChanged(false)".into(), 1)
         ]
     );
-    assert!(
-        !harness
-            .get_widget_with_tag(parent1_tag)
-            .ctx()
-            .is_focus_target()
-    );
-    assert!(
-        !harness
-            .get_widget_with_tag(parent1_tag)
-            .ctx()
-            .has_focus_target()
-    );
+    assert!(!harness.get_widget(parent1_tag).ctx().is_focus_target());
+    assert!(!harness.get_widget(parent1_tag).ctx().has_focus_target());
 }

--- a/masonry/src/tests/update.rs
+++ b/masonry/src/tests/update.rs
@@ -1,6 +1,8 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::mpsc;
+
 use assert_matches::assert_matches;
 use masonry_core::core::{
     CursorIcon, Ime, NewWidget, Properties, TextEvent, Update, Widget, WidgetId, WidgetPod,
@@ -15,7 +17,7 @@ use vello::kurbo::{Point, Size};
 
 use crate::properties::types::Length;
 use crate::theme::default_property_set;
-use crate::widgets::{Button, Flex, SizedBox, TextArea};
+use crate::widgets::{Button, Flex, Label, SizedBox, TextArea};
 
 // TREE
 
@@ -690,4 +692,154 @@ fn change_hovered_when_widget_changes() {
     // We reverted the child to the old size. It should be hovered again.
     assert!(harness.get_widget(child_tag).ctx().is_hovered());
     assert!(!harness.get_widget(parent_tag).ctx().is_hovered());
+}
+
+// STATUS FLAGS
+
+fn make_reporter_parent(
+    child: NewWidget<impl Widget>,
+    sender: mpsc::Sender<(String, u32)>,
+    n: u32,
+) -> impl Widget {
+    ModularWidget::new_parent(child)
+        .accepts_focus(true)
+        .pointer_event_fn(|_, ctx, _, event| {
+            if matches!(event, PointerEvent::Down { .. }) {
+                // Makes widget active
+                ctx.capture_pointer();
+                ctx.set_handled();
+            }
+        })
+        .layout_fn(move |child, ctx, _props, bc| {
+            let _ = ctx.run_layout(child, bc);
+            ctx.place_child(child, Point::ZERO);
+            Size::new(100., 100.)
+        })
+        .update_fn(move |_, _, _, event| {
+            sender.send((event.short_name().to_string(), n)).unwrap();
+        })
+}
+
+#[test]
+fn status_flag_update_order() {
+    let (sender, receiver) = mpsc::channel::<(String, u32)>();
+    let sender1 = sender.clone();
+    let sender2 = sender.clone();
+    let sender3 = sender;
+
+    let parent1_tag = WidgetTag::new("parent1");
+
+    let child = NewWidget::new(Label::new(""));
+    let parent1 = NewWidget::new_with_tag(make_reporter_parent(child, sender1, 1), parent1_tag);
+    let parent2 = NewWidget::new(make_reporter_parent(parent1, sender2, 2));
+    let parent3 = NewWidget::new(make_reporter_parent(parent2, sender3, 3));
+
+    let mut harness = TestHarness::create(default_property_set(), parent3);
+    let parent1_id = harness.get_widget_with_tag(parent1_tag).id();
+    // Flush initial events
+    let _ = receiver.try_iter().count();
+
+    harness.mouse_move_to(parent1_id);
+    let events: Vec<_> = receiver.try_iter().collect();
+    assert_eq!(
+        events,
+        [
+            ("ChildHoveredChanged(true)".into(), 1),
+            ("ChildHoveredChanged(true)".into(), 2),
+            ("ChildHoveredChanged(true)".into(), 3),
+            ("HoveredChanged(true)".into(), 1)
+        ]
+    );
+    assert!(harness.get_widget_with_tag(parent1_tag).ctx().is_hovered());
+    assert!(harness.get_widget_with_tag(parent1_tag).ctx().has_hovered());
+
+    harness.mouse_button_press(PointerButton::Primary);
+    let events: Vec<_> = receiver.try_iter().collect();
+    assert_eq!(
+        events,
+        [
+            ("ChildActiveChanged(true)".into(), 1),
+            ("ChildActiveChanged(true)".into(), 2),
+            ("ChildActiveChanged(true)".into(), 3),
+            ("ActiveChanged(true)".into(), 1)
+        ]
+    );
+    assert!(harness.get_widget_with_tag(parent1_tag).ctx().is_active());
+    assert!(harness.get_widget_with_tag(parent1_tag).ctx().has_active());
+
+    harness.mouse_button_release(PointerButton::Primary);
+    let events: Vec<_> = receiver.try_iter().collect();
+    assert_eq!(
+        events,
+        [
+            ("ChildActiveChanged(false)".into(), 1),
+            ("ChildActiveChanged(false)".into(), 2),
+            ("ChildActiveChanged(false)".into(), 3),
+            ("ActiveChanged(false)".into(), 1)
+        ]
+    );
+    assert!(!harness.get_widget_with_tag(parent1_tag).ctx().is_active());
+    assert!(!harness.get_widget_with_tag(parent1_tag).ctx().has_active());
+
+    harness.mouse_move((-10., -10.));
+    let events: Vec<_> = receiver.try_iter().collect();
+    assert_eq!(
+        events,
+        [
+            ("ChildHoveredChanged(false)".into(), 1),
+            ("ChildHoveredChanged(false)".into(), 2),
+            ("ChildHoveredChanged(false)".into(), 3),
+            ("HoveredChanged(false)".into(), 1)
+        ]
+    );
+    assert!(!harness.get_widget_with_tag(parent1_tag).ctx().is_hovered());
+    assert!(!harness.get_widget_with_tag(parent1_tag).ctx().has_hovered());
+
+    harness.focus_on(Some(parent1_id));
+    let events: Vec<_> = receiver.try_iter().collect();
+    assert_eq!(
+        events,
+        [
+            ("ChildFocusChanged(true)".into(), 1),
+            ("ChildFocusChanged(true)".into(), 2),
+            ("ChildFocusChanged(true)".into(), 3),
+            ("FocusChanged(true)".into(), 1)
+        ]
+    );
+    assert!(
+        harness
+            .get_widget_with_tag(parent1_tag)
+            .ctx()
+            .is_focus_target()
+    );
+    assert!(
+        harness
+            .get_widget_with_tag(parent1_tag)
+            .ctx()
+            .has_focus_target()
+    );
+
+    harness.focus_on(None);
+    let events: Vec<_> = receiver.try_iter().collect();
+    assert_eq!(
+        events,
+        [
+            ("ChildFocusChanged(false)".into(), 1),
+            ("ChildFocusChanged(false)".into(), 2),
+            ("ChildFocusChanged(false)".into(), 3),
+            ("FocusChanged(false)".into(), 1)
+        ]
+    );
+    assert!(
+        !harness
+            .get_widget_with_tag(parent1_tag)
+            .ctx()
+            .is_focus_target()
+    );
+    assert!(
+        !harness
+            .get_widget_with_tag(parent1_tag)
+            .ctx()
+            .has_focus_target()
+    );
 }

--- a/masonry_core/src/core/events.rs
+++ b/masonry_core/src/core/events.rs
@@ -254,15 +254,23 @@ impl Update {
     pub fn short_name(&self) -> &str {
         match self {
             Self::WidgetAdded => "WidgetAdded",
-            Self::DisabledChanged(_) => "DisabledChanged",
-            Self::StashedChanged(_) => "StashedChanged",
-            Self::RequestPanToChild(_) => "RequestPanToChild",
-            Self::HoveredChanged(_) => "HoveredChanged",
-            Self::ChildHoveredChanged(_) => "ChildHoveredChanged",
-            Self::ActiveChanged(_) => "ActiveChanged",
-            Self::ChildActiveChanged(_) => "ChildActiveChanged",
-            Self::FocusChanged(_) => "FocusChanged",
-            Self::ChildFocusChanged(_) => "ChildFocusChanged",
+            Self::DisabledChanged(false) => "DisabledChanged(false)",
+            Self::StashedChanged(false) => "StashedChanged(false)",
+            Self::HoveredChanged(false) => "HoveredChanged(false)",
+            Self::ChildHoveredChanged(false) => "ChildHoveredChanged(false)",
+            Self::ActiveChanged(false) => "ActiveChanged(false)",
+            Self::ChildActiveChanged(false) => "ChildActiveChanged(false)",
+            Self::FocusChanged(false) => "FocusChanged(false)",
+            Self::ChildFocusChanged(false) => "ChildFocusChanged(false)",
+            Self::DisabledChanged(true) => "DisabledChanged(true)",
+            Self::StashedChanged(true) => "StashedChanged(true)",
+            Self::HoveredChanged(true) => "HoveredChanged(true)",
+            Self::ChildHoveredChanged(true) => "ChildHoveredChanged(true)",
+            Self::ActiveChanged(true) => "ActiveChanged(true)",
+            Self::ChildActiveChanged(true) => "ChildActiveChanged(true)",
+            Self::FocusChanged(true) => "FocusChanged(true)",
+            Self::ChildFocusChanged(true) => "ChildFocusChanged(true)",
+            Self::RequestPanToChild(_) => "RequestPanToChild(_)",
         }
     }
 }

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -853,6 +853,12 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
             next_hovered_widget = None;
         }
     }
+    // Check if hovered widget is disabled
+    if let Some(id) = next_hovered_widget
+        && root.widget_arena.get_state(id).is_disabled
+    {
+        next_hovered_widget = None;
+    }
 
     // "Hovered path" means the widget which is considered hovered, and all its parents.
     let prev_hovered_path = std::mem::take(&mut root.global_state.hovered_path);

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -32,6 +32,17 @@ fn get_id_path(root: &RenderRoot, widget_id: Option<WidgetId>) -> Vec<WidgetId> 
         .collect()
 }
 
+fn is_ancestor_of(root: &RenderRoot, ancestor_id: WidgetId, widget_id: Option<WidgetId>) -> bool {
+    let Some(id) = widget_id else {
+        return false;
+    };
+    root.widget_arena
+        .nodes
+        .get_id_path(id)
+        .iter()
+        .any(|id| *id == ancestor_id.to_raw())
+}
+
 /// Make a dummy [`PointerEvent::Cancel`].
 fn dummy_pointer_cancel() -> PointerEvent {
     PointerEvent::Cancel(PointerInfo {
@@ -797,7 +808,7 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
         // TODO - Add unit test to check items are iterated from the bottom up.
         for widget_id in prev_active_path.iter().copied() {
             if root.widget_arena.has(widget_id)
-                && root.widget_arena.get_state_mut(widget_id).is_active
+                && root.widget_arena.get_state_mut(widget_id).has_active
                     != active_set.contains(&widget_id)
             {
                 update_active_status_of(root, widget_id, &active_set);
@@ -805,7 +816,7 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
         }
         for widget_id in next_active_path.iter().copied() {
             if root.widget_arena.has(widget_id)
-                && root.widget_arena.get_state_mut(widget_id).is_active
+                && root.widget_arena.get_state_mut(widget_id).has_active
                     != active_set.contains(&widget_id)
             {
                 update_active_status_of(root, widget_id, &active_set);
@@ -836,12 +847,9 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
     if let Some(capture_target) = root.global_state.pointer_capture_target
         && next_hovered_widget != Some(capture_target)
     {
-        next_hovered_widget = None;
-    }
-    // Check if hovered widget is disabled
-    if let Some(id) = next_hovered_widget {
-        let state = root.widget_arena.get_state(id);
-        if state.is_disabled {
+        if is_ancestor_of(root, capture_target, next_hovered_widget) {
+            next_hovered_widget = Some(capture_target);
+        } else {
             next_hovered_widget = None;
         }
     }
@@ -888,7 +896,7 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
         // TODO - Add unit test to check items are iterated from the bottom up.
         for widget_id in prev_hovered_path.iter().copied() {
             if root.widget_arena.has(widget_id)
-                && root.widget_arena.get_state_mut(widget_id).is_hovered
+                && root.widget_arena.get_state_mut(widget_id).has_hovered
                     != hovered_set.contains(&widget_id)
             {
                 update_hovered_status_of(root, widget_id, &hovered_set);
@@ -896,7 +904,7 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
         }
         for widget_id in next_hovered_path.iter().copied() {
             if root.widget_arena.has(widget_id)
-                && root.widget_arena.get_state_mut(widget_id).is_hovered
+                && root.widget_arena.get_state_mut(widget_id).has_hovered
                     != hovered_set.contains(&widget_id)
             {
                 update_hovered_status_of(root, widget_id, &hovered_set);


### PR DESCRIPTION
When a widget has pointer capture, keep hovering it if the cursor is over a child widget.
Remove some old focus chain code which set some focus flags incorrectly.
Check the right flags in code that tracks changes in has_xxx flags.

Follow-up to #1293.