### PR TITLE
Fix `TextInput` placeholder text alignment

### DIFF
--- a/xilem_masonry/src/view/text_input.rs
+++ b/xilem_masonry/src/view/text_input.rs
@@ -275,6 +275,7 @@ impl<State: ViewArgument, Action: 'static> View<State, Action, ViewCtx>
 
         let text_input =
             widgets::TextInput::from_text_area(NewWidget::new_with_props(text_area, props))
+                .with_text_alignment(self.text_alignment)
                 .with_clip(self.clip)
                 .with_placeholder(self.placeholder.clone());
 
@@ -314,12 +315,16 @@ impl<State: ViewArgument, Action: 'static> View<State, Action, ViewCtx>
             widgets::TextInput::set_placeholder(&mut element, self.placeholder.clone());
         }
 
-        if prev.disabled != self.disabled {
+        if self.disabled != prev.disabled {
             element.ctx.set_disabled(self.disabled);
         }
 
         if self.clip != prev.clip {
             widgets::TextInput::set_clip(&mut element, self.clip);
+        }
+
+        if self.text_alignment != prev.text_alignment {
+            widgets::TextInput::set_text_alignment(&mut element, self.text_alignment);
         }
 
         let mut text_area = widgets::TextInput::text_mut(&mut element);
@@ -349,9 +354,6 @@ impl<State: ViewArgument, Action: 'static> View<State, Action, ViewCtx>
                 &mut text_area,
                 StyleProperty::FontStack(self.font.clone()),
             );
-        }
-        if prev.text_alignment != self.text_alignment {
-            widgets::TextArea::set_text_alignment(&mut text_area, self.text_alignment);
         }
         if prev.insert_newline != self.insert_newline {
             widgets::TextArea::set_insert_newline(&mut text_area, self.insert_newline);


### PR DESCRIPTION
The placeholder text in `TextInput` was not respecting the `text_alignment` property. So I added `text_alignment` field to `TextInput`.

To show why this is a problem, this is my current version of Runebender Xilem, note that the text input boxes are centered when they have values, but I could not find a way to center the placeholder text for the same input boxes.

<img width="1142" height="931" alt="Screenshot 2025-11-29 at 2 55 13 PM" src="https://github.com/user-attachments/assets/91dc96a3-7e58-4cfc-8cdf-16174b3c828e" />