### PR TITLE
Add `assert_any`, `assert_all` and `assert_none` helper macros.

### DIFF
--- a/masonry/src/tests/accessibility.rs
+++ b/masonry/src/tests/accessibility.rs
@@ -4,7 +4,7 @@
 use accesskit::NodeId;
 use assert_matches::assert_matches;
 use masonry_core::core::{NewWidget, Widget, WidgetTag};
-use masonry_testing::{ModularWidget, Record, TestHarness, TestWidgetExt};
+use masonry_testing::{ModularWidget, Record, TestHarness, TestWidgetExt, assert_any, assert_none};
 
 use crate::theme::default_property_set;
 use crate::widgets::SizedBox;
@@ -29,10 +29,10 @@ fn request_accessibility() {
     // Check that `Widget::accessibility()` is called for the child (which did request it)
     // but not the parent (which did not).
     let records = harness.take_records_of(target_tag);
-    assert!(records.iter().any(|r| matches!(r, Record::Accessibility)));
+    assert_any!(records, |r| matches!(r, Record::Accessibility));
 
     let records = harness.take_records_of(parent_tag);
-    assert!(records.iter().all(|r| !matches!(r, Record::Accessibility)));
+    assert_none!(records, |r| matches!(r, Record::Accessibility));
 
     // Check that `Widget::accessibility()` is not called: neither node has requested
     // an accessibility update.

--- a/masonry/src/tests/anim.rs
+++ b/masonry/src/tests/anim.rs
@@ -3,7 +3,7 @@
 
 use assert_matches::assert_matches;
 use masonry_core::core::{NewWidget, WidgetTag};
-use masonry_testing::{ModularWidget, Record, TestHarness, TestWidgetExt};
+use masonry_testing::{ModularWidget, Record, TestHarness, TestWidgetExt, assert_any, assert_none};
 
 use crate::theme::default_property_set;
 use crate::widgets::SizedBox;
@@ -26,14 +26,10 @@ fn needs_anim_flag() {
     harness.animate_ms(42);
 
     let records = harness.take_records_of(target_tag);
-    assert!(
-        records
-            .iter()
-            .any(|r| matches!(r, Record::AnimFrame(42_000_000)))
-    );
+    assert_any!(records, |r| matches!(r, Record::AnimFrame(42_000_000)));
 
     let records = harness.take_records_of(parent_tag);
-    assert!(records.iter().all(|r| !matches!(r, Record::AnimFrame(_))));
+    assert_none!(records, |r| matches!(r, Record::AnimFrame(_)));
 
     harness.animate_ms(42);
 

--- a/masonry/src/tests/update.rs
+++ b/masonry/src/tests/update.rs
@@ -9,7 +9,7 @@ use masonry_core::core::{
     WidgetTag,
 };
 use masonry_testing::{
-    DebugName, ModularWidget, PRIMARY_MOUSE, Record, TestHarness, TestWidgetExt,
+    DebugName, ModularWidget, PRIMARY_MOUSE, Record, TestHarness, TestWidgetExt, assert_any,
     assert_debug_panics,
 };
 use ui_events::pointer::{PointerButton, PointerEvent};
@@ -540,11 +540,10 @@ fn ime_start_stop() {
     harness.set_disabled(textbox_tag, true);
 
     let records = harness.take_records_of(textbox_tag);
-    assert!(
-        records
-            .iter()
-            .any(|r| matches!(r, Record::TextEvent(TextEvent::Ime(Ime::Disabled))))
-    );
+    assert_any!(records, |r| matches!(
+        r,
+        Record::TextEvent(TextEvent::Ime(Ime::Disabled))
+    ));
 
     assert!(!harness.has_ime_session());
 }
@@ -624,11 +623,10 @@ fn lose_hovered_on_pointer_leave_or_cancel() {
     assert!(!harness.get_widget(button_tag).ctx().is_hovered());
 
     let records = harness.take_records_of(button_tag);
-    assert!(
-        records
-            .iter()
-            .any(|r| matches!(r, Record::Update(Update::HoveredChanged(false))))
-    );
+    assert_any!(records, |r| matches!(
+        r,
+        Record::Update(Update::HoveredChanged(false))
+    ));
 
     // Hover button again
     harness.mouse_move_to(button_id);
@@ -641,11 +639,10 @@ fn lose_hovered_on_pointer_leave_or_cancel() {
     assert!(!harness.get_widget(button_tag).ctx().is_hovered());
 
     let records = harness.take_records_of(button_tag);
-    assert!(
-        records
-            .iter()
-            .any(|r| matches!(r, Record::Update(Update::HoveredChanged(false))))
-    );
+    assert_any!(records, |r| matches!(
+        r,
+        Record::Update(Update::HoveredChanged(false))
+    ));
 }
 
 #[test]

--- a/masonry_testing/src/assert_any.rs
+++ b/masonry_testing/src/assert_any.rs
@@ -1,0 +1,103 @@
+// Copyright 2025 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/// Helper macro, checks that at least one item of the given `IntoIterator` matches the given predicate.
+#[macro_export]
+macro_rules! assert_any {
+    ($iter:expr, $pred:expr $(,)?) => {
+        $crate::assert_any_inner($iter, $pred)
+    };
+}
+
+/// Helper macro, checks that all items of the given `IntoIterator` match the given predicate.
+#[macro_export]
+macro_rules! assert_all {
+    ($iter:expr, $pred:expr $(,)?) => {
+        $crate::assert_all_inner($iter, $pred)
+    };
+}
+
+/// Helper macro, checks that no item of the given `IntoIterator` matches the given predicate.
+#[macro_export]
+macro_rules! assert_none {
+    ($iter:expr, $pred:expr $(,)?) => {
+        $crate::assert_none_inner($iter, $pred)
+    };
+}
+
+use std::fmt::{Debug, Write};
+
+#[track_caller]
+#[doc(hidden)]
+pub fn assert_any_inner<I: IntoIterator>(iter: I, mut pred: impl FnMut(I::Item) -> bool)
+where
+    I::Item: Debug,
+{
+    let mut list_contents = String::new();
+
+    for item in iter.into_iter() {
+        writeln!(&mut list_contents, "  {item:?},").unwrap();
+
+        if pred(item) {
+            return;
+        }
+    }
+
+    panic!("assertion failed: no item matched predicate in [\n{list_contents}]");
+}
+
+#[track_caller]
+#[doc(hidden)]
+pub fn assert_all_inner<I: IntoIterator>(iter: I, mut pred: impl FnMut(I::Item) -> bool)
+where
+    I::Item: Debug,
+{
+    let mut list_contents = String::new();
+    let mut error_count = 0;
+
+    for (i, item) in iter.into_iter().enumerate() {
+        let item_dbg = format!("{item:?}");
+
+        if !pred(item) {
+            writeln!(&mut list_contents, "  ({i}) {item_dbg:?},").unwrap();
+            error_count += 1;
+        }
+        if error_count > 5 {
+            writeln!(&mut list_contents, "  ...").unwrap();
+            break;
+        }
+    }
+
+    if error_count != 0 {
+        panic!("assertion failed: items failed to match predicate: [\n{list_contents}]");
+    }
+}
+
+#[track_caller]
+#[doc(hidden)]
+pub fn assert_none_inner<I: IntoIterator>(iter: I, mut pred: impl FnMut(I::Item) -> bool)
+where
+    I::Item: Debug,
+{
+    let mut list_contents = String::new();
+    let mut error_count = 0;
+
+    for (i, item) in iter.into_iter().enumerate() {
+        let item_dbg = format!("{item:?}");
+
+        if pred(item) {
+            writeln!(&mut list_contents, "  ({i}) {item_dbg:?},").unwrap();
+            error_count += 1;
+        }
+        if error_count > 5 {
+            writeln!(&mut list_contents, "  ...").unwrap();
+            break;
+        }
+    }
+
+    if error_count != 0 {
+        panic!(
+            "assertion failed: items matched predicate against expectations: [\n{list_contents}]"
+        );
+    }
+}

--- a/masonry_testing/src/lib.rs
+++ b/masonry_testing/src/lib.rs
@@ -6,6 +6,7 @@
 // TODO: Remove any items listed as "Deferred"
 #![expect(missing_debug_implementations, reason = "Deferred: Noisy")]
 
+mod assert_any;
 mod assert_debug_panics;
 mod debug_name;
 mod harness;
@@ -14,6 +15,7 @@ mod recorder_widget;
 mod screenshots;
 mod wrapper_widget;
 
+pub use assert_any::{assert_all_inner, assert_any_inner, assert_none_inner};
 pub use assert_debug_panics::assert_debug_panics_inner;
 pub use debug_name::DebugName;
 pub use harness::{PRIMARY_MOUSE, TestHarness, TestHarnessParams};


### PR DESCRIPTION
The macros gives rich error messages for cases where we want apply a predicate to an entire collection.