### PR TITLE
Remove enum `Count`

### DIFF
--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -77,7 +77,7 @@ pub use self::message_proxy::{AsyncCtx, MessageProxy, PhantomView, ProxyError, R
 pub use self::view::{View, ViewMarker};
 pub use self::view_argument::{Arg, Edit, Read, ViewArgument};
 pub use self::view_ctx::{ViewId, ViewPathTracker};
-pub use self::view_sequence::{Count, ViewSequence};
+pub use self::view_sequence::ViewSequence;
 pub use self::view_sequences::{WithoutElements, without_elements};
 pub use self::views::{
     Fork, Frozen, Lens, MapMessage, MapState, Memoize, OrphanView, RunOnce, fork, frozen, lens,

--- a/xilem_core/src/view_sequences/impl_array.rs
+++ b/xilem_core/src/view_sequences/impl_array.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    AppendVec, Arg, Count, ElementSplice, MessageCtx, MessageResult, ViewArgument, ViewElement,
-    ViewId, ViewPathTracker, ViewSequence,
+    AppendVec, Arg, ElementSplice, MessageCtx, MessageResult, ViewArgument, ViewElement, ViewId,
+    ViewPathTracker, ViewSequence,
 };
 
 impl<State, Action, Context, Element, Seq, const N: usize>
@@ -16,10 +16,6 @@ where
 {
     /// The fields of the tuple are (number of widgets to skip, child `SeqState`).
     type SeqState = [(usize, Seq::SeqState); N];
-
-    #[doc(hidden)]
-    // TODO: Optimise?
-    const ELEMENTS_COUNT: Count = Count::combine([Seq::ELEMENTS_COUNT; N]);
 
     #[doc(hidden)]
     fn seq_build(

--- a/xilem_core/src/view_sequences/impl_option.rs
+++ b/xilem_core/src/view_sequences/impl_option.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    AppendVec, Arg, Count, ElementSplice, MessageCtx, MessageResult, ViewArgument, ViewElement,
-    ViewId, ViewPathTracker, ViewSequence,
+    AppendVec, Arg, ElementSplice, MessageCtx, MessageResult, ViewArgument, ViewElement, ViewId,
+    ViewPathTracker, ViewSequence,
 };
 
 /// The state used to implement `ViewSequence` for `Option<impl ViewSequence>`
@@ -40,18 +40,6 @@ where
     // comment is always shown. This lets us explain the caveats.
     #[doc(hidden)]
     type SeqState = OptionSeqState<Seq::SeqState>;
-
-    #[doc(hidden)]
-    const ELEMENTS_COUNT: Count = const {
-        match Seq::ELEMENTS_COUNT {
-            // This sequence has zero or one children,
-            // which is best explained as "Many".
-            Count::One => Count::Many,
-            Count::Many => Count::Many,
-            Count::Unknown => Count::Unknown,
-            Count::Zero => Count::Zero,
-        }
-    };
 
     #[doc(hidden)]
     fn seq_build(

--- a/xilem_core/src/view_sequences/impl_tuples.rs
+++ b/xilem_core/src/view_sequences/impl_tuples.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    AppendVec, Arg, Count, ElementSplice, MessageCtx, MessageResult, ViewArgument, ViewElement,
-    ViewId, ViewPathTracker, ViewSequence,
+    AppendVec, Arg, ElementSplice, MessageCtx, MessageResult, ViewArgument, ViewElement, ViewId,
+    ViewPathTracker, ViewSequence,
 };
 
 // --- MARK: for ()
@@ -15,8 +15,6 @@ where
     Element: ViewElement,
 {
     type SeqState = ();
-
-    const ELEMENTS_COUNT: Count = Count::Zero;
 
     fn seq_build(
         &self,
@@ -65,8 +63,6 @@ where
     Element: ViewElement,
 {
     type SeqState = Seq::SeqState;
-
-    const ELEMENTS_COUNT: Count = Seq::ELEMENTS_COUNT;
 
     fn seq_build(
         &self,
@@ -128,8 +124,6 @@ macro_rules! impl_view_tuple {
         {
             /// The fields of the inner tuples are (number of widgets to skip, child state).
             type SeqState = ($((usize, $seq::SeqState),)+);
-
-            const ELEMENTS_COUNT: Count = Count::combine([$($seq::ELEMENTS_COUNT,)+]);
 
             fn seq_build(
                 &self,

--- a/xilem_core/src/view_sequences/impl_vec.rs
+++ b/xilem_core/src/view_sequences/impl_vec.rs
@@ -5,8 +5,8 @@ use alloc::vec::Vec;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use crate::{
-    AppendVec, Arg, Count, ElementSplice, MessageCtx, MessageResult, ViewArgument, ViewElement,
-    ViewId, ViewPathTracker, ViewSequence,
+    AppendVec, Arg, ElementSplice, MessageCtx, MessageResult, ViewArgument, ViewElement, ViewId,
+    ViewPathTracker, ViewSequence,
 };
 
 /// The state used to implement `ViewSequence` for `Vec<impl ViewSequence>`
@@ -72,9 +72,6 @@ where
     // comment is always shown. This lets us explain the caveats.
     #[doc(hidden)]
     type SeqState = VecViewState<Seq::SeqState>;
-
-    #[doc(hidden)]
-    const ELEMENTS_COUNT: Count = Seq::ELEMENTS_COUNT.multiple();
 
     #[doc(hidden)]
     fn seq_build(

--- a/xilem_core/src/view_sequences/without_elements.rs
+++ b/xilem_core/src/view_sequences/without_elements.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 
 use crate::element::NoElement;
 use crate::{
-    AppendVec, Arg, Count, ElementSplice, MessageCtx, MessageResult, ViewArgument, ViewElement,
+    AppendVec, Arg, ElementSplice, MessageCtx, MessageResult, ViewArgument, ViewElement,
     ViewPathTracker, ViewSequence,
 };
 
@@ -92,8 +92,6 @@ where
     Seq: ViewSequence<State, Action, Context, NoElement>,
 {
     type SeqState = Seq::SeqState;
-
-    const ELEMENTS_COUNT: Count = Count::Zero;
 
     fn seq_build(
         &self,


### PR DESCRIPTION
This enum has an interesting role in theory, but in practice it was never used.

We can add it back if we think it's worth having, but in the meantime we should avoid carrying dead code.