### PR TITLE
Organize `masonry` imports in a consistent way.

### DIFF
--- a/masonry/examples/custom_widget.rs
+++ b/masonry/examples/custom_widget.rs
@@ -17,6 +17,7 @@ use masonry::core::{
 use masonry::kurbo::{Affine, BezPath, Point, Rect, Size, Stroke};
 use masonry::parley::style::{FontFamily, FontStack, GenericFamily, StyleProperty};
 use masonry::peniko::{Color, Fill, ImageBrush, ImageFormat};
+use masonry::peniko::{ImageAlphaType, ImageData};
 use masonry::properties::ObjectFit;
 use masonry::theme::default_property_set;
 use masonry::vello::Scene;
@@ -24,7 +25,6 @@ use masonry::{TextAlign, TextAlignOptions, palette};
 use masonry_winit::app::{AppDriver, DriverCtx, NewWindow, WindowId};
 use masonry_winit::winit::window::Window;
 use tracing::{Span, trace_span};
-use vello::peniko::{ImageAlphaType, ImageData};
 
 struct Driver;
 

--- a/masonry/examples/simple_image.rs
+++ b/masonry/examples/simple_image.rs
@@ -11,12 +11,12 @@
 use masonry::core::{ErasedAction, NewWidget, Properties, WidgetId};
 use masonry::dpi::LogicalSize;
 use masonry::peniko::ImageFormat;
+use masonry::peniko::{ImageAlphaType, ImageData};
 use masonry::properties::ObjectFit;
 use masonry::theme::default_property_set;
 use masonry::widgets::Image;
 use masonry_winit::app::{AppDriver, DriverCtx, NewWindow, WindowId};
 use masonry_winit::winit::window::Window;
-use vello::peniko::{ImageAlphaType, ImageData};
 
 struct Driver;
 

--- a/masonry/src/properties/background.rs
+++ b/masonry/src/properties/background.rs
@@ -3,9 +3,8 @@
 
 use std::any::TypeId;
 
-use vello::kurbo::Rect;
-
 use crate::core::{Property, UpdateCtx};
+use crate::kurbo::Rect;
 use crate::peniko::color::{AlphaColor, Srgb};
 use crate::properties::types::Gradient;
 

--- a/masonry/src/properties/border_width.rs
+++ b/masonry/src/properties/border_width.rs
@@ -3,9 +3,8 @@
 
 use std::any::TypeId;
 
-use vello::kurbo::{Point, RoundedRect, Size, Vec2};
-
 use crate::core::{BoxConstraints, Property, UpdateCtx};
+use crate::kurbo::{Point, RoundedRect, Size, Vec2};
 use crate::properties::CornerRadius;
 
 /// The width of a widget's border, in logical pixels.

--- a/masonry/src/properties/box_shadow.rs
+++ b/masonry/src/properties/box_shadow.rs
@@ -4,10 +4,10 @@
 use std::any::TypeId;
 
 use vello::Scene;
-use vello::kurbo::{Affine, BezPath, Insets, Point, RoundedRect, Shape as _, Size};
-use vello::peniko::color::{AlphaColor, Srgb};
 
 use crate::core::{Property, UpdateCtx};
+use crate::kurbo::{Affine, BezPath, Insets, Point, RoundedRect, Shape as _, Size};
+use crate::peniko::color::{AlphaColor, Srgb};
 use crate::properties::CornerRadius;
 
 // TODO - This is a first implementation of box shadows. A full version would need

--- a/masonry/src/properties/object_fit.rs
+++ b/masonry/src/properties/object_fit.rs
@@ -3,8 +3,8 @@
 
 use std::any::TypeId;
 
-use masonry_core::core::{Property, UpdateCtx};
-use vello::kurbo::{Affine, Size};
+use crate::core::{Property, UpdateCtx};
+use crate::kurbo::{Affine, Size};
 
 // These are based on https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit
 /// Strategies for inscribing a rectangle inside another rectangle.

--- a/masonry/src/properties/padding.rs
+++ b/masonry/src/properties/padding.rs
@@ -3,9 +3,8 @@
 
 use std::any::TypeId;
 
-use vello::kurbo::{Point, Size, Vec2};
-
 use crate::core::{BoxConstraints, Property, UpdateCtx};
+use crate::kurbo::{Point, Size, Vec2};
 
 /// The width of padding between a widget's border and its contents.
 #[derive(Default, Clone, Copy, Debug, PartialEq)]

--- a/masonry/src/properties/types/gradient.rs
+++ b/masonry/src/properties/types/gradient.rs
@@ -3,13 +3,12 @@
 
 use std::f64::consts::TAU;
 
-use vello::kurbo::{Point, Rect};
-use vello::peniko::{
-    InterpolationAlphaSpace, LinearGradientPosition, RadialGradientPosition, SweepGradientPosition,
-};
-
+use crate::kurbo::{Point, Rect};
 use crate::peniko::color::{ColorSpaceTag, HueDirection};
 use crate::peniko::{ColorStops, ColorStopsSource, Extend};
+use crate::peniko::{
+    InterpolationAlphaSpace, LinearGradientPosition, RadialGradientPosition, SweepGradientPosition,
+};
 use crate::properties::types::UnitPoint;
 
 /// Properties for the supported [`Gradient`] types.

--- a/masonry/src/properties/types/unit_point.rs
+++ b/masonry/src/properties/types/unit_point.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use vello::kurbo::{Point, Rect};
+use crate::kurbo::{Point, Rect};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 /// A point with coordinates in the range [0.0, 1.0].

--- a/masonry/src/tests/accessibility.rs
+++ b/masonry/src/tests/accessibility.rs
@@ -3,9 +3,9 @@
 
 use accesskit::NodeId;
 use assert_matches::assert_matches;
-use masonry_core::core::{NewWidget, Widget, WidgetTag};
 use masonry_testing::{ModularWidget, Record, TestHarness, TestWidgetExt, assert_any, assert_none};
 
+use crate::core::{NewWidget, Widget, WidgetTag};
 use crate::theme::test_property_set;
 use crate::widgets::SizedBox;
 

--- a/masonry/src/tests/anim.rs
+++ b/masonry/src/tests/anim.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use assert_matches::assert_matches;
-use masonry_core::core::{NewWidget, WidgetTag};
 use masonry_testing::{ModularWidget, Record, TestHarness, TestWidgetExt, assert_any, assert_none};
 
+use crate::core::{NewWidget, WidgetTag};
 use crate::theme::test_property_set;
 use crate::widgets::SizedBox;
 

--- a/masonry/src/tests/compose.rs
+++ b/masonry/src/tests/compose.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use assert_matches::assert_matches;
-use masonry_core::core::{ChildrenIds, NewWidget, Widget, WidgetPod, WidgetTag};
 use masonry_testing::{ModularWidget, Record, TestHarness, TestWidgetExt};
-use vello::kurbo::{Affine, Point, Size, Vec2};
 
+use crate::core::{ChildrenIds, NewWidget, Widget, WidgetPod, WidgetTag};
+use crate::kurbo::{Affine, Point, Size, Vec2};
 use crate::theme::test_property_set;
 use crate::widgets::SizedBox;
 

--- a/masonry/src/tests/event.rs
+++ b/masonry/src/tests/event.rs
@@ -3,14 +3,14 @@
 
 use accesskit::ActionRequest;
 use assert_matches::assert_matches;
-use masonry_core::core::keyboard::{Key, NamedKey};
-use masonry_core::core::pointer::{PointerButton, PointerEvent, PointerInfo, PointerType};
-use masonry_core::core::{AccessEvent, NewWidget, TextEvent, Widget, WidgetTag};
 use masonry_testing::{
     ModularWidget, Record, TestHarness, TestWidgetExt, assert_any, assert_debug_panics,
 };
-use vello::kurbo::Size;
 
+use crate::core::keyboard::{Key, NamedKey};
+use crate::core::pointer::{PointerButton, PointerEvent, PointerInfo, PointerType};
+use crate::core::{AccessEvent, NewWidget, TextEvent, Widget, WidgetTag};
+use crate::kurbo::Size;
 use crate::layout::AsUnit;
 use crate::theme::test_property_set;
 use crate::widgets::{Button, Flex, SizedBox, TextArea};

--- a/masonry/src/tests/layout.rs
+++ b/masonry/src/tests/layout.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use assert_matches::assert_matches;
-use masonry_core::core::{NewWidget, WidgetTag};
 use masonry_testing::{TestWidgetExt, assert_debug_panics};
-use vello::kurbo::{Insets, Point, Size};
 
 use crate::core::Widget;
+use crate::core::{NewWidget, WidgetTag};
+use crate::kurbo::{Insets, Point, Size};
 use crate::layout::{AsUnit, Length};
 use crate::testing::{ModularWidget, TestHarness};
 use crate::theme::test_property_set;

--- a/masonry/src/tests/mutate.rs
+++ b/masonry/src/tests/mutate.rs
@@ -3,9 +3,9 @@
 
 use std::sync::mpsc;
 
-use masonry_core::core::{NewWidget, WidgetTag};
 use masonry_testing::{ModularWidget, TestHarness};
 
+use crate::core::{NewWidget, WidgetTag};
 use crate::theme::test_property_set;
 use crate::widgets::SizedBox;
 

--- a/masonry/src/tests/paint.rs
+++ b/masonry/src/tests/paint.rs
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use assert_matches::assert_matches;
-use masonry_core::core::{NewWidget, WidgetTag};
-use masonry_core::palette::css::{BLUE, GREEN, RED};
-use masonry_core::util::{fill, stroke};
 use masonry_testing::{ModularWidget, Record, TestHarness, TestWidgetExt, assert_render_snapshot};
-use vello::kurbo::{Affine, Circle, Dashes, Point, Size, Stroke, Vec2};
-use vello::peniko::Color;
 
+use crate::core::{NewWidget, WidgetTag};
+use crate::kurbo::{Affine, Circle, Dashes, Point, Size, Stroke, Vec2};
 use crate::layout::Length;
+use crate::palette::css::{BLUE, GREEN, RED};
+use crate::peniko::Color;
 use crate::properties::Background;
 use crate::properties::types::MainAxisAlignment;
 use crate::theme::test_property_set;
+use crate::util::{fill, stroke};
 use crate::widgets::{Flex, SizedBox};
 
 #[test]

--- a/masonry/src/tests/transforms.rs
+++ b/masonry/src/tests/transforms.rs
@@ -6,9 +6,9 @@
 use std::f64::consts::PI;
 
 use masonry_testing::WrapperWidget;
-use vello::kurbo::{Affine, Vec2};
-use vello::peniko::color::palette;
 
+use crate::kurbo::{Affine, Vec2};
+use crate::peniko::color::palette;
 use crate::core::{NewWidget, PointerButton, Properties, Widget, WidgetOptions};
 use crate::properties::types::UnitPoint;
 use crate::layout::AsUnit;

--- a/masonry/src/tests/update.rs
+++ b/masonry/src/tests/update.rs
@@ -4,17 +4,17 @@
 use std::sync::mpsc;
 
 use assert_matches::assert_matches;
-use masonry_core::core::pointer::{PointerButton, PointerEvent};
-use masonry_core::core::{
-    CursorIcon, Ime, NewWidget, Properties, TextEvent, Update, Widget, WidgetId, WidgetPod,
-    WidgetTag,
-};
 use masonry_testing::{
     DebugName, ModularWidget, PRIMARY_MOUSE, Record, TestHarness, TestWidgetExt, assert_any,
     assert_debug_panics,
 };
-use vello::kurbo::{Point, Size};
 
+use crate::core::pointer::{PointerButton, PointerEvent};
+use crate::core::{
+    CursorIcon, Ime, NewWidget, Properties, TextEvent, Update, Widget, WidgetId, WidgetPod,
+    WidgetTag,
+};
+use crate::kurbo::{Point, Size};
 use crate::layout::Length;
 use crate::theme::test_property_set;
 use crate::widgets::{Button, Flex, Label, SizedBox, TextArea};

--- a/masonry/src/tests/widget_tag.rs
+++ b/masonry/src/tests/widget_tag.rs
@@ -1,9 +1,9 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry_core::core::{NewWidget, WidgetTag};
 use masonry_testing::{TestHarness, assert_debug_panics};
 
+use crate::core::{NewWidget, WidgetTag};
 use crate::theme::test_property_set;
 use crate::widgets::{Flex, SizedBox};
 

--- a/masonry/src/widgets/align.rs
+++ b/masonry/src/widgets/align.rs
@@ -9,15 +9,14 @@
 // its computed size. See https://github.com/linebender/xilem/issues/378
 
 use accesskit::{Node, Role};
-use masonry_core::core::WidgetMut;
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Rect, Size};
 
 use crate::core::{
     AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, NoAction, PaintCtx,
-    PropertiesMut, PropertiesRef, RegisterCtx, Widget, WidgetId, WidgetPod,
+    PropertiesMut, PropertiesRef, RegisterCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Rect, Size};
 use crate::properties::types::UnitPoint;
 use crate::util::include_screenshot;
 

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -7,18 +7,17 @@ use std::any::TypeId;
 use std::sync::Arc;
 
 use accesskit::{Node, Role};
