### PR TITLE
Replace outdated `doc_auto_cfg`

### DIFF
--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -152,7 +152,7 @@
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(
     test,
     expect(

--- a/masonry_core/src/lib.rs
+++ b/masonry_core/src/lib.rs
@@ -15,7 +15,7 @@
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(
     test,
     expect(

--- a/masonry_winit/src/lib.rs
+++ b/masonry_winit/src/lib.rs
@@ -76,7 +76,7 @@
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![expect(
     clippy::needless_doctest_main,
     reason = "Having a main function is a deliberate part of the root doc."

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -131,7 +131,7 @@
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(
     test,
     expect(

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -40,7 +40,7 @@
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![no_std]
 // TODO: Remove any items listed as "Deferred"

--- a/xilem_web/src/lib.rs
+++ b/xilem_web/src/lib.rs
@@ -20,7 +20,7 @@
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 // TODO: Remove any items listed as "Deferred"
 #![cfg_attr(test, expect(clippy::print_stdout, reason = "Deferred: Noisy"))]
 #![expect(missing_debug_implementations, reason = "Deferred: Noisy")]


### PR DESCRIPTION
Part of [#linebender > Cargo doc failures in linebender repos](https://xi.zulipchat.com/#narrow/channel/419691-linebender/topic/Cargo.20doc.20failures.20in.20linebender.20repos/with/542106544).

cc @cyncrovee, this should fix the docs failure you're seeing in #1406 (once we land it and you rebase past it)