### PR TITLE
Masonry: Use `type_name` when debug logging actions

### DIFF
--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -790,7 +790,11 @@ impl MasonryState<'_> {
             match signal {
                 RenderRootSignal::Action(action, widget_id) => {
                     let window_id = window.id;
-                    debug!("Action {:?} on widget {:?}", action, widget_id);
+                    debug!(
+                        "Action {:?} on widget {:?}",
+                        (*action).type_name(),
+                        widget_id
+                    );
                     app_driver.on_action(
                         window_id,
                         &mut DriverCtx::new(self, event_loop),


### PR DESCRIPTION
The previous logging was extremely verbose previously. E.g. for Placehero, you'd have lines and lines with all the contents from the statuses being loaded.

The new output for specifically Xilem's async actions is pretty shoddy:
```rust
Action "(alloc::sync::Arc<[xilem_core::view::ViewId]>, xilem_core::message::SendMessage)" on widget WidgetId(18446744073709547519)
```
In particular, the fact that the `SendMessage`'s type isn't expanded is unfortunate.
However, I don't think that there are viable alternatives. It's not like `Debug` has an "abridged" formatting flag.