### PR TITLE
Add Error Handling to virtual cats example

### DIFF
--- a/xilem/examples/virtual_cats.rs
+++ b/xilem/examples/virtual_cats.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use masonry::core::ArcStr;
-use masonry::properties::types::{AsUnit, Length, UnitPoint};
+use masonry::properties::types::{AsUnit, UnitPoint};
 use masonry::properties::{LineBreaking, Padding};
 use vello::peniko::{Blob, Image};
 use winit::dpi::LogicalSize;

--- a/xilem/examples/virtual_cats.rs
+++ b/xilem/examples/virtual_cats.rs
@@ -116,13 +116,13 @@ impl VirtualCats {
             ImageState::Error(err) => {
                 // the people deserve their cat.
                 // It is vital that the cat explains what went wrong.
-                let asciicat = label("😿").text_size(48.);
+                let emojicat = label("😿").text_size(48.);
                 let errorstring = prose(err.to_string())
                     .text_size(18.0)
                     .text_color(Color::from_rgb8(0x85, 0, 0))
                     .weight(FontWeight::BOLD);
 
-                let view = flex((errorstring, asciicat))
+                let view = flex((errorstring, emojicat))
                     .background_color(WHITE)
                     .cross_axis_alignment(xilem::view::CrossAxisAlignment::Start)
                     .padding(16.0)

--- a/xilem/examples/virtual_cats.rs
+++ b/xilem/examples/virtual_cats.rs
@@ -17,6 +17,7 @@ use vello::peniko::{Blob, Image};
 use winit::dpi::LogicalSize;
 use winit::error::EventLoopError;
 use xilem::core::fork;
+use xilem::core::one_of::{OneOf, OneOf3};
 use xilem::palette::css::{BLACK, WHITE};
 use xilem::style::Style as _;
 use xilem::view::{
@@ -25,7 +26,6 @@ use xilem::view::{
 use xilem::{
     Color, EventLoop, EventLoopBuilder, FontWeight, TextAlign, WidgetView, WindowOptions, Xilem,
 };
-use xilem_core::one_of::OneOf3;
 
 /// The main state of the application.
 struct VirtualCats {
@@ -112,7 +112,7 @@ impl VirtualCats {
                 ));
                 OneOf3::A(imgview)
             }
-            ImageState::Pending => OneOf3::B(sized_box(spinner()).width(80.px()).height(80.px())),
+            ImageState::Pending => OneOf::B(sized_box(spinner()).width(80.px()).height(80.px())),
             ImageState::Error(err) => {
                 // the people deserve their cat.
                 // It is vital that the cat explains what went wrong.
@@ -127,7 +127,7 @@ impl VirtualCats {
                     .cross_axis_alignment(xilem::view::CrossAxisAlignment::Start)
                     .padding(16.0)
                     .corner_radius(8.0);
-                OneOf3::C(view)
+                OneOf::C(view)
             }
         };
         fork(flex((prose(item.message.clone()), img)), task)

--- a/xilem/examples/virtual_cats.rs
+++ b/xilem/examples/virtual_cats.rs
@@ -20,13 +20,12 @@ use xilem::core::fork;
 use xilem::palette::css::{BLACK, WHITE};
 use xilem::style::Style as _;
 use xilem::view::{
-    Axis, ObjectFit, ZStackExt, flex, flex_row, image, label, prose, sized_box, spinner,
-    virtual_scroll, zstack,
+    ObjectFit, ZStackExt, flex, image, label, prose, sized_box, spinner, virtual_scroll, zstack,
 };
 use xilem::{
     Color, EventLoop, EventLoopBuilder, TextAlign, WidgetView, WindowOptions, Xilem, palette,
 };
-use xilem_core::one_of::{Either, OneOf3};
+use xilem_core::one_of::OneOf3;
 
 /// The main state of the application.
 struct VirtualCats {


### PR DESCRIPTION
in case of failing to download the image.

I wanted to practice and get to know xilem a little.
When I found this TODO in the source code I thought this nice and silly little example might be a good fit, where I can cause no harm.

Here is the finished result which you may see running this without a connection

<img width="810" height="636" alt="Bildschirmfoto 2025-08-19 um 16 56 33" src="https://github.com/user-attachments/assets/3a99716b-683c-4349-a303-ff3040db2e57" />
