### PR TITLE
Update to Vello 0.7.0, ui-events 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "font-types"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4d2d0cf79d38430cc9dc9aadec84774bff2e1ba30ae2bf6c16cfce9385a23"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "fontique"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,7 +1204,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-core-text",
  "objc2-foundation 0.3.2",
- "read-fonts",
+ "read-fonts 0.35.0",
  "roxmltree",
  "smallvec",
  "windows 0.58.0",
@@ -1547,7 +1556,7 @@ dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
  "core_maths",
- "read-fonts",
+ "read-fonts 0.35.0",
  "smallvec",
 ]
 
@@ -1961,9 +1970,9 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kurbo"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
+checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -2812,7 +2821,7 @@ dependencies = [
  "harfrust",
  "hashbrown 0.16.1",
  "linebender_resource_handle",
- "skrifa",
+ "skrifa 0.37.0",
  "swash",
 ]
 
@@ -2824,9 +2833,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peniko"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c76095c9a636173600478e0373218c7b955335048c2bcd12dc6a79657649d8"
+checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
 dependencies = [
  "color",
  "kurbo",
@@ -3228,7 +3237,17 @@ checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
  "core_maths",
- "font-types",
+ "font-types 0.10.1",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+dependencies = [
+ "bytemuck",
+ "font-types 0.11.0",
 ]
 
 [[package]]
@@ -3669,7 +3688,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
 dependencies = [
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.35.0",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.37.0",
 ]
 
 [[package]]
@@ -3852,7 +3881,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47846491253e976bdd07d0f9cc24b7daf24720d11309302ccbbc6e6b6e53550a"
 dependencies = [
- "skrifa",
+ "skrifa 0.37.0",
  "yazi",
  "zeno",
 ]
@@ -4404,9 +4433,9 @@ dependencies = [
 
 [[package]]
 name = "ui-events"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a57da61c5700db75d28822c56068295055ec216996560af57a5d4a457914d34"
+checksum = "e3e29e3e199888d594edd191c5917a2d5c1893b8bf20076c2bf4df7a40a2ee71"
 dependencies = [
  "dpi",
  "keyboard-types",
@@ -4415,9 +4444,9 @@ dependencies = [
 
 [[package]]
 name = "ui-events-winit"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ef6b086ceb9e4bbf0148e494959b18cf08de7604f8d8e958a94e73fc2d531e"
+checksum = "de12c5f7e256ff97aa9a710a5e2fb345bb59302c98d77a3d2f249100d92145d4"
 dependencies = [
  "ui-events",
  "web-time",
@@ -4504,15 +4533,16 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vello"
-version = "0.6.0"
-source = "git+https://github.com/linebender/vello?rev=cad558fcd7067ea4097cf9299dfedc8ecc53dc41#cad558fcd7067ea4097cf9299dfedc8ecc53dc41"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72fef40773530322d5c2ffe3c1107e9874bd8239ac137d1c2b6c1edad695146e"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
  "log",
  "peniko",
  "png 0.17.16",
- "skrifa",
+ "skrifa 0.40.0",
  "static_assertions",
  "thiserror 2.0.17",
  "vello_encoding",
@@ -4523,20 +4553,22 @@ dependencies = [
 
 [[package]]
 name = "vello_encoding"
-version = "0.6.0"
-source = "git+https://github.com/linebender/vello?rev=cad558fcd7067ea4097cf9299dfedc8ecc53dc41#cad558fcd7067ea4097cf9299dfedc8ecc53dc41"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c91203ec4b483440614a9a5c7c2d991932af72c5349659a63ec49476f0b79c"
 dependencies = [
  "bytemuck",
  "guillotiere",
  "peniko",
- "skrifa",
+ "skrifa 0.40.0",
  "smallvec",
 ]
 
 [[package]]
 name = "vello_shaders"
-version = "0.6.0"
-source = "git+https://github.com/linebender/vello?rev=cad558fcd7067ea4097cf9299dfedc8ecc53dc41#cad558fcd7067ea4097cf9299dfedc8ecc53dc41"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a765d44d4bd354146e44f9a860f4e92effd91a97302549be9e47f0a18d8128c"
 dependencies = [
  "bytemuck",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,19 +50,18 @@ xilem = { version = "0.4.0", path = "xilem", default-features = false }
 tree_arena = { version = "0.2.0", path = "tree_arena" }
 
 anymore = "1.0.0"
-vello = { version = "0.6.0", git = "https://github.com/linebender/vello", rev = "cad558fcd7067ea4097cf9299dfedc8ecc53dc41", default-features = false, features = [
-    "wgpu",
-] }
-kurbo = "0.12.0"
+vello = { version = "0.7.0", default-features = false, features = ["wgpu"] }
+kurbo = "0.13.0"
 parley = { version = "0.7.0", features = ["accesskit"] }
 # TODO: Use no_std correctly in Xilem Web.
-peniko = "0.5.0"
+peniko = "0.6.0"
 winit = "0.30.12"
 tracing = { version = "0.1.43", default-features = false }
 tracing-wasm = "0.2.1"
 console_error_panic_hook = "0.1.7"
-ui-events = { version = "0.2.0", default-features = false, features = ["kurbo"] }
-ui-events-winit = { version = "0.2.0", default-features = false }
+# Remove "std" when that's fixed upstream
+ui-events = { version = "0.3.0", default-features = false, features = ["kurbo"] }
+ui-events-winit = { version = "0.3.0", default-features = false }
 smallvec = "1.15.1"
 hashbrown = { version = "0.16.1", default-features = false, features = ["default-hasher"] }
 dpi = "0.1.2"

--- a/masonry/src/properties/box_shadow.rs
+++ b/masonry/src/properties/box_shadow.rs
@@ -7,6 +7,7 @@ use vello::Scene;
 
 use crate::core::{Property, UpdateCtx};
 use crate::kurbo::{Affine, BezPath, Insets, Point, RoundedRect, Shape as _, Size};
+use crate::peniko::Fill;
 use crate::peniko::color::{AlphaColor, Srgb};
 use crate::properties::CornerRadius;
 
@@ -120,7 +121,7 @@ impl BoxShadow {
                 .chain(carve_out_rect.to_path(0.1).reverse_subpaths()),
         );
 
-        scene.push_clip_layer(transform, &clip_shape);
+        scene.push_clip_layer(Fill::NonZero, transform, &clip_shape);
         scene.draw_blurred_rounded_rect_in(
             &big_rect,
             transform,

--- a/masonry/src/widgets/image.rs
+++ b/masonry/src/widgets/image.rs
@@ -16,7 +16,7 @@ use crate::core::{
 };
 use crate::kurbo::{Affine, Axis, Size};
 use crate::layout::LenReq;
-use crate::peniko::{BlendMode, ImageBrush};
+use crate::peniko::{BlendMode, Fill, ImageBrush};
 use crate::properties::ObjectFit;
 
 // TODO: Make this a configurable option of the widget.
@@ -210,7 +210,13 @@ impl Widget for Image {
         let transform = object_fit.affine(ctx.size(), image_size);
 
         let clip_rect = ctx.size().to_rect();
-        scene.push_layer(BlendMode::default(), 1., Affine::IDENTITY, &clip_rect);
+        scene.push_layer(
+            Fill::NonZero,
+            BlendMode::default(),
+            1.,
+            Affine::IDENTITY,
+            &clip_rect,
+        );
         scene.draw_image(&self.image_data, transform);
         scene.pop_layer();
     }

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -18,7 +18,7 @@ use crate::core::{
 };
 use crate::kurbo::{Affine, Axis, Point, Size};
 use crate::layout::LenReq;
-use crate::peniko::BlendMode;
+use crate::peniko::{BlendMode, Fill};
 use crate::properties::{ContentColor, DisabledContentColor, LineBreaking, Padding};
 use crate::theme::default_text_styles;
 use crate::util::{debug_panic, include_screenshot};
@@ -459,7 +459,13 @@ impl Widget for Label {
 
         if line_break_mode == LineBreaking::Clip {
             let clip_rect = ctx.size().to_rect();
-            scene.push_layer(BlendMode::default(), 1., Affine::IDENTITY, &clip_rect);
+            scene.push_layer(
+                Fill::NonZero,
+                BlendMode::default(),
+                1.,
+                Affine::IDENTITY,
+                &clip_rect,
+            );
         }
         let text_origin = padding.origin_down(Point::ZERO, scale).to_vec2();
         let transform = Affine::translate(text_origin);

--- a/masonry/src/widgets/slider.rs
+++ b/masonry/src/widgets/slider.rs
@@ -18,6 +18,7 @@ use crate::core::{
 };
 use crate::kurbo::{Axis, Circle, Point, Rect, Size};
 use crate::layout::LenReq;
+use crate::peniko::Fill;
 use crate::properties::{Background, BarColor, ThumbColor, ThumbRadius, TrackThickness};
 use crate::theme;
 use crate::util::{fill, include_screenshot, stroke};
@@ -391,6 +392,7 @@ impl Widget for Slider {
         if ctx.is_disabled() {
             const DISABLED_ALPHA: f32 = 0.4;
             scene.push_layer(
+                Fill::NonZero,
                 crate::peniko::Mix::Normal,
                 DISABLED_ALPHA,
                 crate::kurbo::Affine::IDENTITY,

--- a/masonry_core/src/passes/paint.rs
+++ b/masonry_core/src/passes/paint.rs
@@ -82,7 +82,7 @@ fn paint_widget(
         };
 
         if let Some(clip) = state.clip_path {
-            complete_scene.push_clip_layer(transform, &clip);
+            complete_scene.push_clip_layer(Fill::NonZero, transform, &clip);
         }
 
         complete_scene.append(scene, Some(transform));


### PR DESCRIPTION
An old version of `kurbo` is still brought in by `ui-events`.