### PR TITLE
Add efficient child replacement methods to widgets.

### DIFF
--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -172,6 +172,22 @@ impl Grid {
         this.ctx.children_changed();
     }
 
+    /// Replace the child widget at the given index with a new one.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds.
+    pub fn set_child(
+        this: &mut WidgetMut<'_, Self>,
+        idx: usize,
+        child: NewWidget<impl Widget + ?Sized>,
+        params: impl Into<GridParams>,
+    ) {
+        let child = new_grid_child(params.into(), child);
+        let old_child = std::mem::replace(&mut this.widget.children[idx], child);
+        this.ctx.remove_child(old_child.widget);
+    }
+
     /// Set the spacing between grid items.
     pub fn set_spacing(this: &mut WidgetMut<'_, Self>, spacing: Length) {
         this.widget.grid_spacing = spacing;
@@ -442,6 +458,25 @@ mod tests {
         harness.edit_root_widget(|mut grid| {
             Grid::add_child(
                 &mut grid,
+                Button::with_text("A").with_auto_id(),
+                GridParams::new(0, 0, 1, 1),
+            );
+        });
+        assert_render_snapshot!(harness, "grid_initial_2x2"); // Should be back to the original state
+
+        // Test replacement
+        harness.edit_root_widget(|mut grid| {
+            Grid::remove_child(&mut grid, 0);
+            Grid::add_child(
+                &mut grid,
+                Button::with_text("X").with_auto_id(),
+                GridParams::new(0, 0, 1, 1),
+            );
+        });
+        harness.edit_root_widget(|mut grid| {
+            Grid::set_child(
+                &mut grid,
+                0,
                 Button::with_text("A").with_auto_id(),
                 GridParams::new(0, 0, 1, 1),
             );

--- a/masonry/src/widgets/indexed_stack.rs
+++ b/masonry/src/widgets/indexed_stack.rs
@@ -112,6 +112,20 @@ impl IndexedStack {
         this.ctx.children_changed();
     }
 
+    /// Replace the child widget at the given index with a new one.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds.
+    pub fn set_child(
+        this: &mut WidgetMut<'_, Self>,
+        idx: usize,
+        child: NewWidget<impl Widget + ?Sized>,
+    ) {
+        let old_child = std::mem::replace(&mut this.widget.children[idx], child.erased().to_pod());
+        this.ctx.remove_child(old_child);
+    }
+
     /// Change the active child.
     ///
     /// # Panics
@@ -361,5 +375,11 @@ mod tests {
             IndexedStack::set_active_child(&mut stack, 1);
         });
         assert_render_snapshot!(harness, "indexed_stack_initial_builder");
+
+        // Change the active widget
+        harness.edit_root_widget(|mut stack| {
+            IndexedStack::set_child(&mut stack, 1, Button::with_text("D").with_auto_id());
+        });
+        assert_render_snapshot!(harness, "indexed_stack_builder_new_widget");
     }
 }

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -107,6 +107,22 @@ impl ZStack {
         this.ctx.children_changed();
     }
 
+    /// Replace the child widget at the given index with a new one.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds.
+    pub fn set_child(
+        this: &mut WidgetMut<'_, Self>,
+        idx: usize,
+        child: NewWidget<impl Widget + ?Sized>,
+        alignment: impl Into<ChildAlignment>,
+    ) {
+        let child = Child::new(child.erased().to_pod(), alignment.into());
+        let old_child = std::mem::replace(&mut this.widget.children[idx], child);
+        this.ctx.remove_child(old_child.widget);
+    }
+
     /// Remove a child from the `ZStack`.
     pub fn remove_child(this: &mut WidgetMut<'_, Self>, idx: usize) {
         let child = this.widget.children.remove(idx);


### PR DESCRIPTION
The only way to update children of `Flex`, `Grid`, `IndexedStack`, and `ZStack` is with `push` / `insert` / `remove`. This is quite inefficient. In order to replace the 0-index child, you have to first call `remove` and then immediately combo it with `insert`. Both methods are `O(n)` as they will shift the whole collection.

This PR introduces new `set_child` methods to these widgets, allowing for `O(1)` replacement of children.