### PR TITLE
Fix `ScrollBar` pointer move handler.

### DIFF
--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -159,7 +159,9 @@ impl Widget for ScrollBar {
                 ctx.request_render();
             }
             PointerEvent::Move(PointerUpdate { current, .. }) => {
-                if let Some(grab_anchor) = self.grab_anchor {
+                if ctx.is_active()
+                    && let Some(grab_anchor) = self.grab_anchor
+                {
                     let cursor_min_length = theme::SCROLLBAR_MIN_SIZE;
                     self.cursor_progress = self.progress_from_mouse_pos(
                         ctx.size(),
@@ -168,12 +170,11 @@ impl Widget for ScrollBar {
                         ctx.local_position(current.position),
                     );
                     self.moved = true;
+                    ctx.request_render();
                 }
-                ctx.request_render();
             }
             PointerEvent::Up(..) | PointerEvent::Cancel(..) => {
                 self.grab_anchor = None;
-                ctx.request_render();
             }
             _ => {}
         }

--- a/masonry/src/widgets/slider.rs
+++ b/masonry/src/widgets/slider.rs
@@ -186,14 +186,6 @@ impl Widget for Slider {
                     ctx.request_render();
                 }
             }
-            PointerEvent::Up(PointerButtonEvent {
-                button: Some(PointerButton::Primary),
-                ..
-            }) => {
-                if ctx.is_active() {
-                    ctx.release_pointer();
-                }
-            }
             _ => {}
         }
     }


### PR DESCRIPTION
`ScrollBar` was handling move events even when not having captured the pointer. This could result in a state where the scrollbar handle would keep moving and I couldn't stop it without restarting the app. I entered that state when `ScrollBar` handled `Down`, then its parent `Split` handled `Down` and stole the capture, and `ScrollBar` never received a `Up` where it clears `grab_anchor`.

This PR adds the usual `ctx.is_active()` check to `Move` because just `grab_anchor` can't be trusted.

I also moved `request_render()` into the if block and removed it from the `Up` handler. That's because it seems to me paint only depends on `self.cursor_progress` which is not changed in either of those two places where I removed the render request.

---

Removed the manual `release_pointer()` from `Slider` which is not required according to the docs, as it is done automatically after `Up` handling.
