### PR TITLE
Placehero: fix context of unhandled tags

### DIFF
--- a/placehero/src/html_content.rs
+++ b/placehero/src/html_content.rs
@@ -124,12 +124,11 @@ pub(crate) fn status_html_to_plaintext(content: &str) -> String {
                     }
                 }
                 _ => {
-                    tracing::error!(
-                        tag = format_args!("<{:?}>", start_tag.name),
-                        "Unhandled tag."
-                    );
+                    let tag_value = String::from_utf8_lossy(&start_tag.name);
+                    tracing::error!(tag = format_args!("<{:?}>", tag_value), "Unhandled tag.");
                     tracing::trace!(
-                        status = format_args!("<{:?}>", start_tag.name),
+                        tag = format_args!("<{:?}>", tag_value),
+                        status = content,
                         "Context for unhandled tag."
                     );
                     if !start_tag.self_closing {


### PR DESCRIPTION
The context is meant to show the full status, but I accidentally made it be the same as the prior value.