### PR TITLE
masonry: Refactor local transform as `Property`

### DIFF
--- a/masonry/examples/calc_masonry.rs
+++ b/masonry/examples/calc_masonry.rs
@@ -14,7 +14,7 @@
 use std::str::FromStr;
 
 use masonry::core::{
-    ErasedAction, NewWidget, Properties, Property, StyleProperty, Widget, WidgetId, WidgetOptions,
+    ErasedAction, NewWidget, Properties, Property, StyleProperty, Widget, WidgetId,
 };
 use masonry::dpi::LogicalSize;
 use masonry::peniko::Color;
@@ -197,7 +197,7 @@ fn op_button_with_label(op: char, label: String) -> NewWidget<Button> {
     NewWidget::new_with(
         button,
         WidgetId::next(),
-        WidgetOptions::default(),
+        false,
         Properties::new()
             .with(Background::Color(BLUE))
             .with(ActiveBackground(Background::Color(LIGHT_BLUE)))
@@ -225,7 +225,7 @@ fn digit_button(digit: u8) -> NewWidget<Button> {
     NewWidget::new_with(
         button,
         WidgetId::next(),
-        WidgetOptions::default(),
+        false,
         Properties::new()
             .with(Background::Color(GRAY))
             .with(ActiveBackground(Background::Color(LIGHT_GRAY)))

--- a/masonry/examples/grid_masonry.rs
+++ b/masonry/examples/grid_masonry.rs
@@ -9,7 +9,6 @@
 use masonry::TextAlign;
 use masonry::core::{
     ErasedAction, NewWidget, PointerButton, Properties, StyleProperty, Widget as _, WidgetId,
-    WidgetOptions,
 };
 use masonry::dpi::LogicalSize;
 use masonry::peniko::Color;
@@ -71,12 +70,7 @@ pub fn make_grid(grid_spacing: f64) -> NewWidget<Grid> {
     let props = Properties::new()
         .with(BorderColor::new(Color::from_rgb8(40, 40, 80)))
         .with(BorderWidth::all(1.0));
-    let label = SizedBox::new(NewWidget::new_with(
-        label,
-        WidgetId::next(),
-        WidgetOptions::default(),
-        props,
-    ));
+    let label = SizedBox::new(NewWidget::new_with(label, WidgetId::next(), false, props));
 
     let button_inputs = vec![
         GridParams {

--- a/masonry/src/tests/compose.rs
+++ b/masonry/src/tests/compose.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use assert_matches::assert_matches;
-use masonry_core::core::{ChildrenIds, NewWidget, Widget, WidgetPod, WidgetTag};
+use masonry_core::core::{ChildrenIds, NewWidget, Transform, Widget, WidgetPod, WidgetTag};
 use masonry_testing::{ModularWidget, Record, TestHarness, TestWidgetExt};
 use vello::kurbo::{Affine, Point, Size, Vec2};
 
@@ -63,9 +63,7 @@ fn request_compose() {
     assert_matches!(harness.take_records_of(parent_tag)[..], [Record::Compose]);
 
     harness.edit_widget(parent_tag, |mut parent| {
-        parent
-            .ctx
-            .set_transform(Affine::translate(Vec2::new(7., 7.)));
+        parent.insert_prop(Transform::from(Affine::translate(Vec2::new(7., 7.))));
     });
 
     // Origin should be "parent_origin + pos + scroll_offset"

--- a/masonry_core/src/core/mod.rs
+++ b/masonry_core/src/core/mod.rs
@@ -30,13 +30,14 @@ pub use events::{
     AccessEvent, Handled, Ime, ResizeDirection, TextEvent, Update, WindowEvent, WindowTheme,
 };
 pub use properties::{
-    DefaultProperties, HasProperty, Properties, PropertiesMut, PropertiesRef, Property,
+    ChangedProperties, DefaultProperties, GlobalProperty, HasProperty, Properties, PropertiesMut,
+    PropertiesRef, Property, Transform,
 };
 pub use text::{ArcStr, BrushIndex, StyleProperty, StyleSet, render_text};
 pub use widget::find_widget_under_pointer;
 pub use widget::{AllowRawMut, AsDynWidget, ChildrenIds, FromDynWidget, Widget, WidgetId};
 pub use widget_mut::WidgetMut;
-pub use widget_pod::{NewWidget, WidgetOptions, WidgetPod};
+pub use widget_pod::{NewWidget, WidgetPod};
 pub use widget_ref::WidgetRef;
 pub use widget_tag::WidgetTag;
 

--- a/masonry_core/src/core/properties/transform.rs
+++ b/masonry_core/src/core/properties/transform.rs
@@ -1,0 +1,30 @@
+// Copyright 2025 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use vello::kurbo::Affine;
+
+use crate::core::{GlobalProperty, Property};
+
+/// The local transform of a widget
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
+pub struct Transform {
+    /// Local transform of the widget
+    pub transform: Affine,
+}
+
+impl Property for Transform {
+    fn static_default() -> &'static Self {
+        static DEFAULT: Transform = Transform {
+            transform: Affine::IDENTITY,
+        };
+        &DEFAULT
+    }
+}
+
+impl GlobalProperty for Transform {}
+
+impl From<Affine> for Transform {
+    fn from(transform: Affine) -> Self {
+        Self { transform }
+    }
+}

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -16,7 +16,7 @@ use vello::kurbo::{Point, Size};
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, ComposeCtx, CursorIcon, EventCtx, LayoutCtx, NewWidget,
     PaintCtx, PointerEvent, Properties, PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx,
-    TextEvent, Update, UpdateCtx, WidgetOptions, WidgetRef,
+    TextEvent, Update, UpdateCtx, WidgetRef,
 };
 
 /// A unique identifier for a single [`Widget`].
@@ -430,7 +430,7 @@ pub trait Widget: AsDynWidget + Any {
     where
         Self: Sized,
     {
-        NewWidget::new_with(self, WidgetId::next(), WidgetOptions::default(), props)
+        NewWidget::new_with(self, WidgetId::next(), false, props)
     }
 }
 

--- a/masonry_core/src/core/widget_arena.rs
+++ b/masonry_core/src/core/widget_arena.rs
@@ -3,8 +3,8 @@
 
 use tree_arena::{ArenaMut, ArenaRef, TreeArena};
 
-use crate::core::{Widget, WidgetId, WidgetState};
-use crate::util::{AnyMap, TypeSet};
+use crate::core::{ChangedProperties, Widget, WidgetId, WidgetState};
+use crate::util::AnyMap;
 
 pub(crate) struct WidgetArena {
     pub(crate) nodes: TreeArena<WidgetArenaNode>,
@@ -14,7 +14,7 @@ pub(crate) struct WidgetArenaNode {
     pub(crate) widget: Box<dyn Widget>,
     pub(crate) state: WidgetState,
     pub(crate) properties: AnyMap,
-    pub(crate) changed_properties: TypeSet,
+    pub(crate) changed_properties: ChangedProperties,
 }
 
 impl WidgetArena {

--- a/masonry_core/src/core/widget_pod.rs
+++ b/masonry_core/src/core/widget_pod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::any::TypeId;
-use vello::kurbo::Affine;
 
 use crate::core::{Properties, Widget, WidgetId, WidgetTag};
 
@@ -33,22 +32,12 @@ pub struct NewWidget<W: ?Sized> {
     #[cfg(debug_assertions)]
     pub(crate) action_type_name: &'static str,
 
-    /// The options the widget will be created with.
-    pub options: WidgetOptions,
+    /// The disabled state the widget will be created with.
+    pub disabled: bool,
     /// The properties the widget will be created with.
     pub properties: Properties,
 
     pub(crate) tag: &'static str,
-}
-
-// TODO - Remove this and merge it into NewWidget?
-/// The options a new widget will be created with.
-#[derive(Default, Debug)]
-pub struct WidgetOptions {
-    /// The transform the widget will be created with.
-    pub transform: Affine,
-    /// The disabled state the widget will be created with.
-    pub disabled: bool,
 }
 
 // TODO - This is a simple state machine that lets users create WidgetPods
@@ -78,7 +67,7 @@ impl<W: Widget> NewWidget<W> {
             action_type: TypeId::of::<W::Action>(),
             #[cfg(debug_assertions)]
             action_type_name: std::any::type_name::<W::Action>(),
-            options: WidgetOptions::default(),
+            disabled: false,
             properties: Properties::default(),
             tag: "",
         }
@@ -101,23 +90,15 @@ impl<W: Widget> NewWidget<W> {
         }
     }
 
-    /// Create a new widget with custom [`WidgetOptions`].
-    pub fn new_with_options(inner: W, options: WidgetOptions) -> Self {
-        Self {
-            options,
-            ..Self::new(inner)
-        }
-    }
-
-    /// Create a new widget with custom [`WidgetOptions`] and custom [`Properties`].
-    pub fn new_with(inner: W, id: WidgetId, options: WidgetOptions, props: Properties) -> Self {
+    /// Create a new widget with custom disabled state and custom [`Properties`].
+    pub fn new_with(inner: W, id: WidgetId, disabled: bool, props: Properties) -> Self {
         Self {
             widget: Box::new(inner),
             id,
             action_type: TypeId::of::<W::Action>(),
             #[cfg(debug_assertions)]
             action_type_name: std::any::type_name::<W::Action>(),
-            options,
+            disabled,
             properties: props,
             tag: "",
         }
@@ -136,7 +117,7 @@ impl<W: Widget + ?Sized> NewWidget<W> {
             action_type: self.action_type,
             #[cfg(debug_assertions)]
             action_type_name: self.action_type_name,
-            options: self.options,
+            disabled: self.disabled,
             properties: self.properties,
             tag: self.tag,
         }

--- a/masonry_core/src/core/widget_state.rs
+++ b/masonry_core/src/core/widget_state.rs
@@ -6,7 +6,7 @@ use std::any::TypeId;
 use tracing::Span;
 use vello::kurbo::{Affine, Insets, Point, Rect, Size, Vec2};
 
-use crate::core::{LayoutCache, WidgetId, WidgetOptions};
+use crate::core::{LayoutCache, WidgetId};
 
 // TODO - Reduce WidgetState size.
 // See https://github.com/linebender/xilem/issues/706
@@ -118,16 +118,12 @@ pub(crate) struct WidgetState {
     // efficiently hold an arbitrary shape.
     pub(crate) clip_path: Option<Rect>,
 
-    /// Local transform of this widget in the parent coordinate space.
-    pub(crate) transform: Affine,
     /// Global transform of this widget in the window coordinate space.
     ///
     /// Computed from all `transform` and `scroll_translation` values from this to the root widget.
     pub(crate) window_transform: Affine,
     /// Translation applied by scrolling, applied after applying `transform` to this widget.
     pub(crate) scroll_translation: Vec2,
-    /// The `transform` or `scroll_translation` has changed.
-    pub(crate) transform_changed: bool,
 
     /// The `TypeId` of the widget's `Widget::Action` type.
     pub(crate) action_type: TypeId,
@@ -222,7 +218,7 @@ impl WidgetState {
     pub(crate) fn new(
         id: WidgetId,
         widget_name: &'static str,
-        options: WidgetOptions,
+        disabled: bool,
         action_type: TypeId,
         #[cfg(debug_assertions)] action_type_name: &'static str,
     ) -> Self {
@@ -241,9 +237,8 @@ impl WidgetState {
             ime_area: None,
             clip_path: Option::default(),
             scroll_translation: Vec2::ZERO,
-            transform_changed: false,
             action_type,
-            is_explicitly_disabled: options.disabled,
+            is_explicitly_disabled: disabled,
             is_explicitly_stashed: false,
             is_disabled: false,
             is_stashed: false,
@@ -278,7 +273,6 @@ impl WidgetState {
             window_transform: Affine::IDENTITY,
             bounding_rect: Rect::ZERO,
             trace_span: Span::none(),
-            transform: options.transform,
         }
     }
 

--- a/masonry_testing/src/modular_widget.rs
+++ b/masonry_testing/src/modular_widget.rs
@@ -10,7 +10,7 @@ use masonry_core::core::{
     AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ComposeCtx, CursorIcon, EventCtx,
     LayoutCtx, NewWidget, NoAction, PaintCtx, PointerEvent, Properties, PropertiesMut,
     PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
-    WidgetOptions, WidgetPod, WidgetRef, find_widget_under_pointer,
+    WidgetPod, WidgetRef, find_widget_under_pointer,
 };
 use masonry_core::kurbo::{Point, Size};
 use masonry_core::vello::Scene;
@@ -466,6 +466,6 @@ impl<S: 'static> Widget for ModularWidget<S> {
     where
         Self: Sized,
     {
-        NewWidget::new_with(self, WidgetId::next(), WidgetOptions::default(), props)
+        NewWidget::new_with(self, WidgetId::next(), false, props)
     }
 }

--- a/masonry_testing/src/recorder_widget.rs
+++ b/masonry_testing/src/recorder_widget.rs
@@ -17,8 +17,7 @@ use masonry_core::accesskit::{Node, Role};
 use masonry_core::core::{
     AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ComposeCtx, CursorIcon, EventCtx,
     LayoutCtx, NewWidget, PaintCtx, PointerEvent, Properties, PropertiesMut, PropertiesRef,
-    QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetOptions,
-    WidgetRef,
+    QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetRef,
 };
 use masonry_core::kurbo::{Point, Size};
 use masonry_core::vello::Scene;
@@ -308,6 +307,6 @@ impl<W: Widget> Widget for Recorder<W> {
     where
         Self: Sized,
     {
-        NewWidget::new_with(self, WidgetId::next(), WidgetOptions::default(), props)
+        NewWidget::new_with(self, WidgetId::next(), false, props)
     }
 }

--- a/xilem/src/view/button.rs
+++ b/xilem/src/view/button.rs
@@ -140,7 +140,7 @@ where
         (
             ctx.with_action_widget(|ctx| {
                 let mut pod = ctx.create_pod(widgets::Button::new(child.new_widget));
-                pod.new_widget.options.disabled = self.disabled;
+                pod.new_widget.disabled = self.disabled;
                 pod
             }),
             child_state,

--- a/xilem/src/view/checkbox.rs
+++ b/xilem/src/view/checkbox.rs
@@ -71,7 +71,7 @@ where
     fn build(&self, ctx: &mut ViewCtx, _: &mut State) -> (Self::Element, Self::ViewState) {
         ctx.with_leaf_action_widget(|ctx| {
             let mut pod = ctx.create_pod(widgets::Checkbox::new(self.checked, self.label.clone()));
-            pod.new_widget.options.disabled = self.disabled;
+            pod.new_widget.disabled = self.disabled;
             pod
         })
     }

--- a/xilem/src/view/text_input.rs
+++ b/xilem/src/view/text_input.rs
@@ -156,7 +156,7 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for TextInput
         ctx.record_action(id);
 
         let mut pod = ctx.create_pod(text_input);
-        pod.new_widget.options.disabled = self.disabled;
+        pod.new_widget.disabled = self.disabled;
         (pod, ())
     }
 


### PR DESCRIPTION
This got a little bit larger than I would've hoped, and I'm not entirely sure about it (more code without immediate benefit, apart from making the transform a property, which possibly allows other APIs e.g. in Xilem).

It introduces a new marker trait `GlobalProperty` with `impl<P: GlobalProperty, W: Widget> HasProperty<P> for W {}` as suggested in #1278 
And a core property `Transform` which is a new type wrapper around `kurbo::Affine`, it could reasonably also be a directly `Affine` (less boilerplate for sure), but I guess a new type probably is worth it non-the-less. 

This unfortunately disallows other things I had in mind, due to orphan rules (this would result in a similar behavior as xilem_webs `OneOf`):

```rust
impl<
    A: Widget + FromDynWidget + HasProperty<P> + ?Sized,
    B: Widget + FromDynWidget + HasProperty<P> + ?Sized,
    C: Widget + FromDynWidget + HasProperty<P> + ?Sized,
    D: Widget + FromDynWidget + HasProperty<P> + ?Sized,
    E: Widget + FromDynWidget + HasProperty<P> + ?Sized,
    F: Widget + FromDynWidget + HasProperty<P> + ?Sized,
    G: Widget + FromDynWidget + HasProperty<P> + ?Sized,
    H: Widget + FromDynWidget + HasProperty<P> + ?Sized,
    I: Widget + FromDynWidget + HasProperty<P> + ?Sized,
    P: Property,
> HasProperty<P> for OneOfWidget<A, B, C, D, E, F, G, H, I>
{
}
```

So another case why I'm not sure about merging this. But as it's basically finished, it's at the very least worth opening this.