### PR TITLE
Add a `gitignored` `user_data` folder under Placehero

### DIFF
--- a/placehero/user_data/.gitignore
+++ b/placehero/user_data/.gitignore
@@ -1,0 +1,3 @@
+*
+!/.gitignore
+!/README.md

--- a/placehero/user_data/README.md
+++ b/placehero/user_data/README.md
@@ -1,0 +1,7 @@
+# Placehero User Data
+
+This folder is used for your user data when you run [Placehero](../README.md).
+Do not share the contents of this folder, as it primarily contains login tokens and profile data.
+
+Note that currently nothing actually uses this folder; instead it is reserved.
+We have done this to reduce the likelihood of accidental credential uploads when we implement login.


### PR DESCRIPTION
I'm adding this folder now, so that when people try out my PR adding login then switch back to `main`, their `user_data` folder will still be ignored.

(Therefore reducing the risk that they accidentally commit this data)