### PR TITLE
Improve `Properties` ergonomics.

### DIFF
--- a/masonry/src/tests/paint.rs
+++ b/masonry/src/tests/paint.rs
@@ -62,15 +62,15 @@ fn paint_order() {
     const SQUARE_LENGTH: Length = Length::const_px(SQUARE_SIZE);
     let child1 = NewWidget::new_with_props(
         SizedBox::empty().width(SQUARE_LENGTH).height(SQUARE_LENGTH),
-        (Background::Color(RED),).into(),
+        Background::Color(RED),
     );
     let child2 = NewWidget::new_with_props(
         SizedBox::empty().width(SQUARE_LENGTH).height(SQUARE_LENGTH),
-        (Background::Color(GREEN),).into(),
+        Background::Color(GREEN),
     );
     let child3 = NewWidget::new_with_props(
         SizedBox::empty().width(SQUARE_LENGTH).height(SQUARE_LENGTH),
-        (Background::Color(BLUE),).into(),
+        Background::Color(BLUE),
     );
     let children = vec![child1, child2, child3];
     let parent = NewWidget::new(

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -1030,7 +1030,7 @@ mod tests {
                 .with_fixed(Label::new("world").with_auto_id())
                 .with_fixed(Label::new("foo").with_auto_id())
                 .with_fixed(Label::new("bar").with_auto_id()),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)).into(),
+            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)),
         );
 
         let window_size = Size::new(200.0, 150.0);
@@ -1079,7 +1079,7 @@ mod tests {
                     Label::new("bar").with_auto_id(),
                     FlexParams::new(2.0, CrossAxisAlignment::Start),
                 ),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)).into(),
+            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)),
         );
 
         let window_size = Size::new(200.0, 150.0);
@@ -1122,7 +1122,7 @@ mod tests {
                     Label::new("bar").with_auto_id(),
                     FlexParams::new(2.0, CrossAxisAlignment::Start),
                 ),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)).into(),
+            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)),
         );
 
         let window_size = Size::new(200.0, 150.0);
@@ -1180,7 +1180,7 @@ mod tests {
                     Label::new("bar").with_auto_id(),
                     FlexParams::new(2.0, CrossAxisAlignment::Start),
                 ),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)).into(),
+            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)),
         );
 
         let window_size = Size::new(200.0, 150.0);
@@ -1223,7 +1223,7 @@ mod tests {
                     Label::new("bar").with_auto_id(),
                     FlexParams::new(2.0, CrossAxisAlignment::Start),
                 ),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)).into(),
+            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)),
         );
 
         let window_size = Size::new(200.0, 150.0);

--- a/masonry_core/src/core/properties.rs
+++ b/masonry_core/src/core/properties.rs
@@ -111,6 +111,12 @@ impl Properties {
     }
 }
 
+impl<P: Property> From<P> for Properties {
+    fn from(prop: P) -> Self {
+        Self::one(prop)
+    }
+}
+
 macro_rules! impl_props_from_tuple {
     (
         $(

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -432,7 +432,7 @@ pub trait Widget: AsDynWidget + Any {
     }
 
     /// Convenience method to wrap this in a [`NewWidget`] with the given [`Properties`].
-    fn with_props(self, props: Properties) -> NewWidget<Self>
+    fn with_props(self, props: impl Into<Properties>) -> NewWidget<Self>
     where
         Self: Sized,
     {

--- a/masonry_core/src/core/widget_pod.rs
+++ b/masonry_core/src/core/widget_pod.rs
@@ -106,9 +106,9 @@ impl<W: Widget> NewWidget<W> {
 
     // TODO - Replace with builder methods?
     /// Creates a new widget with custom [`Properties`].
-    pub fn new_with_props(inner: W, props: Properties) -> Self {
+    pub fn new_with_props(inner: W, props: impl Into<Properties>) -> Self {
         Self {
-            properties: props,
+            properties: props.into(),
             ..Self::new(inner)
         }
     }
@@ -122,7 +122,12 @@ impl<W: Widget> NewWidget<W> {
     }
 
     /// Creates a new widget with custom [`WidgetOptions`] and custom [`Properties`].
-    pub fn new_with(inner: W, id: WidgetId, options: WidgetOptions, props: Properties) -> Self {
+    pub fn new_with(
+        inner: W,
+        id: WidgetId,
+        options: WidgetOptions,
+        props: impl Into<Properties>,
+    ) -> Self {
         Self {
             widget: Box::new(inner),
             id,
@@ -130,7 +135,7 @@ impl<W: Widget> NewWidget<W> {
             #[cfg(debug_assertions)]
             action_type_name: std::any::type_name::<W::Action>(),
             options,
-            properties: props,
+            properties: props.into(),
             tag: None,
         }
     }

--- a/masonry_testing/src/modular_widget.rs
+++ b/masonry_testing/src/modular_widget.rs
@@ -461,7 +461,7 @@ impl<S: 'static> Widget for ModularWidget<S> {
         NewWidget::new_with_id(self, id)
     }
 
-    fn with_props(self, props: Properties) -> NewWidget<Self>
+    fn with_props(self, props: impl Into<Properties>) -> NewWidget<Self>
     where
         Self: Sized,
     {

--- a/masonry_testing/src/recorder_widget.rs
+++ b/masonry_testing/src/recorder_widget.rs
@@ -304,7 +304,7 @@ impl<W: Widget> Widget for Recorder<W> {
         NewWidget::new_with_id(self, id)
     }
 
-    fn with_props(self, props: Properties) -> NewWidget<Self>
+    fn with_props(self, props: impl Into<Properties>) -> NewWidget<Self>
     where
         Self: Sized,
     {

--- a/xilem_masonry/src/pod.rs
+++ b/xilem_masonry/src/pod.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::core::{FromDynWidget, NewWidget, Widget, WidgetMut};
+use masonry::core::{FromDynWidget, NewWidget, Properties, Widget, WidgetMut};
 
 use crate::ViewCtx;
 use crate::core::{Mut, SuperElement, ViewElement};
@@ -31,6 +31,13 @@ impl<W: Widget + FromDynWidget> Pod<W> {
     pub fn new(widget: W) -> Self {
         Self {
             new_widget: NewWidget::new(widget),
+        }
+    }
+
+    /// Creates a new [`Pod`] with the given `widget` and `props`.
+    pub fn new_with_props(widget: W, props: impl Into<Properties>) -> Self {
+        Self {
+            new_widget: NewWidget::new_with_props(widget, props),
         }
     }
 }


### PR DESCRIPTION
With this PR it will be possible to use a single `Property` directly for `Properties`. With the multi-prop case, you no longer need to call `.into()` yourself.

```diff
--- (some_prop,).into()
+++ some_prop

--- (one_prop, two_prop).into()
+++ (one_prop, two_prop)
```