### PR TITLE
Fix `Portal` size constraints.

### DIFF
--- a/masonry/examples/to_do_list.rs
+++ b/masonry/examples/to_do_list.rs
@@ -74,7 +74,7 @@ pub fn make_widget_tree() -> NewWidget<impl Widget> {
         ))
         .with_fixed_spacer(WIDGET_SPACING);
 
-    NewWidget::new(Portal::new(NewWidget::new_with_tag(list, LIST_TAG)))
+    NewWidget::new(Portal::new(NewWidget::new_with_tag(list, LIST_TAG)).constrain_horizontal(true))
 }
 
 fn main() {


### PR DESCRIPTION
`Portal` already had `constrain_vertical` and `constrain_horizontal` properties but these were only used to hide the scrollbar. They didn't actually affect the child layout in any way.

Indeed, the `Portal` layout implementation had a simple hardcoded `let max_child_size = bc.max()`, meaning that the child was always fully constrained.

This PR implements actual constrainment logic, configurable with the aforementioned properties. When not set to constrain, the child gets unbounded constraints. After all, that is the main point of `Portal` - to be able to scroll over giant children.

Also, when an axis is constrained, `Portal` now also ignores mouse wheel scrolling in that direction, in addition to hiding the visual scrollbar.