### PR TITLE
Placehero: Start preparing for logged-in support by making a parallel version of the app

### DIFF
--- a/placehero/login-design-doc.md
+++ b/placehero/login-design-doc.md
@@ -1,0 +1,8 @@
+# Login
+
+We want to support login in Placehero. As part of this, some refactors will be needed.
+
+We now need some way to store data persistently, because we both need to store a login token, and to.
+For now, we will assume that we are running this within the Xilem repository, and store it in `placehero/user_data/`, which will be `.gitignored`.
+If we aren't in the Xilem repository, we just panic.
+I believe that JSON is the right storage format here?

--- a/placehero/src/lib.rs
+++ b/placehero/src/lib.rs
@@ -19,8 +19,8 @@ use xilem::core::{NoElement, View, fork, lens, map_action, map_state};
 use xilem::masonry::properties::types::AsUnit;
 use xilem::tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use xilem::view::{
-    button, flex_col, flex_row, label, prose, sized_box, spinner, split, task_raw, text_input,
-    worker_raw,
+    CrossAxisAlignment, FlexExt, button, flex_col, flex_row, label, prose, sized_box, spinner,
+    split, task_raw, text_input, worker_raw,
 };
 use xilem::winit::error::EventLoopError;
 use xilem::{EventLoopBuilder, ViewCtx, WidgetView, WindowOptions, Xilem, tokio};
@@ -52,6 +52,16 @@ use crate::login_flow::PlaceheroWithLogin;
 )]
 type Mastodon = Arc<mastodon::Mastodon>;
 
+/// Execute the app in the given winit event loop.
+pub fn run(event_loop: EventLoopBuilder) -> Result<(), EventLoopError> {
+    Xilem::new_simple(
+        MainState::Selecting,
+        select_app,
+        WindowOptions::new("Placehero: A placeholder named Mastodon client"),
+    )
+    .run_in(event_loop)
+}
+
 /// We are developing a version of Placehero which supports login.
 ///
 /// This requires some quite gnarly refactors, so for now we built it "alongside"
@@ -63,54 +73,26 @@ enum MainState {
     New(PlaceheroWithLogin),
 }
 
