### PR TITLE
Xilem: Improve documentation for the text_input widget

### DIFF
--- a/xilem/src/view/text_input.rs
+++ b/xilem/src/view/text_input.rs
@@ -20,6 +20,46 @@ use crate::{InsertNewline, MessageResult, Pod, TextAlign, ViewCtx, WidgetView as
 type Callback<State, Action> = Box<dyn Fn(&mut State, String) -> Action + Send + Sync + 'static>;
 
 /// A view which displays editable text.
+///
+/// The text_input stores the content as a string, that can be set to a variable for
+/// getting/setting the text_input's content from outside it's own logic. It also
+/// needs to be expilicty told how to handle newlines, via the [`insert_newline`] function.
+///
+/// # Examples
+/// Create a basic text input with it's content stored in the app state.
+/// ```
+/// use xilem::view::text_input;
+/// # use xilem::WidgetView;
+///
+/// #[derive(Default)]
+/// struct State {
+///     content: String,
+/// }
+///
+/// # fn view() -> impl WidgetView<State> {
+/// text_input(state.content.clone(), |local_state: &mut State, input: String| {
+///     local_state.buffer = input
+/// })
+/// # }
+/// ```
+///
+/// Create a `text_input` that can hanle inputting a newline when enter is pressed.
+/// ```
+/// use xilem::view::text_input;
+/// # use xilem::WidgetView;
+///
+/// #[derive(Default)]
+/// struct State {
+///     content: String,
+/// }
+///
+/// # fn view() -> impl WidgetView<State> {
+/// text_input(state.content.clone(), |local_state: &mut State, input: String| {
+///     local_state.content = input
+/// })
+/// .insert_newline(InsertNewline::OnEnter)
+/// # }
+/// ```
 pub fn text_input<F, State, Action>(contents: String, on_changed: F) -> TextInput<State, Action>
 where
     F: Fn(&mut State, String) -> Action + Send + Sync + 'static,

--- a/xilem/src/view/text_input.rs
+++ b/xilem/src/view/text_input.rs
@@ -21,8 +21,8 @@ type Callback<State, Action> = Box<dyn Fn(&mut State, String) -> Action + Send +
 
 /// A view which displays editable text.
 ///
-/// The text_input stores the content as a string, that can be set to a variable for
-/// getting/setting the text_input's content from outside it's own logic. It also
+/// The `text_input` stores the content as a string, that can be set to a variable for
+/// getting/setting the `text_input`'s content from outside it's own logic. It also
 /// needs to be expilicty told how to handle newlines, via the [`insert_newline`] function.
 ///
 /// # Examples
@@ -43,7 +43,7 @@ type Callback<State, Action> = Box<dyn Fn(&mut State, String) -> Action + Send +
 /// # }
 /// ```
 ///
-/// Create a `text_input` that can hanle inputting a newline when enter is pressed.
+/// Create a `text_input` that can handle inputting a newline when enter is pressed.
 /// ```
 /// use xilem::view::text_input;
 /// # use xilem::WidgetView;

--- a/xilem/src/view/text_input.rs
+++ b/xilem/src/view/text_input.rs
@@ -23,7 +23,7 @@ type Callback<State, Action> = Box<dyn Fn(&mut State, String) -> Action + Send +
 ///
 /// The `text_input` stores the content as a string, that can be set to a variable for
 /// getting/setting the `text_input`'s content from outside it's own logic. It also
-/// needs to be expilicty told how to handle newlines, via the [`insert_newline`] function.
+/// needs to be expilicty told how to handle newlines, as seen in an example below.
 ///
 /// # Examples
 /// Create a basic text input with it's content stored in the app state.

--- a/xilem/src/view/text_input.rs
+++ b/xilem/src/view/text_input.rs
@@ -38,7 +38,7 @@ type Callback<State, Action> = Box<dyn Fn(&mut State, String) -> Action + Send +
 ///
 /// # fn view(state: &mut State) -> impl WidgetView<State> {
 /// text_input(state.content.clone(), |local_state: &mut State, input: String| {
-///     local_state.buffer = input
+///     local_state.content = input
 /// })
 /// # }
 /// ```

--- a/xilem/src/view/text_input.rs
+++ b/xilem/src/view/text_input.rs
@@ -28,7 +28,7 @@ type Callback<State, Action> = Box<dyn Fn(&mut State, String) -> Action + Send +
 /// # Examples
 /// Create a basic text input with it's content stored in the app state.
 /// ```
-/// use xilem::view::text_input;
+/// use xilem::{view::text_input, InsertNewline};
 /// # use xilem::WidgetView;
 ///
 /// #[derive(Default)]
@@ -36,7 +36,7 @@ type Callback<State, Action> = Box<dyn Fn(&mut State, String) -> Action + Send +
 ///     content: String,
 /// }
 ///
-/// # fn view() -> impl WidgetView<State> {
+/// # fn view(state: &mut State) -> impl WidgetView<State> {
 /// text_input(state.content.clone(), |local_state: &mut State, input: String| {
 ///     local_state.buffer = input
 /// })
@@ -45,7 +45,7 @@ type Callback<State, Action> = Box<dyn Fn(&mut State, String) -> Action + Send +
 ///
 /// Create a `text_input` that can handle inputting a newline when enter is pressed.
 /// ```
-/// use xilem::view::text_input;
+/// use xilem::{view::text_input, InsertNewline};
 /// # use xilem::WidgetView;
 ///
 /// #[derive(Default)]
@@ -53,7 +53,7 @@ type Callback<State, Action> = Box<dyn Fn(&mut State, String) -> Action + Send +
 ///     content: String,
 /// }
 ///
-/// # fn view() -> impl WidgetView<State> {
+/// # fn view(state: &mut State) -> impl WidgetView<State> {
 /// text_input(state.content.clone(), |local_state: &mut State, input: String| {
 ///     local_state.content = input
 /// })


### PR DESCRIPTION
Following the recommendation in [1400](https://github.com/linebender/xilem/pull/1400), I've instead opted to improve the base documentation for the `text_input` widget.