-use masonry_core::core::HasProperty;
 use tracing::{Span, trace, trace_span};
 use vello::Scene;
-use vello::kurbo::{Affine, Size};
 
 use crate::core::keyboard::{Key, NamedKey};
 use crate::core::pointer::PointerButton;
 use crate::core::{
-    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, EventCtx, LayoutCtx, NewWidget, PaintCtx,
-    PointerButtonEvent, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update,
-    UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, EventCtx, HasProperty, LayoutCtx,
+    NewWidget, PaintCtx, PointerButtonEvent, PointerEvent, PropertiesMut, PropertiesRef,
+    RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Affine, Size};
 use crate::properties::{
     ActiveBackground, Background, BorderColor, BorderWidth, BoxShadow, CornerRadius,
     DisabledBackground, FocusedBorderColor, HoveredBorderColor, Padding,
@@ -320,11 +319,10 @@ impl Widget for Button {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use masonry_core::core::CollectionWidget;
     use masonry_testing::{TestHarnessParams, assert_failing_render_snapshot};
 
     use super::*;
-    use crate::core::{PointerButton, Properties, StyleProperty};
+    use crate::core::{CollectionWidget, PointerButton, Properties, StyleProperty};
     use crate::layout::AsUnit;
     use crate::properties::{ContentColor, Gap};
     use crate::testing::{TestHarness, assert_render_snapshot};

--- a/masonry/src/widgets/canvas.rs
+++ b/masonry/src/widgets/canvas.rs
@@ -4,15 +4,14 @@
 //! A canvas widget.
 
 use accesskit::{Node, Role};
-use masonry_core::core::{ArcStr, ChildrenIds};
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::Size;
 
 use crate::core::{
-    AccessCtx, BoxConstraints, LayoutCtx, PaintCtx, PropertiesMut, PropertiesRef, RegisterCtx,
-    Widget, WidgetId, WidgetMut,
+    AccessCtx, ArcStr, BoxConstraints, ChildrenIds, LayoutCtx, PaintCtx, PropertiesMut,
+    PropertiesRef, RegisterCtx, Widget, WidgetId, WidgetMut,
 };
+use crate::kurbo::Size;
 
 /// A widget allowing custom drawing.
 ///
@@ -139,12 +138,12 @@ impl Widget for Canvas {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use masonry_core::core::{DefaultProperties, Properties};
     use masonry_testing::assert_render_snapshot;
-    use vello::kurbo::{Affine, BezPath, Stroke};
-    use vello::peniko::{Color, Fill};
 
     use super::*;
+    use crate::core::{DefaultProperties, Properties};
+    use crate::kurbo::{Affine, BezPath, Stroke};
+    use crate::peniko::{Color, Fill};
     use crate::testing::TestHarness;
 
     #[test]

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -6,17 +6,16 @@
 use std::any::TypeId;
 
 use accesskit::{Node, Role, Toggled};
-use masonry_core::core::HasProperty;
 use tracing::{Span, trace, trace_span};
 use vello::Scene;
-use vello::kurbo::{Affine, BezPath, Cap, Dashes, Join, Rect, Size, Stroke};
 
 use crate::core::keyboard::Key;
 use crate::core::{
-    AccessCtx, AccessEvent, ArcStr, BoxConstraints, ChildrenIds, EventCtx, LayoutCtx, NewWidget,
-    PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update,
-    UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, AccessEvent, ArcStr, BoxConstraints, ChildrenIds, EventCtx, HasProperty, LayoutCtx,
+    NewWidget, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent,
+    Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Affine, BezPath, Cap, Dashes, Join, Rect, Size, Stroke};
 use crate::properties::{
     ActiveBackground, Background, BorderColor, BorderWidth, CheckmarkColor, CheckmarkStrokeWidth,
     CornerRadius, DisabledBackground, DisabledCheckmarkColor, FocusedBorderColor,

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -6,15 +6,15 @@
 use std::any::TypeId;
 
 use accesskit::{Node, Role};
-use masonry_core::core::{CollectionWidget, HasProperty};
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Affine, Axis, Line, Point, Size, Stroke};
 
 use crate::core::{
-    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, NoAction, PaintCtx,
-    PropertiesMut, PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, BoxConstraints, ChildrenIds, CollectionWidget, HasProperty, LayoutCtx, NewWidget,
+    NoAction, PaintCtx, PropertiesMut, PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId,
+    WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Affine, Axis, Line, Point, Size, Stroke};
 use crate::layout::Length;
 use crate::properties::types::{CrossAxisAlignment, MainAxisAlignment};
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Gap, Padding};

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -4,15 +4,15 @@
 use std::any::TypeId;
 
 use accesskit::{Node, Role};
-use masonry_core::core::{CollectionWidget, HasProperty};
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Affine, Line, Point, Size, Stroke};
 
 use crate::core::{
-    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, NoAction, PaintCtx,
-    PropertiesMut, PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, BoxConstraints, ChildrenIds, CollectionWidget, HasProperty, LayoutCtx, NewWidget,
+    NoAction, PaintCtx, PropertiesMut, PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId,
+    WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Affine, Line, Point, Size, Stroke};
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Gap, Padding};
 use crate::util::{debug_panic, fill, include_screenshot, stroke};
 

