### PR TITLE
Remove app_state parameter from teardown

### DIFF
--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -184,7 +184,6 @@ where
             &mut window.view_state,
             &mut window.view_ctx,
             ctx.window_handle_and_render_root(window_id),
-            &mut self.state,
         );
         self.windows.remove(&window_id);
         ctx.close_window(window_id);

--- a/xilem/src/view/button.rs
+++ b/xilem/src/view/button.rs
@@ -187,7 +187,6 @@ where
         _: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         ctx.with_id(LABEL_VIEW_ID, |ctx| {
             View::<State, Action, _>::teardown(
@@ -195,7 +194,6 @@ where
                 &mut (),
                 ctx,
                 widgets::Button::child_mut(&mut element).downcast(),
-                app_state,
             );
         });
         ctx.teardown_leaf(element);

--- a/xilem/src/view/checkbox.rs
+++ b/xilem/src/view/checkbox.rs
@@ -133,7 +133,6 @@ where
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        _: &mut State,
     ) {
         ctx.teardown_leaf(element);
     }

--- a/xilem/src/view/flex.rs
+++ b/xilem/src/view/flex.rs
@@ -281,11 +281,9 @@ where
         FlexState { seq_state, scratch }: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         let mut splice = FlexSplice::new(element, scratch);
-        self.sequence
-            .seq_teardown(seq_state, ctx, &mut splice, app_state);
+        self.sequence.seq_teardown(seq_state, ctx, &mut splice);
         debug_assert!(scratch.is_empty());
     }
 
@@ -635,12 +633,10 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         let mut child = widgets::Flex::child_mut(&mut element.parent, element.idx)
             .expect("FlexWrapper always has a widget child");
-        self.view
-            .teardown(view_state, ctx, child.downcast(), app_state);
+        self.view.teardown(view_state, ctx, child.downcast());
     }
 
     fn message(
@@ -707,14 +703,7 @@ impl<State, Action> View<State, Action, ViewCtx> for FlexSpacer {
         }
     }
 
-    fn teardown(
-        &self,
-        _: &mut Self::ViewState,
-        _: &mut ViewCtx,
-        _: Mut<'_, Self::Element>,
-        _: &mut State,
-    ) {
-    }
+    fn teardown(&self, _: &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Self::Element>) {}
 
     fn message(
         &self,
@@ -846,7 +835,6 @@ where
                             parent: element.parent.reborrow_mut(),
                             idx: element.idx,
                         },
-                        app_state,
                     );
                 });
                 widgets::Flex::remove_child(&mut element.parent, element.idx);
@@ -880,7 +868,6 @@ where
                         parent: element.parent.reborrow_mut(),
                         idx: element.idx,
                     },
-                    &mut (),
                 );
                 widgets::Flex::remove_child(&mut element.parent, element.idx);
 
@@ -908,14 +895,13 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         match self {
             Self::Item(flex_item) => {
-                flex_item.teardown(view_state.inner.as_mut().unwrap(), ctx, element, app_state);
+                flex_item.teardown(view_state.inner.as_mut().unwrap(), ctx, element);
             }
             Self::Spacer(spacer) => {
-                View::<(), (), ViewCtx>::teardown(spacer, &mut (), ctx, element, &mut ());
+                View::<(), (), ViewCtx>::teardown(spacer, &mut (), ctx, element);
             }
         }
     }

--- a/xilem/src/view/grid.rs
+++ b/xilem/src/view/grid.rs
@@ -188,11 +188,9 @@ where
         GridState { seq_state, scratch }: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         let mut splice = GridSplice::new(element, scratch);
-        self.sequence
-            .seq_teardown(seq_state, ctx, &mut splice, app_state);
+        self.sequence.seq_teardown(seq_state, ctx, &mut splice);
         debug_assert!(scratch.is_empty());
     }
 
@@ -497,11 +495,9 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         let mut child = widgets::Grid::child_mut(&mut element.parent, element.idx);
-        self.view
-            .teardown(view_state, ctx, child.downcast(), app_state);
+        self.view.teardown(view_state, ctx, child.downcast());
     }
 
     fn message(

--- a/xilem/src/view/image.rs
+++ b/xilem/src/view/image.rs
@@ -90,14 +90,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Image {
         }
     }
 
-    fn teardown(
-        &self,
-        (): &mut Self::ViewState,
-        _: &mut ViewCtx,
-        _: Mut<'_, Self::Element>,
-        _: &mut State,
-    ) {
-    }
+    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Self::Element>) {}
 
     fn message(
         &self,

--- a/xilem/src/view/indexed_stack.rs
+++ b/xilem/src/view/indexed_stack.rs
@@ -185,11 +185,9 @@ where
         IndexedStackState { seq_state, scratch }: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         let mut splice = IndexedStackSplice::new(element, scratch);
-        self.sequence
-            .seq_teardown(seq_state, ctx, &mut splice, app_state);
+        self.sequence.seq_teardown(seq_state, ctx, &mut splice);
         debug_assert!(scratch.is_empty());
     }
 

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -151,14 +151,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
         }
     }
 
