### PR TITLE
When a new font is loaded, relayout everything

### DIFF
--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -278,8 +278,8 @@ impl Widget for Label {
         } else {
             None
         };
-        let styles_changed = self.styles_changed;
-        if self.styles_changed {
+        let styles_changed = self.styles_changed || ctx.fonts_changed();
+        if styles_changed {
             let (font_ctx, layout_ctx) = ctx.text_contexts();
             // TODO: Should we use a different scale?
             // See https://github.com/linebender/xilem/issues/1264

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -813,6 +813,12 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
             self.rendered_generation = new_generation;
         }
 
+        if ctx.fonts_changed() {
+            // HACK: We force the editor to relayout by pretending to edit the styles.
+            // We know that the lifecycle of dirty tracking in Parley's
+            // editor will need to change eventually anyway...
+            let _ = self.editor.edit_styles();
+        }
         let (fctx, lctx) = ctx.text_contexts();
         let layout = self.editor.layout(fctx, lctx);
         let text_width = max_advance.unwrap_or(layout.full_width());

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -339,7 +339,8 @@ impl RenderRoot {
         if let Some(test_font_data) = test_font {
             // We don't use `register_fonts` here because that requests a global relayout.
             // However, because we are not yet fully initialised (we are before the below call
-            // to `run_rewrite_passes`), `request_layout_all`
+            // to `run_rewrite_passes`), `request_layout_all` will fail, as the root hasn't
+            // been inserted into the arena yet.
             let families = root
                 .global_state
                 .font_context

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -339,7 +339,7 @@ impl RenderRoot {
         if let Some(test_font_data) = test_font {
             // We don't use `register_fonts` here because that requests a global relayout.
             // However, because we are not yet fully initialised (we are before the below call
-            // to `run_rewrite_passes`), `request_layout_all` will fail, as the root hasn't
+            // to `run_rewrite_passes`), `request_layout_all` will panic, as the root hasn't
             // been inserted into the arena yet.
             let families = root
                 .global_state

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -331,11 +331,21 @@ impl_context_method!(
         /// (such as `masonry::widgets::Label`)
         /// as a child for non-interactive text.
         /// These contexts could however be useful for custom text editing, such as for rich text editing.
+        ///
+        /// Any cached text layouts should be invalidated in the layout pass when [`Self::fonts_changed`]
+        /// returns `true`.
         pub fn text_contexts(&mut self) -> (&mut FontContext, &mut LayoutContext<BrushIndex>) {
             (
                 &mut self.global_state.font_context,
                 &mut self.global_state.text_layout_context,
             )
+        }
+
+        /// Whether the set of loaded fonts has changed since layout was most recently called.
+        ///
+        /// Any cached text layouts should be invalidated in the layout pass when this is `true`.
+        pub fn fonts_changed(&mut self) -> bool {
+            self.global_state.fonts_changed
         }
     }
 );

--- a/masonry_core/src/passes/layout.rs
+++ b/masonry_core/src/passes/layout.rs
@@ -247,6 +247,8 @@ pub(crate) fn run_layout_pass(root: &mut RenderRoot) {
     );
     place_widget(&mut root_node.item.state, Point::ORIGIN);
 
+    root.global_state.fonts_changed = false;
+
     if let WindowSizePolicy::Content = root.size_policy {
         let new_size =
             LogicalSize::new(size.width, size.height).to_physical(root.global_state.scale_factor);


### PR DESCRIPTION
This avoids issues where the initial render (say) doesn't have a given font, but the font is later loaded.

This is always the case with when Xilem accesses the font context, but I think it's also just generally the correct behaviour here.

This also fixes a minor issue with `request_render_all`, where it didn't take into account `post_paint`.