### PR TITLE
masonry_winit: add AppDriver::on_wgpu_ready callback

### DIFF
--- a/masonry_winit/src/lib.rs
+++ b/masonry_winit/src/lib.rs
@@ -99,7 +99,7 @@ pub use winit;
 
 /// Types needed for running a Masonry app.
 pub mod app {
-    pub use super::app_driver::{AppDriver, DriverCtx, WindowId};
+    pub use super::app_driver::{AppDriver, DriverCtx, WgpuContext, WindowId};
     pub use super::event_loop_runner::{
         EventLoop, EventLoopBuilder, EventLoopProxy, MasonryState, MasonryUserEvent, NewWindow,
         Window, run, run_with,

--- a/masonry_winit/src/vello_util.rs
+++ b/masonry_winit/src/vello_util.rs
@@ -17,11 +17,19 @@ use wgpu::{
 /// Simple render context that maintains wgpu state for rendering the pipeline.
 pub(crate) struct RenderContext {
     pub instance: Instance,
+    /// Created devices used by this context.
+    ///
+    /// Invariants:
+    /// - Entries are append-only (never deleted or replaced).
+    /// - Indices are stable for the lifetime of the `RenderContext`.
+    ///
+    /// Other parts of the library store indices into this vec (e.g. `RenderSurface::dev_id`) and
+    /// assume they remain valid.
     pub devices: Vec<DeviceHandle>,
 }
 
 pub(crate) struct DeviceHandle {
-    adapter: wgpu::Adapter,
+    pub(crate) adapter: wgpu::Adapter,
     pub device: Device,
     pub queue: wgpu::Queue,
 }


### PR DESCRIPTION
Expose a new `AppDriver::on_wgpu_ready(window_id, &WgpuContext)` hook that fires when Masonry creates a WGPU device. The provided `WgpuContext` gives access to the shared `wgpu::Instance`, `Adapter`, `Device`, and `Queue` so applications can create GPU resources using the same device as Masonry.

This is intended as the first commit in a series of follow-up PRs adding additional WGPU-related features and improvements.