### PR TITLE
Fix linebreaks in `ARCHITECTURE.md`.

### DIFF
--- a/masonry/ARCHITECTURE.md
+++ b/masonry/ARCHITECTURE.md
@@ -63,7 +63,7 @@ Masonry's passes are computations that run on the entire widget tree (iff invali
 
 `event.rs` and `update.rs` include a bunch of related passes.
 Every other file only includes one pass.
-`mod.rs` has a utility functions shared between multiple passes.
+`mod.rs` has utility functions shared between multiple passes.
 
 ### `masonry_core/src/doc/`
 


### PR DESCRIPTION
`ARCHITECTURE.md` did not follow [our policy of one line per sentence](https://linebender.org/wiki/formatting-scheme/#markdown) and this PR fixes that.