### PR TITLE
Rename harness methods to make tests more concise

### DIFF
--- a/masonry/src/tests/accessibility.rs
+++ b/masonry/src/tests/accessibility.rs
@@ -21,7 +21,7 @@ fn request_accessibility() {
     harness.flush_records_of(target_tag);
     harness.flush_records_of(parent_tag);
 
-    harness.edit_widget_with_tag(target_tag, |mut widget| {
+    harness.edit_widget(target_tag, |mut widget| {
         widget.ctx.request_accessibility_update();
     });
     let _ = harness.render();
@@ -58,7 +58,7 @@ fn access_node_children() {
     let mut harness = TestHarness::create(default_property_set(), grandparent);
     let _ = harness.render();
 
-    let parent_ref = harness.get_widget_with_tag(parent_tag);
+    let parent_ref = harness.get_widget(parent_tag);
     let parent_node_id = parent_ref.id();
     let [id_1, id_2, id_3] = parent_ref.inner().children_ids()[..] else {
         unreachable!()
@@ -71,7 +71,7 @@ fn access_node_children() {
     );
 
     // We stash a child
-    harness.edit_widget_with_tag(parent_tag, |mut parent| {
+    harness.edit_widget(parent_tag, |mut parent| {
         parent.ctx.set_stashed(&mut parent.widget.state[1], true);
         parent.ctx.request_accessibility_update();
     });

--- a/masonry/src/tests/anim.rs
+++ b/masonry/src/tests/anim.rs
@@ -20,7 +20,7 @@ fn needs_anim_flag() {
     harness.flush_records_of(target_tag);
     harness.flush_records_of(parent_tag);
 
-    harness.edit_widget_with_tag(target_tag, |mut widget| {
+    harness.edit_widget(target_tag, |mut widget| {
         widget.ctx.request_anim_frame();
     });
     harness.animate_ms(42);

--- a/masonry/src/tests/compose.rs
+++ b/masonry/src/tests/compose.rs
@@ -46,7 +46,7 @@ fn request_compose() {
     harness.flush_records_of(parent_tag);
 
     // Changing pos should lead to a layout and a compose pass.
-    harness.edit_widget_with_tag(parent_tag, |mut parent| {
+    harness.edit_widget(parent_tag, |mut parent| {
         parent.widget.inner_mut().state.pos = Point::new(30., 30.);
         parent.ctx.request_layout();
     });
@@ -56,20 +56,20 @@ fn request_compose() {
     );
 
     // Changing scroll offset only should lead to a compose pass.
-    harness.edit_widget_with_tag(parent_tag, |mut parent| {
+    harness.edit_widget(parent_tag, |mut parent| {
         parent.widget.inner_mut().state.offset = Vec2::new(8., 8.);
         parent.ctx.request_compose();
     });
     assert_matches!(harness.get_records_of(parent_tag)[..], [Record::Compose]);
 
-    harness.edit_widget_with_tag(parent_tag, |mut parent| {
+    harness.edit_widget(parent_tag, |mut parent| {
         parent
             .ctx
             .set_transform(Affine::translate(Vec2::new(7., 7.)));
     });
 
     // Origin should be "parent_origin + pos + scroll_offset"
-    let origin = harness.get_widget_with_tag(child_tag).ctx().window_origin();
+    let origin = harness.get_widget(child_tag).ctx().window_origin();
     assert_eq!(
         origin.to_vec2(),
         Vec2::new(7., 7.) + Point::new(30., 30.).to_vec2() + Vec2::new(8., 8.)
@@ -92,6 +92,6 @@ fn scroll_pixel_snap() {
     let harness = TestHarness::create(default_property_set(), parent);
 
     // Origin should be rounded to (0., 1.) by pixel-snapping.
-    let origin = harness.get_widget_with_tag(child_tag).ctx().window_origin();
+    let origin = harness.get_widget(child_tag).ctx().window_origin();
     assert_eq!(origin, Point::new(0., 1.));
 }

--- a/masonry/src/tests/event.rs
+++ b/masonry/src/tests/event.rs
@@ -32,7 +32,7 @@ fn pointer_event() {
     let button = NewWidget::new_with_tag(Button::with_text("button").record(), button_tag);
 
     let mut harness = TestHarness::create(default_property_set(), button);
-    let button_id = harness.get_widget_with_tag(button_tag).id();
+    let button_id = harness.get_widget(button_tag).id();
 
     harness.flush_records_of(button_tag);
     harness.mouse_move_to(button_id);
@@ -57,7 +57,7 @@ fn pointer_event_bubbling() {
         NewWidget::new_with_tag(ModularWidget::new_parent(parent).record(), grandparent_tag);
 
     let mut harness = TestHarness::create(default_property_set(), grandparent);
-    let button_id = harness.get_widget_with_tag(button_tag).id();
+    let button_id = harness.get_widget(button_tag).id();
 
     harness.flush_records_of(button_tag);
     harness.mouse_click_on(button_id);
@@ -82,7 +82,7 @@ fn pointer_capture_and_cancel() {
 
     let mut harness = TestHarness::create(default_property_set(), target);
 
-    let target_id = harness.get_widget_with_tag(target_tag).id();
+    let target_id = harness.get_widget(target_tag).id();
 
     harness.mouse_move_to(target_id);
     harness.mouse_button_press(PointerButton::Primary);
@@ -105,7 +105,7 @@ fn synthetic_cancel() {
 
     let mut harness = TestHarness::create(default_property_set(), target);
 
-    let target_id = harness.get_widget_with_tag(target_tag).id();
+    let target_id = harness.get_widget(target_tag).id();
 
     harness.mouse_move_to(target_id);
     harness.mouse_button_press(PointerButton::Primary);
@@ -142,8 +142,8 @@ fn pointer_capture_suppresses_neighbors() {
     let mut harness = TestHarness::create(default_property_set(), parent);
     harness.flush_records_of(other_tag);
 
-    let target_id = harness.get_widget_with_tag(target_tag).id();
-    let other_id = harness.get_widget_with_tag(other_tag).id();
+    let target_id = harness.get_widget(target_tag).id();
+    let other_id = harness.get_widget(other_tag).id();
 
     harness.mouse_move_to(target_id);
     harness.mouse_button_press(PointerButton::Primary);
@@ -155,14 +155,14 @@ fn pointer_capture_suppresses_neighbors() {
     assert_matches!(harness.get_records_of(other_tag)[..], []);
 
     // 'other' is not considered hovered either.
-    assert!(!harness.get_widget_with_tag(other_tag).ctx().is_hovered());
+    assert!(!harness.get_widget(other_tag).ctx().is_hovered());
 
     // We end pointer capture.
     harness.mouse_button_release(PointerButton::Primary);
     assert_eq!(harness.pointer_capture_target_id(), None);
 
     // Once the capture is released, 'other' should immediately register as hovered.
-    assert!(harness.get_widget_with_tag(other_tag).ctx().is_hovered());
+    assert!(harness.get_widget(other_tag).ctx().is_hovered());
 }
 
 #[test]
@@ -209,7 +209,7 @@ fn pointer_cancel_on_window_blur() {
 
     let mut harness = TestHarness::create(default_property_set(), target);
 
-    let target_id = harness.get_widget_with_tag(target_tag).id();
+    let target_id = harness.get_widget(target_tag).id();
 
     harness.mouse_move_to(target_id);
     harness.mouse_button_press(PointerButton::Primary);
@@ -246,9 +246,9 @@ fn click_anchors_focus() {
 
     let mut harness = TestHarness::create(default_property_set(), parent);
 
-    let child_3_id = harness.get_widget_with_tag(child_3).id();
-    let child_4_id = harness.get_widget_with_tag(child_4).id();
-    let other_id = harness.get_widget_with_tag(other).id();
+    let child_3_id = harness.get_widget(child_3).id();
+    let child_4_id = harness.get_widget(child_4).id();
+    let other_id = harness.get_widget(other).id();
 
     // Clicking a button doesn't focus it.
     harness.mouse_click_on(child_3_id);
@@ -272,7 +272,7 @@ fn text_event() {
     let target = NewWidget::new_with_tag(TextArea::new_editable("").record(), target_tag);
 
     let mut harness = TestHarness::create(default_property_set(), target);
-    let target_id = harness.get_widget_with_tag(target_tag).id();
+    let target_id = harness.get_widget(target_tag).id();
     harness.flush_records_of(target_tag);
 
     // The widget isn't focused, it doesn't get text events.
@@ -301,7 +301,7 @@ fn text_event_bubbling() {
         NewWidget::new_with_tag(ModularWidget::new_parent(parent).record(), grandparent_tag);
 
     let mut harness = TestHarness::create(default_property_set(), grandparent);
-    let target_id = harness.get_widget_with_tag(target_tag).id();
+    let target_id = harness.get_widget(target_tag).id();
 
     harness.focus_on(Some(target_id));
     harness.process_text_event(TextEvent::key_down(Key::Character("A".into())));
@@ -330,8 +330,8 @@ fn text_event_fallback() {
         .with_auto_id();
 
     let mut harness = TestHarness::create(default_property_set(), parent);
-    let target_id = harness.get_widget_with_tag(target_tag).id();
-    let other_id = harness.get_widget_with_tag(other_tag).id();
+    let target_id = harness.get_widget(target_tag).id();
+    let other_id = harness.get_widget(other_tag).id();
     harness.flush_records_of(target_tag);
     harness.set_focus_fallback(Some(target_id));
 
@@ -369,11 +369,11 @@ fn tab_focus() {
 
     let mut harness = TestHarness::create(default_property_set(), parent);
 
-    let child_1_id = harness.get_widget_with_tag(child_1).id();
-    let child_2_id = harness.get_widget_with_tag(child_2).id();
-    let child_3_id = harness.get_widget_with_tag(child_3).id();
-    let child_4_id = harness.get_widget_with_tag(child_4).id();
-    let child_5_id = harness.get_widget_with_tag(child_5).id();
+    let child_1_id = harness.get_widget(child_1).id();
+    let child_2_id = harness.get_widget(child_2).id();
+    let child_3_id = harness.get_widget(child_3).id();
+    let child_4_id = harness.get_widget(child_4).id();
+    let child_5_id = harness.get_widget(child_5).id();
 
     assert_eq!(harness.focused_widget_id(), None);
 
@@ -412,7 +412,7 @@ fn access_event_bubbling() {
         NewWidget::new_with_tag(ModularWidget::new_parent(parent).record(), grandparent_tag);
 
     let mut harness = TestHarness::create(default_property_set(), grandparent);
-    let target_id = harness.get_widget_with_tag(target_tag).id();
+    let target_id = harness.get_widget(target_tag).id();
 
     // Send random event
     harness.process_access_event(ActionRequest {
@@ -451,8 +451,8 @@ fn accessibility_focus() {
         .with_auto_id();
 
     let mut harness = TestHarness::create(default_property_set(), parent);
-    let child_2_id = harness.get_widget_with_tag(child_2).id();
-    let child_3_id = harness.get_widget_with_tag(child_3).id();
+    let child_2_id = harness.get_widget(child_2).id();
+    let child_3_id = harness.get_widget(child_3).id();
 
     // Send focus event
     harness.process_access_event(ActionRequest {

--- a/masonry/src/tests/layout.rs
+++ b/masonry/src/tests/layout.rs
@@ -39,8 +39,8 @@ fn layout_simple() {
 
     let harness = TestHarness::create(default_property_set(), widget);
 
-    let first_box_rect = harness.get_widget_with_tag(tag_1).ctx().local_layout_rect();
-    let first_box_paint_rect = harness.get_widget_with_tag(tag_1).ctx().paint_rect();
+    let first_box_rect = harness.get_widget(tag_1).ctx().local_layout_rect();
+    let first_box_paint_rect = harness.get_widget(tag_1).ctx().paint_rect();
 
     assert_eq!(first_box_rect.x0, 0.0);
     assert_eq!(first_box_rect.y0, 0.0);
@@ -113,7 +113,7 @@ fn run_layout_on_stashed() {
     let mut harness = TestHarness::create(default_property_set(), widget);
 
     assert_debug_panics!(
-        harness.edit_widget_with_tag(parent_tag, |mut parent| {
+        harness.edit_widget(parent_tag, |mut parent| {
             parent.ctx.set_stashed(&mut parent.widget.state, true);
             parent.ctx.request_layout();
         }),
@@ -157,7 +157,7 @@ fn unstash_then_run_layout() {
 
     let mut harness = TestHarness::create(default_property_set(), widget);
 
-    harness.edit_widget_with_tag(parent_tag, |mut parent| {
+    harness.edit_widget(parent_tag, |mut parent| {
         parent.ctx.set_stashed(&mut parent.widget.state, true);
         parent.ctx.request_layout();
     });
@@ -184,7 +184,7 @@ fn skip_layout_when_cached() {
     let mut harness = TestHarness::create(default_property_set(), parent);
 
     harness.flush_records_of(button_tag);
-    harness.edit_widget_with_tag(sibling_tag, |mut sized_box| {
+    harness.edit_widget(sibling_tag, |mut sized_box| {
         SizedBox::set_width(&mut sized_box, 30.px());
         SizedBox::set_height(&mut sized_box, 30.px());
     });
@@ -208,8 +208,8 @@ fn pixel_snapping() {
 
     let harness = TestHarness::create(default_property_set(), parent);
 
-    let child_pos = harness.get_widget_with_tag(child_tag).ctx().window_origin();
-    let child_size = harness.get_widget_with_tag(child_tag).ctx().size();
+    let child_pos = harness.get_widget(child_tag).ctx().window_origin();
+    let child_size = harness.get_widget(child_tag).ctx().size();
 
     assert_eq!(child_pos, Point::new(5.0, 5.0));
     assert_eq!(child_size, Size::new(10., 11.));
@@ -235,8 +235,8 @@ fn layout_insets() {
 
     let harness = TestHarness::create(default_property_set(), parent_widget);
 
-    let child_paint_rect = harness.get_widget_with_tag(child_tag).ctx().paint_rect();
-    let parent_paint_rect = harness.get_widget_with_tag(parent_tag).ctx().paint_rect();
+    let child_paint_rect = harness.get_widget(child_tag).ctx().paint_rect();
+    let parent_paint_rect = harness.get_widget(parent_tag).ctx().paint_rect();
 
     assert_eq!(child_paint_rect.x0, 0.0);
     assert_eq!(child_paint_rect.y0, -20.0);

--- a/masonry/src/tests/mutate.rs
+++ b/masonry/src/tests/mutate.rs
@@ -22,7 +22,7 @@ fn mutate_order() {
     let sender3 = sender;
 
     let mut harness = TestHarness::create(default_property_set(), grandparent);
-    harness.edit_widget_with_tag(parent_tag, move |mut parent| {
+    harness.edit_widget(parent_tag, move |mut parent| {
         parent.ctx.mutate_self_later(move |_| {
             sender2.send(2).unwrap();
         });
@@ -45,7 +45,7 @@ fn cancel_mutate() {
     let parent = NewWidget::new_with_tag(SizedBox::new(child), parent_tag);
 
     let mut harness = TestHarness::create(default_property_set(), parent);
-    harness.edit_widget_with_tag(parent_tag, move |mut parent| {
+    harness.edit_widget(parent_tag, move |mut parent| {
         {
             let mut child = SizedBox::child_mut(&mut parent).unwrap();
 

--- a/masonry/src/tests/paint.rs
+++ b/masonry/src/tests/paint.rs
@@ -28,7 +28,7 @@ fn request_paint() {
     harness.flush_records_of(parent_tag);
 
     // Paint
-    harness.edit_widget_with_tag(target_tag, |mut widget| {
+    harness.edit_widget(target_tag, |mut widget| {
         widget.ctx.request_paint_only();
     });
     let _ = harness.render();
@@ -39,7 +39,7 @@ fn request_paint() {
     assert_matches!(harness.get_records_of(parent_tag)[..], []);
 
     // Post-paint
-    harness.edit_widget_with_tag(target_tag, |mut widget| {
+    harness.edit_widget(target_tag, |mut widget| {
         widget.ctx.request_post_paint();
     });
     let _ = harness.render();

--- a/masonry/src/tests/update.rs
+++ b/masonry/src/tests/update.rs
@@ -104,7 +104,7 @@ fn disabled_widget_gets_no_event() {
     let parent = NewWidget::new_with_tag(ModularWidget::new_parent(child), parent_tag);
 
     let mut harness = TestHarness::create(default_property_set(), parent);
-    let button_id = harness.get_widget_with_tag(button_tag).id();
+    let button_id = harness.get_widget(button_tag).id();
     harness.focus_on(Some(button_id));
     harness.flush_records_of(button_tag);
 
@@ -145,7 +145,7 @@ fn disable_parent() {
         [Record::Update(Update::DisabledChanged(true))]
     );
 
-    assert!(harness.get_widget_with_tag(button_tag).ctx().is_disabled());
+    assert!(harness.get_widget(button_tag).ctx().is_disabled());
 
     // Then we disable the grandparent: nothing should happen,
     // the parent is already disabled.
@@ -179,11 +179,11 @@ fn stashed_widget_loses_focus() {
     let parent = NewWidget::new_with_tag(ModularWidget::new_parent(child), parent_tag);
 
     let mut harness = TestHarness::create(default_property_set(), parent);
-    let button_id = harness.get_widget_with_tag(button_tag).id();
+    let button_id = harness.get_widget(button_tag).id();
     harness.focus_on(Some(button_id));
     harness.flush_records_of(button_tag);
 
-    harness.edit_widget_with_tag(parent_tag, |mut widget| {
+    harness.edit_widget(parent_tag, |mut widget| {
         widget.ctx.set_stashed(&mut widget.widget.state, true);
     });
     assert_matches!(
@@ -213,7 +213,7 @@ fn stash_parent() {
     harness.flush_records_of(button_tag);
 
     // First we stash the button: the button should get a "StashedChanged" event.
-    harness.edit_widget_with_tag(parent_tag, |mut widget| {
+    harness.edit_widget(parent_tag, |mut widget| {
         widget.ctx.set_stashed(&mut widget.widget.state, true);
     });
     assert_matches!(
@@ -221,24 +221,24 @@ fn stash_parent() {
         [Record::Update(Update::StashedChanged(true))]
     );
 
-    assert!(harness.get_widget_with_tag(button_tag).ctx().is_stashed());
+    assert!(harness.get_widget(button_tag).ctx().is_stashed());
 
     // Then we stash the parent: nothing should happen,
     // the button is already stashed.
-    harness.edit_widget_with_tag(grandparent_tag, |mut widget| {
+    harness.edit_widget(grandparent_tag, |mut widget| {
         widget.ctx.set_stashed(&mut widget.widget.state, true);
     });
     assert_matches!(harness.get_records_of(button_tag)[..], []);
 
     // Then we un-stash the button: nothing should happen,
     // the button is still stashed through the parent.
-    harness.edit_widget_with_tag(parent_tag, |mut widget| {
+    harness.edit_widget(parent_tag, |mut widget| {
         widget.ctx.set_stashed(&mut widget.widget.state, false);
     });
     assert_matches!(harness.get_records_of(button_tag)[..], []);
 
     // Then we un-stash the parent: the button should get a "StashedChanged" event.
-    harness.edit_widget_with_tag(grandparent_tag, |mut widget| {
+    harness.edit_widget(grandparent_tag, |mut widget| {
         widget.ctx.set_stashed(&mut widget.widget.state, false);
     });
     assert_matches!(
@@ -313,7 +313,13 @@ fn focus_order() {
     let mut harness = TestHarness::create(default_property_set(), root);
 
     fn get_name(harness: &TestHarness<impl Widget>, id: Option<WidgetId>) -> Option<String> {
-        Some(harness.get_widget(id?).get_prop::<DebugName>().0.clone())
+        Some(
+            harness
+                .get_widget_with_id(id?)
+                .get_prop::<DebugName>()
+                .0
+                .clone(),
+        )
     }
 
     let mut focusable_widgets = Vec::new();
@@ -385,9 +391,9 @@ fn disable_focusable() {
 
     let mut harness = TestHarness::create(default_property_set(), parent);
 
-    let button1_id = harness.get_widget_with_tag(button1_tag).id();
-    let button2_id = harness.get_widget_with_tag(button2_tag).id();
-    let button3_id = harness.get_widget_with_tag(button3_tag).id();
+    let button1_id = harness.get_widget(button1_tag).id();
+    let button2_id = harness.get_widget(button2_tag).id();
+    let button3_id = harness.get_widget(button3_tag).id();
 
     harness.focus_on(Some(button2_id));
     harness.set_disabled(button2_tag, true);
@@ -418,9 +424,9 @@ fn stash_focusable() {
 
     let mut harness = TestHarness::create(default_property_set(), parent);
 
-    let button1_id = harness.get_widget_with_tag(button1_tag).id();
-    let button2_id = harness.get_widget_with_tag(button2_tag).id();
-    let button3_id = harness.get_widget_with_tag(button3_tag).id();
+    let button1_id = harness.get_widget(button1_tag).id();
+    let button2_id = harness.get_widget(button2_tag).id();
+    let button3_id = harness.get_widget(button3_tag).id();
 
     harness.focus_on(Some(button2_id));
 
@@ -454,9 +460,9 @@ fn remove_focusable() {
 
     let mut harness = TestHarness::create(default_property_set(), parent);
 
-    let button1_id = harness.get_widget_with_tag(button1_tag).id();
-    let button2_id = harness.get_widget_with_tag(button2_tag).id();
-    let button3_id = harness.get_widget_with_tag(button3_tag).id();
+    let button1_id = harness.get_widget(button1_tag).id();
+    let button2_id = harness.get_widget(button2_tag).id();
+    let button3_id = harness.get_widget(button3_tag).id();
 
     harness.focus_on(Some(button2_id));
     harness.edit_root_widget(|mut parent| {
@@ -482,18 +488,15 @@ fn ime_commit() {
     let textbox = NewWidget::new_with_tag(TextArea::new_editable(""), textbox_tag);
 
     let mut harness = TestHarness::create(default_property_set(), textbox);
-    let textbox_id = harness.get_widget_with_tag(textbox_tag).id();
+    let textbox_id = harness.get_widget(textbox_tag).id();
 
     harness.focus_on(Some(textbox_id));
 
     harness.process_text_event(TextEvent::Ime(Ime::Commit("New Text".to_string())));
-    assert_eq!(harness.get_widget_with_tag(textbox_tag).text(), "New Text");
+    assert_eq!(harness.get_widget(textbox_tag).text(), "New Text");
 
     harness.process_text_event(TextEvent::Ime(Ime::Commit(" and more".to_string())));
-    assert_eq!(
-        harness.get_widget_with_tag(textbox_tag).text(),
-        "New Text and more"
-    );
+    assert_eq!(harness.get_widget(textbox_tag).text(), "New Text and more");
 
     let ime_area_size = harness.ime_rect().1;
     assert!(ime_area_size.width > 0. && ime_area_size.height > 0.);
@@ -506,7 +509,7 @@ fn ime_removed() {
     let parent = NewWidget::new(SizedBox::new(textbox));
 
     let mut harness = TestHarness::create(default_property_set(), parent);
-    let textbox_id = harness.get_widget_with_tag(textbox_tag).id();
+    let textbox_id = harness.get_widget(textbox_tag).id();
 
     harness.focus_on(Some(textbox_id));
 
@@ -525,7 +528,7 @@ fn ime_start_stop() {
     let parent = NewWidget::new(ModularWidget::new_parent(textbox));
 
     let mut harness = TestHarness::create(default_property_set(), parent);
-    let textbox_id = harness.get_widget_with_tag(textbox_tag).id();
+    let textbox_id = harness.get_widget(textbox_tag).id();
 
     harness.focus_on(Some(textbox_id));
 
@@ -567,7 +570,7 @@ fn cursor_icon() {
     let parent = NewWidget::new(Flex::row().with_child(label).with_child(icon_widget));
 
     let mut harness = TestHarness::create(default_property_set(), parent);
-    let icon_id = harness.get_widget_with_tag(icon_tag).id();
+    let icon_id = harness.get_widget(icon_tag).id();
 
     assert_eq!(harness.cursor_icon(), CursorIcon::Default);
 
@@ -584,8 +587,8 @@ fn pointer_capture_affects_pointer_icon() {
     let parent = NewWidget::new(Flex::row().with_child(label).with_child(icon_widget));
 
     let mut harness = TestHarness::create(default_property_set(), parent);
-    let icon_id = harness.get_widget_with_tag(icon_tag).id();
-    let label_id = harness.get_widget_with_tag(label_tag).id();
+    let icon_id = harness.get_widget(icon_tag).id();
+    let label_id = harness.get_widget(label_tag).id();
 
     harness.mouse_move_to(icon_id);
     harness.mouse_button_press(PointerButton::Primary);
@@ -606,17 +609,17 @@ fn lose_hovered_on_pointer_leave_or_cancel() {
     let button = NewWidget::new_with_tag(Button::with_text("button").record(), button_tag);
 
     let mut harness = TestHarness::create(default_property_set(), button);
-    let button_id = harness.get_widget_with_tag(button_tag).id();
+    let button_id = harness.get_widget(button_tag).id();
 
     // Hover button
     harness.mouse_move_to(button_id);
-    assert!(harness.get_widget_with_tag(button_tag).ctx().is_hovered());
+    assert!(harness.get_widget(button_tag).ctx().is_hovered());
 
     // POINTER LEAVE
     harness.flush_records_of(button_tag);
     harness.process_pointer_event(PointerEvent::Leave(PRIMARY_MOUSE));
 
-    assert!(!harness.get_widget_with_tag(button_tag).ctx().is_hovered());
+    assert!(!harness.get_widget(button_tag).ctx().is_hovered());
 
     let records = harness.get_records_of(button_tag);
     assert!(
@@ -627,13 +630,13 @@ fn lose_hovered_on_pointer_leave_or_cancel() {
 
     // Hover button again
     harness.mouse_move_to(button_id);
-    assert!(harness.get_widget_with_tag(button_tag).ctx().is_hovered());
+    assert!(harness.get_widget(button_tag).ctx().is_hovered());
 
     // POINTER CANCEL
     harness.flush_records_of(button_tag);
     harness.process_pointer_event(PointerEvent::Cancel(PRIMARY_MOUSE));
 
-    assert!(!harness.get_widget_with_tag(button_tag).ctx().is_hovered());
+    assert!(!harness.get_widget(button_tag).ctx().is_hovered());
 
     let records = harness.get_records_of(button_tag);
     assert!(
@@ -664,27 +667,27 @@ fn change_hovered_when_widget_changes() {
     );
 
     let mut harness = TestHarness::create(default_property_set(), parent);
-    let child_id = harness.get_widget_with_tag(child_tag).id();
+    let child_id = harness.get_widget(child_tag).id();
 
     harness.mouse_move_to(child_id);
-    assert!(harness.get_widget_with_tag(child_tag).ctx().is_hovered());
-    assert!(!harness.get_widget_with_tag(parent_tag).ctx().is_hovered());
+    assert!(harness.get_widget(child_tag).ctx().is_hovered());
+    assert!(!harness.get_widget(parent_tag).ctx().is_hovered());
 
-    harness.edit_widget_with_tag(child_tag, |mut child| {
+    harness.edit_widget(child_tag, |mut child| {
         child.widget.state = Length::ZERO;
         child.ctx.request_layout();
     });
 
     // The pointer hasn't moved, but no longer covers the child.
     // The parent should now be the widget which is hovered.
-    assert!(!harness.get_widget_with_tag(child_tag).ctx().is_hovered());
-    assert!(harness.get_widget_with_tag(parent_tag).ctx().is_hovered());
+    assert!(!harness.get_widget(child_tag).ctx().is_hovered());
+    assert!(harness.get_widget(parent_tag).ctx().is_hovered());
 
-    harness.edit_widget_with_tag(child_tag, |mut child| {
+    harness.edit_widget(child_tag, |mut child| {
         child.widget.state = BOX_SIZE;
         child.ctx.request_layout();
     });
     // We reverted the child to the old size. It should be hovered again.
-    assert!(harness.get_widget_with_tag(child_tag).ctx().is_hovered());
-    assert!(!harness.get_widget_with_tag(parent_tag).ctx().is_hovered());
+    assert!(harness.get_widget(child_tag).ctx().is_hovered());
+    assert!(!harness.get_widget(parent_tag).ctx().is_hovered());
 }

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -554,20 +554,14 @@ mod tests {
 
         assert_render_snapshot!(harness, "portal_button_list_scrolled");
 
-        let item_3_rect = harness
-            .get_widget_with_tag(button_3)
-            .ctx()
-            .local_layout_rect();
+        let item_3_rect = harness.get_widget(button_3).ctx().local_layout_rect();
         harness.edit_root_widget(|mut portal| {
             Portal::pan_viewport_to(&mut portal, item_3_rect);
         });
 
         assert_render_snapshot!(harness, "portal_button_list_scroll_to_item_3");
 
-        let item_13_rect = harness
-            .get_widget_with_tag(button_13)
-            .ctx()
-            .local_layout_rect();
+        let item_13_rect = harness.get_widget(button_13).ctx().local_layout_rect();
         harness.edit_root_widget(|mut portal| {
             Portal::pan_viewport_to(&mut portal, item_13_rect);
         });
@@ -593,7 +587,7 @@ mod tests {
 
         let mut harness =
             TestHarness::create_with_size(default_property_set(), widget, Size::new(200., 200.));
-        let button_id = harness.get_widget_with_tag(button_tag).id();
+        let button_id = harness.get_widget(button_tag).id();
 
         harness.scroll_into_view(button_id);
         assert_render_snapshot!(harness, "portal_scrolled_button_into_view");

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -632,7 +632,7 @@ impl<W: Widget> TestHarness<W> {
     /// - If the widget is scrolled out of view.
     #[track_caller]
     pub fn mouse_move_to(&mut self, id: WidgetId) {
-        let widget = self.get_widget(id);
+        let widget = self.get_widget_with_id(id);
         let local_widget_center = (widget.ctx().size() / 2.0).to_vec2().to_point();
         let widget_center = widget.ctx().window_transform() * local_widget_center;
 
@@ -748,7 +748,7 @@ impl<W: Widget> TestHarness<W> {
 
     /// Helper method to directly enable/disable a widget.
     pub fn set_disabled(&mut self, widget: WidgetTag<impl Widget>, disabled: bool) {
-        self.edit_widget_with_tag(widget, |mut target| {
+        self.edit_widget(widget, |mut target| {
             target.ctx.set_disabled(disabled);
         });
     }
@@ -771,7 +771,7 @@ impl<W: Widget> TestHarness<W> {
     ///
     /// Panics if no widget with this id can be found.
     #[track_caller]
-    pub fn get_widget(&self, id: WidgetId) -> WidgetRef<'_, dyn Widget> {
+    pub fn get_widget_with_id(&self, id: WidgetId) -> WidgetRef<'_, dyn Widget> {
         self.render_root
             .get_widget(id)
             .unwrap_or_else(|| panic!("could not find widget {id}"))
@@ -783,7 +783,7 @@ impl<W: Widget> TestHarness<W> {
     ///
     /// Panics if no widget with this tag can be found.
     #[track_caller]
-    pub fn get_widget_with_tag<W2: Widget + FromDynWidget + ?Sized>(
+    pub fn get_widget<W2: Widget + FromDynWidget + ?Sized>(
         &self,
         tag: WidgetTag<W2>,
     ) -> WidgetRef<'_, W2> {
@@ -799,7 +799,7 @@ impl<W: Widget> TestHarness<W> {
     /// Panics if no widget with this tag can be found.
     #[track_caller]
     pub fn get_records_of<W2: Widget>(&self, tag: WidgetTag<Recorder<W2>>) -> Vec<Record> {
-        self.get_widget_with_tag(tag).inner().recording().drain()
+        self.get_widget(tag).inner().recording().drain()
     }
 
     /// Flush the events recorded by the [`Recorder`] widget with the given tag.
@@ -809,7 +809,7 @@ impl<W: Widget> TestHarness<W> {
     /// Panics if no widget with this tag can be found.
     #[track_caller]
     pub fn flush_records_of<W2: Widget>(&self, tag: WidgetTag<Recorder<W2>>) {
-        self.get_widget_with_tag(tag).inner().recording().clear();
+        self.get_widget(tag).inner().recording().clear();
     }
 
     /// Try to return a [`WidgetRef`] to the widget with the given id.
@@ -871,7 +871,7 @@ impl<W: Widget> TestHarness<W> {
     /// Get a [`WidgetMut`] to a specific widget.
     ///
     /// Because of how `WidgetMut` works, it can only be passed to a user-provided callback.
-    pub fn edit_widget<R>(
+    pub fn edit_widget_with_id<R>(
         &mut self,
         id: WidgetId,
         f: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R,
@@ -885,7 +885,7 @@ impl<W: Widget> TestHarness<W> {
     ///
     /// Because of how `WidgetMut` works, it can only be passed to a user-provided callback.
     #[track_caller]
-    pub fn edit_widget_with_tag<R, W2: Widget + FromDynWidget + ?Sized>(
+    pub fn edit_widget<R, W2: Widget + FromDynWidget + ?Sized>(
         &mut self,
         tag: WidgetTag<W2>,
         f: impl FnOnce(WidgetMut<'_, W2>) -> R,


### PR DESCRIPTION
Rename `edit_widget_with_tag` to `edit_widget`.
Rename `get_widget_with_tag` to `get_widget`.
Rename `edit_widget` to `edit_widget_with_id`.
Rename `get_widget` to `get_widget_with_id`.

(The latter two are used much less often.)