### PR TITLE
Remove outdated links from root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,4 @@ Some files used for examples are under different licenses:
 - The data file (`status.csv`) in `xilem/resources/data/http_cats_status/` is licensed solely as documented in that folder (and is not licensed under the Apache License, Version 2.0).
 - The data file (`emoji.csv`) in `xilem/resources/data/emoji_names/` is licensed solely as documented in that folder (and is not licensed under the Apache License, Version 2.0).
 
-[Html.lazy]: https://guide.elm-lang.org/optimization/lazy.html
-[Html map]: https://package.elm-lang.org/packages/elm/html/latest/Html#map
-[Rc::make_mut]: https://doc.rust-lang.org/std/rc/struct.Rc.html#method.make_mut
-[AnyView]: https://developer.apple.com/documentation/swiftui/anyview
-[Panoramix]: https://github.com/PoignardAzur/panoramix
-[Xilem: an architecture for UI in Rust]: https://raphlinus.github.io/rust/gui/2022/05/07/ui-architecture.html
-[xkbcommon]: https://github.com/xkbcommon/libxkbcommon
 [Rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct

--- a/masonry_core/README.md
+++ b/masonry_core/README.md
@@ -60,7 +60,7 @@ Cases where this apply include:
 - Writing an alternative driver for Masonry (alike to [Masonry Winit][]).
 - Witing a library containing one or more custom widget (such as a 2d mapping widget).
 
-Masonry Core can also be used by by applications wishing to not use Masonry's provided
+Masonry Core can also be used by applications wishing to not use Masonry's provided
 set of widgets, so as to have more control.
 This can be especially useful if you wish to exactly match the appearance of an existing library,
 or enforce following a specific design guide, which Masonry's widgets may not always allow.

--- a/masonry_core/src/lib.rs
+++ b/masonry_core/src/lib.rs
@@ -31,7 +31,7 @@
 //! - Writing an alternative driver for Masonry (alike to [Masonry Winit][]).
 //! - Witing a library containing one or more custom widget (such as a 2d mapping widget).
 //!
-//! Masonry Core can also be used by by applications wishing to not use Masonry's provided
+//! Masonry Core can also be used by applications wishing to not use Masonry's provided
 //! set of widgets, so as to have more control.
 //! This can be especially useful if you wish to exactly match the appearance of an existing library,
 //! or enforce following a specific design guide, which Masonry's widgets may not always allow.


### PR DESCRIPTION
Also fix typo in masonry_core/README.