### PR TITLE
masonry_winit: allow configuring WGPU device request

### DIFF
--- a/masonry_winit/src/app_driver.rs
+++ b/masonry_winit/src/app_driver.rs
@@ -66,6 +66,18 @@ pub struct WgpuContext<'a> {
     pub queue: &'a wgpu::Queue,
 }
 
+/// Strategy for selecting `wgpu::Limits` when requesting the WGPU device.
+#[derive(Clone, Debug, Default)]
+pub enum WgpuLimits {
+    /// Use `wgpu::Limits::default()`.
+    #[default]
+    Default,
+    /// Use `adapter.limits()` (maximum supported by the selected adapter).
+    Adapter,
+    /// Use the provided limits.
+    Custom(wgpu::Limits),
+}
+
 /// A trait for defining how your app interacts with the Masonry widget tree.
 ///
 /// When launching your app with [`crate::app::run`], you need to provide

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -30,7 +30,8 @@ use winit::event_loop::ActiveEventLoop;
 use winit::window::{Window as WindowHandle, WindowAttributes, WindowId as HandleId};
 
 use crate::app::{
-    AppDriver, DriverCtx, WgpuContext, masonry_resize_direction_to_winit, winit_ime_to_masonry,
+    AppDriver, DriverCtx, WgpuContext, WgpuLimits, masonry_resize_direction_to_winit,
+    winit_ime_to_masonry,
 };
 use crate::app_driver::WindowId;
 use crate::vello_util::{RenderContext, RenderSurface};
@@ -400,6 +401,46 @@ impl MasonryState<'_> {
             new_windows,
             need_first_frame: Vec::new(),
         }
+    }
+
+    /// Configure how Masonry requests the WGPU device (features and limits).
+    ///
+    /// This must be called before the first surface/device is created (i.e. before the first
+    /// redraw). A good place is [`AppDriver::on_start`].
+    ///
+    /// `features` is best-effort: Masonry intersects it with `adapter.features()`, so unsupported
+    /// feature bits are ignored.
+    ///
+    /// This method will return `false` if it was called too late and a device had already been
+    /// created.
+    pub fn set_wgpu_device_options(
+        &mut self,
+        features: wgpu::Features,
+        limits: WgpuLimits,
+    ) -> bool {
+        self.render_cx.set_wgpu_device_options(features, limits)
+    }
+
+    /// Add extra WGPU features to request when creating the device.
+    ///
+    /// This must be called before the first surface/device is created (i.e. before the first
+    /// redraw). A good place is [`AppDriver::on_start`].
+    ///
+    /// This method will return `false` if it was called too late and a device had already been
+    /// created.
+    pub fn add_wgpu_features(&mut self, features: wgpu::Features) -> bool {
+        self.render_cx.add_wgpu_features(features)
+    }
+
+    /// Configure the WGPU limits strategy used when requesting the device.
+    ///
+    /// This must be called before the first surface/device is created (i.e. before the first
+    /// redraw). A good place is [`AppDriver::on_start`].
+    ///
+    /// This method will return `false` if it was called too late and a device had already been
+    /// created.
+    pub fn set_wgpu_limits(&mut self, limits: WgpuLimits) -> bool {
+        self.render_cx.set_wgpu_limits(limits)
     }
 
     // --- MARK: RESUMED

--- a/masonry_winit/src/lib.rs
+++ b/masonry_winit/src/lib.rs
@@ -99,7 +99,7 @@ pub use winit;
 
 /// Types needed for running a Masonry app.
 pub mod app {
-    pub use super::app_driver::{AppDriver, DriverCtx, WgpuContext, WindowId};
+    pub use super::app_driver::{AppDriver, DriverCtx, WgpuContext, WgpuLimits, WindowId};
     pub use super::event_loop_runner::{
         EventLoop, EventLoopBuilder, EventLoopProxy, MasonryState, MasonryUserEvent, NewWindow,
         Window, run, run_with,


### PR DESCRIPTION
- Add `WgpuLimits` and expose it via `masonry_winit::app`
- Add `MasonryState::{set_wgpu_device_options, add_wgpu_features, set_wgpu_limits}` to configure requested `wgpu::Features` and limits before device creation
- Thread requested features/limits through `RenderContext::new_device` (best-effort features via intersection with adapter features)