### PR TITLE
Optimize and fix window resizing.

### DIFF
--- a/masonry/src/tests/update.rs
+++ b/masonry/src/tests/update.rs
@@ -35,8 +35,6 @@ fn app_creation() {
             Record::Update(Update::WidgetAdded),
             Record::Layout(_),
             Record::Compose,
-            Record::Layout(_),
-            Record::Compose,
             Record::AnimFrame(0),
             Record::Paint,
             Record::PostPaint,

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -194,6 +194,9 @@ pub struct RenderRootOptions {
     /// Defines how the window size should be determined.
     pub size_policy: WindowSizePolicy,
 
+    /// The size of the window.
+    pub size: PhysicalSize<u32>,
+
     /// The scale factor to use for rendering.
     ///
     /// Useful for high-DPI displays.
@@ -295,6 +298,7 @@ impl RenderRoot {
             default_properties,
             use_system_fonts,
             size_policy,
+            size,
             scale_factor,
             test_font,
         } = options;
@@ -304,7 +308,7 @@ impl RenderRoot {
             root: root_widget.erased().to_pod(),
             window_node_id: WidgetId::next().into(),
             size_policy,
-            size: PhysicalSize::new(0, 0),
+            size,
             last_mouse_pos: None,
             default_properties,
             global_state: RenderRootState {
@@ -613,6 +617,11 @@ impl RenderRoot {
         self.run_rewrite_passes();
 
         res
+    }
+
+    /// Get the current size of the window.
+    pub fn size(&self) -> PhysicalSize<u32> {
+        self.size
     }
 
     pub(crate) fn get_kurbo_size(&self) -> Size {

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -327,6 +327,7 @@ impl<W: Widget> TestHarness<W> {
                     default_properties: Arc::new(default_props),
                     use_system_fonts: false,
                     size_policy: WindowSizePolicy::User,
+                    size: window_size,
                     scale_factor: params.scale_factor,
                     test_font: Some(data),
                 },
@@ -349,7 +350,6 @@ impl<W: Widget> TestHarness<W> {
         };
 
         // Set up the initial state, and clear invalidation flags.
-        harness.process_window_event(WindowEvent::Resize(window_size));
         harness.process_window_event(WindowEvent::EnableAccessTree);
         harness.animate_ms(0);
 


### PR DESCRIPTION
The Masonry `Window` struct was being created with a `0x0` size and a `1.0` scale factor. Initial layout and render passes ran with that. Then there would be an event for scale change (but still zero size) and another pass. Then there would be a size change event and useful work would finally take place.

This PR removes all that early useless work and creates the `Window` struct immediately with the correct info.

---

A bunch of places would ask Winit for the window size, including the `render` function. At least on Windows this would cause Winit to execute a syscall. That is needless overhead, especially in a hot path, because we already store that info in the `RenderRoot` struct.

This PR exposes that size info.

---

Masonry has been suffering from crashes on Windows 11 whenever a window would be minimized or otherwise resized to zero (#979).

This PR resolves that issue. Fixes #979.

First, I refactored the redraw code so that there is a single source of truth for the behavior. There was already divergence with the first frame not doing the `AnimFrame` event and more issues could easily follow with such a duplicated approach.

The redraw refactoring also introduced on-demand surface creation. This is useful to actually solve the Windows crash issue, as now we can just delete the old surface when a zero sized resize event comes in. Whenever a reasonable size redraw happens, the surface will be recreated.

---

I have tested this as working nicely on Windows 11. Trying out crazy resizings (especially to zero!), minimizing, and suspending on other platforms would be very welcome.