### PR TITLE
masonry: Use `ui-events` from `masonry_core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,7 +2178,6 @@ dependencies = [
  "parley",
  "profiling",
  "tracing",
- "ui-events",
  "vello",
 ]
 

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -28,7 +28,6 @@ masonry_core.workspace = true
 masonry_testing = { workspace = true, optional = true }
 parley.workspace = true
 tracing = { workspace = true, features = ["default"] }
-ui-events.workspace = true
 vello.workspace = true
 
 [dev-dependencies]

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -215,7 +215,6 @@ pub use vello::peniko::color::palette;
 pub use vello::{kurbo, peniko};
 pub use {dpi, parley, vello};
 
-pub use masonry_core::{app, core, util};
+pub use masonry_core::{app, core, ui_events, util};
 #[cfg(any(feature = "testing", test))]
 pub use masonry_testing as testing;
-pub use ui_events;

--- a/masonry/src/tests/event.rs
+++ b/masonry/src/tests/event.rs
@@ -3,12 +3,12 @@
 
 use accesskit::ActionRequest;
 use assert_matches::assert_matches;
+use masonry_core::core::keyboard::{Key, NamedKey};
+use masonry_core::core::pointer::{PointerButton, PointerEvent, PointerInfo, PointerType};
 use masonry_core::core::{AccessEvent, NewWidget, TextEvent, Widget, WidgetTag};
 use masonry_testing::{
     ModularWidget, Record, TestHarness, TestWidgetExt, assert_any, assert_debug_panics,
 };
-use ui_events::keyboard::{Key, NamedKey};
-use ui_events::pointer::{PointerButton, PointerEvent, PointerInfo, PointerType};
 use vello::kurbo::Size;
 
 use crate::properties::types::AsUnit;

--- a/masonry/src/tests/update.rs
+++ b/masonry/src/tests/update.rs
@@ -4,6 +4,7 @@
 use std::sync::mpsc;
 
 use assert_matches::assert_matches;
+use masonry_core::core::pointer::{PointerButton, PointerEvent};
 use masonry_core::core::{
     CursorIcon, Ime, NewWidget, Properties, TextEvent, Update, Widget, WidgetId, WidgetPod,
     WidgetTag,
@@ -12,7 +13,6 @@ use masonry_testing::{
     DebugName, ModularWidget, PRIMARY_MOUSE, Record, TestHarness, TestWidgetExt, assert_any,
     assert_debug_panics,
 };
-use ui_events::pointer::{PointerButton, PointerEvent};
 use vello::kurbo::{Point, Size};
 
 use crate::properties::types::Length;

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -9,12 +9,12 @@ use std::sync::Arc;
 use accesskit::{Node, Role};
 use masonry_core::core::HasProperty;
 use tracing::{Span, trace, trace_span};
-use ui_events::pointer::PointerButton;
 use vello::Scene;
 use vello::kurbo::{Affine, Size};
 use vello::peniko::Color;
 
 use crate::core::keyboard::{Key, NamedKey};
+use crate::core::pointer::PointerButton;
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, EventCtx, LayoutCtx, NewWidget, PaintCtx,
     PointerButtonEvent, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update,

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -8,11 +8,11 @@ use std::any::TypeId;
 use accesskit::{Node, Role, Toggled};
 use masonry_core::core::HasProperty;
 use tracing::{Span, trace, trace_span};
-use ui_events::keyboard::Key;
 use vello::Scene;
 use vello::kurbo::Rect;
 use vello::kurbo::{Affine, BezPath, Cap, Dashes, Join, Size, Stroke};
 
+use crate::core::keyboard::Key;
 use crate::core::{
     AccessCtx, AccessEvent, ArcStr, BoxConstraints, ChildrenIds, EventCtx, LayoutCtx, NewWidget,
     PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update,

--- a/masonry/src/widgets/slider.rs
+++ b/masonry/src/widgets/slider.rs
@@ -7,11 +7,11 @@ use std::any::TypeId;
 
 use accesskit::{ActionData, Node, Role};
 use tracing::{Span, trace_span};
-use ui_events::pointer::PointerButton;
 use vello::Scene;
 use vello::kurbo::{Circle, Point, Rect, Size};
 
 use crate::core::keyboard::{Key, NamedKey};
+use crate::core::pointer::PointerButton;
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, EventCtx, HasProperty, LayoutCtx,
     PaintCtx, PointerButtonEvent, PointerEvent, PointerUpdate, PropertiesMut, PropertiesRef,


### PR DESCRIPTION
This is preferable to both `masonry_core` and `masonry` having a dependency on `ui-events` when `masonry_core` also re-exports it and `masonry` depends on `masonry_core`.