### PR TITLE
WIP: Add support for per-side, symmetric, and uniform borders in BorderWidth

### DIFF
--- a/masonry/examples/calc_masonry.rs
+++ b/masonry/examples/calc_masonry.rs
@@ -204,7 +204,7 @@ fn op_button_with_label(op: char, label: String) -> NewWidget<Button> {
             .with(ActiveBackground(Background::Color(LIGHT_BLUE)))
             .with(HoveredBorderColor(BorderColor::new(Color::WHITE)))
             .with(BorderColor::new(Color::TRANSPARENT))
-            .with(BorderWidth::all(2.0))
+            .with(BorderWidth::uniform(2.0))
             .with(CalcAction::Op(op)),
     )
 }
@@ -232,7 +232,7 @@ fn digit_button(digit: u8) -> NewWidget<Button> {
             .with(ActiveBackground(Background::Color(LIGHT_GRAY)))
             .with(HoveredBorderColor(BorderColor::new(Color::WHITE)))
             .with(BorderColor::new(Color::TRANSPARENT))
-            .with(BorderWidth::all(2.0))
+            .with(BorderWidth::uniform(2.0))
             .with(CalcAction::Digit(digit)),
     )
 }

--- a/masonry/examples/grid_masonry.rs
+++ b/masonry/examples/grid_masonry.rs
@@ -70,7 +70,7 @@ pub fn make_grid(grid_gap: f64) -> NewWidget<Grid> {
 
     let props = Properties::new()
         .with(BorderColor::new(Color::from_rgb8(40, 40, 80)))
-        .with(BorderWidth::all(1.0));
+        .with(BorderWidth::uniform(1.0));
     let label = SizedBox::new(NewWidget::new_with(
         label,
         WidgetId::next(),

--- a/masonry/src/properties/border_width.rs
+++ b/masonry/src/properties/border_width.rs
@@ -3,84 +3,210 @@
 
 use std::any::TypeId;
 
-use vello::kurbo::{Point, RoundedRect, Size, Vec2};
-
 use crate::core::{BoxConstraints, Property, UpdateCtx};
 use crate::properties::CornerRadius;
+use crate::util::stroke;
 
-/// The width of a widget's border, in logical pixels.
-#[expect(missing_docs, reason = "field names are self-descriptive")]
+use vello::Scene;
+use vello::kurbo::{self, Affine, Cap, Join, Line, Point, RoundedRect, Size, Stroke, Vec2};
+use vello::peniko::Color;
+
+/// Border widths for each side of a widget, in logical pixels.
+/// Order follows CSS convention: Top, Right, Bottom, Left.
 #[derive(Default, Clone, Copy, Debug, PartialEq)]
 pub struct BorderWidth {
-    pub width: f64,
+    /// Thickness of the top border.
+    pub top: f64,
+    /// Thickness of the right border.
+    pub right: f64,
+    /// Thickness of the bottom border.
+    pub bottom: f64,
+    /// Thickness of the left border.
+    pub left: f64,
 }
-
-// TODO - To match CSS, we should use a non-zero default width
-// and a "border style" of "None".
 
 impl Property for BorderWidth {
     fn static_default() -> &'static Self {
-        static DEFAULT: BorderWidth = BorderWidth { width: 0. };
+        static DEFAULT: BorderWidth = BorderWidth {
+            top: 0.0,
+            right: 0.0,
+            bottom: 0.0,
+            left: 0.0,
+        };
         &DEFAULT
     }
 }
 
 impl BorderWidth {
-    /// Creates new `BorderWidth` with given value.
-    pub const fn all(width: f64) -> Self {
-        Self { width }
+    /// Creates a new `BorderWidth` with (Top, Right, Bottom, Left) values.
+    pub const fn new(top: f64, right: f64, bottom: f64, left: f64) -> Self {
+        Self {
+            top,
+            right,
+            bottom,
+            left,
+        }
     }
 
-    /// Helper function to be called in [`Widget::property_changed`](crate::core::Widget::property_changed).
-    pub fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        if property_type != TypeId::of::<Self>() {
-            return;
+    /// Creates a uniform border with the same thickness on all sides.
+    pub fn uniform(width: f64) -> Self {
+        Self {
+            top: width,
+            right: width,
+            bottom: width,
+            left: width,
         }
-        ctx.request_layout();
+    }
+
+    /// Creates a symmetric border with vertical and horizontal values.
+    pub fn symmetric(vertical: f64, horizontal: f64) -> Self {
+        Self {
+            top: vertical,
+            right: horizontal,
+            bottom: vertical,
+            left: horizontal,
+        }
+    }
+
+    /// Returns the minimum side thickness.
+    pub fn min_side(&self) -> f64 {
+        self.top.min(self.right).min(self.bottom).min(self.left)
+    }
+
+    /// Returns true if all sides are equal within a small epsilon.
+    pub fn is_uniform(&self) -> bool {
+        let eps = 1e-9;
+        (self.top - self.right).abs() < eps
+            && (self.top - self.bottom).abs() < eps
+            && (self.top - self.left).abs() < eps
+    }
+
+    /// Requests a layout update if this property type has changed.
+    pub fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
+        if property_type == TypeId::of::<Self>() {
+            ctx.request_layout();
+        }
     }
 
     /// Shrinks the box constraints by the border width.
-    ///
-    /// Helper function to be called in [`Widget::layout`](crate::core::Widget::layout).
     pub fn layout_down(&self, bc: BoxConstraints) -> BoxConstraints {
-        bc.shrink((self.width * 2., self.width * 2.))
+        bc.shrink((self.left + self.right, self.top + self.bottom))
     }
 
     /// Expands the size and raises the baseline by the border width.
-    ///
-    /// Helper function to be called in [`Widget::layout`](crate::core::Widget::layout).
     pub fn layout_up(&self, size: Size, baseline: f64) -> (Size, f64) {
-        let size = Size::new(size.width + self.width * 2., size.height + self.width * 2.);
-        let baseline = baseline + self.width;
-        (size, baseline)
+        let new_size = Size::new(
+            size.width + self.left + self.right,
+            size.height + self.top + self.bottom,
+        );
+        (new_size, baseline + self.top)
     }
 
     /// Shifts the position by the border width.
-    ///
-    /// Helper function to be called in [`Widget::layout`](crate::core::Widget::layout).
     pub fn place_down(&self, pos: Point) -> Point {
-        pos + Vec2::new(self.width, self.width)
+        pos + Vec2::new(self.left, self.top)
     }
 
-    /// Creates a rounded rectangle that is inset by the border width.
-    ///
-    /// Use to display a box's background.
-    ///
-    /// Helper function to be called in [`Widget::paint`](crate::core::Widget::paint).
+    /// Rounded rectangle inset by the full border width (for background fill).
     pub fn bg_rect(&self, size: Size, border_radius: &CornerRadius) -> RoundedRect {
-        size.to_rect()
-            .inset(-self.width)
-            .to_rounded_rect((border_radius.radius - self.width).max(0.))
+        let insets = kurbo::Insets::new(self.left, self.top, self.right, self.bottom);
+        let inner_radius = (border_radius.radius - self.min_side()).max(0.0);
+        size.to_rect().inset(insets).to_rounded_rect(inner_radius)
     }
 
-    /// Creates a rounded rectangle that is inset by half the border width.
-    ///
-    /// Use to display a box's border.
-    ///
-    /// Helper function to be called in [`Widget::paint`](crate::core::Widget::paint).
+    /// Rounded rectangle inset by half the border width (for centered stroke).
     pub fn border_rect(&self, size: Size, border_radius: &CornerRadius) -> RoundedRect {
+        let insets = kurbo::Insets::new(
+            self.left / 2.0,
+            self.top / 2.0,
+            self.right / 2.0,
+            self.bottom / 2.0,
+        );
         size.to_rect()
-            .inset(-self.width / 2.0)
+            .inset(insets)
             .to_rounded_rect(border_radius.radius)
     }
+
+    /// Paints the border. Uses rounded rect stroke for uniform borders,
+    /// and explicit line strokes for non-uniform borders.
+    pub fn paint(&self, scene: &mut Scene, border_rect: &RoundedRect, color: Color, size: Size) {
+        if self.is_uniform() {
+            if self.top > 0.0 {
+                stroke(scene, border_rect, color, self.top);
+            }
+        } else {
+            let r = size.to_rect();
+
+            // Top
+            Self::stroke_side(
+                scene,
+                (r.x0, r.y0 + self.top / 2.0),
+                (r.x1, r.y0 + self.top / 2.0),
+                color,
+                self.top,
+            );
+
+            // Bottom
+            Self::stroke_side(
+                scene,
+                (r.x0, r.y1 - self.bottom / 2.0),
+                (r.x1, r.y1 - self.bottom / 2.0),
+                color,
+                self.bottom,
+            );
+
+            // Left
+            Self::stroke_side(
+                scene,
+                (r.x0 + self.left / 2.0, r.y0),
+                (r.x0 + self.left / 2.0, r.y1),
+                color,
+                self.left,
+            );
+
+            // Right
+            Self::stroke_side(
+                scene,
+                (r.x1 - self.right / 2.0, r.y0),
+                (r.x1 - self.right / 2.0, r.y1),
+                color,
+                self.right,
+            );
+        }
+    }
+
+    /// Helper to stroke a single side with flat caps and sharp joins.
+    fn stroke_side(
+        scene: &mut Scene,
+        p0: impl Into<Point>,
+        p1: impl Into<Point>,
+        color: Color,
+        width: f64,
+    ) {
+        if width > 0.0 {
+            let line = Line::new(p0, p1);
+            let mut style = Stroke::new(width);
+            style.start_cap = Cap::Butt;
+            style.end_cap = Cap::Butt;
+            style.join = Join::Miter;
+            scene.stroke(&style, Affine::IDENTITY, color, None, &line);
+        }
+    }
 }
+
+impl From<f64> for BorderWidth {
+    fn from(w: f64) -> Self {
+        Self::uniform(w)
+    }
+}
+impl From<(f64, f64)> for BorderWidth {
+    fn from((v, h): (f64, f64)) -> Self {
+        Self::symmetric(v, h)
+    }
+}
+impl From<(f64, f64, f64, f64)> for BorderWidth {
+    fn from((t, r, b, l): (f64, f64, f64, f64)) -> Self {
+        Self::new(t, r, b, l)
+    }
+}
+

--- a/masonry/src/theme.rs
+++ b/masonry/src/theme.rs
@@ -64,7 +64,10 @@ pub fn default_property_set() -> DefaultProperties {
     properties.insert::<Button, _>(Padding::from_vh(6., 16.));
     properties.insert::<Button, _>(CornerRadius { radius: 6. });
     properties.insert::<Button, _>(BorderWidth {
-        width: BORDER_WIDTH,
+        top: BORDER_WIDTH,
+        left: BORDER_WIDTH,
+        right: BORDER_WIDTH,
+        bottom: BORDER_WIDTH,
     });
 
     properties.insert::<Button, _>(Background::Color(ZYNC_800));
@@ -77,7 +80,10 @@ pub fn default_property_set() -> DefaultProperties {
     // Checkbox
     properties.insert::<Checkbox, _>(CornerRadius { radius: 4. });
     properties.insert::<Checkbox, _>(BorderWidth {
-        width: BORDER_WIDTH,
+        top: BORDER_WIDTH,
+        left: BORDER_WIDTH,
+        right: BORDER_WIDTH,
+        bottom: BORDER_WIDTH,
     });
 
     properties.insert::<Checkbox, _>(Background::Color(ZYNC_800));
@@ -103,7 +109,10 @@ pub fn default_property_set() -> DefaultProperties {
     properties.insert::<TextInput, _>(Padding::from_vh(6., 12.));
     properties.insert::<TextInput, _>(CornerRadius { radius: 4. });
     properties.insert::<TextInput, _>(BorderWidth {
-        width: BORDER_WIDTH,
+        top: BORDER_WIDTH,
+        left: BORDER_WIDTH,
+        right: BORDER_WIDTH,
+        bottom: BORDER_WIDTH,
     });
     properties.insert::<TextInput, _>(BorderColor { color: ZYNC_600 });
     properties.insert::<TextInput, _>(FocusedBorderColor(BorderColor { color: FOCUS_COLOR }));
@@ -147,7 +156,10 @@ pub fn default_property_set() -> DefaultProperties {
     // ProgressBar
     properties.insert::<ProgressBar, _>(CornerRadius { radius: 2. });
     properties.insert::<ProgressBar, _>(BorderWidth {
-        width: BORDER_WIDTH,
+        top: BORDER_WIDTH,
+        left: BORDER_WIDTH,
+        right: BORDER_WIDTH,
+        bottom: BORDER_WIDTH,
     });
 
     properties.insert::<ProgressBar, _>(Background::Color(ZYNC_900));

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -24,7 +24,7 @@ use crate::properties::{
     DisabledBackground, FocusedBorderColor, HoveredBorderColor, Padding,
 };
 use crate::theme;
-use crate::util::{fill, include_screenshot, stroke};
+use crate::util::{fill, include_screenshot};
 use crate::widgets::Label;
 
 /// A button with a child widget.
@@ -272,7 +272,7 @@ impl Widget for Button {
 
         let brush = bg.get_peniko_brush_for_rect(bg_rect.rect());
         fill(scene, &bg_rect, &brush);
-        stroke(scene, &border_rect, border_color.color, border_width.width);
+        border_width.paint(scene, &border_rect, border_color.color, size);
     }
 
     fn post_paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
@@ -421,7 +421,12 @@ mod tests {
 
         harness.edit_root_widget(|mut button| {
             button.insert_prop(BorderColor { color: red });
-            button.insert_prop(BorderWidth { width: 5.0 });
+            button.insert_prop(BorderWidth {
+                top: 5.0,
+                left: 5.0,
+                right: 5.0,
+                bottom: 5.0,
+            });
             button.insert_prop(CornerRadius { radius: 20.0 });
             button.insert_prop(Padding::from_vh(3., 8.));
 

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -23,7 +23,7 @@ use crate::properties::{
     HoveredBorderColor, Padding,
 };
 use crate::theme;
-use crate::util::{fill, include_screenshot, stroke};
+use crate::util::{fill, include_screenshot};
 use crate::widgets::Label;
 
 /// A checkbox that can be toggled.
@@ -258,7 +258,7 @@ impl Widget for Checkbox {
         // Paint the checkbox box background and border
         let brush = bg.get_peniko_brush_for_rect(bg_rect.rect());
         fill(scene, &bg_rect, &brush);
-        stroke(scene, &border_rect, border_color.color, border_width.width);
+        border_width.paint(scene, &border_rect, border_color.color, size);
 
         // Paint the checkmark if checked
         if self.checked {

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -17,7 +17,7 @@ use crate::core::{
 };
 use crate::properties::types::{CrossAxisAlignment, Length, MainAxisAlignment};
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Gap, Padding};
-use crate::util::{debug_panic, fill, include_screenshot, stroke};
+use crate::util::{debug_panic, fill, include_screenshot};
 
 /// A container with either horizontal or vertical layout.
 ///
@@ -862,8 +862,7 @@ impl Widget for Flex {
 
         let brush = bg.get_peniko_brush_for_rect(bg_rect.rect());
         fill(scene, &bg_rect, &brush);
-        stroke(scene, &border_rect, border_color.color, border_width.width);
-
+        border_width.paint(scene, &border_rect, border_color.color, ctx.size());
         // paint the baseline if we're debugging layout
         if ctx.debug_paint_enabled() && ctx.baseline_offset() != 0.0 {
             let color = ctx.debug_color();
@@ -1030,7 +1029,7 @@ mod tests {
                 .with_fixed(Label::new("world").with_auto_id())
                 .with_fixed(Label::new("foo").with_auto_id())
                 .with_fixed(Label::new("bar").with_auto_id()),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)).into(),
+            (BorderWidth::uniform(2.0), BorderColor::new(ACCENT_COLOR)).into(),
         );
 
         let window_size = Size::new(200.0, 150.0);
@@ -1079,7 +1078,7 @@ mod tests {
                     Label::new("bar").with_auto_id(),
                     FlexParams::new(2.0, CrossAxisAlignment::Start),
                 ),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)).into(),
+            (BorderWidth::uniform(2.0), BorderColor::new(ACCENT_COLOR)).into(),
         );
 
         let window_size = Size::new(200.0, 150.0);
@@ -1122,7 +1121,7 @@ mod tests {
                     Label::new("bar").with_auto_id(),
                     FlexParams::new(2.0, CrossAxisAlignment::Start),
                 ),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)).into(),
+            (BorderWidth::uniform(2.0), BorderColor::new(ACCENT_COLOR)).into(),
         );
 
         let window_size = Size::new(200.0, 150.0);
@@ -1180,7 +1179,7 @@ mod tests {
                     Label::new("bar").with_auto_id(),
                     FlexParams::new(2.0, CrossAxisAlignment::Start),
                 ),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)).into(),
+            (BorderWidth::uniform(2.0), BorderColor::new(ACCENT_COLOR)).into(),
         );
 
         let window_size = Size::new(200.0, 150.0);
@@ -1223,7 +1222,7 @@ mod tests {
                     Label::new("bar").with_auto_id(),
                     FlexParams::new(2.0, CrossAxisAlignment::Start),
                 ),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)).into(),
