### PR TITLE
Enable Label properties for VariableLabel too

### DIFF
--- a/masonry/src/widgets/variable_label.rs
+++ b/masonry/src/widgets/variable_label.rs
@@ -169,6 +169,10 @@ impl VariableLabel {
     }
 }
 
+impl HasProperty<ContentColor> for VariableLabel {}
+impl HasProperty<DisabledContentColor> for VariableLabel {}
+impl HasProperty<LineBreaking> for VariableLabel {}
+
 // --- MARK: IMPL WIDGET
 impl Widget for VariableLabel {
     type Action = NoAction;


### PR DESCRIPTION
On Xilem side ContentColor and other Label properties are not usable with VariableLabel. This intends to fix it.