-    fn teardown(
-        &self,
-        (): &mut Self::ViewState,
-        _: &mut ViewCtx,
-        _: Mut<'_, Self::Element>,
-        _: &mut State,
-    ) {
-    }
+    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Self::Element>) {}
 
     fn message(
         &self,

--- a/xilem/src/view/portal.rs
+++ b/xilem/src/view/portal.rs
@@ -64,11 +64,9 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         let child_element = widgets::Portal::child_mut(&mut element);
-        self.child
-            .teardown(view_state, ctx, child_element, app_state);
+        self.child.teardown(view_state, ctx, child_element);
     }
 
     fn message(

--- a/xilem/src/view/progress_bar.rs
+++ b/xilem/src/view/progress_bar.rs
@@ -46,7 +46,6 @@ impl<State, Action> View<State, Action, ViewCtx> for ProgressBar {
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        _: &mut State,
     ) {
         ctx.teardown_leaf(element);
     }

--- a/xilem/src/view/prose.rs
+++ b/xilem/src/view/prose.rs
@@ -175,14 +175,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
         }
     }
 
-    fn teardown(
-        &self,
-        (): &mut Self::ViewState,
-        _: &mut ViewCtx,
-        _: Mut<'_, Self::Element>,
-        _: &mut State,
-    ) {
-    }
+    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Self::Element>) {}
 
     fn message(
         &self,

--- a/xilem/src/view/sized_box.rs
+++ b/xilem/src/view/sized_box.rs
@@ -170,12 +170,10 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         let mut child = widgets::SizedBox::child_mut(&mut element)
             .expect("We only create SizedBox with a child");
-        self.inner
-            .teardown(view_state, ctx, child.downcast(), app_state);
+        self.inner.teardown(view_state, ctx, child.downcast());
     }
 
     fn message(

--- a/xilem/src/view/spinner.rs
+++ b/xilem/src/view/spinner.rs
@@ -86,14 +86,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Spinner {
             .rebuild_properties(&prev.properties, &mut element);
     }
 
-    fn teardown(
-        &self,
-        (): &mut Self::ViewState,
-        _: &mut ViewCtx,
-        _: Mut<'_, Self::Element>,
-        _: &mut State,
-    ) {
-    }
+    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Self::Element>) {}
 
     fn message(
         &self,

--- a/xilem/src/view/split.rs
+++ b/xilem/src/view/split.rs
@@ -255,15 +255,12 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         let child1_element = widgets::Split::child1_mut(&mut element);
-        self.child1
-            .teardown(&mut view_state.0, ctx, child1_element, app_state);
+        self.child1.teardown(&mut view_state.0, ctx, child1_element);
 
         let child2_element = widgets::Split::child2_mut(&mut element);
-        self.child2
-            .teardown(&mut view_state.1, ctx, child2_element, app_state);
+        self.child2.teardown(&mut view_state.1, ctx, child2_element);
     }
 
     fn message(

--- a/xilem/src/view/task.rs
+++ b/xilem/src/view/task.rs
@@ -111,7 +111,6 @@ where
         join_handle: &mut Self::ViewState,
         _: &mut ViewCtx,
         _: Mut<'_, Self::Element>,
-        _: &mut State,
     ) {
         join_handle.abort();
     }

--- a/xilem/src/view/text_input.rs
+++ b/xilem/src/view/text_input.rs
@@ -253,7 +253,6 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for TextInput
         _: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        _: &mut State,
     ) {
         ctx.teardown_leaf(element);
     }

--- a/xilem/src/view/transform.rs
+++ b/xilem/src/view/transform.rs
@@ -144,10 +144,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.child
-            .teardown(&mut view_state.child, ctx, element, app_state);
+        self.child.teardown(&mut view_state.child, ctx, element);
     }
 
     fn message(

--- a/xilem/src/view/variable_label.rs
+++ b/xilem/src/view/variable_label.rs
@@ -134,7 +134,6 @@ impl<State, Action> View<State, Action, ViewCtx> for VariableLabel {
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         ctx.with_id(ViewId::new(0), |ctx| {
             View::<State, Action, _>::teardown(
@@ -142,7 +141,6 @@ impl<State, Action> View<State, Action, ViewCtx> for VariableLabel {
                 &mut (),
                 ctx,
                 widgets::VariableLabel::label_mut(&mut element),
-                app_state,
             );
         });
     }

--- a/xilem/src/view/virtual_scroll.rs
+++ b/xilem/src/view/virtual_scroll.rs
@@ -178,7 +178,6 @@ where
                             &mut child_state.state,
                             ctx,
                             widgets::VirtualScroll::child_mut(&mut element, idx).downcast(),
-                            app_state,
                         );
                         widgets::VirtualScroll::remove_child(&mut element, idx);
                     });
@@ -252,7 +251,6 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         for (&idx, child) in &mut view_state.children {
             ctx.with_id(view_id_for_index(idx), |ctx| {
@@ -260,7 +258,6 @@ where
                     &mut child.state,
                     ctx,
                     widgets::VirtualScroll::child_mut(&mut element, idx).downcast(),
-                    app_state,
                 );
             });
         }

--- a/xilem/src/view/worker.rs
+++ b/xilem/src/view/worker.rs
@@ -207,13 +207,7 @@ where
     ) {
     }
 
-    fn teardown(
-        &self,
-        handle: &mut Self::ViewState,
-        _: &mut ViewCtx,
-        _: Mut<'_, Self::Element>,
-        _: &mut State,
-    ) {
+    fn teardown(&self, handle: &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Self::Element>) {
         handle.abort();
     }
 

--- a/xilem/src/view/zstack.rs
+++ b/xilem/src/view/zstack.rs
@@ -124,11 +124,9 @@ where
         ZStackState { seq_state, scratch }: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         let mut splice = ZStackSplice::new(element, scratch);
-        self.sequence
-            .seq_teardown(seq_state, ctx, &mut splice, app_state);
+        self.sequence.seq_teardown(seq_state, ctx, &mut splice);
         debug_assert!(scratch.is_empty());
     }
 