-struct Placehero {
-    mastodon: Mastodon,
-    instance: Option<Instance>,
-    timeline: Option<Timeline>,
-    show_context: Option<Status>,
-    context: Option<Context>,
-    context_sender: Option<UnboundedSender<String>>,
-    account_sender: Option<UnboundedSender<String>>,
-    timeline_box_contents: String,
-    loading_timeline: bool,
-    not_found_acct: Option<String>,
-}
-
 fn select_app(state: &mut MainState) -> impl WidgetView<MainState> + use<> {
     match state {
-        MainState::Selecting => OneOf3::A(flex_row((
-            button("Browse Anonymously", |state: &mut MainState| {
-                // TODO: Configurable server?
-                let base_url = "https://mastodon.online".to_string();
-                // TODO: Determine what user agent we want to send.
-                // Currently we send "megalodon", as that is the default in the library.
-                let user_agent = None;
-
-                #[expect(
-                    clippy::disallowed_types,
-                    reason = "We are constructing a value of the type, which we will never directly use elsewhere"
-                )]
-                let mastodon = mastodon::Mastodon::new(base_url, None, user_agent)
-                    .expect("Provided User Agent is valid");
-
-                let app_state = Placehero {
-                    mastodon: Arc::new(mastodon),
-                    instance: None,
-                    timeline: None,
-                    show_context: None,
-                    context: None,
-                    context_sender: None,
-                    account_sender: None,
-                    timeline_box_contents: "raph".to_string(),
-                    loading_timeline: false,
-                    not_found_acct: None,
-                };
-                *state = MainState::Old(app_state);
-            }),
-            button("Login", |state: &mut MainState| {
-                *state = MainState::New(PlaceheroWithLogin::default());
-            }),
-        ))),
+        MainState::Selecting => OneOf3::A(
+            flex_col((
+                prose("Welcome to Placehero. This is an example of the Xilem GUI framework, which is a Mastodon client.\n\
+                    We currently have decent support for browsing anonymously, and are currently developing our logged-in support in parallel to avoid regressions.")
+                    .text_alignment(xilem::TextAlign::Center)
+                    .flex(CrossAxisAlignment::Center),
+                flex_row((
+                    button("Browse Anonymously", |state: &mut MainState| {
+                        *state = MainState::Old(Placehero::default());
+                    }),
+                    button("Log In", |state: &mut MainState| {
+                        *state = MainState::New(PlaceheroWithLogin::default());
+                    }),
+                ))
+                .main_axis_alignment(xilem::view::MainAxisAlignment::Center),
+            ))
+            .main_axis_alignment(xilem::view::MainAxisAlignment::Center),
+        ),
         MainState::Old(_) => OneOf::B(lens(app_logic, |state| {
             let MainState::Old(placehero) = state else {
                 unreachable!()
@@ -126,14 +108,47 @@ fn select_app(state: &mut MainState) -> impl WidgetView<MainState> + use<> {
     }
 }
 
-/// Execute the app in the given winit event loop.
-pub fn run(event_loop: EventLoopBuilder) -> Result<(), EventLoopError> {
-    Xilem::new_simple(
-        MainState::Selecting,
-        select_app,
-        WindowOptions::new("Placehero: A placeholder named Mastodon client"),
-    )
-    .run_in(event_loop)
+struct Placehero {
+    mastodon: Mastodon,
+    instance: Option<Instance>,
+    timeline: Option<Timeline>,
+    show_context: Option<Status>,
+    context: Option<Context>,
+    context_sender: Option<UnboundedSender<String>>,
+    account_sender: Option<UnboundedSender<String>>,
+    timeline_box_contents: String,
+    loading_timeline: bool,
+    not_found_acct: Option<String>,
+}
+
+impl Default for Placehero {
+    fn default() -> Self {
+        // TODO: Configurable server?
+        let base_url = "https://mastodon.online".to_string();
+        // TODO: Determine what user agent we want to send.
+        // Currently we send "megalodon", as that is the default in the library.
+        let user_agent = None;
+
+        #[expect(
+            clippy::disallowed_types,
+            reason = "We are constructing a value of the type, which we will never directly use elsewhere"
+        )]
+        let mastodon = mastodon::Mastodon::new(base_url, None, user_agent)
+            .expect("Provided User Agent is valid");
+
+        Self {
+            mastodon: Arc::new(mastodon),
+            instance: None,
+            timeline: None,
+            show_context: None,
+            context: None,
+            context_sender: None,
+            account_sender: None,
+            timeline_box_contents: "raph".to_string(),
+            loading_timeline: false,
+            not_found_acct: None,
+        }
+    }
 }
 
 impl Placehero {

--- a/placehero/src/lib.rs
+++ b/placehero/src/lib.rs
@@ -14,12 +14,13 @@ use std::sync::Arc;
 use megalodon::entities::{Context, Instance, Status};
 use megalodon::error::{Kind, OwnError};
 use megalodon::{Megalodon, mastodon};
-use xilem::core::one_of::{Either, OneOf, OneOf6};
-use xilem::core::{NoElement, View, fork, map_action, map_state};
+use xilem::core::one_of::{Either, OneOf, OneOf3, OneOf6};
+use xilem::core::{NoElement, View, fork, lens, map_action, map_state};
 use xilem::masonry::properties::types::AsUnit;
 use xilem::tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use xilem::view::{
-    button, flex_col, label, prose, sized_box, spinner, split, task_raw, text_input, worker_raw,
+    button, flex_col, flex_row, label, prose, sized_box, spinner, split, task_raw, text_input,
+    worker_raw,
 };
 use xilem::winit::error::EventLoopError;
 use xilem::{EventLoopBuilder, ViewCtx, WidgetView, WindowOptions, Xilem, tokio};
@@ -28,12 +29,14 @@ mod actions;
 mod avatars;
 mod components;
 mod html_content;
+mod login_flow;
 
 pub(crate) use avatars::Avatars;
 pub(crate) use html_content::status_html_to_plaintext;
 
 use crate::actions::Navigation;
 use crate::components::{Timeline, thread};
+use crate::login_flow::PlaceheroWithLogin;
 
 /// Our shared API client type.
 ///
@@ -49,6 +52,17 @@ use crate::components::{Timeline, thread};
 )]
 type Mastodon = Arc<mastodon::Mastodon>;
 
+/// We are developing a version of Placehero which supports login.
+///
+/// This requires some quite gnarly refactors, so for now we built it "alongside"
+/// the main Placehero.
+#[expect(clippy::large_enum_variant, reason = "Not passed around.")]
+enum MainState {
+    Selecting,
+    Old(Placehero),
+    New(PlaceheroWithLogin),
+}
+
 struct Placehero {
     mastodon: Mastodon,
     instance: Option<Instance>,
@@ -62,37 +76,61 @@ struct Placehero {
     not_found_acct: Option<String>,
 }
 
+fn select_app(state: &mut MainState) -> impl WidgetView<MainState> + use<> {
+    match state {
+        MainState::Selecting => OneOf3::A(flex_row((
+            button("Browse Anonymously", |state: &mut MainState| {
+                // TODO: Configurable server?
+                let base_url = "https://mastodon.online".to_string();
+                // TODO: Determine what user agent we want to send.
+                // Currently we send "megalodon", as that is the default in the library.
+                let user_agent = None;
+
+                #[expect(
+                    clippy::disallowed_types,
+                    reason = "We are constructing a value of the type, which we will never directly use elsewhere"
+                )]
+                let mastodon = mastodon::Mastodon::new(base_url, None, user_agent)
+                    .expect("Provided User Agent is valid");
+
+                let app_state = Placehero {
+                    mastodon: Arc::new(mastodon),
+                    instance: None,
+                    timeline: None,
+                    show_context: None,
+                    context: None,
+                    context_sender: None,
+                    account_sender: None,
+                    timeline_box_contents: "raph".to_string(),
+                    loading_timeline: false,
+                    not_found_acct: None,
+                };
+                *state = MainState::Old(app_state);
+            }),
+            button("Login", |state: &mut MainState| {
+                *state = MainState::New(PlaceheroWithLogin::default());
+            }),
+        ))),
+        MainState::Old(_) => OneOf::B(lens(app_logic, |state| {
+            let MainState::Old(placehero) = state else {
+                unreachable!()
+            };
+            placehero
+        })),
+        MainState::New(_) => OneOf::C(lens(login_flow::app_logic, |state| {
+            let MainState::New(placehero) = state else {
+                unreachable!()
+            };
+            placehero
+        })),
+    }
+}
+
 /// Execute the app in the given winit event loop.
 pub fn run(event_loop: EventLoopBuilder) -> Result<(), EventLoopError> {
-    // TODO: Configurable server?
-    let base_url = "https://mastodon.online".to_string();
-    // TODO: Determine what user agent we want to send.
-    // Currently we send "megalodon", as that is the default in the library.
-    let user_agent = None;
-
-    #[expect(
-        clippy::disallowed_types,
-        reason = "We are constructing a value of the type, which we will never directly use elsewhere"
-    )]
-    let mastodon =
-        mastodon::Mastodon::new(base_url, None, user_agent).expect("Provided User Agent is valid");
-
-    let app_state = Placehero {
-        mastodon: Arc::new(mastodon),
-        instance: None,
-        timeline: None,
-        show_context: None,
-        context: None,
-        context_sender: None,
-        account_sender: None,
-        timeline_box_contents: "raph".to_string(),
-        loading_timeline: false,
-        not_found_acct: None,
-    };
-
     Xilem::new_simple(
-        app_state,
-        app_logic,
+        MainState::Selecting,
+        select_app,
         WindowOptions::new("Placehero: A placeholder named Mastodon client"),
     )
     .run_in(event_loop)