--- a/masonry/src/widgets/image.rs
+++ b/masonry/src/widgets/image.rs
@@ -9,13 +9,13 @@ use std::any::TypeId;
 use accesskit::{Node, Role};
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Affine, Size};
-use vello::peniko::{BlendMode, ImageBrush};
 
 use crate::core::{
     AccessCtx, ArcStr, BoxConstraints, ChildrenIds, HasProperty, LayoutCtx, NoAction, PaintCtx,
     PropertiesMut, PropertiesRef, RegisterCtx, Update, UpdateCtx, Widget, WidgetId, WidgetMut,
 };
+use crate::kurbo::{Affine, Size};
+use crate::peniko::{BlendMode, ImageBrush};
 use crate::properties::ObjectFit;
 
 // TODO - Resolve name collision between masonry::Image and peniko::Image
@@ -184,10 +184,9 @@ impl Widget for Image {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use masonry_core::core::NewWidget;
-    use vello::peniko::{ImageAlphaType, ImageData, ImageFormat};
-
     use super::*;
+    use crate::core::NewWidget;
+    use crate::peniko::{ImageAlphaType, ImageData, ImageFormat};
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::test_property_set;
 

--- a/masonry/src/widgets/indexed_stack.rs
+++ b/masonry/src/widgets/indexed_stack.rs
@@ -4,15 +4,15 @@
 use std::any::TypeId;
 
 use accesskit::{Node, Role};
-use masonry_core::core::{CollectionWidget, HasProperty};
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Affine, Line, Point, Size, Stroke};
 
 use crate::core::{
-    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, NoAction, PaintCtx,
-    PropertiesMut, PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, BoxConstraints, ChildrenIds, CollectionWidget, HasProperty, LayoutCtx, NewWidget,
+    NoAction, PaintCtx, PropertiesMut, PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId,
+    WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Affine, Line, Point, Size, Stroke};
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use crate::util::{debug_panic, fill, include_screenshot, stroke};
 

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -7,18 +7,17 @@ use std::any::TypeId;
 use std::mem::Discriminant;
 
 use accesskit::{Node, NodeId, Role};
