### PR TITLE
Masonry: Give driver control over the Checkbox state

### DIFF
--- a/masonry/screenshots/checkbox_hello_hovered.png
+++ b/masonry/screenshots/checkbox_hello_hovered.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26673b4a335dd9a02880d5ed11bc1bb1c92aa1cc548e36fbffe75b25afd03b5a
+size 605

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -29,7 +29,13 @@ use crate::widgets::Label;
 ///
 #[doc = include_screenshot!("checkbox_hello_checked.png", "Checkbox with checked state.")]
 ///
-/// Emits [`CheckboxToggled`] when toggled.
+/// Emits [`CheckboxToggled`] when it should toggle.
+/// Note that the checked state does not automatically toggle, and so one of
+/// the responses to a `CheckboxToggled` is to call [`Checkbox::set_checked`]
+/// on the originating widget.
+///
+/// This allows higher-level components to choose how the checkbox responds,
+/// and ensure that its value is based on their correct source of truth.
 pub struct Checkbox {
     checked: bool,
     // FIXME - Remove label child, have this widget only be a box with a checkmark.
@@ -76,9 +82,9 @@ impl Checkbox {
     }
 }
 
-/// The action type emitted by [`Checkbox`] when it is toggled.
+/// The action type emitted by [`Checkbox`] when it is activated.
 ///
-/// The field is the toggle state (i.e. true is "checked").
+/// The field is the target toggle state (i.e. true is "this checkbox would like to become checked").
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct CheckboxToggled(pub bool);
 
@@ -95,18 +101,13 @@ impl Widget for Checkbox {
         match event {
             PointerEvent::Down { .. } => {
                 ctx.capture_pointer();
-                // Checked state impacts appearance and accessibility node
-                ctx.request_render();
                 trace!("Checkbox {:?} pressed", ctx.widget_id());
             }
             PointerEvent::Up { .. } => {
                 if ctx.is_active() && ctx.is_hovered() {
-                    self.checked = !self.checked;
-                    ctx.submit_action::<Self::Action>(CheckboxToggled(self.checked));
+                    ctx.submit_action::<Self::Action>(CheckboxToggled(!self.checked));
                     trace!("Checkbox {:?} released", ctx.widget_id());
                 }
-                // Checked state impacts appearance and accessibility node
-                ctx.request_render();
             }
             _ => (),
         }
@@ -121,10 +122,7 @@ impl Widget for Checkbox {
         match event {
             TextEvent::Keyboard(event) if event.state.is_up() => {
                 if matches!(&event.key, Key::Character(c) if c == " ") {
-                    self.checked = !self.checked;
-                    ctx.submit_action::<Self::Action>(CheckboxToggled(self.checked));
-                    // Checked state impacts appearance and accessibility node
-                    ctx.request_render();
+                    ctx.submit_action::<Self::Action>(CheckboxToggled(!self.checked));
                 }
             }
             _ => (),
@@ -144,10 +142,7 @@ impl Widget for Checkbox {
     ) {
         match event.action {
             accesskit::Action::Click => {
-                self.checked = !self.checked;
-                ctx.submit_action::<Self::Action>(CheckboxToggled(self.checked));
-                // Checked state impacts appearance and accessibility node
-                ctx.request_render();
+                ctx.submit_action::<Self::Action>(CheckboxToggled(!self.checked));
             }
             _ => {}
         }
@@ -366,6 +361,10 @@ mod tests {
             harness.pop_action::<CheckboxToggled>(),
             Some((CheckboxToggled(true), checkbox_id))
         );
+
+        assert_render_snapshot!(harness, "checkbox_hello_hovered");
+
+        harness.edit_root_widget(|mut checkbox| Checkbox::set_checked(&mut checkbox, true));
 
         assert_render_snapshot!(harness, "checkbox_hello_checked");
 


### PR DESCRIPTION
This makes things easier for Xilem, as it controls the source of truth for being checked. This operates somewhat similarly to `VirtualScroll`, and also addresses the issues found in https://github.com/linebender/xilem/pull/265.
I think it better reflects Masonry's low-level nature.

Working on this has uncovered another issue, which is that the tests aren't properly updated since #1314.
That PR added a large indicator, even when hovered.
However, those indicators are inflated to draw outside of the widget's area, so aren't captured here.
I don't have the motivation to fix this at the moment, but @tannal if you are willing to that would be great. A similar "flex" approach as in the new test from #1314 would be fine; just applying that to both tests (this should likelyalso use `WidgetTag`).

I'd also like to see a test of checkbox with the Padding property, because I'm not sure the rendering is correct, since `paint` doesn't take it into account. (Either for the focused indicator, or for the "box" position.
I suppose we should open an issue for that?