@@ -238,12 +236,10 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         let mut child = widgets::ZStack::child_mut(&mut element.parent, element.idx)
             .expect("ZStackWrapper always has a widget child");
-        self.view
-            .teardown(view_state, ctx, child.downcast(), app_state);
+        self.view.teardown(view_state, ctx, child.downcast());
     }
 
     fn message(

--- a/xilem/src/window_view.rs
+++ b/xilem/src/window_view.rs
@@ -69,11 +69,10 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         (_, render_root): Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         render_root.edit_root_widget(|mut root| {
             self.root_widget_view
-                .teardown(view_state, ctx, root.downcast(), app_state);
+                .teardown(view_state, ctx, root.downcast());
         });
     }
 

--- a/xilem_core/examples/filesystem.rs
+++ b/xilem_core/examples/filesystem.rs
@@ -192,7 +192,6 @@ impl<State, Action> View<State, Action, ViewCtx> for File {
         _view_state: &mut Self::ViewState,
         _ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        _app_state: &mut State,
     ) {
         let _ = std::fs::remove_file(element);
     }

--- a/xilem_core/examples/user_interface.rs
+++ b/xilem_core/examples/user_interface.rs
@@ -84,7 +84,6 @@ impl<State, Action> View<State, Action, ViewCtx> for Button {
         _view_state: &mut Self::ViewState,
         _ctx: &mut ViewCtx,
         _element: Mut<'_, Self::Element>,
-        _app_state: &mut State,
     ) {
         // Nothing to do
     }

--- a/xilem_core/src/any_view.rs
+++ b/xilem_core/src/any_view.rs
@@ -51,7 +51,6 @@ pub trait AnyView<State, Action, Context, Element: ViewElement> {
         dyn_state: &mut AnyViewState,
         ctx: &mut Context,
         element: Element::Mut<'el>,
-        app_state: &mut State,
     ) -> Element::Mut<'el>;
 
     /// Type erased [`View::message`].
@@ -117,7 +116,7 @@ where
             // Otherwise, teardown the old element, then replace the value
             // Note that we need to use `dyn_teardown` here, because `prev`
             // is of a different type.
-            element = prev.dyn_teardown(dyn_state, ctx, element, app_state);
+            element = prev.dyn_teardown(dyn_state, ctx, element);
 
             // Increase the generation, because the underlying widget has been swapped out.
             // Overflow condition: Impossible to overflow, as u64 only ever incremented by 1
@@ -135,7 +134,6 @@ where
         dyn_state: &mut AnyViewState,
         ctx: &mut Context,
         element: DynamicElement::Mut<'el>,
-        app_state: &mut State,
     ) -> DynamicElement::Mut<'el> {
         let state = dyn_state
             .inner_state
@@ -145,7 +143,7 @@ where
         // We only need to teardown the inner value - there's no other state to cleanup in this widget
         DynamicElement::with_downcast(element, |element| {
             ctx.with_id(ViewId::new(dyn_state.generation), |ctx| {
-                self.teardown(state, ctx, element, app_state);
+                self.teardown(state, ctx, element);
             });
         })
     }
@@ -219,9 +217,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.dyn_teardown(view_state, ctx, element, app_state);
+        self.dyn_teardown(view_state, ctx, element);
     }
 
     fn message(
@@ -274,9 +271,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.dyn_teardown(view_state, ctx, element, app_state);
+        self.dyn_teardown(view_state, ctx, element);
     }
 
     fn message(
@@ -327,9 +323,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.dyn_teardown(view_state, ctx, element, app_state);
+        self.dyn_teardown(view_state, ctx, element);
     }
 
     fn message(
@@ -380,9 +375,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.dyn_teardown(view_state, ctx, element, app_state);
+        self.dyn_teardown(view_state, ctx, element);
     }
 
     fn message(

--- a/xilem_core/src/environment.rs
+++ b/xilem_core/src/environment.rs
@@ -291,7 +291,6 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Ctx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         // Make our value available in the child teardown.
         let env = ctx.environment();
@@ -299,7 +298,7 @@ where
         core::mem::swap(&mut slot.item, &mut view_state.this_state);
 
         self.child
-            .teardown(&mut view_state.child_state, ctx, element, app_state);
+            .teardown(&mut view_state.child_state, ctx, element);
 
         let env = ctx.environment();
         let slot = &mut env.slots[usize::try_from(view_state.environment_slot).unwrap()];
@@ -543,7 +542,6 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Ctx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         if let Some(_listener_idx) = view_state.listener_index {
             // TODO: Potentially garbage collect the listener.
@@ -554,7 +552,7 @@ where
             // TODO: We will probably want some access to the context in teardown at some point.
             view_state
                 .prev
-                .teardown(&mut view_state.child_state, ctx, element, app_state);
+                .teardown(&mut view_state.child_state, ctx, element);
         });
     }
 
@@ -692,10 +690,9 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         self.child
-            .teardown(&mut view_state.child_state, ctx, element, app_state);
+            .teardown(&mut view_state.child_state, ctx, element);
     }
 
     fn message(

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -96,11 +96,6 @@ pub trait View<State, Action, Context: ViewPathTracker>: ViewMarker + 'static {
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        // TODO: If the app state no longer exists (e.g. if we're a view over some data, and
-        // that data has been removed) what do we do?
-        // There is potential value in the app state still being available, but maybe
-        // those use cases should migrate to the environment?
-        app_state: &mut State,
     );
 
     /// Route `message` to `id_path`, if that is still a valid path.