-use masonry_core::core::{HasProperty, NoAction};
 use parley::{Layout, LayoutAccessibility};
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Affine, Point, Size};
-use vello::peniko::BlendMode;
 
 use crate::core::{
-    AccessCtx, ArcStr, BoxConstraints, BrushIndex, ChildrenIds, LayoutCtx, PaintCtx, PropertiesMut,
-    PropertiesRef, RegisterCtx, StyleProperty, StyleSet, Update, UpdateCtx, Widget, WidgetId,
-    WidgetMut, render_text,
+    AccessCtx, ArcStr, BoxConstraints, BrushIndex, ChildrenIds, HasProperty, LayoutCtx, NoAction,
+    PaintCtx, PropertiesMut, PropertiesRef, RegisterCtx, StyleProperty, StyleSet, Update,
+    UpdateCtx, Widget, WidgetId, WidgetMut, render_text,
 };
+use crate::kurbo::{Affine, Point, Size};
+use crate::peniko::BlendMode;
 use crate::properties::{ContentColor, DisabledContentColor, LineBreaking, Padding};
 use crate::theme::default_text_styles;
 use crate::util::{debug_panic, include_screenshot};
@@ -410,12 +409,11 @@ impl Widget for Label {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use masonry_core::core::NewWidget;
     use parley::style::GenericFamily;
     use parley::{FontFamily, StyleProperty};
 
     use super::*;
-    use crate::core::Properties;
+    use crate::core::{NewWidget, Properties};
     use crate::layout::AsUnit;
     use crate::properties::Gap;
     use crate::properties::types::CrossAxisAlignment;

--- a/masonry/src/widgets/passthrough.rs
+++ b/masonry/src/widgets/passthrough.rs
@@ -6,12 +6,12 @@
 use accesskit::{Node, Role};
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Point, Size};
 
 use crate::core::{
     AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, NoAction, PaintCtx,
     PropertiesMut, PropertiesRef, RegisterCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Point, Size};
 
 /// A pass-through container that hosts exactly one child, which may be replaced dynamically.
 ///
