### PR TITLE
Remove the re-export of  `AnyViewState`

### DIFF
--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -15,10 +15,10 @@ use masonry_winit::app::{
 
 use crate::any_view::DynWidget;
 use crate::core::{
-    AnyViewState, DynMessage, MessageContext, MessageResult, ProxyError, RawProxy, SendMessage,
-    View, ViewId, ViewPathTracker,
+    DynMessage, MessageContext, MessageResult, ProxyError, RawProxy, SendMessage, View, ViewId,
+    ViewPathTracker,
 };
-use crate::window_view::WindowView;
+use crate::window_view::{WindowView, WindowViewState};
 use crate::{AppState, ViewCtx};
 
 pub struct MasonryDriver<State: 'static, Logic> {
@@ -35,7 +35,7 @@ pub struct MasonryDriver<State: 'static, Logic> {
 struct Window<State: 'static> {
     view: WindowView<State>,
     view_ctx: ViewCtx,
-    view_state: AnyViewState,
+    view_state: WindowViewState,
 }
 
 impl<State, Logic, WindowIter> MasonryDriver<State, Logic>

--- a/xilem/src/window_view.rs
+++ b/xilem/src/window_view.rs
@@ -7,7 +7,7 @@ use masonry::theme::BACKGROUND_COLOR;
 use masonry_winit::app::{NewWindow, Window, WindowId};
 use xilem_core::Edit;
 
-use crate::core::{AnyViewState, Arg, MessageContext, Mut, View, ViewElement, ViewMarker};
+use crate::core::{Arg, MessageContext, Mut, View, ViewElement, ViewMarker};
 use crate::{AnyWidgetView, ViewCtx, WidgetView, WindowOptions};
 
 /// A view representing a window.
@@ -18,6 +18,8 @@ pub struct WindowView<State: 'static> {
     /// The base color of the window.
     base_color: Color,
 }
+
+pub(crate) type WindowViewState = <Box<AnyWidgetView<(), ()>> as View<(), (), ViewCtx>>::ViewState;
 
 /// A view representing a window.
 ///
@@ -72,7 +74,7 @@ impl<State> ViewMarker for WindowView<State> where State: 'static {}
 impl<State> View<Edit<State>, (), ViewCtx> for WindowView<State> {
     type Element = PodWindow;
 
-    type ViewState = AnyViewState;
+    type ViewState = WindowViewState;
 
     fn build(
         &self,
@@ -150,7 +152,7 @@ where
     pub(crate) fn rebuild_root_widget(
         &self,
         prev: &Self,
-        root_widget_view_state: &mut AnyViewState,
+        root_widget_view_state: &mut WindowViewState,
         ctx: &mut ViewCtx,
         render_root: &mut RenderRoot,
         app_state: &mut State,

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -86,6 +86,6 @@ pub use self::views::{
 };
 
 // TODO - Remove this re-export and rewrite code importing it
-pub use self::views::{AnyView, AnyViewState};
+pub use self::views::AnyView;
 
 pub mod docs;

--- a/xilem_core/src/views/any_view.rs
+++ b/xilem_core/src/views/any_view.rs
@@ -177,6 +177,10 @@ where
 
 /// The state used by [`AnyView`].
 #[doc(hidden)]
+#[expect(
+    unnameable_types,
+    reason = "Implementation detail, public because of trait visibility rules"
+)]
 #[derive(Debug)]
 pub struct AnyViewState {
     inner_state: Box<dyn Any>,

--- a/xilem_core/src/views/mod.rs
+++ b/xilem_core/src/views/mod.rs
@@ -12,7 +12,7 @@ mod memoize;
 mod orphan;
 mod run_once;
 
-pub use self::any_view::{AnyView, AnyViewState};
+pub use self::any_view::AnyView;
 pub use self::fork::{Fork, fork};
 pub use self::lens::{Lens, lens};
 pub use self::map_message::{MapMessage, map_action, map_message};


### PR DESCRIPTION
This was clearly marked as an implementation detail, and now matches every other view state in being private.