### PR TITLE
Placehero: Add padding to the status list

### DIFF
--- a/placehero/src/components/timeline.rs
+++ b/placehero/src/components/timeline.rs
@@ -9,7 +9,7 @@ use xilem::core::one_of::{OneOf, OneOf3};
 use xilem::masonry::core::ArcStr;
 use xilem::masonry::properties::types::AsUnit;
 use xilem::palette::css;
-use xilem::style::Style;
+use xilem::style::{Padding, Style};
 use xilem::tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use xilem::view::{flex, prose, sized_box, spinner, virtual_scroll, worker_raw};
 use xilem::{TextAlign, WidgetView};
@@ -184,8 +184,12 @@ pub(crate) fn timeline_status(status: &Status) -> impl WidgetView<Timeline, Navi
     } else {
         (None, status)
     };
-    sized_box(flex((info_line, base_status(primary_status))))
-        .border(css::WHITE, 2.0)
-        .padding(10.0)
-        .corner_radius(5.)
+    // Use a wrapping sized box for margin
+    sized_box(
+        sized_box(flex((info_line, base_status(primary_status))))
+            .border(css::WHITE, 2.0)
+            .padding(10.0)
+            .corner_radius(5.),
+    )
+    .padding(Padding::from_vh(5., 4.))
 }


### PR DESCRIPTION
<img width="802" height="629" alt="image" src="https://github.com/user-attachments/assets/f282040c-5dbd-4ace-99b6-072866f7c47d" />
Previously, they were too close together (see screenshot in #1337)