@@ -201,9 +196,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.deref().teardown(view_state, ctx, element, app_state);
+        self.deref().teardown(view_state, ctx, element);
     }
 
     fn message(
@@ -270,10 +264,9 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         self.deref()
-            .teardown(&mut view_state.view_state, ctx, element, app_state);
+            .teardown(&mut view_state.view_state, ctx, element);
     }
 
     fn message(
@@ -334,10 +327,9 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         self.deref()
-            .teardown(&mut view_state.view_state, ctx, element, app_state);
+            .teardown(&mut view_state.view_state, ctx, element);
     }
 
     fn message(

--- a/xilem_core/src/views/fork.rs
+++ b/xilem_core/src/views/fork.rs
@@ -77,15 +77,13 @@ where
         (active_state, alongside_state): &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         ctx.with_id(ViewId::new(0), |ctx| {
             self.alongside_view
-                .seq_teardown(alongside_state, ctx, &mut NoElements, app_state);
+                .seq_teardown(alongside_state, ctx, &mut NoElements);
         });
         ctx.with_id(ViewId::new(1), |ctx| {
-            self.active_view
-                .teardown(active_state, ctx, element, app_state);
+            self.active_view.teardown(active_state, ctx, element);
         });
     }
 

--- a/xilem_core/src/views/lens.rs
+++ b/xilem_core/src/views/lens.rs
@@ -135,10 +135,8 @@ where
         (child, child_view_state): &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        app_state: &mut ParentState,
     ) {
-        let child_state = (self.access_state)(app_state);
-        child.teardown(child_view_state, ctx, element, child_state);
+        child.teardown(child_view_state, ctx, element);
     }
 
     fn message(

--- a/xilem_core/src/views/map_message.rs
+++ b/xilem_core/src/views/map_message.rs
@@ -152,9 +152,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.child.teardown(view_state, ctx, element, app_state);
+        self.child.teardown(view_state, ctx, element);
     }
 
     fn message(

--- a/xilem_core/src/views/map_state.rs
+++ b/xilem_core/src/views/map_state.rs
@@ -120,10 +120,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        app_state: &mut ParentState,
     ) {
-        self.child
-            .teardown(view_state, ctx, element, (self.map_state)(app_state));
+        self.child.teardown(view_state, ctx, element);
     }
 
     fn message(

--- a/xilem_core/src/views/memoize.rs
+++ b/xilem_core/src/views/memoize.rs
@@ -153,11 +153,10 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         view_state
             .view
-            .teardown(&mut view_state.view_state, ctx, element, app_state);
+            .teardown(&mut view_state.view_state, ctx, element);
     }
 }
 
@@ -255,11 +254,10 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         view_state
             .view
