### PR TITLE
Fix confusing log message in `VirtualScroll::message`

### DIFF
--- a/xilem/src/view/virtual_scroll.rs
+++ b/xilem/src/view/virtual_scroll.rs
@@ -286,7 +286,9 @@ where
                 );
                 return result;
             } else {
-                tracing::error!("Message sent type in VirtualScroll::message: {message:?}");
+                tracing::error!(
+                    "Message sent to unloaded view in `VirtualScroll::message`: {message:?}"
+                );
                 return MessageResult::Stale;
             }
         }


### PR DESCRIPTION
The previous message was completely inscrutable!