+            (BorderWidth::uniform(2.0), BorderColor::new(ACCENT_COLOR)).into(),
         );
 
         let window_size = Size::new(200.0, 150.0);

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -14,7 +14,7 @@ use crate::core::{
     PropertiesMut, PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Gap, Padding};
-use crate::util::{debug_panic, fill, include_screenshot, stroke};
+use crate::util::{debug_panic, fill, include_screenshot};
 
 /// A widget that arranges its children in a grid.
 ///
@@ -343,8 +343,7 @@ impl Widget for Grid {
 
         let brush = bg.get_peniko_brush_for_rect(bg_rect.rect());
         fill(scene, &bg_rect, &brush);
-        stroke(scene, &border_rect, border_color.color, border_width.width);
-
+        border_width.paint(scene, &border_rect, border_color.color, ctx.size());
         // paint the baseline if we're debugging layout
         if ctx.debug_paint_enabled() && ctx.baseline_offset() != 0.0 {
             let color = ctx.debug_color();

--- a/masonry/src/widgets/indexed_stack.rs
+++ b/masonry/src/widgets/indexed_stack.rs
@@ -14,7 +14,7 @@ use crate::core::{
     PropertiesMut, PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
-use crate::util::{debug_panic, fill, include_screenshot, stroke};
+use crate::util::{debug_panic, fill, include_screenshot};
 
 // TODO - Rename "active" widget to "visible" widget?
 // Active already means something else.
@@ -288,8 +288,7 @@ impl Widget for IndexedStack {
 
         let brush = bg.get_peniko_brush_for_rect(bg_rect.rect());
         fill(scene, &bg_rect, &brush);
-        stroke(scene, &border_rect, border_color.color, border_width.width);
-
+        border_width.paint(scene, &border_rect, border_color.color, ctx.size());
         // paint the baseline if we're debugging layout
         if ctx.debug_paint_enabled() && ctx.baseline_offset() != 0.0 {
             let color = ctx.debug_color();

--- a/masonry/src/widgets/progress_bar.rs
+++ b/masonry/src/widgets/progress_bar.rs
@@ -18,7 +18,7 @@ use crate::core::{
 use crate::properties::{
     Background, BarColor, BorderColor, BorderWidth, CornerRadius, LineBreaking,
 };
-use crate::util::{fill, include_screenshot, stroke};
+use crate::util::{fill, include_screenshot};
 use crate::widgets::Label;
 
 // TODO - NaN probably shouldn't be a meaningful value in our API.
@@ -169,8 +169,7 @@ impl Widget for ProgressBar {
         let brush = bg.get_peniko_brush_for_rect(bg_rect.rect());
         fill(scene, &bg_rect, &brush);
         fill(scene, &progress_rect, bar_color.0);
-
-        stroke(scene, &border_rect, border_color.color, border_width.width);
+        border_width.paint(scene, &border_rect, border_color.color, ctx.size());
     }
 
     fn accessibility_role(&self) -> Role {

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -17,7 +17,7 @@ use crate::core::{
 };
 use crate::properties::types::Length;
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
-use crate::util::{fill, include_screenshot, stroke};
+use crate::util::{fill, include_screenshot};
 
 /// A widget with predefined size.
 ///
@@ -317,7 +317,7 @@ impl Widget for SizedBox {
 
         let brush = bg.get_peniko_brush_for_rect(bg_rect.rect());
         fill(scene, &bg_rect, &brush);
-        stroke(scene, &border_rect, border_color.color, border_width.width);
+        border_width.paint(scene, &border_rect, border_color.color, ctx.size());
     }
 
     fn accessibility_role(&self) -> Role {
@@ -379,7 +379,7 @@ mod tests {
     fn empty_box() {
         let mut box_props = Properties::new();
         box_props.insert(BorderColor::new(palette::css::BLUE));
-        box_props.insert(BorderWidth::all(5.0));
+        box_props.insert(BorderWidth::uniform(5.0));
         box_props.insert(CornerRadius::all(5.0));
 
         let widget = SizedBox::empty()
@@ -397,7 +397,7 @@ mod tests {
     fn label_box_no_size() {
         let mut box_props = Properties::new();
         box_props.insert(BorderColor::new(palette::css::BLUE));
-        box_props.insert(BorderWidth::all(5.0));
+        box_props.insert(BorderWidth::uniform(5.0));
         box_props.insert(CornerRadius::all(5.0));
 
         let widget = SizedBox::new(Label::new("hello").with_auto_id()).with_props(box_props);
@@ -412,7 +412,7 @@ mod tests {
     fn label_box_with_size() {
         let mut box_props = Properties::new();
         box_props.insert(BorderColor::new(palette::css::BLUE));
-        box_props.insert(BorderWidth::all(5.0));
+        box_props.insert(BorderWidth::uniform(5.0));
         box_props.insert(CornerRadius::all(5.0));
 
         let widget = SizedBox::new(Label::new("hello").with_auto_id())
@@ -430,7 +430,7 @@ mod tests {
     fn label_box_with_padding() {
         let mut box_props = Properties::new();
         box_props.insert(BorderColor::new(palette::css::BLUE));
-        box_props.insert(BorderWidth::all(5.0));
+        box_props.insert(BorderWidth::uniform(5.0));
         box_props.insert(CornerRadius::all(5.0));
         box_props.insert(Padding::from_vh(15., 10.));
 
@@ -471,7 +471,7 @@ mod tests {
         ]);
         box_props.insert(Background::Gradient(gradient));
         box_props.insert(BorderColor::new(palette::css::LIGHT_SKY_BLUE));
-        box_props.insert(BorderWidth::all(5.0));
+        box_props.insert(BorderWidth::uniform(5.0));
         box_props.insert(CornerRadius::all(10.0));
 
         let widget = SizedBox::empty()
@@ -498,7 +498,7 @@ mod tests {
         ]);
         box_props.insert(Background::Gradient(gradient));
         box_props.insert(BorderColor::new(palette::css::LIGHT_SKY_BLUE));
-        box_props.insert(BorderWidth::all(5.0));
+        box_props.insert(BorderWidth::uniform(5.0));
         box_props.insert(CornerRadius::all(10.0));
 
         let widget = SizedBox::empty()
@@ -525,7 +525,7 @@ mod tests {
         ]);
         box_props.insert(Background::Gradient(gradient));
         box_props.insert(BorderColor::new(palette::css::LIGHT_SKY_BLUE));
-        box_props.insert(BorderWidth::all(5.0));
+        box_props.insert(BorderWidth::uniform(5.0));
         box_props.insert(CornerRadius::all(10.0));
 
         let widget = SizedBox::empty()
@@ -544,7 +544,7 @@ mod tests {
         let mut box_props = Properties::new();
         box_props.insert(Background::Color(palette::css::PLUM));
         box_props.insert(BorderColor::new(palette::css::LIGHT_SKY_BLUE));
-        box_props.insert(BorderWidth::all(5.0));
+        box_props.insert(BorderWidth::uniform(5.0));
         box_props.insert(Padding::all(25.));
 
         let widget = SizedBox::new(Label::new("hello").with_auto_id())
@@ -565,11 +565,11 @@ mod tests {
         // Copy-pasted from empty_box
         let mut box_props = Properties::new();
         box_props.insert(BorderColor::new(palette::css::BLUE));
-        box_props.insert(BorderWidth::all(5.0));
+        box_props.insert(BorderWidth::uniform(5.0));
         box_props.insert(CornerRadius::all(5.0));
 
         // This is the difference
-        box_props.insert(BorderWidth::all(5.2));
+        box_props.insert(BorderWidth::uniform(5.2));
 
         let widget = SizedBox::empty()
             .width(20.px())

--- a/masonry/src/widgets/text_input.rs
+++ b/masonry/src/widgets/text_input.rs
@@ -20,7 +20,7 @@ use crate::properties::{
     DisabledBackground, FocusedBorderColor, Padding, PlaceholderColor, SelectionColor,
     UnfocusedSelectionColor,
 };
-use crate::util::{fill, stroke};
+use crate::util::fill;
 use crate::widgets::{Label, TextArea};
 
 /// The text input widget displays text which can be edited by the user,
@@ -326,7 +326,7 @@ impl Widget for TextInput {
 
         let brush = bg.get_peniko_brush_for_rect(bg_rect.rect());
         fill(scene, &bg_rect, &brush);
-        stroke(scene, &border_rect, border_color.color, border_width.width);
+        border_width.paint(scene, &border_rect, border_color.color, ctx.size());
     }
 
     fn accessibility_role(&self) -> Role {

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -294,12 +294,12 @@ mod tests {
         let mut bg_props = Properties::new();
         bg_props.insert(Background::Color(palette::css::BLUE));
         bg_props.insert(BorderColor::new(palette::css::TEAL));
-        bg_props.insert(BorderWidth::all(2.0));
+        bg_props.insert(BorderWidth::uniform(2.0));
 
         let mut fg_props = Properties::new();
         fg_props.insert(Background::Color(palette::css::RED));
         fg_props.insert(BorderColor::new(palette::css::PINK));
-        fg_props.insert(BorderWidth::all(2.0));
+        fg_props.insert(BorderWidth::uniform(2.0));
 
         let widget = ZStack::new()
             .with(

--- a/xilem_masonry/src/style.rs
+++ b/xilem_masonry/src/style.rs
@@ -133,12 +133,12 @@ pub trait Style<State: ViewArgument, Action: 'static>: WidgetView<State, Action>
     fn border(
         self,
         color: Color,
-        width: f64,
+        width: impl Into<BorderWidth>, // Change f64 to this
     ) -> Prop<BorderWidth, Prop<BorderColor, Self, State, Action>, State, Action>
     where
         Self::Widget: HasProperty<BorderColor> + HasProperty<BorderWidth>,
     {
-        self.prop(BorderColor { color }).prop(BorderWidth { width })
+        self.prop(BorderColor { color }).prop(width.into())
     }
 
     /// Sets the element's border color.
@@ -166,11 +166,13 @@ pub trait Style<State: ViewArgument, Action: 'static>: WidgetView<State, Action>
     }
 
     /// Sets the element's border width.
-    fn border_width(self, width: f64) -> Prop<BorderWidth, Self, State, Action>
+    fn border_width(self, width: impl Into<BorderWidth>) -> Prop<BorderWidth, Self, State, Action>
     where
         Self::Widget: HasProperty<BorderWidth>,
     {
-        self.prop(BorderWidth { width })
+        // width.into() automatically converts f64, (f64, f64), etc.
+        // into your new 4-sided BorderWidth struct
+        self.prop(width.into())
     }
 
     /// Sets the element's box shadow.


### PR DESCRIPTION
Changes:
- added per-side border widths (top/right/bottom/left)
- added symmetric borders (horizontal/vertical)
- added uniform borders
- updated layout/geometry to handle these
- added paint method to BorderWidth

Reason:
main goal is flexibility being able to style only the borders you care about instead of all sides at once.

Why is paint here:
without a paint method in BorderWidth, every widget that needs to draw borders would end up with a big if/else mess to handle 4 sides, symmetric cases, and uniform cases. putting the paint logic inside BorderWidth keeps that complexity in one place and avoids blotting the codebase with repeated drawing logic.

Notes:
i’m new to the codebase, so if this doesn’t fit the design direction i’m open to adjusting. border_color will follow in a separate change.
