### PR TITLE
Rename `Harness::get_records_of` to `Harness::take_records_of`

### DIFF
--- a/masonry/src/tests/accessibility.rs
+++ b/masonry/src/tests/accessibility.rs
@@ -28,17 +28,17 @@ fn request_accessibility() {
 
     // Check that `Widget::accessibility()` is called for the child (which did request it)
     // but not the parent (which did not).
-    let records = harness.get_records_of(target_tag);
+    let records = harness.take_records_of(target_tag);
     assert!(records.iter().any(|r| matches!(r, Record::Accessibility)));
 
-    let records = harness.get_records_of(parent_tag);
+    let records = harness.take_records_of(parent_tag);
     assert!(records.iter().all(|r| !matches!(r, Record::Accessibility)));
 
     // Check that `Widget::accessibility()` is not called: neither node has requested
     // an accessibility update.
     let _ = harness.render();
-    assert_matches!(harness.get_records_of(target_tag)[..], []);
-    assert_matches!(harness.get_records_of(parent_tag)[..], []);
+    assert_matches!(harness.take_records_of(target_tag)[..], []);
+    assert_matches!(harness.take_records_of(parent_tag)[..], []);
 }
 
 #[test]

--- a/masonry/src/tests/anim.rs
+++ b/masonry/src/tests/anim.rs
@@ -25,18 +25,18 @@ fn needs_anim_flag() {
     });
     harness.animate_ms(42);
 
-    let records = harness.get_records_of(target_tag);
+    let records = harness.take_records_of(target_tag);
     assert!(
         records
             .iter()
             .any(|r| matches!(r, Record::AnimFrame(42_000_000)))
     );
 
-    let records = harness.get_records_of(parent_tag);
+    let records = harness.take_records_of(parent_tag);
     assert!(records.iter().all(|r| !matches!(r, Record::AnimFrame(_))));
 
     harness.animate_ms(42);
 
     // We didn't re-request an animation, so nothing should happen.
-    assert_matches!(harness.get_records_of(parent_tag)[..], []);
+    assert_matches!(harness.take_records_of(parent_tag)[..], []);
 }

--- a/masonry/src/tests/compose.rs
+++ b/masonry/src/tests/compose.rs
@@ -51,7 +51,7 @@ fn request_compose() {
         parent.ctx.request_layout();
     });
     assert_matches!(
-        harness.get_records_of(parent_tag)[..],
+        harness.take_records_of(parent_tag)[..],
         [Record::Layout(_), Record::Compose,]
     );
 
@@ -60,7 +60,7 @@ fn request_compose() {
         parent.widget.inner_mut().state.offset = Vec2::new(8., 8.);
         parent.ctx.request_compose();
     });