-            .teardown(&mut view_state.view_state, ctx, element, app_state);
+            .teardown(&mut view_state.view_state, ctx, element);
     }
 
     fn message(

--- a/xilem_core/src/views/one_of.rs
+++ b/xilem_core/src/views/one_of.rs
@@ -395,47 +395,47 @@ where
         ctx.with_id(id, |ctx| match (prev, &mut view_state.inner_state) {
             (Self::A(prev), OneOf::A(state)) => {
                 Context::with_downcast_a(&mut element, |element| {
-                    prev.teardown(state, ctx, element, app_state);
+                    prev.teardown(state, ctx, element);
                 });
             }
             (Self::B(prev), OneOf::B(state)) => {
                 Context::with_downcast_b(&mut element, |element| {
-                    prev.teardown(state, ctx, element, app_state);
+                    prev.teardown(state, ctx, element);
                 });
             }
             (Self::C(prev), OneOf::C(state)) => {
                 Context::with_downcast_c(&mut element, |element| {
-                    prev.teardown(state, ctx, element, app_state);
+                    prev.teardown(state, ctx, element);
                 });
             }
             (Self::D(prev), OneOf::D(state)) => {
                 Context::with_downcast_d(&mut element, |element| {
-                    prev.teardown(state, ctx, element, app_state);
+                    prev.teardown(state, ctx, element);
                 });
             }
             (Self::E(prev), OneOf::E(state)) => {
                 Context::with_downcast_e(&mut element, |element| {
-                    prev.teardown(state, ctx, element, app_state);
+                    prev.teardown(state, ctx, element);
                 });
             }
             (Self::F(prev), OneOf::F(state)) => {
                 Context::with_downcast_f(&mut element, |element| {
-                    prev.teardown(state, ctx, element, app_state);
+                    prev.teardown(state, ctx, element);
                 });
             }
             (Self::G(prev), OneOf::G(state)) => {
                 Context::with_downcast_g(&mut element, |element| {
-                    prev.teardown(state, ctx, element, app_state);
+                    prev.teardown(state, ctx, element);
                 });
             }
             (Self::H(prev), OneOf::H(state)) => {
                 Context::with_downcast_h(&mut element, |element| {
-                    prev.teardown(state, ctx, element, app_state);
+                    prev.teardown(state, ctx, element);
                 });
             }
             (Self::I(prev), OneOf::I(state)) => {
                 Context::with_downcast_i(&mut element, |element| {
-                    prev.teardown(state, ctx, element, app_state);
+                    prev.teardown(state, ctx, element);
                 });
             }
             _ => unreachable!(),
@@ -495,53 +495,52 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
         mut element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         ctx.with_id(ViewId::new(view_state.generation), |ctx| {
             match (self, &mut view_state.inner_state) {
                 (Self::A(v), OneOf::A(state)) => {
                     Context::with_downcast_a(&mut element, |element| {
-                        v.teardown(state, ctx, element, app_state);
+                        v.teardown(state, ctx, element);
                     });
                 }
                 (Self::B(v), OneOf::B(state)) => {
                     Context::with_downcast_b(&mut element, |element| {
-                        v.teardown(state, ctx, element, app_state);
+                        v.teardown(state, ctx, element);
                     });
                 }
                 (Self::C(v), OneOf::C(state)) => {
                     Context::with_downcast_c(&mut element, |element| {
-                        v.teardown(state, ctx, element, app_state);
+                        v.teardown(state, ctx, element);
                     });
                 }
                 (Self::D(v), OneOf::D(state)) => {
                     Context::with_downcast_d(&mut element, |element| {
-                        v.teardown(state, ctx, element, app_state);
+                        v.teardown(state, ctx, element);
                     });
                 }
                 (Self::E(v), OneOf::E(state)) => {
                     Context::with_downcast_e(&mut element, |element| {
-                        v.teardown(state, ctx, element, app_state);
+                        v.teardown(state, ctx, element);
                     });
                 }
                 (Self::F(v), OneOf::F(state)) => {
                     Context::with_downcast_f(&mut element, |element| {
-                        v.teardown(state, ctx, element, app_state);
+                        v.teardown(state, ctx, element);
                     });
                 }
                 (Self::G(v), OneOf::G(state)) => {
                     Context::with_downcast_g(&mut element, |element| {
-                        v.teardown(state, ctx, element, app_state);
+                        v.teardown(state, ctx, element);
                     });
                 }
                 (Self::H(v), OneOf::H(state)) => {
                     Context::with_downcast_h(&mut element, |element| {
-                        v.teardown(state, ctx, element, app_state);
+                        v.teardown(state, ctx, element);
                     });
                 }
                 (Self::I(v), OneOf::I(state)) => {
                     Context::with_downcast_i(&mut element, |element| {
-                        v.teardown(state, ctx, element, app_state);
+                        v.teardown(state, ctx, element);
                     });
                 }
                 _ => unreachable!(),
@@ -633,7 +632,6 @@ mod hidden {
             _: &mut Self::ViewState,
             _: &mut Context,
             _: crate::Mut<'_, Self::Element>,
-            _: &mut State,
         ) {
             match *self {}
         }

--- a/xilem_core/src/views/orphan.rs
+++ b/xilem_core/src/views/orphan.rs
@@ -35,7 +35,6 @@ pub trait OrphanView<V, State, Action>: ViewPathTracker + Sized {
         view_state: &mut Self::OrphanViewState,
         ctx: &mut Self,
         element: Mut<'_, Self::OrphanElement>,
-        app_state: &mut State,
     );
 
     /// See [`View::message`]
@@ -84,9 +83,8 @@ macro_rules! impl_orphan_view_for {
                 view_state: &mut Self::ViewState,
                 ctx: &mut Context,
                 element: Mut<'_, Self::Element>,
-                app_state: &mut State,
             ) {
-                Context::orphan_teardown(self, view_state, ctx, element, app_state);
+                Context::orphan_teardown(self, view_state, ctx, element);
             }
 
             fn message(

--- a/xilem_core/src/views/run_once.rs
+++ b/xilem_core/src/views/run_once.rs
@@ -109,13 +109,7 @@ where
         // Nothing to do
     }
 
-    fn teardown(
-        &self,
-        (): &mut Self::ViewState,
-        _: &mut Context,
-        _: Mut<'_, Self::Element>,
-        _: &mut State,
-    ) {
+    fn teardown(&self, (): &mut Self::ViewState, _: &mut Context, _: Mut<'_, Self::Element>) {
         // Nothing to do
     }
 

--- a/xilem_core/tests/arc.rs
+++ b/xilem_core/tests/arc.rs
@@ -87,7 +87,7 @@ fn arc_passthrough_teardown() {
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
-    view1.teardown(&mut state, &mut ctx, &mut element, &mut ());
+    view1.teardown(&mut state, &mut ctx, &mut element);
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -164,7 +164,7 @@ fn box_passthrough_teardown() {
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
-    view1.teardown(&mut state, &mut ctx, &mut element, &mut ());
+    view1.teardown(&mut state, &mut ctx, &mut element);
     ctx.assert_empty();
     assert_eq!(
         element.operations,

--- a/xilem_core/tests/array_sequence.rs
+++ b/xilem_core/tests/array_sequence.rs
@@ -53,7 +53,7 @@ fn two_element_passthrough() {
         &[Operation::Build(1), Operation::Rebuild { from: 1, to: 4 }]
     );
 
-    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
+    view2.teardown(&mut state, &mut ctx, &mut element);
     assert_eq!(
         element.operations,
         &[

--- a/xilem_core/tests/base_sequence.rs
+++ b/xilem_core/tests/base_sequence.rs
@@ -57,7 +57,7 @@ fn one_element_sequence_passthrough() {
         assert_action(result, 2);
     });
 
-    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
+    view2.teardown(&mut state, &mut ctx, &mut element);
     assert_eq!(
         element.operations,
         &[
@@ -108,7 +108,7 @@ fn option_none_none() {
     assert!(seq_children.deleted.is_empty());
     assert!(seq_children.active.is_empty());
 
-    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
+    view2.teardown(&mut state, &mut ctx, &mut element);
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -158,7 +158,7 @@ fn option_some_some() {
         &[Operation::Build(0), Operation::Rebuild { from: 0, to: 2 }]
     );
 
-    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
+    view2.teardown(&mut state, &mut ctx, &mut element);
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -211,7 +211,7 @@ fn option_none_some() {
     let child = seq_children.active.first().unwrap();
     assert_eq!(child.operations, &[Operation::Build(1)]);
 
-    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
+    view2.teardown(&mut state, &mut ctx, &mut element);
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -268,7 +268,7 @@ fn option_some_none() {
         &[Operation::Build(0), Operation::Teardown(0)]
     );
 
-    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
+    view2.teardown(&mut state, &mut ctx, &mut element);
     ctx.assert_empty();
     assert_eq!(
         element.operations,

--- a/xilem_core/tests/common/mod.rs
+++ b/xilem_core/tests/common/mod.rs
@@ -148,7 +148,6 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut TestCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut (),
     ) {
         assert_eq!(&*element.view_path, ctx.view_path());
         element.operations.push(Operation::Teardown(self.id));
@@ -157,8 +156,7 @@ where
             ix: 0,
             scratch: &mut view_state.1,
         };
-        self.seq
-            .seq_teardown(&mut view_state.0, ctx, &mut elements, app_state);
+        self.seq.seq_teardown(&mut view_state.0, ctx, &mut elements);
     }
 
     fn message(
@@ -215,7 +213,6 @@ impl<const N: u32> View<(), Action, TestCtx> for OperationView<N> {
         _: &mut Self::ViewState,
         ctx: &mut TestCtx,
         element: Mut<'_, Self::Element>,
-        (): &mut (),
     ) {
         assert_eq!(&*element.view_path, ctx.view_path());
         element.operations.push(Operation::Teardown(self.0));

--- a/xilem_core/tests/one_of.rs
+++ b/xilem_core/tests/one_of.rs
@@ -214,7 +214,7 @@ fn one_of_passthrough_teardown() {
     ctx.assert_empty();
     assert_eq!(element.operations, &[Operation::Build(0)]);
 
-    view1.teardown(&mut state, &mut ctx, &mut element, &mut ());
+    view1.teardown(&mut state, &mut ctx, &mut element);
     ctx.assert_empty();
     assert_eq!(element.view_path[0], ViewId::new(0));
     assert_eq!(

--- a/xilem_core/tests/orphan.rs
+++ b/xilem_core/tests/orphan.rs
@@ -63,7 +63,6 @@ impl<State, Action> OrphanView<&'static str, State, Action> for TestCtx {
         generation: &mut Self::OrphanViewState,
         _ctx: &mut Self,
         element: Mut<'_, Self::OrphanElement>,
-        _app_state: &mut State,
     ) {
         element.operations.push(Operation::Teardown(*generation));
     }
@@ -96,6 +95,6 @@ fn str_as_orphan_view() {
         &mut (),
     );
     assert_eq!(element.operations[1], Operation::Rebuild { from: 0, to: 1 });
-    View::<(), (), TestCtx>::teardown(&view1, &mut generation, &mut ctx, &mut element, &mut ());
+    View::<(), (), TestCtx>::teardown(&view1, &mut generation, &mut ctx, &mut element);
     assert_eq!(element.operations[2], Operation::Teardown(1));
 }

--- a/xilem_core/tests/tuple_sequence.rs
+++ b/xilem_core/tests/tuple_sequence.rs
@@ -64,7 +64,7 @@ fn one_element_passthrough() {
         assert_action(result, 2);
     });
 
-    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
+    view2.teardown(&mut state, &mut ctx, &mut element);
     assert_eq!(
         element.operations,
         &[
@@ -132,7 +132,7 @@ fn two_element_passthrough() {
         &[Operation::Build(1), Operation::Rebuild { from: 1, to: 4 }]
     );
 
-    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
+    view2.teardown(&mut state, &mut ctx, &mut element);
     assert_eq!(
         element.operations,
         &[

--- a/xilem_core/tests/vec_sequence.rs
+++ b/xilem_core/tests/vec_sequence.rs
@@ -36,7 +36,7 @@ fn zero_zero() {
     assert!(seq_children.deleted.is_empty());
     assert!(seq_children.active.is_empty());
 
-    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
+    view2.teardown(&mut state, &mut ctx, &mut element);
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -86,7 +86,7 @@ fn one_zero() {
         &[Operation::Build(0), Operation::Teardown(0)]
     );
 
-    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
+    view2.teardown(&mut state, &mut ctx, &mut element);
     ctx.assert_empty();
     assert_eq!(
         element.operations,
@@ -145,7 +145,7 @@ fn one_two() {
     assert_eq!(second_child.operations, &[Operation::Build(3)]);
     assert_eq!(second_child.view_path.len(), 1);
 
-    view2.teardown(&mut state, &mut ctx, &mut element, &mut ());
+    view2.teardown(&mut state, &mut ctx, &mut element);
     ctx.assert_empty();
     assert_eq!(
         element.operations,

--- a/xilem_web/src/after_update.rs
+++ b/xilem_web/src/after_update.rs
@@ -140,9 +140,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         el: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.element.teardown(view_state, ctx, el, app_state);
+        self.element.teardown(view_state, ctx, el);
     }
 
     fn message(
@@ -196,9 +195,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         el: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.element.teardown(view_state, ctx, el, app_state);
+        self.element.teardown(view_state, ctx, el);
     }
 
     fn message(
@@ -245,10 +243,9 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         el: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         (self.callback)(el.node);
-        self.element.teardown(view_state, ctx, el, app_state);
+        self.element.teardown(view_state, ctx, el);
     }
 
     fn message(

--- a/xilem_web/src/concurrent/interval.rs
+++ b/xilem_web/src/concurrent/interval.rs
@@ -132,7 +132,6 @@ where
         view_state: &mut Self::ViewState,
         _: &mut ViewCtx,
         _: Mut<'_, Self::Element>,
-        _: &mut State,
     ) {
         clear_interval(view_state.interval_handle);
     }

--- a/xilem_web/src/concurrent/memoized_await.rs
+++ b/xilem_web/src/concurrent/memoized_await.rs
@@ -234,13 +234,7 @@ where
         }
     }
 
-    fn teardown(
-        &self,
-        state: &mut Self::ViewState,
-        _: &mut ViewCtx,
-        (): Mut<'_, Self::Element>,
-        _: &mut State,
-    ) {
+    fn teardown(&self, state: &mut Self::ViewState, _: &mut ViewCtx, (): Mut<'_, Self::Element>) {
         state.clear_update_timeout();
     }
 

--- a/xilem_web/src/concurrent/task.rs
+++ b/xilem_web/src/concurrent/task.rs
@@ -173,7 +173,6 @@ where
         view_state: &mut Self::ViewState,
         _: &mut ViewCtx,
         _: Mut<'_, Self::Element>,
-        _: &mut State,
     ) {
         let handle = view_state.abort_handle.take().unwrap_throw();
         handle.abort();

--- a/xilem_web/src/elements.rs
+++ b/xilem_web/src/elements.rs
@@ -47,7 +47,6 @@ pub(crate) trait DomViewSequence<State, Action>: 'static {
         seq_state: &mut Box<dyn Any>,
         ctx: &mut ViewCtx,
         elements: &mut DomChildrenSplice<'_, '_, '_, '_>,
-        app_state: &mut State,
     );
 
     /// Propagate a message.
@@ -104,14 +103,8 @@ where
         seq_state: &mut Box<dyn Any>,
         ctx: &mut ViewCtx,
         elements: &mut DomChildrenSplice<'_, '_, '_, '_>,
-        app_state: &mut State,
     ) {
-        self.seq_teardown(
-            seq_state.downcast_mut().unwrap_throw(),
-            ctx,
-            elements,
-            app_state,
-        );
+        self.seq_teardown(seq_state.downcast_mut().unwrap_throw(), ctx, elements);
     }
 
     fn dyn_seq_message(
@@ -313,7 +306,6 @@ pub(crate) fn teardown_element<State, Action, Element>(
     element: Mut<'_, Pod<Element>>,
     state: &mut ElementState,
     ctx: &mut ViewCtx,
-    app_state: &mut State,
 ) where
     State: 'static,
     Action: 'static,
@@ -329,12 +321,7 @@ pub(crate) fn teardown_element<State, Action, Element>(
         true,
         ctx.is_hydrating(),
     );
-    children.dyn_seq_teardown(
-        &mut state.seq_state,
-        ctx,
-        &mut dom_children_splice,
-        app_state,
-    );
+    children.dyn_seq_teardown(&mut state.seq_state, ctx, &mut dom_children_splice);
 }
 
 pub(crate) fn message_element<State, Action, Element>(
@@ -448,9 +435,8 @@ where
         element_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        teardown_element(&*self.children, element, element_state, ctx, app_state);
+        teardown_element(&*self.children, element, element_state, ctx);
     }
 
     fn message(
@@ -529,9 +515,8 @@ macro_rules! define_element {
                 element_state: &mut Self::ViewState,
                 ctx: &mut ViewCtx,
                 element: Mut<'_, Self::Element>,
-                app_state: &mut State,
             ) {
-                teardown_element(&*self.children, element, element_state, ctx, app_state);
+                teardown_element(&*self.children, element, element_state, ctx);
             }
 
             fn message(

--- a/xilem_web/src/events.rs
+++ b/xilem_web/src/events.rs
@@ -200,7 +200,6 @@ fn teardown_event_listener<State, Action, V>(
     state: &mut OnEventState<V::ViewState>,
     _capture: bool,
     ctx: &mut ViewCtx,
-    app_state: &mut State,
 ) where
     State: 'static,
     Action: 'static,
@@ -209,7 +208,7 @@ fn teardown_event_listener<State, Action, V>(
     // TODO: is this really needed (as the element will be removed anyway)?
     // remove_event_listener(element.as_ref(), event, &state.callback, capture);
     ctx.with_id(ON_EVENT_VIEW_ID, |ctx| {
-        element_view.teardown(&mut state.child_state, ctx, element, app_state);
+        element_view.teardown(&mut state.child_state, ctx, element);
     });
 }
 
@@ -322,7 +321,6 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         teardown_event_listener(
             &self.dom_view,
@@ -331,7 +329,6 @@ where
             view_state,
             self.capture,
             ctx,
-            app_state,
         );
     }
 
@@ -452,9 +449,8 @@ macro_rules! event_definitions {
                 view_state: &mut Self::ViewState,
                 ctx: &mut ViewCtx,
                 element: Mut<'_, Self::Element>,
-                app_state: &mut State
             ) {
-                teardown_event_listener(&self.dom_view, element, $event_name, view_state, self.capture, ctx, app_state);
+                teardown_event_listener(&self.dom_view, element, $event_name, view_state, self.capture, ctx);
             }
 
             fn message(
@@ -635,12 +631,11 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         ctx.with_id(ON_EVENT_VIEW_ID, |ctx| {
             view_state.observer.disconnect();
             self.dom_view
-                .teardown(&mut view_state.child_state, ctx, element, app_state);
+                .teardown(&mut view_state.child_state, ctx, element);
         });
     }
 

--- a/xilem_web/src/modifiers/attribute.rs
+++ b/xilem_web/src/modifiers/attribute.rs
@@ -341,9 +341,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.inner.teardown(view_state, ctx, element, app_state);
+        self.inner.teardown(view_state, ctx, element);
     }
 
     fn message(

--- a/xilem_web/src/modifiers/class.rs
+++ b/xilem_web/src/modifiers/class.rs
@@ -379,9 +379,8 @@ where
         (_, view_state): &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.el.teardown(view_state, ctx, element, app_state);
+        self.el.teardown(view_state, ctx, element);
     }
 
     fn message(

--- a/xilem_web/src/modifiers/overwrite.rs
+++ b/xilem_web/src/modifiers/overwrite.rs
@@ -232,9 +232,8 @@ macro_rules! overwrite_bool_modifier_view {
                 view_state: &mut Self::ViewState,
                 ctx: &mut $crate::ViewCtx,
                 element: $crate::core::Mut<'_, Self::Element>,
-                app_state: &mut State,
             ) {
-                self.inner.teardown(view_state, ctx, element, app_state);
+                self.inner.teardown(view_state, ctx, element);
             }
 
             fn message(

--- a/xilem_web/src/modifiers/style.rs
+++ b/xilem_web/src/modifiers/style.rs
@@ -500,9 +500,8 @@ where
         (_, view_state): &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.el.teardown(view_state, ctx, element, app_state);
+        self.el.teardown(view_state, ctx, element);
     }
 
     fn message(
@@ -596,9 +595,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.el.teardown(view_state, ctx, element, app_state);
+        self.el.teardown(view_state, ctx, element);
     }
 
     fn message(
@@ -722,9 +720,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.el.teardown(view_state, ctx, element, app_state);
+        self.el.teardown(view_state, ctx, element);
     }
 
     fn message(

--- a/xilem_web/src/pointer.rs
+++ b/xilem_web/src/pointer.rs
@@ -189,12 +189,11 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
         ctx.with_id(POINTER_VIEW_ID, |ctx| {
             // TODO remove event listeners from child or is this not necessary?
             self.child
-                .teardown(&mut view_state.child_state, ctx, element, app_state);
+                .teardown(&mut view_state.child_state, ctx, element);
         });
     }
 

--- a/xilem_web/src/svg/common_attrs.rs
+++ b/xilem_web/src/svg/common_attrs.rs
@@ -158,9 +158,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.child.teardown(view_state, ctx, element, app_state);
+        self.child.teardown(view_state, ctx, element);
     }
 
     fn message(
@@ -287,9 +286,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.child.teardown(view_state, ctx, element, app_state);
+        self.child.teardown(view_state, ctx, element);
     }
 
     fn message(

--- a/xilem_web/src/svg/kurbo_shape.rs
+++ b/xilem_web/src/svg/kurbo_shape.rs
@@ -67,7 +67,6 @@ impl<State: 'static, Action: 'static> OrphanView<Line, State, Action> for ViewCt
         (): &mut Self::OrphanViewState,
         _ctx: &mut Self,
         _element: Mut<'_, Self::OrphanElement>,
-        _: &mut State,
     ) {
     }
 
@@ -125,7 +124,6 @@ impl<State: 'static, Action: 'static> OrphanView<Rect, State, Action> for ViewCt
         (): &mut Self::OrphanViewState,
         _ctx: &mut Self,
         _element: Mut<'_, Self::OrphanElement>,
-        _: &mut State,
     ) {
     }
 
@@ -180,7 +178,6 @@ impl<State: 'static, Action: 'static> OrphanView<Circle, State, Action> for View
         (): &mut Self::OrphanViewState,
         _ctx: &mut Self,
         _element: Mut<'_, Self::OrphanElement>,
-        _: &mut State,
     ) {
     }
 
@@ -237,7 +234,6 @@ impl<State: 'static, Action: 'static> OrphanView<BezPath, State, Action> for Vie
         _view_state: &mut Self::OrphanViewState,
         _ctx: &mut Self,
         _element: Mut<'_, Self::OrphanElement>,
-        _: &mut State,
     ) {
     }
 

--- a/xilem_web/src/templated.rs
+++ b/xilem_web/src/templated.rs
@@ -69,9 +69,8 @@ where
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
         element: Mut<'_, Self::Element>,
-        app_state: &mut State,
     ) {
-        self.0.teardown(view_state, ctx, element, app_state);
+        self.0.teardown(view_state, ctx, element);
     }
 
     fn message(

--- a/xilem_web/src/text.rs
+++ b/xilem_web/src/text.rs
@@ -45,7 +45,6 @@ macro_rules! impl_string_view {
                 _view_state: &mut Self::OrphanViewState,
                 _ctx: &mut ViewCtx,
                 _element: Mut<'_, Self::OrphanElement>,
-                _: &mut State,
             ) {
             }
 
@@ -105,7 +104,6 @@ macro_rules! impl_to_string_view {
                 _view_state: &mut Self::OrphanViewState,
                 _ctx: &mut ViewCtx,
                 _element: Mut<'_, Pod<web_sys::Text>>,
-                _: &mut State,
             ) {
             }
 


### PR DESCRIPTION
Per the discussion in https://xi.zulipchat.com/#narrow/channel/354396-xilem/topic/Incoherent.20state.20issues, the consensus seems to be to remove the `app_state` parameter from the teardown functions since the state may no longer exist or be valid at that point.