### PR TITLE
Standardize widget code markings.

### DIFF
--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -43,6 +43,7 @@ pub struct Checkbox {
     label: WidgetPod<Label>,
 }
 
+// --- MARK: BUILDERS
 impl Checkbox {
     /// Create a new `Checkbox` with a text label.
     pub fn new(checked: bool, text: impl Into<ArcStr>) -> Self {

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -86,7 +86,7 @@ enum Child {
     FlexedSpacer(f64, f64),
 }
 
-// --- MARK: IMPL FLEX
+// --- MARK: BUILDERS
 impl Flex {
     /// Create a new `Flex` oriented along the provided axis.
     pub fn for_axis(axis: Axis) -> Self {
@@ -199,7 +199,10 @@ impl Flex {
         self.children.push(new_child);
         self
     }
+}
 
+// --- MARK: METHODS
+impl Flex {
     /// Returns the number of children (widgets and spacers) this flex container has.
     pub fn len(&self) -> usize {
         self.children.len()

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -48,7 +48,7 @@ pub struct GridParams {
     pub height: i32,
 }
 
-// --- MARK: IMPL GRID
+// --- MARK: BUILDERS
 impl Grid {
     /// Create a new grid with the given number of columns and rows.
     pub fn with_dimensions(width: i32, height: i32) -> Self {

--- a/masonry/src/widgets/indexed_stack.rs
+++ b/masonry/src/widgets/indexed_stack.rs
@@ -32,7 +32,7 @@ pub struct IndexedStack {
     active_child: usize,
 }
 
-// --- MARK: IMPL INDEXEDSTACK
+// --- MARK: BUILDERS
 impl IndexedStack {
     /// Create a new stack with no children.
     pub fn new() -> Self {
@@ -65,7 +65,10 @@ impl IndexedStack {
         self.active_child = idx;
         self
     }
+}
 
+// --- MARK: METHODS
+impl IndexedStack {
     /// Returns the number of children in this stack.
     pub fn len(&self) -> usize {
         self.children.len()
@@ -82,7 +85,7 @@ impl IndexedStack {
     }
 }
 
-// --- MARK: IMPL WIDGETMUT
+// --- MARK: WIDGETMUT
 impl IndexedStack {
     /// Add a child widget to the end of the stack.
     ///

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -84,13 +84,6 @@ impl Label {
         }
     }
 
-    /// Get the current text of this label.
-    ///
-    /// To update the text of an active label, use [`set_text`](Self::set_text).
-    pub fn text(&self) -> &ArcStr {
-        &self.text
-    }
-
     /// Set a style property for the new label.
     ///
     /// Setting [`StyleProperty::Brush`](parley::StyleProperty::Brush) is not supported.
@@ -152,6 +145,16 @@ impl Label {
             );
         }
         self.styles.insert(property)
+    }
+}
+
+// --- MARK: METHODS
+impl Label {
+    /// Get the current text of this label.
+    ///
+    /// To update the text of an active label, use [`set_text`](Self::set_text).
+    pub fn text(&self) -> &ArcStr {
+        &self.text
     }
 }
 

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -60,11 +60,6 @@ impl<W: Widget + ?Sized> Portal<W> {
         }
     }
 
-    #[expect(missing_docs, reason = "TODO")]
-    pub fn get_viewport_pos(&self) -> Point {
-        self.viewport_pos
-    }
-
     // TODO - rewrite doc
     /// Builder-style method for deciding whether to constrain the child vertically.
     ///
@@ -128,7 +123,13 @@ pub(crate) fn compute_pan_range(mut viewport: Range<f64>, target: Range<f64>) ->
     viewport
 }
 
+// --- MARK: METHODS
 impl<W: Widget + ?Sized> Portal<W> {
+    #[expect(missing_docs, reason = "TODO")]
+    pub fn get_viewport_pos(&self) -> Point {
+        self.viewport_pos
+    }
+
     // TODO - rename
     fn set_viewport_pos_raw(&mut self, portal_size: Size, content_size: Size, pos: Point) -> bool {
         let viewport_max_pos =

--- a/masonry/src/widgets/progress_bar.rs
+++ b/masonry/src/widgets/progress_bar.rs
@@ -34,6 +34,7 @@ pub struct ProgressBar {
     label: WidgetPod<Label>,
 }
 
+// --- MARK: BUILDERS
 impl ProgressBar {
     /// Create a new `ProgressBar`.
     ///
@@ -47,7 +48,10 @@ impl ProgressBar {
             NewWidget::new_with_props(Label::new(Self::value(progress)), label_props).to_pod();
         Self { progress, label }
     }
+}
 
+// --- MARK: METHODS
+impl ProgressBar {
     fn value_accessibility(&self) -> Box<str> {
         if let Some(value) = self.progress {
             format!("{:.0}%", value * 100.).into()

--- a/masonry/src/widgets/prose.rs
+++ b/masonry/src/widgets/prose.rs
@@ -36,6 +36,7 @@ pub struct Prose {
     clip: bool,
 }
 
+// --- MARK: BUILDERS
 impl Prose {
     /// Create a new `Prose` with the given text.
     ///
@@ -62,7 +63,10 @@ impl Prose {
         self.clip = clip;
         self
     }
+}
 
+// --- MARK: METHODS
+impl Prose {
     /// Read the underlying text area. Useful for getting its ID.
     // This is a bit of a hack, to work around `from_text_area_pod` not being
     // able to set padding.
@@ -178,6 +182,7 @@ impl Widget for Prose {
     }
 }
 
+// --- MARK: TESTS
 // TODO - Add more tests
 #[cfg(test)]
 mod tests {

--- a/masonry/src/widgets/resize_observer.rs
+++ b/masonry/src/widgets/resize_observer.rs
@@ -142,6 +142,7 @@ impl Widget for ResizeObserver {
     }
 }
 
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use dpi::PhysicalSize;

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -46,16 +46,17 @@ impl ScrollBar {
             grab_anchor: None,
         }
     }
+}
 
+// --- MARK: METHODS
+impl ScrollBar {
     /// Returns how far the scrollbar is from its initial point.
     ///
     /// Values range from 0.0 (beginning) to 1.0 (end).
     pub fn cursor_progress(&self) -> f64 {
         self.cursor_progress
     }
-}
 
-impl ScrollBar {
     fn get_cursor_rect(&self, layout_size: Size, min_length: f64) -> Rect {
         // TODO - handle invalid sizes
         let size_ratio = self.portal_size / self.content_size;

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -131,6 +131,34 @@ impl SizedBox {
     }
 }
 
+// --- MARK: METHODS
+impl SizedBox {
+    fn child_constraints(&self, bc: &BoxConstraints) -> BoxConstraints {
+        // if we don't have a width/height, we don't change that axis.
+        // if we have a width/height, we clamp it on that axis.
+        let (min_width, max_width) = match self.width {
+            Some(width) => {
+                let w = width.max(bc.min().width).min(bc.max().width);
+                (w, w)
+            }
+            None => (bc.min().width, bc.max().width),
+        };
+
+        let (min_height, max_height) = match self.height {
+            Some(height) => {
+                let h = height.max(bc.min().height).min(bc.max().height);
+                (h, h)
+            }
+            None => (bc.min().height, bc.max().height),
+        };
+
+        BoxConstraints::new(
+            Size::new(min_width, min_height),
+            Size::new(max_width, max_height),
+        )
+    }
+}
+
 // --- MARK: WIDGETMUT
 impl SizedBox {
     /// Replace the child widget with a new one.
@@ -202,34 +230,6 @@ impl SizedBox {
     pub fn child_mut<'t>(this: &'t mut WidgetMut<'_, Self>) -> Option<WidgetMut<'t, dyn Widget>> {
         let child = this.widget.child.as_mut()?;
         Some(this.ctx.get_mut(child))
-    }
-}
-
-// --- MARK: INTERNALS
-impl SizedBox {
-    fn child_constraints(&self, bc: &BoxConstraints) -> BoxConstraints {
-        // if we don't have a width/height, we don't change that axis.
-        // if we have a width/height, we clamp it on that axis.
-        let (min_width, max_width) = match self.width {
-            Some(width) => {
-                let w = width.max(bc.min().width).min(bc.max().width);
-                (w, w)
-            }
-            None => (bc.min().width, bc.max().width),
-        };
-
-        let (min_height, max_height) = match self.height {
-            Some(height) => {
-                let h = height.max(bc.min().height).min(bc.max().height);
-                (h, h)
-            }
-            None => (bc.min().height, bc.max().height),
-        };
-
-        BoxConstraints::new(
-            Size::new(min_width, min_height),
-            Size::new(max_width, max_height),
-        )
     }
 }
 

--- a/masonry/src/widgets/slider.rs
+++ b/masonry/src/widgets/slider.rs
@@ -51,42 +51,7 @@ impl Slider {
     }
 }
 
-// --- MARK: WIDGETMUT
-impl Slider {
-    /// Sets the current value of the slider.
-    pub fn set_value(this: &mut WidgetMut<'_, Self>, value: f64) {
-        let clamped_value = value.clamp(this.widget.min, this.widget.max);
-        let new_value = if let Some(step) = this.widget.step {
-            ((clamped_value / step).round() * step).clamp(this.widget.min, this.widget.max)
-        } else {
-            clamped_value
-        };
-        if (new_value - this.widget.value).abs() > f64::EPSILON {
-            this.widget.value = new_value;
-            this.ctx.request_render();
-        }
-    }
-
-    /// Sets or removes the stepping interval of the slider.
-    pub fn set_step(this: &mut WidgetMut<'_, Self>, step: Option<f64>) {
-        let filtered_step = step.filter(|s| *s > 0.0);
-        if this.widget.step != filtered_step {
-            this.widget.set_step_internal(filtered_step);
-            this.ctx.request_render();
-        }
-    }
-
-    /// Sets the range (min and max) of the slider.
-    pub fn set_range(this: &mut WidgetMut<'_, Self>, min: f64, max: f64) {
-        if this.widget.min != min || this.widget.max != max {
-            this.widget.min = min;
-            this.widget.max = max;
-            Self::set_value(this, this.widget.value);
-        }
-    }
-}
-
-// --- MARK: INTERNALS
+// --- MARK: METHODS
 impl Slider {
     fn set_step_internal(&mut self, step: Option<f64>) {
         self.step = step.filter(|s| *s > 0.0);
@@ -126,6 +91,41 @@ impl Slider {
             true
         } else {
             false
+        }
+    }
+}
+
+// --- MARK: WIDGETMUT
+impl Slider {
+    /// Sets the current value of the slider.
+    pub fn set_value(this: &mut WidgetMut<'_, Self>, value: f64) {
+        let clamped_value = value.clamp(this.widget.min, this.widget.max);
+        let new_value = if let Some(step) = this.widget.step {
+            ((clamped_value / step).round() * step).clamp(this.widget.min, this.widget.max)
+        } else {
+            clamped_value
+        };
+        if (new_value - this.widget.value).abs() > f64::EPSILON {
+            this.widget.value = new_value;
+            this.ctx.request_render();
+        }
+    }
+
+    /// Sets or removes the stepping interval of the slider.
+    pub fn set_step(this: &mut WidgetMut<'_, Self>, step: Option<f64>) {
+        let filtered_step = step.filter(|s| *s > 0.0);
+        if this.widget.step != filtered_step {
+            this.widget.set_step_internal(filtered_step);
+            this.ctx.request_render();
+        }
+    }
+
+    /// Sets the range (min and max) of the slider.
+    pub fn set_range(this: &mut WidgetMut<'_, Self>, min: f64, max: f64) {
+        if this.widget.min != min || this.widget.max != max {
+            this.widget.min = min;
+            this.widget.max = max;
+            Self::set_value(this, this.widget.value);
         }
     }
 }
@@ -457,7 +457,7 @@ impl Widget for Slider {
     }
 }
 
-// --- MARK: TESTS ---
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use vello::kurbo::{Point, Size};

--- a/masonry/src/widgets/spinner.rs
+++ b/masonry/src/widgets/spinner.rs
@@ -33,17 +33,18 @@ pub struct Spinner {
     t: f64,
 }
 
+// --- MARK: DEFAULT
+impl Default for Spinner {
+    fn default() -> Self {
+        Self { t: 0.0 }
+    }
+}
+
 // --- MARK: BUILDERS
 impl Spinner {
     /// Create a spinner widget
     pub fn new() -> Self {
         Self::default()
-    }
-}
-
-impl Default for Spinner {
-    fn default() -> Self {
-        Self { t: 0.0 }
     }
 }
 

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -137,13 +137,13 @@ impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
     }
 }
 
-// --- MARK: INTERNALS
 // TODO - Remove this function, and remove pixel-snapping code from this file.
 #[doc(hidden)]
 pub fn ceil_length(l: Length) -> Length {
     Length::px(l.get().ceil())
 }
 
+// --- MARK: METHODS
 impl<ChildA: Widget + ?Sized, ChildB: Widget + ?Sized> Split<ChildA, ChildB> {
     /// Returns the size of the splitter bar area.
     #[inline]

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -134,20 +134,6 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
         }
     }
 
-    /// Get the current text of this text area.
-    ///
-    /// To update the text of an active text area, use [`reset_text`](Self::reset_text).
-    ///
-    /// The return value is not just `&str` to handle IME preedits.
-    pub fn text(&self) -> SplitString<'_> {
-        self.editor.text()
-    }
-
-    /// Check if this text area holds nothing, including IME preedit content.
-    pub fn is_empty(&self) -> bool {
-        self.editor.raw_text().is_empty()
-    }
-
     /// Set a style property for the new text area.
     ///
     /// Style properties set by this method include [text size](parley::StyleProperty::FontSize),
@@ -249,8 +235,22 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
     }
 }
 
-// --- MARK: HELPERS
+// --- MARK: METHODS
 impl<const EDITABLE: bool> TextArea<EDITABLE> {
+    /// Get the current text of this text area.
+    ///
+    /// To update the text of an active text area, use [`reset_text`](Self::reset_text).
+    ///
+    /// The return value is not just `&str` to handle IME preedits.
+    pub fn text(&self) -> SplitString<'_> {
+        self.editor.text()
+    }
+
+    /// Check if this text area holds nothing, including IME preedit content.
+    pub fn is_empty(&self) -> bool {
+        self.editor.raw_text().is_empty()
+    }
+
     /// Get the IME area from the editor, accounting for padding.
     ///
     /// This should only be called when the editor layout is available.
@@ -1046,6 +1046,7 @@ pub enum InsertNewline {
 // - Clicking in the right place changes the selection as expected?
 // - Keyboard actions have expected results?
 
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use masonry_core::core::NewWidget;

--- a/masonry/src/widgets/text_input.rs
+++ b/masonry/src/widgets/text_input.rs
@@ -43,6 +43,7 @@ pub struct TextInput {
     clip: bool,
 }
 
+// --- MARK: BUILDERS
 impl TextInput {
     /// Create a new `TextInput` with the given text.
     ///
@@ -83,7 +84,10 @@ impl TextInput {
         self.clip = clip;
         self
     }
+}
 
+// --- MARK: METHODS
+impl TextInput {
     /// Read the underlying text area.
     ///
     /// Useful for getting its ID, as most actions from the text input will be sent by the child.
@@ -334,6 +338,7 @@ impl Widget for TextInput {
     }
 }
 
+// --- MARK: TESTS
 // TODO - Add more tests
 #[cfg(test)]
 mod tests {

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -248,6 +248,7 @@ impl std::fmt::Debug for VirtualScroll {
     }
 }
 
+// --- MARK: BUILDERS
 impl VirtualScroll {
     /// Create a new virtual scrolling list.
     ///
@@ -287,7 +288,10 @@ impl VirtualScroll {
         self.validate_valid_range();
         self
     }
+}
 
+// --- MARK: METHODS
+impl VirtualScroll {
     /// The number of currently active children in this widget.
     ///
     /// This is intended for sanity-checking of higher-level processes (i.e. so that inconsistencies can be caught early).
@@ -514,6 +518,7 @@ impl VirtualScroll {
 /// too few items, that will be sorted relatively quickly.
 const DEFAULT_MEAN_ITEM_HEIGHT: f64 = 60.;
 
+// --- MARK: IMPL WIDGET
 impl Widget for VirtualScroll {
     type Action = VirtualScrollAction;
 
@@ -1036,6 +1041,7 @@ fn opt_iter_difference(
         .chain(new_range.end.max(old_range.start)..old_range.end)
 }
 
+// --- MARK: TESTS
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -27,28 +27,6 @@ pub enum ChildAlignment {
     SelfAligned(UnitPoint),
 }
 
-/// A widget container that lays the child widgets on top of each other.
-///
-/// The alignment of how the children are placed can be specified globally using [`with_alignment`][Self::with_alignment].
-/// Each child can additionally override the global alignment using [`ChildAlignment::SelfAligned`].
-///
-#[doc = include_screenshot!("zstack_alignment_default.png", "Red foreground widget on top of blue background widget.")]
-pub struct ZStack {
-    children: Vec<Child>,
-    alignment: UnitPoint,
-}
-
-impl Default for ZStack {
-    fn default() -> Self {
-        Self {
-            children: Vec::default(),
-            alignment: UnitPoint::CENTER,
-        }
-    }
-}
-
-// --- MARK: IMPL ALIGNMENTS
-
 impl From<UnitPoint> for ChildAlignment {
     fn from(value: UnitPoint) -> Self {
         Self::SelfAligned(value)
@@ -65,7 +43,28 @@ impl Child {
     }
 }
 
-// --- MARK: IMPL ZSTACK
+/// A widget container that lays the child widgets on top of each other.
+///
+/// The alignment of how the children are placed can be specified globally using [`with_alignment`][Self::with_alignment].
+/// Each child can additionally override the global alignment using [`ChildAlignment::SelfAligned`].
+///
+#[doc = include_screenshot!("zstack_alignment_default.png", "Red foreground widget on top of blue background widget.")]
+pub struct ZStack {
+    children: Vec<Child>,
+    alignment: UnitPoint,
+}
+
+// --- MARK: DEFAULT
+impl Default for ZStack {
+    fn default() -> Self {
+        Self {
+            children: Vec::default(),
+            alignment: UnitPoint::CENTER,
+        }
+    }
+}
+
+// --- MARK: BUILDERS
 impl ZStack {
     /// Constructs a new empty `ZStack` widget.
     pub fn new() -> Self {


### PR DESCRIPTION
The VSCode markings are quite useful and they would be even more useful if they would always follow the same pattern. I analyzed all the widget markings and came up with a standard that didn't require too much modification.

```rust
DEFAULT
BUILDERS
METHODS
WIDGETMUT
IMPL WIDGET
TESTS
```

This PR adds the missing marks and moves code around so that all widgets follow this order. There are no code changes.