### PR TITLE
Implement borders in Masonry Core.

### DIFF
--- a/masonry/src/layers/tooltip.rs
+++ b/masonry/src/layers/tooltip.rs
@@ -9,15 +9,12 @@ use vello::Scene;
 use vello::kurbo::{Axis, Size};
 
 use crate::core::{
-    AccessCtx, AccessEvent, ChildrenIds, EventCtx, HasProperty, Layer, LayoutCtx, MeasureCtx,
-    NewWidget, NoAction, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx,
-    TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, AccessEvent, ChildrenIds, EventCtx, Layer, LayoutCtx, MeasureCtx, NewWidget,
+    NoAction, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update,
+    UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::layout::{LayoutSize, LenReq, SizeDef};
-use crate::properties::{
-    BorderColor, BorderWidth, CornerRadius, FocusedBorderColor, HoveredBorderColor, Padding,
-};
-use crate::util::stroke;
+use crate::properties::{BorderWidth, Padding};
 
 /// A [`Layer`] representing a simple tooltip showing some content until the mouse moves.
 pub struct Tooltip {
@@ -50,10 +47,6 @@ impl Tooltip {
     }
 }
 
-impl HasProperty<BorderColor> for Tooltip {}
-impl HasProperty<BorderWidth> for Tooltip {}
-impl HasProperty<CornerRadius> for Tooltip {}
-
 // --- MARK: IMPL WIDGET
 impl Widget for Tooltip {
     type Action = NoAction;
@@ -82,24 +75,19 @@ impl Widget for Tooltip {
     ) {
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx<'_>, _props: &mut PropertiesMut<'_>, event: &Update) {
-        match event {
-            Update::HoveredChanged(_) | Update::FocusChanged(_) => {
-                ctx.request_paint_only();
-            }
-            _ => {}
-        }
+    fn update(
+        &mut self,
+        _ctx: &mut UpdateCtx<'_>,
+        _props: &mut PropertiesMut<'_>,
+        _event: &Update,
+    ) {
     }
 
     fn register_children(&mut self, ctx: &mut RegisterCtx<'_>) {
         ctx.register_child(&mut self.child);
     }
 
-    fn property_changed(&mut self, ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        BorderColor::prop_changed(ctx, property_type);
-        BorderWidth::prop_changed(ctx, property_type);
-        CornerRadius::prop_changed(ctx, property_type);
-    }
+    fn property_changed(&mut self, _ctx: &mut UpdateCtx<'_>, _property_type: TypeId) {}
 
     fn measure(
         &mut self,
@@ -165,26 +153,7 @@ impl Widget for Tooltip {
         ctx.set_baseline_offset(child_baseline + bottom_gap);
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
-        let is_focused = ctx.is_focus_target();
-        let is_hovered = ctx.is_hovered();
-        let size = ctx.size();
-
-        let border_width = props.get::<BorderWidth>();
-        let border_radius = props.get::<CornerRadius>();
-
-        let border_rect = border_width.border_rect(size, border_radius);
-
-        let border_color = if is_focused {
-            &props.get::<FocusedBorderColor>().0
-        } else if is_hovered {
-            &props.get::<HoveredBorderColor>().0
-        } else {
-            props.get::<BorderColor>()
-        };
-
-        stroke(scene, &border_rect, border_color.color, border_width.width);
-    }
+    fn paint(&mut self, _ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, _scene: &mut Scene) {}
 
     fn accessibility_role(&self) -> Role {
         Role::Tooltip

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -9,6 +9,7 @@ use include_doc_path::include_doc_path;
 use tracing::{Span, trace, trace_span};
 use vello::Scene;
 
+use crate::core::MeasureCtx;
 use crate::core::keyboard::{Key, NamedKey};
 use crate::core::pointer::PointerButton;
 use crate::core::{
@@ -16,14 +17,10 @@ use crate::core::{
     PointerButtonEvent, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent, Update,
     UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
-use crate::core::{HasProperty, MeasureCtx};
 use crate::kurbo::{Axis, Size};
 use crate::layout::{LayoutSize, LenReq, SizeDef};
-use crate::properties::{
-    BorderColor, BorderWidth, CornerRadius, FocusedBorderColor, HoveredBorderColor, Padding,
-};
+use crate::properties::{BorderWidth, Padding};
 use crate::theme;
-use crate::util::stroke;
 use crate::widgets::Label;
 
 /// A button with a child widget.
@@ -100,12 +97,6 @@ pub struct ButtonPress {
     pub button: Option<PointerButton>,
 }
 
-impl HasProperty<FocusedBorderColor> for Button {}
-impl HasProperty<HoveredBorderColor> for Button {}
-impl HasProperty<BorderColor> for Button {}
-impl HasProperty<BorderWidth> for Button {}
-impl HasProperty<CornerRadius> for Button {}
-
 // --- MARK: IMPL WIDGET
 impl Widget for Button {
     type Action = ButtonPress;
@@ -168,26 +159,19 @@ impl Widget for Button {
         }
     }
 
-    fn update(&mut self, ctx: &mut UpdateCtx<'_>, _props: &mut PropertiesMut<'_>, event: &Update) {
-        match event {
-            Update::HoveredChanged(_) | Update::FocusChanged(_) => {
-                ctx.request_paint_only();
-            }
-            _ => {}
-        }
+    fn update(
+        &mut self,
+        _ctx: &mut UpdateCtx<'_>,
+        _props: &mut PropertiesMut<'_>,
+        _event: &Update,
+    ) {
     }
 
     fn register_children(&mut self, ctx: &mut RegisterCtx<'_>) {
         ctx.register_child(&mut self.child);
     }
 
-    fn property_changed(&mut self, ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        FocusedBorderColor::prop_changed(ctx, property_type);
-        HoveredBorderColor::prop_changed(ctx, property_type);
-        BorderColor::prop_changed(ctx, property_type);
-        BorderWidth::prop_changed(ctx, property_type);
-        CornerRadius::prop_changed(ctx, property_type);
-    }
+    fn property_changed(&mut self, _ctx: &mut UpdateCtx<'_>, _property_type: TypeId) {}
 
     fn measure(
         &mut self,
@@ -261,26 +245,7 @@ impl Widget for Button {
         ctx.set_baseline_offset(child_baseline + bottom_gap);
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
-        let is_focused = ctx.is_focus_target();
-        let is_hovered = ctx.is_hovered();
-        let size = ctx.size();
-
-        let border_width = props.get::<BorderWidth>();
-        let border_radius = props.get::<CornerRadius>();
-
-        let border_rect = border_width.border_rect(size, border_radius);
-
-        let border_color = if is_focused {
-            &props.get::<FocusedBorderColor>().0
-        } else if is_hovered {
-            &props.get::<HoveredBorderColor>().0
-        } else {
-            props.get::<BorderColor>()
-        };
-
-        stroke(scene, &border_rect, border_color.color, border_width.width);
-    }
+    fn paint(&mut self, _ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, _scene: &mut Scene) {}
 
     fn accessibility_role(&self) -> Role {
         Role::Button
@@ -322,7 +287,7 @@ mod tests {
     use super::*;
     use crate::core::{CollectionWidget, PointerButton, Properties, StyleProperty};
     use crate::layout::AsUnit;
-    use crate::properties::{BoxShadow, ContentColor, Gap};
+    use crate::properties::{BorderColor, BoxShadow, ContentColor, CornerRadius, Gap};
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::{ACCENT_COLOR, test_property_set};
     use crate::widgets::{Flex, Grid, GridParams, Label, SizedBox};

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -16,9 +16,8 @@ use crate::core::{
 use crate::kurbo::{Affine, Axis, Line, Point, Size, Stroke};
 use crate::layout::{LayoutSize, LenDef, LenReq, Length};
 use crate::properties::types::{CrossAxisAlignment, MainAxisAlignment};
-use crate::properties::{BorderColor, BorderWidth, CornerRadius, Gap, Padding};
+use crate::properties::{BorderWidth, Gap, Padding};
 use crate::util::Sanitize;
-use crate::util::stroke;
 
 /// A container with either horizontal or vertical layout.
 ///
@@ -678,9 +677,6 @@ fn get_spacing(alignment: MainAxisAlignment, extra: f64, child_count: usize) -> 
     (space_before, space_between)
 }
 
-impl HasProperty<BorderColor> for Flex {}
-impl HasProperty<BorderWidth> for Flex {}
-impl HasProperty<CornerRadius> for Flex {}
 impl HasProperty<Gap> for Flex {}
 
 // --- MARK: IMPL WIDGET
@@ -698,9 +694,6 @@ impl Widget for Flex {
     }
 
     fn property_changed(&mut self, ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        BorderColor::prop_changed(ctx, property_type);
-        BorderWidth::prop_changed(ctx, property_type);
-        CornerRadius::prop_changed(ctx, property_type);
         Gap::prop_changed(ctx, property_type);
     }
 
@@ -1178,15 +1171,7 @@ impl Widget for Flex {
         ctx.set_baseline_offset(baseline.unwrap_or(0.));
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
-        let border_width = props.get::<BorderWidth>();
-        let border_radius = props.get::<CornerRadius>();
-        let border_color = props.get::<BorderColor>();
-
-        let border_rect = border_width.border_rect(ctx.size(), border_radius);
-
-        stroke(scene, &border_rect, border_color.color, border_width.width);
-
+    fn paint(&mut self, ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, scene: &mut Scene) {
         // paint the baseline if we're debugging layout
         if ctx.debug_paint_enabled() && ctx.baseline_offset() != 0.0 {
             let color = ctx.debug_color();
@@ -1230,6 +1215,7 @@ mod tests {
 
     use super::*;
     use crate::layout::AsUnit;
+    use crate::properties::BorderColor;
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::{ACCENT_COLOR, test_property_set};
     use crate::widgets::Label;

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -15,8 +15,8 @@ use crate::core::{
 };
 use crate::kurbo::{Affine, Axis, Line, Point, Size, Stroke};
 use crate::layout::{LayoutSize, LenReq, SizeDef};
-use crate::properties::{BorderColor, BorderWidth, CornerRadius, Gap, Padding};
-use crate::util::{debug_panic, stroke};
+use crate::properties::{BorderWidth, Gap, Padding};
+use crate::util::debug_panic;
 
 /// A widget that arranges its children in a grid.
 ///
@@ -281,9 +281,6 @@ impl CollectionWidget<GridParams> for Grid {
     }
 }
 
-impl HasProperty<BorderColor> for Grid {}
-impl HasProperty<BorderWidth> for Grid {}
-impl HasProperty<CornerRadius> for Grid {}
 impl HasProperty<Gap> for Grid {}
 
 // --- MARK: IMPL WIDGET
@@ -301,9 +298,6 @@ impl Widget for Grid {
     }
 
     fn property_changed(&mut self, ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        BorderColor::prop_changed(ctx, property_type);
-        BorderWidth::prop_changed(ctx, property_type);
-        CornerRadius::prop_changed(ctx, property_type);
         Gap::prop_changed(ctx, property_type);
     }
 
@@ -417,15 +411,7 @@ impl Widget for Grid {
         }
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
-        let border_width = props.get::<BorderWidth>();
-        let border_radius = props.get::<CornerRadius>();
-        let border_color = props.get::<BorderColor>();
-
-        let border_rect = border_width.border_rect(ctx.size(), border_radius);
-
-        stroke(scene, &border_rect, border_color.color, border_width.width);
-
+    fn paint(&mut self, ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, scene: &mut Scene) {
         // paint the baseline if we're debugging layout
         if ctx.debug_paint_enabled() && ctx.baseline_offset() != 0.0 {
             let color = ctx.debug_color();

--- a/masonry/src/widgets/indexed_stack.rs
+++ b/masonry/src/widgets/indexed_stack.rs
@@ -9,14 +9,12 @@ use tracing::{Span, trace_span};
 use vello::Scene;
 
 use crate::core::{
-    AccessCtx, ChildrenIds, CollectionWidget, HasProperty, LayoutCtx, MeasureCtx, NewWidget,
-    NoAction, PaintCtx, PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut,
-    WidgetPod,
+    AccessCtx, ChildrenIds, CollectionWidget, LayoutCtx, MeasureCtx, NewWidget, NoAction, PaintCtx,
+    PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::kurbo::{Affine, Axis, Line, Point, Size, Stroke};
 use crate::layout::{LayoutSize, LenReq, SizeDef};
-use crate::properties::{BorderColor, BorderWidth, CornerRadius, Padding};
-use crate::util::stroke;
+use crate::properties::{BorderWidth, Padding};
 
 // TODO - Rename "active" widget to "visible" widget?
 // Active already means something else.
@@ -216,10 +214,6 @@ impl CollectionWidget<()> for IndexedStack {
     }
 }
 
-impl HasProperty<BorderColor> for IndexedStack {}
-impl HasProperty<BorderWidth> for IndexedStack {}
-impl HasProperty<CornerRadius> for IndexedStack {}
-
 // --- MARK: IMPL WIDGET
 impl Widget for IndexedStack {
     type Action = NoAction;
@@ -230,11 +224,7 @@ impl Widget for IndexedStack {
         }
     }
 
-    fn property_changed(&mut self, ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        BorderColor::prop_changed(ctx, property_type);
-        BorderWidth::prop_changed(ctx, property_type);
-        CornerRadius::prop_changed(ctx, property_type);
-    }
+    fn property_changed(&mut self, _ctx: &mut UpdateCtx<'_>, _property_type: TypeId) {}
 
     fn measure(
         &mut self,
@@ -320,15 +310,7 @@ impl Widget for IndexedStack {
         ctx.set_baseline_offset(child_baseline + bottom_gap);
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
-        let border_width = props.get::<BorderWidth>();
-        let border_radius = props.get::<CornerRadius>();
-        let border_color = props.get::<BorderColor>();
-
-        let border_rect = border_width.border_rect(ctx.size(), border_radius);
-
-        stroke(scene, &border_rect, border_color.color, border_width.width);
-
+    fn paint(&mut self, ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, scene: &mut Scene) {
         // paint the baseline if we're debugging layout
         if ctx.debug_paint_enabled() && ctx.baseline_offset() != 0.0 {
             let color = ctx.debug_color();

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -9,13 +9,12 @@ use tracing::{Span, trace_span};
 use vello::Scene;
 
 use crate::core::{
-    AccessCtx, ChildrenIds, HasProperty, LayoutCtx, MeasureCtx, NewWidget, NoAction, PaintCtx,
-    PropertiesRef, RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    AccessCtx, ChildrenIds, LayoutCtx, MeasureCtx, NewWidget, NoAction, PaintCtx, PropertiesRef,
+    RegisterCtx, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::kurbo::{Axis, Point, Size};
 use crate::layout::{LayoutSize, LenReq, Length};
-use crate::properties::{BorderColor, BorderWidth, CornerRadius, Padding};
-use crate::util::stroke;
+use crate::properties::{BorderWidth, Padding};
 
 /// A widget with bi-directional size enforcement.
 ///
@@ -208,10 +207,6 @@ impl SizedBox {
     }
 }
 
-impl HasProperty<BorderColor> for SizedBox {}
-impl HasProperty<BorderWidth> for SizedBox {}
-impl HasProperty<CornerRadius> for SizedBox {}
-
 // --- MARK: IMPL WIDGET
 impl Widget for SizedBox {
     type Action = NoAction;
@@ -226,11 +221,7 @@ impl Widget for SizedBox {
         }
     }
 
-    fn property_changed(&mut self, ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        BorderColor::prop_changed(ctx, property_type);
-        BorderWidth::prop_changed(ctx, property_type);
-        CornerRadius::prop_changed(ctx, property_type);
-    }
+    fn property_changed(&mut self, _ctx: &mut UpdateCtx<'_>, _property_type: TypeId) {}
 
     fn measure(
         &mut self,
@@ -315,15 +306,7 @@ impl Widget for SizedBox {
         ctx.set_baseline_offset(child_baseline);
     }
 
-    fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
-        let border_width = props.get::<BorderWidth>();
-        let border_color = props.get::<BorderColor>();
-        let corner_radius = props.get::<CornerRadius>();
-
-        let border_rect = border_width.border_rect(ctx.size(), corner_radius);
-
-        stroke(scene, &border_rect, border_color.color, border_width.width);
-    }
+    fn paint(&mut self, _ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, _scene: &mut Scene) {}
 
     fn accessibility_role(&self) -> Role {
         Role::GenericContainer
@@ -357,8 +340,8 @@ mod tests {
     use crate::core::Properties;
     use crate::layout::{AsUnit, UnitPoint};
     use crate::palette;
-    use crate::properties::Background;
     use crate::properties::types::Gradient;
+    use crate::properties::{Background, BorderColor, CornerRadius};
     use crate::testing::{TestHarness, assert_failing_render_snapshot, assert_render_snapshot};
     use crate::theme::test_property_set;
     use crate::widgets::Label;

--- a/masonry/src/widgets/switch.rs
+++ b/masonry/src/widgets/switch.rs
@@ -90,11 +90,6 @@ impl Switch {
 }
 
 impl HasProperty<ToggledBackground> for Switch {}
-impl HasProperty<FocusedBorderColor> for Switch {}
-impl HasProperty<HoveredBorderColor> for Switch {}
-impl HasProperty<BorderColor> for Switch {}
-impl HasProperty<BorderWidth> for Switch {}
-impl HasProperty<CornerRadius> for Switch {}
 impl HasProperty<ThumbRadius> for Switch {}
 impl HasProperty<ThumbColor> for Switch {}
 impl HasProperty<TrackThickness> for Switch {}
@@ -184,11 +179,6 @@ impl Widget for Switch {
 
     fn property_changed(&mut self, ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
         ToggledBackground::prop_changed(ctx, property_type);
-        HoveredBorderColor::prop_changed(ctx, property_type);
-        BorderColor::prop_changed(ctx, property_type);
-        FocusedBorderColor::prop_changed(ctx, property_type);
-        BorderWidth::prop_changed(ctx, property_type);
-        CornerRadius::prop_changed(ctx, property_type);
         ThumbRadius::prop_changed(ctx, property_type);
         ThumbColor::prop_changed(ctx, property_type);
         TrackThickness::prop_changed(ctx, property_type);

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -687,11 +687,17 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
             widget.update(ctx, props, &Update::FocusChanged(false));
             ctx.widget_state.request_accessibility = true;
             ctx.widget_state.needs_accessibility = true;
+            // FocusedBorderColor needs pre-paint
+            ctx.widget_state.request_pre_paint = true;
+            ctx.widget_state.needs_paint = true;
         });
         run_single_update_pass(root, next_focused, |widget, ctx, props| {
             widget.update(ctx, props, &Update::FocusChanged(true));
             ctx.widget_state.request_accessibility = true;
             ctx.widget_state.needs_accessibility = true;
+            // FocusedBorderColor needs pre-paint
+            ctx.widget_state.request_pre_paint = true;
+            ctx.widget_state.needs_paint = true;
         });
 
         if let Some(next_focused) = next_focused {
@@ -951,10 +957,16 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
     if prev_hovered_widget != next_hovered_widget {
         run_single_update_pass(root, prev_hovered_widget, |widget, ctx, props| {
             ctx.widget_state.is_hovered = false;
+            // HoveredBorderColor needs pre-paint
+            ctx.widget_state.request_pre_paint = true;
+            ctx.widget_state.needs_paint = true;
             widget.update(ctx, props, &Update::HoveredChanged(false));
         });
         run_single_update_pass(root, next_hovered_widget, |widget, ctx, props| {
             ctx.widget_state.is_hovered = true;
+            // HoveredBorderColor needs pre-paint
+            ctx.widget_state.request_pre_paint = true;
+            ctx.widget_state.needs_paint = true;
             widget.update(ctx, props, &Update::HoveredChanged(true));
         });
     }

--- a/masonry_core/src/properties/background.rs
+++ b/masonry_core/src/properties/background.rs
@@ -1,9 +1,7 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::any::TypeId;
-
-use crate::core::{HasProperty, Property, UpdateCtx, Widget};
+use crate::core::{HasProperty, Property, Widget};
 use crate::kurbo::Rect;
 use crate::peniko::color::{AlphaColor, Srgb};
 use crate::properties::types::Gradient;
@@ -75,16 +73,6 @@ impl Background {
             Self::Gradient(_) => true,
         }
     }
-
-    /// Requests paint if this property changed.
-    ///
-    /// This is called by Masonry during widget properties mutation.
-    pub(crate) fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        if property_type != TypeId::of::<Self>() {
-            return;
-        }
-        ctx.request_paint_only();
-    }
 }
 
 // ---
@@ -104,18 +92,6 @@ impl Default for ActiveBackground {
     }
 }
 
-impl ActiveBackground {
-    /// Requests paint if this property changed.
-    ///
-    /// This is called by Masonry during widget properties mutation.
-    pub(crate) fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        if property_type != TypeId::of::<Self>() {
-            return;
-        }
-        ctx.request_paint_only();
-    }
-}
-
 // ---
 
 impl Property for DisabledBackground {
@@ -130,17 +106,5 @@ impl Property for DisabledBackground {
 impl Default for DisabledBackground {
     fn default() -> Self {
         Self::static_default().clone()
-    }
-}
-
-impl DisabledBackground {
-    /// Requests paint if this property changed.
-    ///
-    /// This is called by Masonry during widget properties mutation.
-    pub(crate) fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        if property_type != TypeId::of::<Self>() {
-            return;
-        }
-        ctx.request_paint_only();
     }
 }

--- a/masonry_core/src/properties/border_color.rs
+++ b/masonry_core/src/properties/border_color.rs
@@ -1,11 +1,14 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::any::TypeId;
-
-use crate::core::{Property, UpdateCtx};
+use crate::core::{HasProperty, Property, Widget};
 use crate::peniko::BrushRef;
 use crate::peniko::color::{AlphaColor, Srgb};
+
+// Every widget has a border color.
+impl<W: Widget> HasProperty<FocusedBorderColor> for W {}
+impl<W: Widget> HasProperty<HoveredBorderColor> for W {}
+impl<W: Widget> HasProperty<BorderColor> for W {}
 
 /// The color of a widget's border.
 #[expect(missing_docs, reason = "field names are self-descriptive")]
@@ -55,12 +58,12 @@ impl BorderColor {
         Self { color }
     }
 
-    /// Helper function to be called in [`Widget::property_changed`](crate::core::Widget::property_changed).
-    pub fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        if property_type != TypeId::of::<Self>() {
-            return;
-        }
-        ctx.request_paint_only();
+    /// Returns `false` if the color can be safely treated as non-existent.
+    ///
+    /// May have false positives.
+    pub const fn is_visible(&self) -> bool {
+        let alpha = self.color.components[3];
+        alpha != 0.0
     }
 }
 
@@ -81,16 +84,6 @@ impl Property for HoveredBorderColor {
     }
 }
 
-impl HoveredBorderColor {
-    /// Helper function to be called in [`Widget::property_changed`](crate::core::Widget::property_changed).
-    pub fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        if property_type != TypeId::of::<Self>() {
-            return;
-        }
-        ctx.request_paint_only();
-    }
-}
-
 // ---
 
 impl Default for FocusedBorderColor {
@@ -105,15 +98,5 @@ impl Property for FocusedBorderColor {
             color: AlphaColor::TRANSPARENT,
         });
         &DEFAULT
-    }
-}
-
-impl FocusedBorderColor {
-    /// Helper function to be called in [`Widget::property_changed`](crate::core::Widget::property_changed).
-    pub fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        if property_type != TypeId::of::<Self>() {
-            return;
-        }
-        ctx.request_paint_only();
     }
 }

--- a/masonry_core/src/properties/border_width.rs
+++ b/masonry_core/src/properties/border_width.rs
@@ -1,12 +1,13 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::any::TypeId;
-
-use crate::core::{Property, UpdateCtx};
+use crate::core::{HasProperty, Property, Widget};
 use crate::kurbo::{Axis, Point, RoundedRect, Size, Vec2};
 use crate::layout::Length;
 use crate::properties::CornerRadius;
+
+// Every widget has a border width.
+impl<W: Widget> HasProperty<BorderWidth> for W {}
 
 /// The width of a widget's border, in logical pixels.
 #[expect(missing_docs, reason = "field names are self-descriptive")]
@@ -31,14 +32,6 @@ impl BorderWidth {
         Self { width }
     }
 
-    /// Helper function to be called in [`Widget::property_changed`](crate::core::Widget::property_changed).
-    pub fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        if property_type != TypeId::of::<Self>() {
-            return;
-        }
-        ctx.request_layout();
-    }
-
     /// Returns the total [`Length`] of this border on the given `axis`.
     ///
     /// For [`Axis::Horizontal`] it will return the sum of the left and right border width.
@@ -53,7 +46,7 @@ impl BorderWidth {
     ///
     /// The provided `size` must be in device pixels.
     ///
-    /// Helper function to be called in [`Widget::layout`](crate::core::Widget::layout).
+    /// Helper function to be called in [`Widget::layout`].
     pub fn size_down(&self, size: Size, scale: f64) -> Size {
         let width = (size.width - Length::px(self.width).dp(scale) * 2.).max(0.);
         let height = (size.height - Length::px(self.width).dp(scale) * 2.).max(0.);
@@ -66,7 +59,7 @@ impl BorderWidth {
     ///
     /// The provided `baseline` must be in device pixels.
     ///
-    /// Helper function to be called in [`Widget::layout`](crate::core::Widget::layout).
+    /// Helper function to be called in [`Widget::layout`].
     pub fn baseline_up(&self, baseline: f64, scale: f64) -> f64 {
         baseline + Length::px(self.width).dp(scale)
     }
@@ -77,7 +70,7 @@ impl BorderWidth {
     ///
     /// The provided `baseline` must be in device pixels.
     ///
-    /// Helper function to be called in [`Widget::layout`](crate::core::Widget::layout).
+    /// Helper function to be called in [`Widget::layout`].
     pub fn baseline_down(&self, baseline: f64, scale: f64) -> f64 {
         baseline - Length::px(self.width).dp(scale)
     }
@@ -88,7 +81,7 @@ impl BorderWidth {
     ///
     /// The provided `origin` must be in device pixels.
     ///
-    /// Helper function to be called in [`Widget::layout`](crate::core::Widget::layout).
+    /// Helper function to be called in [`Widget::layout`].
     pub fn origin_down(&self, origin: Point, scale: f64) -> Point {
         let width = Length::px(self.width).dp(scale);
         origin + Vec2::new(width, width)
@@ -98,7 +91,7 @@ impl BorderWidth {
     ///
     /// Use to display a box's background.
     ///
-    /// Helper function to be called in [`Widget::paint`](crate::core::Widget::paint).
+    /// Helper function to be called in [`Widget::paint`].
     pub fn bg_rect(&self, size: Size, border_radius: &CornerRadius) -> RoundedRect {
         size.to_rect()
             .inset(-self.width)
@@ -109,7 +102,7 @@ impl BorderWidth {
     ///
     /// Use to display a box's border.
     ///
-    /// Helper function to be called in [`Widget::paint`](crate::core::Widget::paint).
+    /// Helper function to be called in [`Widget::paint`].
     pub fn border_rect(&self, size: Size, border_radius: &CornerRadius) -> RoundedRect {
         size.to_rect()
             .inset(-self.width / 2.0)

--- a/masonry_core/src/properties/box_shadow.rs
+++ b/masonry_core/src/properties/box_shadow.rs
@@ -1,11 +1,9 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::any::TypeId;
-
 use vello::Scene;
 
-use crate::core::{HasProperty, Property, UpdateCtx, Widget};
+use crate::core::{HasProperty, Property, Widget};
 use crate::kurbo::{Affine, BezPath, Insets, Point, RoundedRect, Shape as _, Size};
 use crate::peniko::Fill;
 use crate::peniko::color::{AlphaColor, Srgb};
@@ -137,17 +135,5 @@ impl BoxShadow {
             x1: (blur_radius + self.offset.x).max(0.),
             y1: (blur_radius + self.offset.y).max(0.),
         }
-    }
-
-    /// Requests layout if this property changed.
-    ///
-    /// This is called by Masonry during widget properties mutation.
-    pub(crate) fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        if property_type != TypeId::of::<Self>() {
-            return;
-        }
-        // TODO: We'd like to request a paint pass instead, which should be lighter. However,
-        //       box shadow affects the size of the paint rect, which is handled in layout.
-        ctx.request_layout();
     }
 }

--- a/masonry_core/src/properties/corner_radius.rs
+++ b/masonry_core/src/properties/corner_radius.rs
@@ -1,9 +1,10 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::any::TypeId;
+use crate::core::{HasProperty, Property, Widget};
 
-use crate::core::{Property, UpdateCtx};
+// Every widget has a corner radius.
+impl<W: Widget> HasProperty<CornerRadius> for W {}
 
 /// The radius of a widget's box corners, in logical pixels.
 #[expect(missing_docs, reason = "field names are self-descriptive")]
@@ -23,13 +24,5 @@ impl CornerRadius {
     /// Creates new `CornerRadius` with given value.
     pub const fn all(radius: f64) -> Self {
         Self { radius }
-    }
-
-    /// Helper function to be called in [`Widget::property_changed`](crate::core::Widget::property_changed).
-    pub fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        if property_type != TypeId::of::<Self>() {
-            return;
-        }
-        ctx.request_layout();
     }
 }

--- a/masonry_core/src/properties/dimensions.rs
+++ b/masonry_core/src/properties/dimensions.rs
@@ -1,12 +1,10 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::any::TypeId;
-
 use vello::kurbo::Axis;
 
 use crate::{
-    core::{HasProperty, Property, UpdateCtx, Widget},
+    core::{HasProperty, Property, Widget},
     layout::{Dim, Length},
 };
 
@@ -165,15 +163,5 @@ impl Dimensions {
             Axis::Horizontal => self.width,
             Axis::Vertical => self.height,
         }
-    }
-
-    /// Requests layout if this property changed.
-    ///
-    /// This is called by Masonry during widget properties mutation.
-    pub(crate) fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        if property_type != TypeId::of::<Self>() {
-            return;
-        }
-        ctx.request_layout();
     }
 }

--- a/masonry_core/src/properties/mod.rs
+++ b/masonry_core/src/properties/mod.rs
@@ -13,6 +13,8 @@ mod padding;
 
 pub mod types;
 
+use std::any::TypeId;
+
 pub use background::*;
 pub use border_color::*;
 pub use border_width::*;
@@ -20,3 +22,29 @@ pub use box_shadow::*;
 pub use corner_radius::*;
 pub use dimensions::*;
 pub use padding::*;
+
+use crate::core::{Property, UpdateCtx};
+
+/// Handles core property changes.
+pub(crate) fn core_property_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
+    // TODO: For BoxShadow we'd like to request a mere pre-paint pass.
+    //       However, it affects the size of the paint rect, which is handled in layout.
+    if Dimensions::matches(property_type)
+        || BoxShadow::matches(property_type)
+        || BorderWidth::matches(property_type)
+        || CornerRadius::matches(property_type)
+        || Padding::matches(property_type)
+    {
+        ctx.request_layout();
+    } else if DisabledBackground::matches(property_type)
+        || ActiveBackground::matches(property_type)
+        || Background::matches(property_type)
+        || FocusedBorderColor::matches(property_type)
+        || HoveredBorderColor::matches(property_type)
+        || BorderColor::matches(property_type)
+        || BorderWidth::matches(property_type)
+        || CornerRadius::matches(property_type)
+    {
+        ctx.request_pre_paint();
+    }
+}

--- a/masonry_core/src/properties/padding.rs
+++ b/masonry_core/src/properties/padding.rs
@@ -1,9 +1,7 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::any::TypeId;
-
-use crate::core::{HasProperty, Property, UpdateCtx, Widget};
+use crate::core::{HasProperty, Property, Widget};
 use crate::kurbo::{Axis, Point, Size, Vec2};
 use crate::layout::Length;
 
@@ -125,16 +123,6 @@ impl Padding {
 }
 
 impl Padding {
-    /// Requests layout if this property changed.
-    ///
-    /// This is called by Masonry during widget properties mutation.
-    pub(crate) fn prop_changed(ctx: &mut UpdateCtx<'_>, property_type: TypeId) {
-        if property_type != TypeId::of::<Self>() {
-            return;
-        }
-        ctx.request_layout();
-    }
-
     /// Returns the total [`Length`] of this padding on the given `axis`.
     ///
     /// For [`Axis::Horizontal`] it will return the sum of the left and right padding width.


### PR DESCRIPTION
`BorderColor`, `BorderWidth`, and `CornerRadius` will now be painted for all widgets.

The painting is done in the default implementation of `Widget::pre_paint` which was introduced in #1593. A good example of a partial override is the `ProgressBar` widget which opts to delay its border painting until after its progress bar has been painted. Even so it can easily re-use the default implementations with the helper functions and doesn't need to reimplement any of the painting logic.

Focused and hovered state changes also request pre-paint for the related widgets, making the default `FocusedBorderColor` / `HoveredBorderColor` handling truly automatic.

This PR is a follow-up to #1588.