### PR TITLE
Split ARCHITECTURE.md into two files

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,0 +1,20 @@
+# History of Masonry and Xilem
+
+This crates evolved from various experiments in the Linebender community (Druid, masonry, idiopath, lasagna, crochet, etc)
+
+This document describes the high-level architecture of xilem. If you want to familirize yourself with the code base, you are just in the right place!
+
+An evolution of the ideas implemented in xilem can be found in the following resources:
+- [Data Oriented GUI (2018)](https://www.youtube.com/watch?v=4YTfxresvS8)
+- [A Journey through incremental computation (2020)](https://www.youtube.com/watch?v=DSuX-LIAU-I)
+- [Raph Levien on UI Frameworks (2021)](https://www.youtube.com/watch?v=PwuwG2-0n3I)
+- [High Performance Rust UI (2022)](https://www.youtube.com/watch?v=zVUTZlNCb8U)
+- [Ergonomic APIs for hard problems (2022)](https://www.youtube.com/watch?v=Phk0C-kLlho&t=2706s)
+- [Xilem Vector Graphics (2023)](https://www.youtube.com/watch?v=XjbVnwBtVEk)
+- [Announcing Masonry 0.1, and my vision for Rust UI (2023)](https://poignardazur.github.io/2023/02/02/masonry-01-and-my-vision-for-rust-ui/)
+- [So you want to write a GUI framework (2021)](https://www.cmyr.net/blog/gui-framework-ingredients.html)
+- [Rust GUI Infrastructure (2021)](https://www.cmyr.net/blog/rust-gui-infra.html)
+- [Towards a unified theory of reactive UI (2019)](https://raphlinus.github.io/ui/druid/2019/11/22/reactive-ui.html)
+- [Towards principled reactive UI (2020)](https://raphlinus.github.io/rust/druid/2020/09/25/principled-reactive-ui.html)
+- [Xilem: an architecture for UI in Rust (2022)](https://raphlinus.github.io/rust/gui/2022/05/07/ui-architecture.html)
+- [Advice for the next dozen Rust GUIs (2022)](https://raphlinus.github.io/rust/gui/2022/07/15/next-dozen-guis.html)

--- a/xilem/ARCHITECTURE.md
+++ b/xilem/ARCHITECTURE.md
@@ -1,24 +1,7 @@
 # ARCHITECTURE
 Xilem is a framework that aims to provide a performant and productive option for Rust GUI.
 
-This crates evolved from various experiments in the Linebender community (Druid, masonry, idiopath, lasagna, crochet, etc)
-
 This document describes the high-level architecture of xilem. If you want to familirize yourself with the code base, you are just in the right place!
-
-An evolution of the ideas implemented in xilem can be found in the following resources:
-- [Data Oriented GUI (2018)](https://www.youtube.com/watch?v=4YTfxresvS8)
-- [A Journey through incremental computation (2020)](https://www.youtube.com/watch?v=DSuX-LIAU-I)
-- [Raph Levien on UI Frameworks (2021)](https://www.youtube.com/watch?v=PwuwG2-0n3I)
-- [High Performance Rust UI (2022)](https://www.youtube.com/watch?v=zVUTZlNCb8U)
-- [Ergonomic APIs for hard problems (2022)](https://www.youtube.com/watch?v=Phk0C-kLlho&t=2706s)
-- [Xilem Vector Graphics (2023)](https://www.youtube.com/watch?v=XjbVnwBtVEk)
-- [Announcing Masonry 0.1, and my vision for Rust UI (2023)](https://poignardazur.github.io/2023/02/02/masonry-01-and-my-vision-for-rust-ui/)
-- [So you want to write a GUI framework (2021)](https://www.cmyr.net/blog/gui-framework-ingredients.html)
-- [Rust GUI Infrastructure (2021)](https://www.cmyr.net/blog/rust-gui-infra.html)
-- [Towards a unified theory of reactive UI (2019)](https://raphlinus.github.io/ui/druid/2019/11/22/reactive-ui.html)
-- [Towards principled reactive UI (2020)](https://raphlinus.github.io/rust/druid/2020/09/25/principled-reactive-ui.html)
-- [Xilem: an architecture for UI in Rust (2022)](https://raphlinus.github.io/rust/gui/2022/05/07/ui-architecture.html)
-- [Advice for the next dozen Rust GUIs (2022)](https://raphlinus.github.io/rust/gui/2022/07/15/next-dozen-guis.html)
 
 ## High-level Goals
 - **High Performance.** Lightweight state management, retained widget layer, massively parallel rendering backend (Vello), fast startup time, small binary size


### PR DESCRIPTION
This is a first step towards refactoring the top-level Xilem docs.

I've deliberately avoided content changes: this only moves doc around.