@@ -113,9 +113,8 @@ impl Widget for Passthrough {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use vello::kurbo::Size;
-
     use super::*;
+    use crate::kurbo::Size;
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::test_property_set;
     use crate::widgets::Label;

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -7,7 +7,6 @@ use accesskit::{Node, Role};
 use dpi::PhysicalPosition;
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Axis, Point, Rect, Size, Vec2};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ComposeCtx, EventCtx, FromDynWidget,
@@ -15,6 +14,7 @@ use crate::core::{
     PropertiesRef, RegisterCtx, ScrollDelta, TextEvent, Update, UpdateCtx, Widget, WidgetId,
     WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Axis, Point, Rect, Size, Vec2};
 use crate::widgets::ScrollBar;
 
 // TODO - refactor - see https://github.com/linebender/xilem/issues/366
@@ -512,9 +512,8 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use masonry_core::core::WidgetTag;
-
     use super::*;
+    use crate::core::WidgetTag;
     use crate::layout::AsUnit;
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::test_property_set;

--- a/masonry/src/widgets/progress_bar.rs
+++ b/masonry/src/widgets/progress_bar.rs
@@ -6,15 +6,15 @@
 use std::any::TypeId;
 
 use accesskit::{Node, Role};
-use masonry_core::core::{NewWidget, Properties};
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Point, Size};
 
 use crate::core::{
-    AccessCtx, ArcStr, BoxConstraints, ChildrenIds, LayoutCtx, NoAction, PaintCtx, PropertiesMut,
-    PropertiesRef, RegisterCtx, Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, ArcStr, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, NoAction, PaintCtx,
+    Properties, PropertiesMut, PropertiesRef, RegisterCtx, Update, UpdateCtx, Widget, WidgetId,
+    WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Point, Size};
 use crate::properties::{
     Background, BarColor, BorderColor, BorderWidth, CornerRadius, LineBreaking,
 };
