### PR TITLE
Make `assert_any`, `assert_all` and `assert_none` not be macros

### DIFF
--- a/masonry/src/tests/accessibility.rs
+++ b/masonry/src/tests/accessibility.rs
@@ -29,10 +29,10 @@ fn request_accessibility() {
     // Check that `Widget::accessibility()` is called for the child (which did request it)
     // but not the parent (which did not).
     let records = harness.take_records_of(target_tag);
-    assert_any!(records, |r| matches!(r, Record::Accessibility));
+    assert_any(records, |r| matches!(r, Record::Accessibility));
 
     let records = harness.take_records_of(parent_tag);
-    assert_none!(records, |r| matches!(r, Record::Accessibility));
+    assert_none(records, |r| matches!(r, Record::Accessibility));
 
     // Check that `Widget::accessibility()` is not called: neither node has requested
     // an accessibility update.

--- a/masonry/src/tests/anim.rs
+++ b/masonry/src/tests/anim.rs
@@ -26,10 +26,10 @@ fn needs_anim_flag() {
     harness.animate_ms(42);
 
     let records = harness.take_records_of(target_tag);
-    assert_any!(records, |r| matches!(r, Record::AnimFrame(42_000_000)));
+    assert_any(records, |r| matches!(r, Record::AnimFrame(42_000_000)));
 
     let records = harness.take_records_of(parent_tag);
-    assert_none!(records, |r| matches!(r, Record::AnimFrame(_)));
+    assert_none(records, |r| matches!(r, Record::AnimFrame(_)));
 
     harness.animate_ms(42);
 

--- a/masonry/src/tests/event.rs
+++ b/masonry/src/tests/event.rs
@@ -40,10 +40,9 @@ fn pointer_event() {
     harness.mouse_move_to(button_id);
 
     let records = harness.take_records_of(button_tag);
-    assert_any!(records, |r| matches!(
-        r,
-        Record::PointerEvent(PointerEvent::Move(_))
-    ));
+    assert_any(records, |r| {
+        matches!(r, Record::PointerEvent(PointerEvent::Move(_)))
+    });
 }
 
 #[test]
@@ -67,9 +66,9 @@ fn pointer_event_bubbling() {
         matches!(record, Record::PointerEvent(PointerEvent::Down { .. }))
     }
 
-    assert_any!(harness.take_records_of(button_tag), is_pointer_down);
-    assert_any!(harness.take_records_of(parent_tag), is_pointer_down);
-    assert_any!(harness.take_records_of(grandparent_tag), is_pointer_down);
+    assert_any(harness.take_records_of(button_tag), is_pointer_down);
+    assert_any(harness.take_records_of(parent_tag), is_pointer_down);
+    assert_any(harness.take_records_of(grandparent_tag), is_pointer_down);
 }
 
 #[test]
@@ -115,10 +114,9 @@ fn synthetic_cancel() {
     harness.set_disabled(target_tag, true);
 
     let records = harness.take_records_of(target_tag);
-    assert_any!(records, |r| matches!(
-        r,
-        Record::PointerEvent(PointerEvent::Cancel(_))
-    ));
+    assert_any(records, |r| {
+        matches!(r, Record::PointerEvent(PointerEvent::Cancel(_)))
+    });
 }
 
 #[test]
@@ -217,10 +215,9 @@ fn pointer_cancel_on_window_blur() {
     harness.process_text_event(TextEvent::WindowFocusChange(false));
 
     let records = harness.take_records_of(target_tag);
-    assert_any!(records, |r| matches!(
-        r,
-        Record::PointerEvent(PointerEvent::Cancel(..))
-    ));
+    assert_any(records, |r| {
+        matches!(r, Record::PointerEvent(PointerEvent::Cancel(..)))
+    });
 }
 
 #[test]
@@ -280,7 +277,7 @@ fn text_event() {
     harness.focus_on(Some(target_id));
     harness.keyboard_type_chars("A");
     let records = harness.take_records_of(target_tag);
-    assert_any!(records, |r| matches!(r, Record::TextEvent(_)));
+    assert_any(records, |r| matches!(r, Record::TextEvent(_)));
 }
 
 #[test]
@@ -307,9 +304,9 @@ fn text_event_bubbling() {
         matches!(record, Record::TextEvent(TextEvent::Keyboard(_)))
     }
 
-    assert_any!(harness.take_records_of(target_tag), is_keyboard_event);
-    assert_any!(harness.take_records_of(parent_tag), is_keyboard_event);
-    assert_any!(harness.take_records_of(grandparent_tag), is_keyboard_event);
+    assert_any(harness.take_records_of(target_tag), is_keyboard_event);
+    assert_any(harness.take_records_of(parent_tag), is_keyboard_event);
+    assert_any(harness.take_records_of(grandparent_tag), is_keyboard_event);
 }
 
 #[test]
@@ -337,7 +334,7 @@ fn text_event_fallback() {
     harness.focus_on(None);
     harness.keyboard_type_chars("A");
     let records = harness.take_records_of(target_tag);
-    assert_any!(records, |r| matches!(r, Record::TextEvent(_)));
+    assert_any(records, |r| matches!(r, Record::TextEvent(_)));
 
     // Unless it's disabled.
     harness.set_disabled(target_tag, true);
@@ -426,9 +423,9 @@ fn access_event_bubbling() {
         )
     }
 
