### PR TITLE
Add `Sanitize` util trait.

### DIFF
--- a/masonry_core/src/util.rs
+++ b/masonry_core/src/util.rs
@@ -36,6 +36,13 @@ macro_rules! debug_panic {
 pub use crate::debug_panic;
 
 /// Provides sanitization of values.
+///
+/// This is a generic trait that doesn't specify what sanitization exactly means,
+/// as that will be implementations specific per type.
+///
+/// Right now it is also implemented for `f64` and `Option<f64>` in a way
+/// where it forbids non-finite and negative values. This is immediately useful for
+/// Masonry itself but is likely to go away as we migrate our float usage to newtypes.
 pub trait Sanitize {
     /// Returns the sanitized value.
     ///


### PR DESCRIPTION
This is such a common check that needs to happen when dealing with floats that it's worth improving the ergonomics of it to a method call.

Now, one quirk of this implementation is that the docs talk about non-negative not being allowed but the actual check is for below zero. That is to say `-0.` is allowed through.

I'm not sure if it's worth forbidding `-0.`, because:

```
5. + -0. == 5.
5. - -0. == 5.
5. * -0. == -0.
5. / -0. == -inf
5_f64.powf(-0.) == 1.
```

We don't want to be dividing by zero anyway and have checks for that, so the only real sign carryover happens with multiplication, but the result will always be zero, so the problem doesn't "grow" into other negatvie numbers.

We could check for the sign bit instead and then if it's negative, do a special check for `-0.` and silently convert it to positive. Maybe worth doing?

