### PR TITLE
Replace futures crate with sub-crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,28 +1188,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -1217,17 +1201,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-intrusive"
@@ -1288,7 +1261,6 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -3898,7 +3870,7 @@ version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
- "futures",
+ "futures-util",
  "gloo-timers",
  "log",
  "xilem_web",
@@ -5832,7 +5804,8 @@ dependencies = [
 name = "xilem_web"
 version = "0.4.0"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "peniko",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/xilem_web/Cargo.toml
+++ b/xilem_web/Cargo.toml
@@ -21,7 +21,8 @@ default = []
 intern_strings = ["wasm-bindgen/enable-interning"]
 
 [dependencies]
-futures = "0.3.31"
+futures-channel = "0.3.31"
+futures-util = "0.3.31"
 peniko.workspace = true
 wasm-bindgen = "0.2.104"
 wasm-bindgen-futures = "0.4.54"

--- a/xilem_web/src/concurrent/task.rs
+++ b/xilem_web/src/concurrent/task.rs
@@ -5,8 +5,8 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
-use futures::FutureExt;
-use futures::channel::oneshot;
+use futures_channel::oneshot;
+use futures_util::FutureExt;
 use wasm_bindgen::UnwrapThrowExt;
 use wasm_bindgen_futures::spawn_local;
 

--- a/xilem_web/web_examples/spawn_tasks/Cargo.toml
+++ b/xilem_web/web_examples/spawn_tasks/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dependencies]
 console_error_panic_hook = "0.1.7"
 console_log = { version = "1.0.0", features = ["color"] }
-futures = "0.3.31"
+futures-util = "0.3.31"
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 log = "0.4.28"
 xilem_web = { path = "../.." }

--- a/xilem_web/web_examples/spawn_tasks/src/main.rs
+++ b/xilem_web/web_examples/spawn_tasks/src/main.rs
@@ -4,7 +4,7 @@
 //! This example shows how (external) tasks can send messages
 //! to be able to change the app state.
 
-use futures::{FutureExt, select};
+use futures_util::{FutureExt, select};
 use gloo_timers::future::TimeoutFuture;
 use xilem_web::concurrent::{ShutdownSignal, TaskProxy, task};
 use xilem_web::core::one_of::Either;


### PR DESCRIPTION
Get rid of `futures-executor`. Could have also disabled default features on `futures`, but this is better for build pipelining too. (and maybe `futures-util` will also be replaced by sth. like `futures-lite` down the line?)