### PR TITLE
Don't publish screenshots (and assets) in Masonry

### DIFF
--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-exclude = ["screenshots", "examples/assetss"]
+exclude = ["screenshots", "examples/assets"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This is now required as of https://github.com/linebender/xilem/pull/1391

None of the other workspace packages currently have a `screenshots` folder, as far as I can tell.