### PR TITLE
Standardize widget child management methods.

### DIFF
--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -146,14 +146,14 @@ impl Grid {
     pub fn add_child(
         this: &mut WidgetMut<'_, Self>,
         child: NewWidget<impl Widget + ?Sized>,
-        params: GridParams,
+        params: impl Into<GridParams>,
     ) {
-        let child = new_grid_child(params, child);
+        let child = new_grid_child(params.into(), child);
         this.widget.children.push(child);
         this.ctx.children_changed();
     }
 
-    /// Insert a child widget already wrapped in a [`WidgetPod`] at the given index.
+    /// Insert a child widget at the given index.
     ///
     /// This lets you control the order in which the children are drawn. Children are
     /// drawn in index order (i.e. each child is drawn on top of the children with lower indices).
@@ -161,7 +161,7 @@ impl Grid {
     /// # Panics
     ///
     /// Panics if the index is larger than the number of children.
-    pub fn insert_grid_child_at(
+    pub fn insert_child(
         this: &mut WidgetMut<'_, Self>,
         idx: usize,
         child: NewWidget<impl Widget + ?Sized>,
@@ -520,7 +520,7 @@ mod tests {
         // Draw a widget under the others by putting it at index 0
         // Make it wide enough to see it stick out, with half of it under A and B.
         harness.edit_root_widget(|mut grid| {
-            Grid::insert_grid_child_at(
+            Grid::insert_child(
                 &mut grid,
                 0,
                 Button::with_text("C").with_auto_id(),

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -79,7 +79,6 @@ impl ZStack {
     }
 
     /// Appends a child widget to the `ZStack`.
-    /// The child are placed back to front, in the order they are added.
     pub fn with_child(
         mut self,
         child: NewWidget<impl Widget + ?Sized>,
@@ -94,16 +93,31 @@ impl ZStack {
 // --- MARK: WIDGETMUT
 impl ZStack {
     /// Add a child widget to the `ZStack`.
-    /// The child are placed back to front, in the order they are added.
     ///
     /// See also [`with_child`][Self::with_child].
-    pub fn insert_child(
+    pub fn add_child(
         this: &mut WidgetMut<'_, Self>,
         child: NewWidget<impl Widget + ?Sized>,
         alignment: impl Into<ChildAlignment>,
     ) {
         let child = Child::new(child.erased().to_pod(), alignment.into());
         this.widget.children.push(child);
+        this.ctx.children_changed();
+    }
+
+    /// Insert a child widget at the given index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is larger than the number of children.
+    pub fn insert_child(
+        this: &mut WidgetMut<'_, Self>,
+        idx: usize,
+        child: NewWidget<impl Widget + ?Sized>,
+        alignment: impl Into<ChildAlignment>,
+    ) {
+        let child = Child::new(child.erased().to_pod(), alignment.into());
+        this.widget.children.insert(idx, child);
         this.ctx.children_changed();
     }
 
@@ -124,18 +138,26 @@ impl ZStack {
     }
 
     /// Remove a child from the `ZStack`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds.
     pub fn remove_child(this: &mut WidgetMut<'_, Self>, idx: usize) {
         let child = this.widget.children.remove(idx);
         this.ctx.remove_child(child.widget);
     }
 
     /// Get a mutable reference to a child of the `ZStack`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds.
     pub fn child_mut<'t>(
         this: &'t mut WidgetMut<'_, Self>,
         idx: usize,
-    ) -> Option<WidgetMut<'t, dyn Widget>> {
+    ) -> WidgetMut<'t, dyn Widget> {
         let child = &mut this.widget.children[idx].widget;
-        Some(this.ctx.get_mut(child))
+        this.ctx.get_mut(child)
     }
 
     /// Change the alignment of the `ZStack`.
@@ -147,6 +169,10 @@ impl ZStack {
     }
 
     /// Change the alignment of a child of the `ZStack`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds.
     pub fn update_child_alignment(
         this: &mut WidgetMut<'_, Self>,
         idx: usize,

--- a/xilem/src/view/grid.rs
+++ b/xilem/src/view/grid.rs
@@ -247,7 +247,7 @@ impl ElementSplice<GridElement> for GridSplice<'_, '_> {
     fn with_scratch<R>(&mut self, f: impl FnOnce(&mut AppendVec<GridElement>) -> R) -> R {
         let ret = f(self.scratch);
         for element in self.scratch.drain() {
-            widgets::Grid::insert_grid_child_at(
+            widgets::Grid::insert_child(
                 &mut self.element,
                 self.idx,
                 element.child.new_widget,
@@ -259,7 +259,7 @@ impl ElementSplice<GridElement> for GridSplice<'_, '_> {
     }
 
     fn insert(&mut self, element: GridElement) {
-        widgets::Grid::insert_grid_child_at(
+        widgets::Grid::insert_child(
             &mut self.element,
             self.idx,
             element.child.new_widget,

--- a/xilem/src/view/zstack.rs
+++ b/xilem/src/view/zstack.rs
@@ -235,8 +235,7 @@ where
                     self.alignment,
                 );
             }
-            let mut child = widgets::ZStack::child_mut(&mut element.parent, element.idx)
-                .expect("ZStackWrapper always has a widget child");
+            let mut child = widgets::ZStack::child_mut(&mut element.parent, element.idx);
             self.view
                 .rebuild(&prev.view, view_state, ctx, child.downcast(), app_state);
         }
@@ -248,8 +247,7 @@ where
         ctx: &mut ViewCtx,
         mut element: Mut<'_, Self::Element>,
     ) {
-        let mut child = widgets::ZStack::child_mut(&mut element.parent, element.idx)
-            .expect("ZStackWrapper always has a widget child");
+        let mut child = widgets::ZStack::child_mut(&mut element.parent, element.idx);
         self.view.teardown(view_state, ctx, child.downcast());
     }
 
@@ -260,8 +258,7 @@ where
         mut element: Mut<'_, Self::Element>,
         app_state: Arg<'_, State>,
     ) -> MessageResult<Action> {
-        let mut child = widgets::ZStack::child_mut(&mut element.parent, element.idx)
-            .expect("ZStackWrapper always has a corresponding child");
+        let mut child = widgets::ZStack::child_mut(&mut element.parent, element.idx);
         self.view
             .message(view_state, message, child.downcast(), app_state)
     }
@@ -322,8 +319,7 @@ impl<W: Widget + FromDynWidget + ?Sized> SuperElement<Pod<W>, ViewCtx> for ZStac
         f: impl FnOnce(Mut<'_, Pod<W>>) -> R,
     ) -> (Self::Mut<'_>, R) {
         let ret = {
-            let mut child = widgets::ZStack::child_mut(&mut this.parent, this.idx)
-                .expect("This is supposed to be a widget");
+            let mut child = widgets::ZStack::child_mut(&mut this.parent, this.idx);
             let downcast = child.downcast();
             f(downcast)
         };
@@ -373,7 +369,7 @@ impl ElementSplice<ZStackElement> for ZStackSplice<'_, '_> {
     fn with_scratch<R>(&mut self, f: impl FnOnce(&mut AppendVec<ZStackElement>) -> R) -> R {
         let ret = f(self.scratch);
         for element in self.scratch.drain() {
-            widgets::ZStack::insert_child(
+            widgets::ZStack::add_child(
                 &mut self.element,
                 element.widget.new_widget,
                 element.alignment,
@@ -384,7 +380,7 @@ impl ElementSplice<ZStackElement> for ZStackSplice<'_, '_> {
     }
 
     fn insert(&mut self, element: ZStackElement) {
-        widgets::ZStack::insert_child(
+        widgets::ZStack::add_child(
             &mut self.element,
             element.widget.new_widget,
             element.alignment,


### PR DESCRIPTION
This PR makes all the widgets that have child management functions use the same conventions.

* `Grid::add_child` now takes `impl Into<GridParams>` like the other `Grid` methods
* `Grid::insert_grid_child_at` renamed to `Grid::insert_child`
* `ZStack::insert_child` renamed to `ZStack::add_child`
* A new `ZStack::insert_child` that takes an index
* `ZStack::child_mut` no longer returns an `Option` as it didn't ever give `None`
* More complete panic docs for `ZStack`