### PR TITLE
Improve paint insets docs.

### DIFF
--- a/masonry/src/widgets/align.rs
+++ b/masonry/src/widgets/align.rs
@@ -142,8 +142,6 @@ impl Widget for Align {
             .resolve(Rect::new(0., 0., extra_width, extra_height));
         ctx.place_child(&mut self.child, origin);
 
-        let my_insets = ctx.compute_insets_from_child(&self.child, my_size);
-        ctx.set_paint_insets(my_insets);
         if self.height_factor.is_some() {
             let baseline_offset = ctx.child_baseline_offset(&self.child);
             if baseline_offset > 0_f64 {

--- a/masonry_core/src/core/widget_state.rs
+++ b/masonry_core/src/core/widget_state.rs
@@ -83,8 +83,10 @@ pub(crate) struct WidgetState {
     /// In general, these will be zero; the exception is for things like
     /// drop shadows or overflowing text.
     pub(crate) paint_insets: Insets,
-    // TODO - Document
-    // The computed paint rect, in local coordinates.
+    /// The computed paint rect, in local coordinates.
+    ///
+    /// It is the union of this widget's and all of its descendants'
+    /// paint rects, i.e. layout rect + paint insets.
     pub(crate) local_paint_rect: Rect,
     /// An axis aligned bounding rect (AABB in 2D), containing itself and all its descendents in window coordinates. Includes `paint_insets`.
     pub(crate) bounding_rect: Rect,


### PR DESCRIPTION
The docs weren't clear about paint rect already containing the children, so this PR adds that clarity.

I also removed `LayoutCtx::compute_insets_from_child` which is a historical remnant that has zero utility now. `Align`, being an old widget, was still mistakenly using it but it was having no effect.