### PR TITLE
Fix the docs failure

### DIFF
--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -984,6 +984,8 @@ impl<W: Widget> TestHarness<W> {
     /// * `manifest_dir`: directory where `Cargo.toml` can be found.
     /// * `test_name`: arbitrary name; second argument of [`assert_render_snapshot`].
     /// * `expect_failure`: whether the snapshot is expected to fail to match.
+    ///
+    /// [`assert_render_snapshot`]: crate::assert_render_snapshot
     #[doc(hidden)]
     #[track_caller]
     pub fn check_render_snapshot(


### PR DESCRIPTION
This fixes [#masonry > CI: Docs failing because of macros](https://xi.zulipchat.com/#narrow/channel/317477-masonry/topic/CI.3A.20Docs.20failing.20because.20of.20macros/with/542445707)