@@ -206,10 +206,8 @@ impl Widget for ProgressBar {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use masonry_core::core::NewWidget;
-
     use super::*;
-    use crate::core::Properties;
+    use crate::core::{NewWidget, Properties};
     use crate::palette;
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::test_property_set;

--- a/masonry/src/widgets/prose.rs
+++ b/masonry/src/widgets/prose.rs
@@ -4,13 +4,13 @@
 use accesskit::{Node, Role};
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Point, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, EventCtx, LayoutCtx, NewWidget, NoAction,
     PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Point, Size};
 use crate::util::include_screenshot;
 use crate::widgets::TextArea;
 
@@ -186,12 +186,12 @@ impl Widget for Prose {
 // TODO - Add more tests
 #[cfg(test)]
 mod tests {
-    use masonry_core::core::Properties;
     use parley::StyleProperty;
-    use vello::kurbo::Size;
 
     use super::*;
     use crate::TextAlign;
+    use crate::core::Properties;
+    use crate::kurbo::Size;
     use crate::layout::AsUnit;
     use crate::properties::Gap;
     use crate::properties::types::CrossAxisAlignment;

--- a/masonry/src/widgets/resize_observer.rs
+++ b/masonry/src/widgets/resize_observer.rs
@@ -3,11 +3,11 @@
 
 use std::mem;
 
-use masonry_core::core::{
+use crate::core::{
     AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, PaintCtx, PropertiesMut,
     PropertiesRef, RegisterCtx, Widget, WidgetMut, WidgetPod,
 };
-use vello::kurbo::{Point, Size};
+use crate::kurbo::{Point, Size};
 
 /// A widget which sends a [`LayoutChanged`] whenever its size changes.
 ///
@@ -146,10 +146,10 @@ impl Widget for ResizeObserver {
 #[cfg(test)]
 mod tests {
     use dpi::PhysicalSize;
-    use masonry_core::core::{NewWidget, Widget, WidgetTag, WindowEvent};
     use masonry_testing::TestHarness;
-    use vello::kurbo::Size;
 
+    use crate::core::{NewWidget, Widget, WidgetTag, WindowEvent};
+    use crate::kurbo::Size;
     use crate::layout::AsUnit;
     use crate::theme::default_property_set;
     use crate::widgets::{Flex, LayoutChanged, ResizeObserver, SizedBox};

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -4,13 +4,13 @@
 use accesskit::{Node, Role};
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Axis, Point, Rect, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, AllowRawMut, BoxConstraints, ChildrenIds, EventCtx, LayoutCtx,
     NoAction, PaintCtx, PointerButtonEvent, PointerEvent, PointerUpdate, PropertiesMut,
     PropertiesRef, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut,
 };
+use crate::kurbo::{Axis, Point, Rect, Size};
 use crate::theme;
 use crate::util::{fill_color, include_screenshot, stroke};
 
@@ -266,10 +266,8 @@ impl AllowRawMut for ScrollBar {}
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use masonry_core::core::NewWidget;
-
     use super::*;
-    use crate::core::PointerButton;
+    use crate::core::{NewWidget, PointerButton};
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::test_property_set;
 

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -6,15 +6,14 @@
 use std::any::TypeId;
 
 use accesskit::{Node, Role};
-use masonry_core::core::HasProperty;
 use tracing::{Span, trace_span, warn};
 use vello::Scene;
-use vello::kurbo::{Point, Size};
 
 use crate::core::{
-    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, NoAction, PaintCtx,
+    AccessCtx, BoxConstraints, ChildrenIds, HasProperty, LayoutCtx, NewWidget, NoAction, PaintCtx,
     PropertiesMut, PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Point, Size};
 use crate::layout::Length;
 use crate::properties::{Background, BorderColor, BorderWidth, CornerRadius, Padding};
 use crate::util::{fill, include_screenshot, stroke};

--- a/masonry/src/widgets/slider.rs
+++ b/masonry/src/widgets/slider.rs
@@ -8,7 +8,6 @@ use std::any::TypeId;
 use accesskit::{ActionData, Node, Role};
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Circle, Point, Rect, Size};
 
 use crate::core::keyboard::{Key, NamedKey};
 use crate::core::pointer::PointerButton;
@@ -17,6 +16,7 @@ use crate::core::{
     PaintCtx, PointerButtonEvent, PointerEvent, PointerUpdate, PropertiesMut, PropertiesRef,
     RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut,
 };
+use crate::kurbo::{Circle, Point, Rect, Size};
 use crate::properties::{Background, BarColor, ThumbColor, ThumbRadius, TrackThickness};
 use crate::theme;
 use crate::util::{fill, include_screenshot, stroke};
@@ -368,9 +368,9 @@ impl Widget for Slider {
         if ctx.is_disabled() {
             const DISABLED_ALPHA: f32 = 0.4;
             scene.push_layer(
-                vello::peniko::Mix::Normal,
+                crate::peniko::Mix::Normal,
                 DISABLED_ALPHA,
-                vello::kurbo::Affine::IDENTITY,
+                crate::kurbo::Affine::IDENTITY,
                 &ctx.size().to_rect(),
             );
         }
@@ -460,10 +460,9 @@ impl Widget for Slider {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use vello::kurbo::{Point, Size};
-
     use super::*;
     use crate::core::{PointerButton, TextEvent};
+    use crate::kurbo::{Point, Size};
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::test_property_set;
 

--- a/masonry/src/widgets/spinner.rs
+++ b/masonry/src/widgets/spinner.rs
@@ -7,15 +7,14 @@ use std::any::TypeId;
 use std::f64::consts::PI;
 
 use accesskit::{Node, Role};
-use masonry_core::core::HasProperty;
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Affine, Cap, Line, Point, Size, Stroke, Vec2};
 
 use crate::core::{
-    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, NoAction, PaintCtx, PropertiesMut,
-    PropertiesRef, RegisterCtx, Update, UpdateCtx, Widget, WidgetId,
+    AccessCtx, BoxConstraints, ChildrenIds, HasProperty, LayoutCtx, NoAction, PaintCtx,
+    PropertiesMut, PropertiesRef, RegisterCtx, Update, UpdateCtx, Widget, WidgetId,
 };
+use crate::kurbo::{Affine, Cap, Line, Point, Size, Stroke, Vec2};
 use crate::properties::ContentColor;
 use crate::theme;
 use crate::util::include_screenshot;
@@ -150,9 +149,8 @@ impl Widget for Spinner {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use masonry_core::core::{NewWidget, Properties};
-
     use super::*;
+    use crate::core::{NewWidget, Properties};
     use crate::palette;
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::test_property_set;

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -6,7 +6,6 @@
 use accesskit::{Node, Role};
 use tracing::{Span, trace_span, warn};
 use vello::Scene;
-use vello::kurbo::{Axis, Line, Point, Rect, Size};
 
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, CursorIcon, EventCtx, FromDynWidget,
@@ -14,6 +13,7 @@ use crate::core::{
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Widget, WidgetId, WidgetMut,
     WidgetPod,
 };
+use crate::kurbo::{Axis, Line, Point, Rect, Size};
 use crate::layout::{AsUnit, Length};
 use crate::peniko::Color;
 use crate::theme;

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -5,13 +5,10 @@ use std::any::TypeId;
 use std::mem::Discriminant;
 
 use accesskit::{Node, NodeId, Role};
-use masonry_core::util::bounding_box_to_rect;
 use parley::PlainEditor;
 use parley::editing::{Generation, SplitString};
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Affine, Point, Rect, Size};
-use vello::peniko::Fill;
 
 use crate::core::keyboard::{Key, KeyState, NamedKey};
 use crate::core::{
@@ -20,10 +17,13 @@ use crate::core::{
     PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, StyleProperty, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetMut, render_text,
 };
+use crate::kurbo::{Affine, Point, Rect, Size};
+use crate::peniko::Fill;
 use crate::properties::{
     CaretColor, ContentColor, DisabledContentColor, SelectionColor, UnfocusedSelectionColor,
 };
 use crate::theme::default_text_styles;
+use crate::util::bounding_box_to_rect;
 use crate::util::debug_panic;
 use crate::{TextAlign, theme};
 
@@ -1049,12 +1049,11 @@ pub enum InsertNewline {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use masonry_core::core::NewWidget;
     use masonry_testing::TestHarnessParams;
-    use vello::kurbo::Size;
 
     use super::*;
-    use crate::core::{KeyboardEvent, Modifiers, Properties};
+    use crate::core::{KeyboardEvent, Modifiers, NewWidget, Properties};
+    use crate::kurbo::Size;
     use crate::palette;
     use crate::testing::TestHarness;
     use crate::theme::test_property_set;

--- a/masonry/src/widgets/text_input.rs
+++ b/masonry/src/widgets/text_input.rs
@@ -4,17 +4,16 @@
 use std::any::TypeId;
 
 use accesskit::{Node, Role};
-use masonry_core::core::HasProperty;
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Affine, Point, Rect, Size};
 
 use crate::TextAlign;
 use crate::core::{
-    AccessCtx, ArcStr, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, NoAction, PaintCtx,
-    Properties, PropertiesMut, PropertiesRef, RegisterCtx, Update, UpdateCtx, Widget, WidgetId,
-    WidgetMut, WidgetPod,
+    AccessCtx, ArcStr, BoxConstraints, ChildrenIds, HasProperty, LayoutCtx, NewWidget, NoAction,
+    PaintCtx, Properties, PropertiesMut, PropertiesRef, RegisterCtx, Update, UpdateCtx, Widget,
+    WidgetId, WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Affine, Point, Rect, Size};
 use crate::properties::{
     Background, BorderColor, BorderWidth, BoxShadow, CaretColor, ContentColor, CornerRadius,
     DisabledBackground, FocusedBorderColor, Padding, PlaceholderColor, SelectionColor,
@@ -359,12 +358,11 @@ impl Widget for TextInput {
 // TODO - Add more tests
 #[cfg(test)]
 mod tests {
-    use masonry_core::core::TextEvent;
     use masonry_testing::TestHarnessParams;
-    use vello::kurbo::Size;
 
     use super::*;
-    use crate::core::StyleProperty;
+    use crate::core::{StyleProperty, TextEvent};
+    use crate::kurbo::Size;
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::test_property_set;
     use crate::widgets::TextArea;

--- a/masonry/src/widgets/variable_label.rs
+++ b/masonry/src/widgets/variable_label.rs
@@ -6,17 +6,16 @@
 use std::cmp::Ordering;
 
 use accesskit::{Node, Role};
-use masonry_core::core::NoAction;
 use parley::style::FontWeight;
 use tracing::{Span, trace_span};
 use vello::Scene;
-use vello::kurbo::{Point, Size};
 
 use crate::core::{
-    AccessCtx, ArcStr, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, PaintCtx, PropertiesMut,
-    PropertiesRef, RegisterCtx, StyleProperty, Update, UpdateCtx, Widget, WidgetId, WidgetMut,
-    WidgetPod,
+    AccessCtx, ArcStr, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, NoAction, PaintCtx,
+    PropertiesMut, PropertiesRef, RegisterCtx, StyleProperty, Update, UpdateCtx, Widget, WidgetId,
+    WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Point, Size};
 use crate::widgets::Label;
 
 /// An `f32` value which can move towards a target value at a linear rate over time.

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -6,14 +6,13 @@
 use std::collections::HashMap;
 use std::ops::Range;
 
-use vello::kurbo::{Point, Size, Vec2};
-
 use crate::core::keyboard::{Key, KeyState, NamedKey};
 use crate::core::{
     AccessCtx, AccessEvent, BoxConstraints, ChildrenIds, ComposeCtx, EventCtx, KeyboardEvent,
     LayoutCtx, NewWidget, PaintCtx, PointerEvent, PointerScrollEvent, PropertiesMut, PropertiesRef,
     RegisterCtx, ScrollDelta, TextEvent, Update, UpdateCtx, Widget, WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Point, Size, Vec2};
 use crate::util::debug_panic;
 
 /// The action type sent by the [`VirtualScroll`] widget.
@@ -1052,9 +1051,9 @@ mod tests {
 
     use super::opt_iter_difference;
     use crate::core::{NewWidget, Widget, WidgetId, WidgetMut};
+    use crate::kurbo;
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::test_property_set;
-    use crate::vello::kurbo;
     use crate::widgets::{Label, VirtualScroll, VirtualScrollAction};
 
     #[test]

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -2,15 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use accesskit::{Node, Role};
-use masonry_core::core::CollectionWidget;
 use tracing::trace_span;
 use vello::Scene;
-use vello::kurbo::{Rect, Size};
 
 use crate::core::{
-    AccessCtx, BoxConstraints, ChildrenIds, LayoutCtx, NewWidget, NoAction, PaintCtx,
-    PropertiesMut, PropertiesRef, RegisterCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, BoxConstraints, ChildrenIds, CollectionWidget, LayoutCtx, NewWidget, NoAction,
+    PaintCtx, PropertiesMut, PropertiesRef, RegisterCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
+use crate::kurbo::{Rect, Size};
 use crate::properties::types::UnitPoint;
 use crate::util::include_screenshot;
 
@@ -279,11 +278,10 @@ impl Widget for ZStack {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    use vello::peniko::color::palette;
-
     use super::*;
     use crate::core::Properties;
     use crate::layout::AsUnit;
+    use crate::peniko::color::palette;
     use crate::properties::{Background, BorderColor, BorderWidth};
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::test_property_set;


### PR DESCRIPTION
There were two kind of imports, Rust Analyzer generated ones and manual ones that prioritize using the `crate::` prefix. This PR merges a bunch of the Rust Analyzer ones with the manual ones.

For example:

`vello::kurbo -> crate::kurbo`
`masonry_core::core::Foo -> crate::core::Foo`