### PR TITLE
masonry_winit: Remove window ID from on_wgpu_ready

### DIFF
--- a/masonry_winit/src/app_driver.rs
+++ b/masonry_winit/src/app_driver.rs
@@ -100,11 +100,8 @@ pub trait AppDriver {
         ctx.exit();
     }
 
-    /// Called when Masonry has created a WGPU device.
-    ///
-    /// This may be called more than once if multiple devices are created (e.g. multiple windows
-    /// requiring different compatible adapters).
-    fn on_wgpu_ready(&mut self, _window_id: WindowId, _wgpu: &WgpuContext<'_>) {}
+    /// Called when Masonry has created its WGPU device.
+    fn on_wgpu_ready(&mut self, _wgpu: &WgpuContext<'_>) {}
 }
 
 impl DriverCtx<'_, '_> {

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -622,7 +622,7 @@ impl MasonryState<'_> {
                     device: &device_handle.device,
                     queue: &device_handle.queue,
                 };
-                app_driver.on_wgpu_ready(window.id, &wgpu);
+                app_driver.on_wgpu_ready(&wgpu);
             }
 
             surface


### PR DESCRIPTION
Per review comment from Daniel, this isn't needed as we move forward, and if it is, we'll have more work to do fix things. In the meantime, having this here results in incorrect assumptions.