### PR TITLE
masonry theme: Inline usage of `LABEL_X_PADDING`

### DIFF
--- a/masonry/src/theme.rs
+++ b/masonry/src/theme.rs
@@ -29,9 +29,6 @@ pub const ACCENT_COLOR: Color = Color::from_rgb8(0x3b, 0x7e, 0xe4);
 pub const TEXT_COLOR: Color = Color::from_rgb8(0xf0, 0xf0, 0xea);
 pub const DISABLED_TEXT_COLOR: Color = Color::from_rgb8(0xa0, 0xa0, 0x9a);
 
-/// Default horizontal padding for [`Label`], in logical pixels.
-pub const LABEL_X_PADDING: f64 = 2.0;
-
 // TODO: The following constants are not being used in properties
 pub const TEXT_SIZE_NORMAL: f32 = 15.0;
 pub const BASIC_WIDGET_HEIGHT: f64 = 18.0;
@@ -99,7 +96,7 @@ pub fn default_property_set() -> DefaultProperties {
         .insert::<TextArea<true>, _>(DisabledContentColor(ContentColor::new(DISABLED_TEXT_COLOR)));
 
     // Label
-    properties.insert::<Label, _>(Padding::from_vh(0., LABEL_X_PADDING));
+    properties.insert::<Label, _>(Padding::from_vh(0., 2.));
     properties.insert::<Label, _>(ContentColor::new(TEXT_COLOR));
     properties.insert::<Label, _>(DisabledContentColor(ContentColor::new(DISABLED_TEXT_COLOR)));
 


### PR DESCRIPTION
This is only used when configuring the label padding, so it doesn't need a `pub const`. The other paddings are inlined and not using a `pub const`.