### PR TITLE
Add as_impl_view methods to check that view builders have the right bounds

### DIFF
--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -167,7 +167,7 @@ pub trait View<State: ViewArgument, Action, Context: ViewPathTracker>:
     #[doc(hidden)]
     /// An identity function, that lets us assert that
     /// the receiver always implements WidgetView<..>
-    fn as_impl_view(self) -> Self
+    fn check_impl_view(self) -> Self
     where
         Self: Sized,
     {

--- a/xilem_masonry/src/view/button.rs
+++ b/xilem_masonry/src/view/button.rs
@@ -98,7 +98,7 @@ pub fn button<
         disabled: false,
         phantom: PhantomData,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 /// A button with default styled text.

--- a/xilem_masonry/src/view/checkbox.rs
+++ b/xilem_masonry/src/view/checkbox.rs
@@ -50,7 +50,7 @@ where
         disabled: false,
         phantom: PhantomData,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 /// The [`View`] created by [`checkbox`] from a `label`, a bool value and a callback.

--- a/xilem_masonry/src/view/flex.rs
+++ b/xilem_masonry/src/view/flex.rs
@@ -94,7 +94,7 @@ pub fn flex<State: ViewArgument, Action: 'static, Seq: FlexSequence<State, Actio
         fill_major_axis: false,
         phantom: PhantomData,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 /// A layout where the children are laid out in a row.

--- a/xilem_masonry/src/view/grid.rs
+++ b/xilem_masonry/src/view/grid.rs
@@ -57,7 +57,7 @@ pub fn grid<State: ViewArgument, Action: 'static, Seq: GridSequence<State, Actio
         width,
         phantom: PhantomData,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 /// The [`View`] created by [`grid`] from a sequence, which also consumes custom width and height.

--- a/xilem_masonry/src/view/indexed_stack.rs
+++ b/xilem_masonry/src/view/indexed_stack.rs
@@ -62,7 +62,7 @@ pub fn indexed_stack<
         active_child: 0,
         phantom: PhantomData,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 /// The [`View`] created by [`indexed_stack`] from a sequence.

--- a/xilem_masonry/src/view/label.rs
+++ b/xilem_masonry/src/view/label.rs
@@ -33,7 +33,7 @@ use crate::{Pod, TextAlign, ViewCtx, WidgetView};
 /// # }
 /// ```
 pub fn label(label: impl Into<ArcStr>) -> Label {
-    WidgetView::<()>::as_impl_widget_view(Label {
+    WidgetView::<()>::check_impl_widget_view(Label {
         label: label.into(),
         text_alignment: TextAlign::default(),
         text_size: masonry::theme::TEXT_SIZE_NORMAL,

--- a/xilem_masonry/src/view/portal.rs
+++ b/xilem_masonry/src/view/portal.rs
@@ -20,7 +20,7 @@ where
         child,
         phantom: PhantomData,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 /// The [`View`] created by [`portal`].

--- a/xilem_masonry/src/view/progress_bar.rs
+++ b/xilem_masonry/src/view/progress_bar.rs
@@ -10,7 +10,7 @@ use crate::{Pod, ViewCtx, WidgetView};
 ///
 /// This can be for showing progress of a task or a download.
 pub fn progress_bar(progress: Option<f64>) -> ProgressBar {
-    WidgetView::<()>::as_impl_widget_view(ProgressBar { progress })
+    WidgetView::<()>::check_impl_widget_view(ProgressBar { progress })
 }
 
 /// The [`View`] created by [`progress_bar`].

--- a/xilem_masonry/src/view/prose.rs
+++ b/xilem_masonry/src/view/prose.rs
@@ -25,7 +25,7 @@ pub fn prose<State: ViewArgument, Action: 'static>(
         weight: FontWeight::NORMAL,
         phantom: PhantomData,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 /// A version of [`prose`] suitable for including in the same line

--- a/xilem_masonry/src/view/resize_observer.rs
+++ b/xilem_masonry/src/view/resize_observer.rs
@@ -72,7 +72,7 @@ where
         on_resize,
         phantom: PhantomData,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 /// The [`View`] created by [`resize_observer`].

--- a/xilem_masonry/src/view/sized_box.rs
+++ b/xilem_masonry/src/view/sized_box.rs
@@ -43,7 +43,7 @@ where
         width: None,
         phantom: PhantomData,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 /// The [`View`] created by [`sized_box`].

--- a/xilem_masonry/src/view/slider.rs
+++ b/xilem_masonry/src/view/slider.rs
@@ -42,7 +42,7 @@ where
         disabled: false,
         phantom: PhantomData,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 impl<State, Action, F> Slider<State, Action, F> {

--- a/xilem_masonry/src/view/spinner.rs
+++ b/xilem_masonry/src/view/spinner.rs
@@ -34,7 +34,7 @@ use crate::{Pod, ViewCtx, WidgetView};
 /// }
 /// ```
 pub fn spinner() -> Spinner {
-    WidgetView::<()>::as_impl_widget_view(Spinner)
+    WidgetView::<()>::check_impl_widget_view(Spinner)
 }
 
 /// The [`View`] created by [`spinner`].

--- a/xilem_masonry/src/view/split.rs
+++ b/xilem_masonry/src/view/split.rs
@@ -63,7 +63,7 @@ where
         child2,
         phantom: PhantomData,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 /// The [`View`] created by [`split`].

--- a/xilem_masonry/src/view/task.rs
+++ b/xilem_masonry/src/view/task.rs
@@ -51,7 +51,7 @@ where
         on_event,
         message: PhantomData,
     }
-    .as_impl_view()
+    .check_impl_view()
 }
 
 /// Launch a task which will run until the view is no longer in the tree.

--- a/xilem_masonry/src/view/text_input.rs
+++ b/xilem_masonry/src/view/text_input.rs
@@ -105,7 +105,7 @@ where
         // not clipping
         clip: true,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 /// The [`View`] created by [`text_input`].

--- a/xilem_masonry/src/view/transform.rs
+++ b/xilem_masonry/src/view/transform.rs
@@ -29,7 +29,7 @@ where
         transform: Affine::IDENTITY,
         phantom: PhantomData,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 /// The view for [`transformed`].

--- a/xilem_masonry/src/view/variable_label.rs
+++ b/xilem_masonry/src/view/variable_label.rs
@@ -13,7 +13,7 @@ use crate::{Pod, TextAlign, ViewCtx, WidgetView};
 
 /// A view for displaying non-editable text, with a variable [weight](masonry::parley::style::FontWeight).
 pub fn variable_label(text: impl Into<ArcStr>) -> VariableLabel {
-    WidgetView::<()>::as_impl_widget_view(VariableLabel {
+    WidgetView::<()>::check_impl_widget_view(VariableLabel {
         label: label(text),
         target_weight: FontWeight::NORMAL,
         over_millis: 0.,

--- a/xilem_masonry/src/view/virtual_scroll.rs
+++ b/xilem_masonry/src/view/virtual_scroll.rs
@@ -64,7 +64,7 @@ where
         func,
         valid_range,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 /// Component for a [`VirtualScroll`] with unlimited children.

--- a/xilem_masonry/src/view/worker.rs
+++ b/xilem_masonry/src/view/worker.rs
@@ -71,7 +71,7 @@ where
         on_response,
         message: PhantomData,
     }
-    .as_impl_view()
+    .check_impl_view()
 }
 
 /// A version of [`worker`] which can store its message sender in the environment.
@@ -107,7 +107,7 @@ where
         on_response,
         message: PhantomData,
     }
-    .as_impl_view()
+    .check_impl_view()
 }
 
 /// An internal struct used to make [`env_worker`]/[`worker`] work.
@@ -158,7 +158,7 @@ where
         },
         message: PhantomData,
     }
-    .as_impl_view()
+    .check_impl_view()
 }
 
 /// The View type for [`worker`], [`env_worker`] and [`worker_raw`]. See its documentation for details.

--- a/xilem_masonry/src/view/zstack.rs
+++ b/xilem_masonry/src/view/zstack.rs
@@ -41,7 +41,7 @@ pub fn zstack<State: ViewArgument, Action: 'static, Seq: ZStackSequence<State, A
         sequence,
         alignment: UnitPoint::CENTER,
     }
-    .as_impl_widget_view()
+    .check_impl_widget_view()
 }
 
 /// A view container that lays the child widgets on top of each other.

--- a/xilem_masonry/src/widget_view.rs
+++ b/xilem_masonry/src/widget_view.rs
@@ -83,7 +83,7 @@ pub trait WidgetView<State: ViewArgument, Action: 'static = ()>:
     #[doc(hidden)]
     /// An identity function, that lets us assert that
     /// the receiver always implements WidgetView<..>
-    fn as_impl_widget_view(self) -> Self
+    fn check_impl_widget_view(self) -> Self
     where
         Self: Sized,
     {
@@ -121,7 +121,7 @@ pub trait WidgetViewSequence<State: ViewArgument, Action = ()>:
     #[doc(hidden)]
     /// An identity function, that lets us assert that
     /// the receiver always implements WidgetViewSequence<..>
-    fn as_impl_widget_view_seq(self) -> Self
+    fn check_impl_widget_view_seq(self) -> Self
     where
         Self: Sized,
     {


### PR DESCRIPTION
This doesn't change which programs will compile, but tends to make error messages shorter and more informative.