### PR TITLE
Add reasonably cursory docs to Masonry Testing's README

### DIFF
--- a/masonry_testing/README.md
+++ b/masonry_testing/README.md
@@ -31,7 +31,7 @@ The widget can of course have children, which allows this crate to be used for t
 
 The testing harness can:
 
-- Simulate any external event, including mouse movement, key presses, text input, accessibility events.
+- Simulate any external event which Masonry handles, including mouse movement, key presses, text input, accessibility events.
 - Control the flow of time to the application (i.e. for testing animations).
 - Take screenshots of the application, save these to a file, and ensure that these are up-to-date.
   See [Screenshots](#screenshots) for more details.

--- a/masonry_testing/src/lib.rs
+++ b/masonry_testing/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! The testing harness can:
 //!
-//! - Simulate any external event, including mouse movement, key presses, text input, accessibility events.
+//! - Simulate any external event which Masonry handles, including mouse movement, key presses, text input, accessibility events.
 //! - Control the flow of time to the application (i.e. for testing animations).
 //! - Take screenshots of the application, save these to a file, and ensure that these are up-to-date.
 //!   See [Screenshots](#screenshots) for more details.


### PR DESCRIPTION
This is important for the upcoming release. It needn't be perfect, but it's just useful to help orient people.