### PR TITLE
Reorder reexports in xilem crates

### DIFF
--- a/xilem/src/view/mod.rs
+++ b/xilem/src/view/mod.rs
@@ -8,68 +8,48 @@
 // See https://github.com/linebender/xilem/issues/1254
 pub use masonry::core::Axis;
 
-mod task;
-pub use task::*;
-
-mod worker;
-pub use worker::*;
-
 mod button;
-pub use button::*;
-
 mod checkbox;
-pub use checkbox::*;
-
 mod flex;
-pub use flex::*;
-
 mod grid;
-pub use grid::*;
-
-mod sized_box;
-pub use sized_box::*;
-
-mod slider;
-pub use slider::*;
-
-mod spinner;
-pub use spinner::*;
-
 mod image;
-pub use image::*;
-
 mod indexed_stack;
-pub use indexed_stack::*;
-
 mod label;
-pub use label::*;
-
-mod variable_label;
-pub use variable_label::*;
-
-mod progress_bar;
-pub use progress_bar::*;
-
-mod prop;
-pub use prop::*;
-
-mod prose;
-pub use prose::*;
-
-mod text_input;
-pub use text_input::*;
-
-mod virtual_scroll;
-pub use virtual_scroll::*;
-
 mod portal;
-pub use portal::*;
-
-mod zstack;
-pub use zstack::*;
-
-mod transform;
-pub use transform::*;
-
+mod progress_bar;
+mod prop;
+mod prose;
+mod sized_box;
+mod slider;
+mod spinner;
 mod split;
-pub use split::*;
+mod task;
+mod text_input;
+mod transform;
+mod variable_label;
+mod virtual_scroll;
+mod worker;
+mod zstack;
+
+pub use self::button::*;
+pub use self::checkbox::*;
+pub use self::flex::*;
+pub use self::grid::*;
+pub use self::image::*;
+pub use self::indexed_stack::*;
+pub use self::label::*;
+pub use self::portal::*;
+pub use self::progress_bar::*;
+pub use self::prop::*;
+pub use self::prose::*;
+pub use self::sized_box::*;
+pub use self::slider::*;
+pub use self::spinner::*;
+pub use self::split::*;
+pub use self::task::*;
+pub use self::text_input::*;
+pub use self::transform::*;
+pub use self::variable_label::*;
+pub use self::virtual_scroll::*;
+pub use self::worker::*;
+pub use self::zstack::*;

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -48,46 +48,39 @@
 #![no_std]
 // TODO: Remove any items listed as "Deferred"
 #![expect(clippy::allow_attributes_without_reason, reason = "Deferred: Noisy")]
+
 extern crate alloc;
 
 pub use anymore;
 
+mod any_view;
 mod context;
-pub use context::MessageContext;
-
 mod deferred;
-pub use deferred::{AsyncCtx, MessageProxy, PhantomView, ProxyError, RawProxy};
-
+mod element;
 mod environment;
-pub use environment::{
+mod message;
+mod sequence;
+mod state;
+mod view;
+mod views;
+
+pub use self::any_view::{AnyView, AnyViewState};
+pub use self::context::MessageContext;
+pub use self::deferred::{AsyncCtx, MessageProxy, PhantomView, ProxyError, RawProxy};
+pub use self::element::{AnyElement, Mut, NoElement, SuperElement, ViewElement};
+pub use self::environment::{
     Environment, EnvironmentItem, OnActionWithContext, Provides, Rebuild, Resource, Slot,
     WithContext, on_action_with_context, provides, with_context,
 };
-
-mod view;
-pub use view::{View, ViewId, ViewMarker, ViewPathTracker};
-
-mod views;
-pub use views::{
+pub use self::message::{DynMessage, MessageResult, SendMessage};
+pub use self::sequence::{
+    AppendVec, Count, ElementSplice, ViewSequence, WithoutElements, without_elements,
+};
+pub use self::state::{Arg, Edit, Read, ViewArgument};
+pub use self::view::{View, ViewId, ViewMarker, ViewPathTracker};
+pub use self::views::{
     Fork, Frozen, Lens, MapMessage, MapState, Memoize, OrphanView, RunOnce, fork, frozen, lens,
     map_action, map_message, map_state, memoize, one_of, run_once, run_once_raw,
-};
-
-mod message;
-pub use message::{DynMessage, MessageResult, SendMessage};
-
-mod element;
-pub use element::{AnyElement, Mut, NoElement, SuperElement, ViewElement};
-
-mod any_view;
-pub use any_view::{AnyView, AnyViewState};
-
-mod state;
-pub use state::{Arg, Edit, Read, ViewArgument};
-
-mod sequence;
-pub use sequence::{
-    AppendVec, Count, ElementSplice, ViewSequence, WithoutElements, without_elements,
 };
 
 pub mod docs;

--- a/xilem_core/src/views/mod.rs
+++ b/xilem_core/src/views/mod.rs
@@ -1,25 +1,20 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-mod run_once;
-pub use run_once::{RunOnce, run_once, run_once_raw};
-
-mod lens;
-pub use lens::{Lens, lens};
-
-mod map_state;
-pub use map_state::{MapState, map_state};
-
-mod map_message;
-pub use map_message::{MapMessage, map_action, map_message};
-
 mod fork;
-pub use fork::{Fork, fork};
-
+mod lens;
+mod map_message;
+mod map_state;
 mod memoize;
-pub use memoize::{Frozen, Memoize, frozen, memoize};
+mod orphan;
+mod run_once;
+
+pub use self::fork::{Fork, fork};
+pub use self::lens::{Lens, lens};
+pub use self::map_message::{MapMessage, map_action, map_message};
+pub use self::map_state::{MapState, map_state};
+pub use self::memoize::{Frozen, Memoize, frozen, memoize};
+pub use self::orphan::OrphanView;
+pub use self::run_once::{RunOnce, run_once, run_once_raw};
 
 pub mod one_of;
-
-mod orphan;
-pub use orphan::OrphanView;


### PR DESCRIPTION
This is shorter, plays better with rustfmt, and is less likely to lead to merge conflicts if two people add a module in parallel.