### PR TITLE
Regularize `RenderRoot` and `RenderRootState` fields

### DIFF
--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -73,13 +73,12 @@ pub struct RenderRoot {
 
     /// The widget tree; stores widgets and their states.
     pub(crate) widget_arena: WidgetArena,
-    pub(crate) debug_paint: bool,
 }
 
 /// State shared between passes.
 pub(crate) struct RenderRootState {
     /// Sink for signals to be processed by the event loop.
-    signal_sink: Box<dyn FnMut(RenderRootSignal)>,
+    pub(crate) signal_sink: Box<dyn FnMut(RenderRootSignal)>,
 
     /// Currently focused widget.
     pub(crate) focused_widget: Option<WidgetId>,
@@ -149,6 +148,8 @@ pub(crate) struct RenderRootState {
 
     /// Pass tracing configuration, used to skip tracing to limit overhead.
     pub(crate) trace: PassTracing,
+
+    /// Internal state of the widget inspector.
     pub(crate) inspector_state: InspectorState,
 
     /// Whether the next accessibility pass tree should be updated during `render()`.
@@ -158,6 +159,9 @@ pub(crate) struct RenderRootState {
     ///
     /// Kurbo coordinates are assumed to be in logical pixels
     pub(crate) scale_factor: f64,
+
+    /// Whether to paint widget's bounding boxes and other visual helpers.
+    pub(crate) debug_paint: bool,
 }
 
 pub(crate) struct MutateCallback {
@@ -338,11 +342,11 @@ impl RenderRoot {
                 },
                 access_tree_active: false,
                 scale_factor,
+                debug_paint,
             },
             widget_arena: WidgetArena {
                 nodes: TreeArena::new(),
             },
-            debug_paint,
         };
 
         if let Some(test_font_data) = test_font {

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -128,7 +128,6 @@ pub struct PaintCtx<'a> {
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) widget_state: &'a WidgetState,
     pub(crate) children: ArenaMutList<'a, WidgetArenaNode>,
-    pub(crate) debug_paint: bool,
 }
 
 /// A context passed to [`Widget::accessibility`] method.
@@ -1476,7 +1475,7 @@ impl PaintCtx<'_> {
     ///
     /// Debug paint can be enabled by setting the environment variable `MASONRY_DEBUG_PAINT`.
     pub fn debug_paint_enabled(&self) -> bool {
-        self.debug_paint
+        self.global_state.debug_paint
     }
 
     /// A color used for debug painting in this widget.

--- a/masonry_core/src/passes/event.rs
+++ b/masonry_core/src/passes/event.rs
@@ -312,7 +312,7 @@ pub(crate) fn run_on_text_event_pass(root: &mut RenderRoot, event: &TextEvent) -
             && key.state == KeyState::Down
             && handled == Handled::No
         {
-            root.debug_paint = !root.debug_paint;
+            root.global_state.debug_paint = !root.global_state.debug_paint;
             root.root_state_mut().needs_paint = true;
             handled = Handled::Yes;
         }

--- a/masonry_core/src/passes/paint.rs
+++ b/masonry_core/src/passes/paint.rs
@@ -21,7 +21,6 @@ fn paint_widget(
     complete_scene: &mut Scene,
     scene_cache: &mut HashMap<WidgetId, (Scene, Scene)>,
     node: ArenaMut<'_, WidgetArenaNode>,
-    debug_paint: bool,
 ) {
     let mut children = node.children;
     let widget = &mut *node.item.widget;
@@ -49,7 +48,6 @@ fn paint_widget(
             global_state,
             widget_state: state,
             children: children.reborrow_mut(),
-            debug_paint,
         };
 
         // TODO - Reserve scene
@@ -103,7 +101,6 @@ fn paint_widget(
             complete_scene,
             scene_cache,
             node.reborrow_mut(),
-            debug_paint,
         );
         parent_state.merge_up(&mut node.item.state);
     });
@@ -113,7 +110,7 @@ fn paint_widget(
         let bounding_rect = state.bounding_rect;
 
         // draw the global axis aligned bounding rect of the widget
-        if debug_paint {
+        if global_state.debug_paint {
             const BORDER_WIDTH: f64 = 1.0;
             let color = get_debug_color(id.to_raw());
             let rect = bounding_rect.inset(BORDER_WIDTH / -2.0);
@@ -156,7 +153,6 @@ pub(crate) fn run_paint_pass(root: &mut RenderRoot) -> Scene {
         &mut complete_scene,
         &mut scene_cache,
         root_node,
-        root.debug_paint,
     );
     root.global_state.scene_cache = scene_cache;
 


### PR DESCRIPTION
Document all undocumented fields.
Move `debug_paint` to `RenderRootState`.