-    assert_any!(harness.take_records_of(target_tag), is_access_click);
-    assert_any!(harness.take_records_of(parent_tag), is_access_click);
-    assert_any!(harness.take_records_of(grandparent_tag), is_access_click);
+    assert_any(harness.take_records_of(target_tag), is_access_click);
+    assert_any(harness.take_records_of(parent_tag), is_access_click);
+    assert_any(harness.take_records_of(grandparent_tag), is_access_click);
 }
 
 #[test]

--- a/masonry/src/tests/update.rs
+++ b/masonry/src/tests/update.rs
@@ -540,10 +540,9 @@ fn ime_start_stop() {
     harness.set_disabled(textbox_tag, true);
 
     let records = harness.take_records_of(textbox_tag);
-    assert_any!(records, |r| matches!(
-        r,
-        Record::TextEvent(TextEvent::Ime(Ime::Disabled))
-    ));
+    assert_any(records, |r| {
+        matches!(r, Record::TextEvent(TextEvent::Ime(Ime::Disabled)))
+    });
 
     assert!(!harness.has_ime_session());
 }
@@ -623,10 +622,9 @@ fn lose_hovered_on_pointer_leave_or_cancel() {
     assert!(!harness.get_widget(button_tag).ctx().is_hovered());
 
     let records = harness.take_records_of(button_tag);
-    assert_any!(records, |r| matches!(
-        r,
-        Record::Update(Update::HoveredChanged(false))
-    ));
+    assert_any(records, |r| {
+        matches!(r, Record::Update(Update::HoveredChanged(false)))
+    });
 
     // Hover button again
     harness.mouse_move_to(button_id);
@@ -639,10 +637,9 @@ fn lose_hovered_on_pointer_leave_or_cancel() {
     assert!(!harness.get_widget(button_tag).ctx().is_hovered());
 
     let records = harness.take_records_of(button_tag);
-    assert_any!(records, |r| matches!(
-        r,
-        Record::Update(Update::HoveredChanged(false))
-    ));
+    assert_any(records, |r| {
+        matches!(r, Record::Update(Update::HoveredChanged(false)))
+    });
 }
 
 #[test]

--- a/masonry_testing/src/assert_any.rs
+++ b/masonry_testing/src/assert_any.rs
@@ -1,35 +1,13 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-/// Helper macro, checks that at least one item of the given `IntoIterator` matches the given predicate.
-#[macro_export]
-macro_rules! assert_any {
-    ($iter:expr, $pred:expr $(,)?) => {
-        $crate::assert_any_inner($iter, $pred)
-    };
-}
-
-/// Helper macro, checks that all items of the given `IntoIterator` match the given predicate.
-#[macro_export]
-macro_rules! assert_all {
-    ($iter:expr, $pred:expr $(,)?) => {
-        $crate::assert_all_inner($iter, $pred)
-    };
-}
-
-/// Helper macro, checks that no item of the given `IntoIterator` matches the given predicate.
-#[macro_export]
-macro_rules! assert_none {
-    ($iter:expr, $pred:expr $(,)?) => {
-        $crate::assert_none_inner($iter, $pred)
-    };
-}
-
 use std::fmt::{Debug, Write};
 
+/// Assert that `pred` returns true for at least one item in `iter`.
+///
+/// This provides a panic message showing the values, to aid debugging.
 #[track_caller]
-#[doc(hidden)]
-pub fn assert_any_inner<I: IntoIterator>(iter: I, mut pred: impl FnMut(I::Item) -> bool)
+pub fn assert_any<I: IntoIterator>(iter: I, mut pred: impl FnMut(I::Item) -> bool)
 where
     I::Item: Debug,
 {
@@ -46,9 +24,11 @@ where
     panic!("assertion failed: no item matched predicate in [\n{list_contents}]");
 }
 
+/// Assert that `pred` returns true for every item in `iter`.
+///
+/// This provides an error message showing which values failed the condition, to aid debugging.
 #[track_caller]
-#[doc(hidden)]
-pub fn assert_all_inner<I: IntoIterator>(iter: I, mut pred: impl FnMut(I::Item) -> bool)
+pub fn assert_all<I: IntoIterator>(iter: I, mut pred: impl FnMut(I::Item) -> bool)
 where
     I::Item: Debug,
 {
@@ -73,9 +53,11 @@ where
     }
 }
 
+/// Assert that `pred` returns false for every item in `iter`.
+///
+/// This provides an error message showing which values succeeded the condition, to aid debugging.
 #[track_caller]
-#[doc(hidden)]
-pub fn assert_none_inner<I: IntoIterator>(iter: I, mut pred: impl FnMut(I::Item) -> bool)
+pub fn assert_none<I: IntoIterator>(iter: I, mut pred: impl FnMut(I::Item) -> bool)
 where
     I::Item: Debug,
 {

--- a/masonry_testing/src/lib.rs
+++ b/masonry_testing/src/lib.rs
@@ -15,7 +15,7 @@ mod recorder_widget;
 mod screenshots;
 mod wrapper_widget;
 
-pub use assert_any::{assert_all_inner, assert_any_inner, assert_none_inner};
+pub use assert_any::{assert_all, assert_any, assert_none};
 pub use assert_debug_panics::assert_debug_panics_inner;
 pub use debug_name::DebugName;
 pub use harness::{PRIMARY_MOUSE, TestHarness, TestHarnessParams};


### PR DESCRIPTION
Follow-up to https://github.com/linebender/xilem/pull/1335

The macros added in that PR were not using the fact that they are macros. This would be confusing to users, as macros are to be avoided unless necessary.

If in future we want to add assertion message support, etc, we can always make them macros again (reasonably trivially)