--- a/placehero/src/login_flow.rs
+++ b/placehero/src/login_flow.rs
@@ -1,0 +1,16 @@
+// Copyright 2025 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! The login flow for Placehero.
+
+use xilem::{WidgetView, view::label};
+
+/// The "global" state for a version of Placehero redesigned for login
+#[derive(Default)]
+pub(crate) struct PlaceheroWithLogin {}
+
+pub(crate) fn app_logic(
+    _state: &mut PlaceheroWithLogin,
+) -> impl WidgetView<PlaceheroWithLogin> + use<> {
+    label("Todo")
+}


### PR DESCRIPTION
Our existing code makes a lot of architectural assumptions (in particular, that there's always one unchanging `Mastodon`) which become untrue when there's support for logging in. As such, adding login support will require a lot of refactoring, disguising the actually interesting changes.
Because of this, my plan is to develop the login feature in a more piecemeal fashion. First, I will develop a simple "login flow", which achieves "logging into an account, persisting (at least some of) the login information, and displaying some basic information about yourself". Then I will work to integrate this with the existing code, including fixing the assumptions.

To facilitate this, this PR shows an option between "login" and "Browse Anonymously" at app startup, i.e.:
<img width="802" height="629" alt="image" src="https://github.com/user-attachments/assets/8bdb8fe4-461a-4896-a236-52be353f397a" />
 
The "Browse Anonymously" is exactly the old `app_logic`, and Login is just a stub todo page.