-    assert_matches!(harness.get_records_of(parent_tag)[..], [Record::Compose]);
+    assert_matches!(harness.take_records_of(parent_tag)[..], [Record::Compose]);
 
     harness.edit_widget(parent_tag, |mut parent| {
         parent

--- a/masonry/src/tests/event.rs
+++ b/masonry/src/tests/event.rs
@@ -37,7 +37,7 @@ fn pointer_event() {
     harness.flush_records_of(button_tag);
     harness.mouse_move_to(button_id);
 
-    let records = harness.get_records_of(button_tag);
+    let records = harness.take_records_of(button_tag);
     assert!(
         records
             .iter()
@@ -68,9 +68,9 @@ fn pointer_event_bubbling() {
             .any(|r| matches!(r, Record::PointerEvent(PointerEvent::Down { .. })))
     };
 
-    assert!(has_pointer_down(harness.get_records_of(button_tag)));
-    assert!(has_pointer_down(harness.get_records_of(parent_tag)));
-    assert!(has_pointer_down(harness.get_records_of(grandparent_tag)));
+    assert!(has_pointer_down(harness.take_records_of(button_tag)));
+    assert!(has_pointer_down(harness.take_records_of(parent_tag)));
+    assert!(has_pointer_down(harness.take_records_of(grandparent_tag)));
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn synthetic_cancel() {
     // synthetic PointerCancel event.
     harness.set_disabled(target_tag, true);
 
-    let records = harness.get_records_of(target_tag);
+    let records = harness.take_records_of(target_tag);
     assert!(
         records
             .iter()
@@ -152,7 +152,7 @@ fn pointer_capture_suppresses_neighbors() {
 
     // As long as 'target' is captured, 'other' doesn't get pointer events, even when the cursor is on it.
     harness.mouse_move_to(other_id);
-    assert_matches!(harness.get_records_of(other_tag)[..], []);
+    assert_matches!(harness.take_records_of(other_tag)[..], []);
 
     // 'other' is not considered hovered either.
     assert!(!harness.get_widget(other_tag).ctx().is_hovered());
@@ -218,7 +218,7 @@ fn pointer_cancel_on_window_blur() {
 
     harness.process_text_event(TextEvent::WindowFocusChange(false));
 
-    let records = harness.get_records_of(target_tag);
+    let records = harness.take_records_of(target_tag);
     assert!(
         records
             .iter()
@@ -277,12 +277,12 @@ fn text_event() {
 
     // The widget isn't focused, it doesn't get text events.
     harness.keyboard_type_chars("A");
-    assert_matches!(harness.get_records_of(target_tag)[..], []);
+    assert_matches!(harness.take_records_of(target_tag)[..], []);
 
     // We focus on the widget, now it gets text events.
     harness.focus_on(Some(target_id));
     harness.keyboard_type_chars("A");
-    let records = harness.get_records_of(target_tag);
+    let records = harness.take_records_of(target_tag);
     assert!(records.iter().any(|r| matches!(r, Record::TextEvent(_))));
 }
 
@@ -312,9 +312,9 @@ fn text_event_bubbling() {
             .any(|r| matches!(r, Record::TextEvent(TextEvent::Keyboard(_))))
     };
 
-    assert!(has_keyboard_event(harness.get_records_of(target_tag)));
-    assert!(has_keyboard_event(harness.get_records_of(parent_tag)));
-    assert!(has_keyboard_event(harness.get_records_of(grandparent_tag)));
+    assert!(has_keyboard_event(harness.take_records_of(target_tag)));
+    assert!(has_keyboard_event(harness.take_records_of(parent_tag)));
+    assert!(has_keyboard_event(harness.take_records_of(grandparent_tag)));
 }
 
 #[test]
@@ -336,19 +336,19 @@ fn text_event_fallback() {
     harness.set_focus_fallback(Some(target_id));
 
     harness.focus_on(Some(other_id));
-    assert_matches!(harness.get_records_of(target_tag)[..], []);
+    assert_matches!(harness.take_records_of(target_tag)[..], []);
 
     // If a widget is set as focus fallback, that widget gets text events when no widget is focused.
     harness.focus_on(None);
     harness.keyboard_type_chars("A");
-    let records = harness.get_records_of(target_tag);
+    let records = harness.take_records_of(target_tag);
     assert!(records.iter().any(|r| matches!(r, Record::TextEvent(_))));
 
     // Unless it's disabled.
     harness.set_disabled(target_tag, true);
     harness.flush_records_of(target_tag);
     harness.keyboard_type_chars("A");
-    assert_matches!(harness.get_records_of(target_tag)[..], []);
+    assert_matches!(harness.take_records_of(target_tag)[..], []);
 }
 
 #[test]
@@ -433,9 +433,9 @@ fn access_event_bubbling() {
         })
     };
 
-    assert!(has_access_event(harness.get_records_of(target_tag)));
-    assert!(has_access_event(harness.get_records_of(parent_tag)));
-    assert!(has_access_event(harness.get_records_of(grandparent_tag)));
+    assert!(has_access_event(harness.take_records_of(target_tag)));
+    assert!(has_access_event(harness.take_records_of(parent_tag)));
+    assert!(has_access_event(harness.take_records_of(grandparent_tag)));
 }
 
 #[test]

--- a/masonry/src/tests/layout.rs
+++ b/masonry/src/tests/layout.rs
@@ -191,7 +191,7 @@ fn skip_layout_when_cached() {
 
     // The button did not request layout and its input constraints are the same:
     // Nothing should happen to it.
-    assert_matches!(harness.get_records_of(button_tag)[..], []);
+    assert_matches!(harness.take_records_of(button_tag)[..], []);
 }
 
 #[test]

--- a/masonry/src/tests/paint.rs
+++ b/masonry/src/tests/paint.rs
@@ -35,8 +35,8 @@ fn request_paint() {
 
     // Check that `Widget::paint()` is called for the child (which did request it)
     // but not the parent (which did not).
-    assert_matches!(harness.get_records_of(target_tag)[..], [Record::Paint]);
-    assert_matches!(harness.get_records_of(parent_tag)[..], []);
+    assert_matches!(harness.take_records_of(target_tag)[..], [Record::Paint]);
+    assert_matches!(harness.take_records_of(parent_tag)[..], []);
 
     // Post-paint
     harness.edit_widget(target_tag, |mut widget| {
@@ -46,14 +46,14 @@ fn request_paint() {
 
     // Check that `Widget::post_paint()` is called for the child (which did request it)
     // but not the parent (which did not).
-    assert_matches!(harness.get_records_of(target_tag)[..], [Record::PostPaint]);
-    assert_matches!(harness.get_records_of(parent_tag)[..], []);
+    assert_matches!(harness.take_records_of(target_tag)[..], [Record::PostPaint]);
+    assert_matches!(harness.take_records_of(parent_tag)[..], []);
 
     // Check that `Widget::paint()` and `Widget::post_paint()` are not called:
     // neither widget has requested an update.
     let _ = harness.render();
-    assert_matches!(harness.get_records_of(parent_tag)[..], []);
-    assert_matches!(harness.get_records_of(target_tag)[..], []);
+    assert_matches!(harness.take_records_of(parent_tag)[..], []);
+    assert_matches!(harness.take_records_of(target_tag)[..], []);
 }
 
 #[test]

--- a/masonry/src/tests/update.rs
+++ b/masonry/src/tests/update.rs
@@ -29,7 +29,7 @@ fn app_creation() {
     let harness = TestHarness::create(default_property_set(), widget);
 
     assert_matches!(
-        harness.get_records_of(widget_tag)[..],
+        harness.take_records_of(widget_tag)[..],
         [
             Record::RegisterChildren,
             Record::Update(Update::WidgetAdded),
@@ -59,7 +59,7 @@ fn new_widget() {
     });
 
     assert_matches!(
-        harness.get_records_of(widget_tag)[0..2],
+        harness.take_records_of(widget_tag)[0..2],
         [
             Record::RegisterChildren,
             Record::Update(Update::WidgetAdded)
@@ -112,7 +112,7 @@ fn disabled_widget_gets_no_event() {
 
     harness.set_disabled(button_tag, true);
     assert_matches!(
-        harness.get_records_of(button_tag)[..],
+        harness.take_records_of(button_tag)[..],
         [
             Record::Update(Update::DisabledChanged(true)),
             Record::Update(Update::ChildFocusChanged(false)),
@@ -121,7 +121,7 @@ fn disabled_widget_gets_no_event() {
     );
 
     harness.mouse_click_on(button_id);
-    assert_matches!(harness.get_records_of(button_tag)[..], []);
+    assert_matches!(harness.take_records_of(button_tag)[..], []);
 
     assert_matches!(harness.focused_widget_id(), None);
 
@@ -143,7 +143,7 @@ fn disable_parent() {
     // First we disable the parent: the button should get a "DisabledChanged" event.
     harness.set_disabled(parent_tag, true);
     assert_matches!(
-        harness.get_records_of(button_tag)[..],
+        harness.take_records_of(button_tag)[..],
         [Record::Update(Update::DisabledChanged(true))]
     );
 
@@ -152,23 +152,23 @@ fn disable_parent() {
     // Then we disable the grandparent: nothing should happen,
     // the parent is already disabled.
     harness.set_disabled(grandparent_tag, true);
-    assert_matches!(harness.get_records_of(button_tag)[..], []);
+    assert_matches!(harness.take_records_of(button_tag)[..], []);
 
     // Then we re-enable the parent: nothing should happen,
     // the parent is still disabled through the grandparent.
     harness.set_disabled(parent_tag, false);
-    assert_matches!(harness.get_records_of(button_tag)[..], []);
+    assert_matches!(harness.take_records_of(button_tag)[..], []);
 
     // Then we re-enable the grandparent: the button should get a "DisabledChanged" event.
     harness.set_disabled(grandparent_tag, false);
     assert_matches!(
-        harness.get_records_of(button_tag)[..],
+        harness.take_records_of(button_tag)[..],
         [Record::Update(Update::DisabledChanged(false))]
     );
 
     // Finally we re-enable the button: no effect, it's already enabled.
     harness.set_disabled(button_tag, false);
-    assert_matches!(harness.get_records_of(button_tag)[..], []);
+    assert_matches!(harness.take_records_of(button_tag)[..], []);
 }
 
 // STASHED
@@ -189,7 +189,7 @@ fn stashed_widget_loses_focus() {
         widget.ctx.set_stashed(&mut widget.widget.state, true);
     });
     assert_matches!(
-        harness.get_records_of(button_tag)[..],
+        harness.take_records_of(button_tag)[..],
         [
             Record::Update(Update::StashedChanged(true)),
             Record::Update(Update::ChildFocusChanged(false)),
@@ -219,7 +219,7 @@ fn stash_parent() {
         widget.ctx.set_stashed(&mut widget.widget.state, true);
     });
     assert_matches!(
-        harness.get_records_of(button_tag)[..],
+        harness.take_records_of(button_tag)[..],
         [Record::Update(Update::StashedChanged(true))]
     );
 
@@ -230,21 +230,21 @@ fn stash_parent() {
     harness.edit_widget(grandparent_tag, |mut widget| {
         widget.ctx.set_stashed(&mut widget.widget.state, true);
     });
-    assert_matches!(harness.get_records_of(button_tag)[..], []);
+    assert_matches!(harness.take_records_of(button_tag)[..], []);
 
     // Then we un-stash the button: nothing should happen,
     // the button is still stashed through the parent.
     harness.edit_widget(parent_tag, |mut widget| {
         widget.ctx.set_stashed(&mut widget.widget.state, false);
     });
-    assert_matches!(harness.get_records_of(button_tag)[..], []);
+    assert_matches!(harness.take_records_of(button_tag)[..], []);
 
     // Then we un-stash the parent: the button should get a "StashedChanged" event.
     harness.edit_widget(grandparent_tag, |mut widget| {
         widget.ctx.set_stashed(&mut widget.widget.state, false);
     });
     assert_matches!(
-        harness.get_records_of(button_tag)[..],
+        harness.take_records_of(button_tag)[..],
         [
             Record::Update(Update::StashedChanged(false)),
             // Un-stashing also requests a layout pass.
@@ -539,7 +539,7 @@ fn ime_start_stop() {
     harness.flush_records_of(textbox_tag);
     harness.set_disabled(textbox_tag, true);
 
-    let records = harness.get_records_of(textbox_tag);
+    let records = harness.take_records_of(textbox_tag);
     assert!(
         records
             .iter()
@@ -623,7 +623,7 @@ fn lose_hovered_on_pointer_leave_or_cancel() {
 
     assert!(!harness.get_widget(button_tag).ctx().is_hovered());
 
-    let records = harness.get_records_of(button_tag);
+    let records = harness.take_records_of(button_tag);
     assert!(
         records
             .iter()
@@ -640,7 +640,7 @@ fn lose_hovered_on_pointer_leave_or_cancel() {
 
     assert!(!harness.get_widget(button_tag).ctx().is_hovered());
 
-    let records = harness.get_records_of(button_tag);
+    let records = harness.take_records_of(button_tag);
     assert!(
         records
             .iter()

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -792,13 +792,13 @@ impl<W: Widget> TestHarness<W> {
             .unwrap_or_else(|| panic!("could not find widget '{tag}'"))
     }
 
-    /// Return the events recorded by the [`Recorder`] widget with the given tag.
+    /// Drain the events recorded by the [`Recorder`] widget with the given tag.
     ///
     /// # Panics
     ///
     /// Panics if no widget with this tag can be found.
     #[track_caller]
-    pub fn get_records_of<W2: Widget>(&self, tag: WidgetTag<Recorder<W2>>) -> Vec<Record> {
+    pub fn take_records_of<W2: Widget>(&self, tag: WidgetTag<Recorder<W2>>) -> Vec<Record> {
         self.get_widget(tag).inner().recording().drain()
     }
 


### PR DESCRIPTION
The name better conveys that the method drains the records from the given widget.