### PR TITLE
Add `swap_children` to collection widgets.

### DIFF
--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -443,6 +443,16 @@ impl Flex {
         this.ctx.request_layout();
     }
 
+    /// Swap the index of two children.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `a` or `b` are out of bounds.
+    pub fn swap_children(this: &mut WidgetMut<'_, Self>, a: usize, b: usize) {
+        this.widget.children.swap(a, b);
+        this.ctx.children_changed();
+    }
+
     /// Remove the child at `idx`.
     ///
     /// This child can be a widget or a spacer.

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -188,6 +188,25 @@ impl Grid {
         this.ctx.remove_child(old_child.widget);
     }
 
+    /// Swap the index of two children.
+    ///
+    /// This also swaps the [`GridParams`] `x` and `y` with the other child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `a` or `b` are out of bounds.
+    pub fn swap_children(this: &mut WidgetMut<'_, Self>, a: usize, b: usize) {
+        let (a_x, a_y) = (this.widget.children[a].x, this.widget.children[a].y);
+        let (b_x, b_y) = (this.widget.children[b].x, this.widget.children[b].y);
+
+        this.widget.children.swap(a, b);
+
+        (this.widget.children[a].x, this.widget.children[a].y) = (a_x, a_y);
+        (this.widget.children[b].x, this.widget.children[b].y) = (b_x, b_y);
+
+        this.ctx.children_changed();
+    }
+
     /// Set the spacing between grid items.
     pub fn set_spacing(this: &mut WidgetMut<'_, Self>, spacing: Length) {
         this.widget.grid_spacing = spacing;

--- a/masonry/src/widgets/indexed_stack.rs
+++ b/masonry/src/widgets/indexed_stack.rs
@@ -129,6 +129,16 @@ impl IndexedStack {
         this.ctx.remove_child(old_child);
     }
 
+    /// Swap the index of two children.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `a` or `b` are out of bounds.
+    pub fn swap_children(this: &mut WidgetMut<'_, Self>, a: usize, b: usize) {
+        this.widget.children.swap(a, b);
+        this.ctx.children_changed();
+    }
+
     /// Change the active child.
     ///
     /// # Panics

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -136,6 +136,16 @@ impl ZStack {
         this.ctx.remove_child(old_child.widget);
     }
 
+    /// Swap the index of two children.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `a` or `b` are out of bounds.
+    pub fn swap_children(this: &mut WidgetMut<'_, Self>, a: usize, b: usize) {
+        this.widget.children.swap(a, b);
+        this.ctx.children_changed();
+    }
+
     /// Remove a child from the `ZStack`.
     ///
     /// # Panics


### PR DESCRIPTION
These functions allow not having to create new children when just their location changed.