### PR TITLE
Fix `Portal` `MinContent` measurement.

### DIFF
--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -436,7 +436,8 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
         cross_length: Option<f64>,
     ) -> f64 {
         match len_req {
-            LenReq::MinContent | LenReq::MaxContent => {
+            LenReq::MinContent => 0.,
+            LenReq::MaxContent => {
                 let context_size = LayoutSize::maybe(axis.cross(), cross_length);
                 let auto_length = len_req.into();
 


### PR DESCRIPTION
The minimum size of `Portal` is zero, not the minimum size of its child.
The maximum size of `Portal` continues to be the maximum size of its child.