### PR TITLE
fix: declare_property_tuple macro uses private scope

### DIFF
--- a/xilem/src/property_tuple.rs
+++ b/xilem/src/property_tuple.rs
@@ -109,7 +109,7 @@ macro_rules! __declare_property_tuple_loop {
             }
         }
 
-        impl $crate::property_tuple::PropertyTuple for $Props
+        impl $crate::PropertyTuple for $Props
         {
             fn build_properties(&self) -> $crate::masonry::core::Properties {
                 let mut props = $crate::masonry::core::Properties::new();


### PR DESCRIPTION
The `declare_property_tuple` macro is currently unusable outside of the `xilem` crate because it references the `PropertyTuple` trait via its module path (`$crate::property_tuple::PropertyTuple`) and that module is private. This PR changes the macro to access the trait via its public re-export in the crate root.