### PR TITLE
Update to the last version of ui_events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4559,8 +4559,7 @@ dependencies = [
 [[package]]
 name = "ui-events"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4c2cc34489c685d4e7a1a1f97b7b4416c5aa789892114ae77df6cd2a60f0ec4"
+source = "git+https://github.com/endoli/ui-events?branch=main#08c942cfbce0e010d844683726ad811936dc12e0"
 dependencies = [
  "dpi",
  "keyboard-types",
@@ -4569,10 +4568,10 @@ dependencies = [
 [[package]]
 name = "ui-events-winit"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de84ebdb9c2e756d18fcd378802b5a0d359863fcee3ced54ac2d2fbb19cf74"
+source = "git+https://github.com/endoli/ui-events?branch=main#08c942cfbce0e010d844683726ad811936dc12e0"
 dependencies = [
  "ui-events",
+ "web-time",
  "winit",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ parley = { git = "https://github.com/linebender/parley", rev = "587b7634ae8601c1
 peniko = "0.4.0"
 winit = "0.30.10"
 tracing = { version = "0.1.41", default-features = false }
-ui-events = "0.1.0"
-ui-events-winit = "0.1.0"
+ui-events = { git = "https://github.com/endoli/ui-events", branch = "main" }
+ui-events-winit = { git = "https://github.com/endoli/ui-events", branch = "main" }
 smallvec = "1.15.0"
 hashbrown = "0.15.3"
 dpi = "0.1.2"

--- a/masonry/src/doc/color_rectangle.rs
+++ b/masonry/src/doc/color_rectangle.rs
@@ -42,6 +42,7 @@ use masonry::core::{ChildrenIds, RegisterCtx};
 use masonry::core::WidgetMut;
 // ---
 use masonry::properties::Background;
+use ui_events::pointer::PointerButtonEvent;
 
 // ---
 
@@ -85,10 +86,10 @@ impl Widget for ColorRectangle {
         event: &PointerEvent,
     ) {
         match event {
-            PointerEvent::Down {
+            PointerEvent::Down(PointerButtonEvent {
                 button: Some(PointerButton::Primary),
                 ..
-            } => {
+            }) => {
                 ctx.submit_action::<Self::Action>(ColorRectanglePress);
             }
             _ => {}

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use accesskit::{Node, Role};
 use masonry_core::core::HasProperty;
 use tracing::{Span, trace, trace_span};
-use ui_events::pointer::PointerButton;
+use ui_events::pointer::{PointerButton, PointerButtonEvent};
 use vello::Scene;
 use vello::kurbo::{Affine, Size};
 use vello::peniko::Color;
@@ -118,7 +118,7 @@ impl Widget for Button {
                 ctx.request_paint_only();
                 trace!("Button {:?} pressed", ctx.widget_id());
             }
-            PointerEvent::Up { button, .. } => {
+            PointerEvent::Up(PointerButtonEvent { button, .. }) => {
                 if ctx.is_active() && ctx.is_hovered() {
                     ctx.submit_action::<Self::Action>(ButtonPress { button: *button });
                     trace!("Button {:?} released", ctx.widget_id());

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -6,6 +6,7 @@ use std::ops::Range;
 use accesskit::{Node, Role};
 use dpi::PhysicalPosition;
 use tracing::{Span, trace_span};
+use ui_events::pointer::PointerScrollEvent;
 use vello::Scene;
 use vello::kurbo::{Point, Rect, Size, Vec2};
 
@@ -270,7 +271,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
         let content_size = self.content_size;
 
         match *event {
-            PointerEvent::Scroll { delta, .. } => {
+            PointerEvent::Scroll(PointerScrollEvent { delta, .. }) => {
                 // TODO - Remove reference to scale factor.
                 // See https://github.com/linebender/xilem/issues/1264
                 let delta = match delta {

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -3,6 +3,7 @@
 
 use accesskit::{Node, Role};
 use tracing::{Span, trace_span};
+use ui_events::pointer::PointerButtonEvent;
 use vello::Scene;
 use vello::kurbo::{Point, Rect, Size};
 
@@ -129,7 +130,7 @@ impl Widget for ScrollBar {
         event: &PointerEvent,
     ) {
         match event {
-            PointerEvent::Down { state, .. } => {
+            PointerEvent::Down(PointerButtonEvent { state, .. }) => {
                 ctx.capture_pointer();
 
                 let cursor_min_length = theme::SCROLLBAR_MIN_SIZE;

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -5,6 +5,7 @@
 
 use accesskit::{Node, Role};
 use tracing::{Span, trace_span, warn};
+use ui_events::pointer::PointerButtonEvent;
 use vello::Scene;
 use vello::kurbo::{Line, Point, Rect, Size};
 
@@ -395,7 +396,7 @@ where
     ) {
         if self.draggable {
             match event {
-                PointerEvent::Down { state, .. } => {
+                PointerEvent::Down(PointerButtonEvent { state, .. }) => {
                     let pos = ctx.local_position(state.position);
                     if self.bar_hit_test(ctx.size(), pos) {
                         ctx.set_handled();

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -8,6 +8,7 @@ use accesskit::{Node, NodeId, Role};
 use parley::PlainEditor;
 use parley::editor::{Generation, SplitString};
 use tracing::{Span, trace_span};
+use ui_events::pointer::PointerButtonEvent;
 use vello::Scene;
 use vello::kurbo::{Affine, Point, Rect, Size};
 use vello::peniko::Fill;
@@ -429,7 +430,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
         }
 
         match event {
-            PointerEvent::Down { button, state, .. } => {
+            PointerEvent::Down(PointerButtonEvent { button, state, .. }) => {
                 if matches!(button, None | Some(PointerButton::Primary)) {
                     let cursor_pos = ctx.local_position(state.position);
                     let (fctx, lctx) = ctx.text_contexts();

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 use std::ops::Range;
 
+use ui_events::pointer::PointerScrollEvent;
 use vello::kurbo::{Point, Size, Vec2};
 
 use crate::core::keyboard::{Key, KeyState, NamedKey};
@@ -524,7 +525,7 @@ impl Widget for VirtualScroll {
         event: &PointerEvent,
     ) {
         match event {
-            PointerEvent::Scroll { delta, .. } => {
+            PointerEvent::Scroll(PointerScrollEvent { delta, .. }) => {
                 // TODO - Remove reference to scale factor.
                 // See https://github.com/linebender/xilem/issues/1264
                 let delta = match delta {
@@ -1032,6 +1033,7 @@ mod tests {
 
     use dpi::PhysicalPosition;
     use parley::StyleProperty;
+    use ui_events::pointer::PointerScrollEvent;
     use vello::kurbo::Size;
 
     use crate::core::{
@@ -1114,11 +1116,11 @@ mod tests {
         drive_to_fixpoint(&mut harness, virtual_scroll_id, driver);
         assert_render_snapshot!(harness, "virtual_scroll_moved");
         harness.mouse_move_to(virtual_scroll_id);
-        harness.process_pointer_event(PointerEvent::Scroll {
+        harness.process_pointer_event(PointerEvent::Scroll(PointerScrollEvent {
             pointer: PRIMARY_MOUSE,
             delta: ScrollDelta::PixelDelta(PhysicalPosition::<f64> { x: 0., y: 25. }),
             state: PointerState::default(),
-        });
+        }));
         drive_to_fixpoint(&mut harness, virtual_scroll_id, driver);
         assert_render_snapshot!(harness, "virtual_scroll_scrolled");
     }
@@ -1159,11 +1161,11 @@ mod tests {
         });
         drive_to_fixpoint(&mut harness, virtual_scroll_id, driver);
         harness.mouse_move_to(virtual_scroll_id);
-        harness.process_pointer_event(PointerEvent::Scroll {
+        harness.process_pointer_event(PointerEvent::Scroll(PointerScrollEvent {
             pointer: PRIMARY_MOUSE,
             delta: ScrollDelta::PixelDelta(PhysicalPosition::<f64> { x: 0., y: 200. }),
             state: PointerState::default(),
-        });
+        }));
         drive_to_fixpoint(&mut harness, virtual_scroll_id, driver);
     }
 
@@ -1203,11 +1205,11 @@ mod tests {
         });
         drive_to_fixpoint(&mut harness, virtual_scroll_id, driver);
         harness.mouse_move_to(virtual_scroll_id);
-        harness.process_pointer_event(PointerEvent::Scroll {
+        harness.process_pointer_event(PointerEvent::Scroll(PointerScrollEvent {
             pointer: PRIMARY_MOUSE,
             delta: ScrollDelta::PixelDelta(PhysicalPosition::<f64> { x: 0., y: 200. }),
             state: PointerState::default(),
-        });
+        }));
         drive_to_fixpoint(&mut harness, virtual_scroll_id, driver);
     }
 
@@ -1247,11 +1249,11 @@ mod tests {
         });
         drive_to_fixpoint(&mut harness, virtual_scroll_id, driver);
         harness.mouse_move_to(virtual_scroll_id);
-        harness.process_pointer_event(PointerEvent::Scroll {
+        harness.process_pointer_event(PointerEvent::Scroll(PointerScrollEvent {
             pointer: PRIMARY_MOUSE,
             delta: ScrollDelta::PixelDelta(PhysicalPosition::<f64> { x: 0., y: 200. }),
             state: PointerState::default(),
-        });
+        }));
         drive_to_fixpoint(&mut harness, virtual_scroll_id, driver);
     }
 
@@ -1306,22 +1308,22 @@ mod tests {
             original_range = widget.active_range.clone();
         }
         harness.mouse_move_to(virtual_scroll_id);
-        harness.process_pointer_event(PointerEvent::Scroll {
+        harness.process_pointer_event(PointerEvent::Scroll(PointerScrollEvent {
             pointer: PRIMARY_MOUSE,
             delta: ScrollDelta::PixelDelta(PhysicalPosition::<f64> { x: 0., y: -50. }),
             state: PointerState::default(),
-        });
+        }));
         drive_to_fixpoint(&mut harness, virtual_scroll_id, driver);
         {
             let widget = harness.root_widget();
             assert_ne!(widget.anchor_index, MIN);
             assert_ne!(widget.active_range, original_range);
         }
-        harness.process_pointer_event(PointerEvent::Scroll {
+        harness.process_pointer_event(PointerEvent::Scroll(PointerScrollEvent {
             pointer: PRIMARY_MOUSE,
             delta: ScrollDelta::PixelDelta(PhysicalPosition::<f64> { x: 0., y: 60. }),
             state: PointerState::default(),
-        });
+        }));
         drive_to_fixpoint(&mut harness, virtual_scroll_id, driver);
         {
             let widget = harness.root_widget();
@@ -1383,22 +1385,22 @@ mod tests {
             assert_render_snapshot!(harness, "virtual_scroll_limited_up_bottom");
         }
         harness.mouse_move_to(virtual_scroll_id);
-        harness.process_pointer_event(PointerEvent::Scroll {
+        harness.process_pointer_event(PointerEvent::Scroll(PointerScrollEvent {
             pointer: PRIMARY_MOUSE,
             delta: ScrollDelta::PixelDelta(PhysicalPosition::<f64> { x: 0., y: 5. }),
             state: PointerState::default(),
-        });
+        }));
         drive_to_fixpoint(&mut harness, virtual_scroll_id, driver);
         {
             let widget = harness.root_widget();
             assert_ne!(widget.anchor_index, MAX);
             assert_ne!(widget.active_range, original_range);
         }
-        harness.process_pointer_event(PointerEvent::Scroll {
+        harness.process_pointer_event(PointerEvent::Scroll(PointerScrollEvent {
             pointer: PRIMARY_MOUSE,
             delta: ScrollDelta::PixelDelta(PhysicalPosition::<f64> { x: 0., y: -6. }),
             state: PointerState::default(),
-        });
+        }));
         drive_to_fixpoint(&mut harness, virtual_scroll_id, driver);
         {
             let widget = harness.root_widget();

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -850,6 +850,11 @@ impl RenderRoot {
     pub fn emit_signal(&mut self, signal: RenderRootSignal) {
         self.global_state.emit_signal(signal);
     }
+
+    /// Returns the scale factor
+    pub fn get_scale_factor(&self) -> f64 {
+        self.global_state.scale_factor
+    }
 }
 
 impl RenderRootState {

--- a/masonry_core/src/passes/event.rs
+++ b/masonry_core/src/passes/event.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use tracing::{debug, info_span, trace};
-use ui_events::pointer::PointerType;
+use ui_events::pointer::{
+    PointerButtonEvent, PointerGestureEvent, PointerScrollEvent, PointerType,
+};
 
 use crate::app::{RenderRoot, RenderRootSignal};
 use crate::core::keyboard::{Key, KeyState, NamedKey};
@@ -54,16 +56,18 @@ fn pointer_event_short_name(e: &PointerEvent) -> &'static str {
         PointerEvent::Leave(..) => "Leave",
         PointerEvent::Cancel(..) => "Cancel",
         PointerEvent::Scroll { .. } => "Scroll",
+        PointerEvent::Gesture { .. } => "Gesture",
     }
 }
 
 /// A position if the event has one.
 fn try_event_position(event: &PointerEvent) -> Option<PhysicalPosition<f64>> {
     match event {
-        PointerEvent::Down { state, .. }
-        | PointerEvent::Up { state, .. }
+        PointerEvent::Down(PointerButtonEvent { state, .. })
+        | PointerEvent::Up(PointerButtonEvent { state, .. })
         | PointerEvent::Move(PointerUpdate { current: state, .. })
-        | PointerEvent::Scroll { state, .. } => Some(state.position),
+        | PointerEvent::Scroll(PointerScrollEvent { state, .. }) => Some(state.position),
+        PointerEvent::Gesture(PointerGestureEvent { state, .. }) => Some(state.position),
         _ => None,
     }
 }

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -15,6 +15,7 @@ use image::{DynamicImage, ImageFormat, ImageReader, Rgba, RgbaImage};
 use masonry_core::accesskit::{Action, ActionRequest, Node, Role, Tree, TreeUpdate};
 use masonry_core::anymore::AnyDebug;
 use masonry_core::core::keyboard::{Code, Key, KeyState, NamedKey};
+use masonry_core::core::pointer::{PointerButtonEvent, PointerScrollEvent};
 use oxipng::{Options, optimize_from_memory};
 use tracing::debug;
 
@@ -596,30 +597,30 @@ impl<W: Widget> TestHarness<W> {
     /// Send a [`Down`](PointerEvent::Down) event to the window.
     pub fn mouse_button_press(&mut self, button: PointerButton) {
         self.mouse_state.buttons.insert(button);
-        self.process_pointer_event(PointerEvent::Down {
+        self.process_pointer_event(PointerEvent::Down(PointerButtonEvent {
             pointer: PRIMARY_MOUSE,
             button: button.into(),
             state: self.mouse_state.clone(),
-        });
+        }));
     }
 
     /// Send an [`Up`](PointerEvent::Up) event to the window.
     pub fn mouse_button_release(&mut self, button: PointerButton) {
         self.mouse_state.buttons.remove(button);
-        self.process_pointer_event(PointerEvent::Up {
+        self.process_pointer_event(PointerEvent::Up(PointerButtonEvent {
             pointer: PRIMARY_MOUSE,
             button: button.into(),
             state: self.mouse_state.clone(),
-        });
+        }));
     }
 
     /// Send a [`Scroll`](PointerEvent::Scroll) event to the window.
     pub fn mouse_wheel(&mut self, Vec2 { x, y }: Vec2) {
-        self.process_pointer_event(PointerEvent::Scroll {
+        self.process_pointer_event(PointerEvent::Scroll(PointerScrollEvent {
             pointer: PRIMARY_MOUSE,
             delta: ScrollDelta::PixelDelta(PhysicalPosition { x, y }),
             state: self.mouse_state.clone(),
-        });
+        }));
     }
 
     /// Send events that lead to a given widget being clicked.

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -639,7 +639,9 @@ impl MasonryState<'_> {
                 is_synthetic: true,
                 ..
             }
-        ) && let Some(wet) = window.event_reducer.reduce(&event)
+        ) && let Some(wet) = window
+            .event_reducer
+            .reduce(window.render_root.get_scale_factor(), &event)
         {
             match wet {
                 WindowEventTranslation::Keyboard(k) => {


### PR DESCRIPTION
[ui-events](https://github.com/endoli/ui-events) 0.2.0 will introduce support for pinch and rotate gestures (fixes #1375).  

Currently, since version 0.2.0 has not been released yet, I have set the `ui-events` version in the `Cargo.toml` to the Git repository. I'm unsure if this is a good practice (though it's not a bad one) as I am still a newbie in Rust, but it is temporary while we wait for the release.

> _That's why I set this as a draft PR. However, if it's not a problem, let's mark it as ready for review._

I have tested this PR on my project (see the [example](https://github.com/tuan-ide/tuan/blob/9b04e68f32ccfa8ca5c9f7ec5d442e5f3f02f9fd/crates/tuan/src/graph_view/graph_view.rs#L143-L147)), and it works correctly. I can detect the events as before, along with the new pinch event.