### PR TITLE
Fix various widget baselines.

### DIFF
--- a/masonry/src/layers/tooltip.rs
+++ b/masonry/src/layers/tooltip.rs
@@ -165,10 +165,12 @@ impl Widget for Tooltip {
         let child_origin = ((size - child_size).to_vec2() * 0.5).to_point();
         ctx.place_child(&mut self.child, child_origin);
 
-        let baseline = ctx.child_baseline_offset(&self.child);
-        let baseline = border.baseline_up(baseline, scale);
-        let baseline = padding.baseline_up(baseline, scale);
-        ctx.set_baseline_offset(baseline);
+        let child_baseline = ctx.child_baseline_offset(&self.child);
+        let child_baseline = border.baseline_up(child_baseline, scale);
+        let child_baseline = padding.baseline_up(child_baseline, scale);
+        let child_bottom = child_origin.y + child_size.height;
+        let bottom_gap = size.height - child_bottom;
+        ctx.set_baseline_offset(child_baseline + bottom_gap);
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {

--- a/masonry/src/widgets/align.rs
+++ b/masonry/src/widgets/align.rs
@@ -168,10 +168,10 @@ impl Widget for Align {
             .resolve(Rect::new(0., 0., extra_width, extra_height));
         ctx.place_child(&mut self.child, child_origin);
 
-        if self.height_factor.is_some() {
-            let baseline = ctx.child_baseline_offset(&self.child);
-            ctx.set_baseline_offset(baseline + extra_height * 0.5);
-        }
+        let child_baseline = ctx.child_baseline_offset(&self.child);
+        let child_bottom = child_origin.y + child_size.height;
+        let bottom_gap = size.height - child_bottom;
+        ctx.set_baseline_offset(child_baseline + bottom_gap);
     }
 
     fn paint(&mut self, _ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, _scene: &mut Scene) {}

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -266,10 +266,12 @@ impl Widget for Button {
         let child_origin = ((size - child_size).to_vec2() * 0.5).to_point();
         ctx.place_child(&mut self.child, child_origin);
 
-        let baseline = ctx.child_baseline_offset(&self.child);
-        let baseline = border.baseline_up(baseline, scale);
-        let baseline = padding.baseline_up(baseline, scale);
-        ctx.set_baseline_offset(baseline);
+        let child_baseline = ctx.child_baseline_offset(&self.child);
+        let child_baseline = border.baseline_up(child_baseline, scale);
+        let child_baseline = padding.baseline_up(child_baseline, scale);
+        let child_bottom = child_origin.y + child_size.height;
+        let bottom_gap = size.height - child_bottom;
+        ctx.set_baseline_offset(child_baseline + bottom_gap);
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -16,7 +16,7 @@ use crate::core::{
     NewWidget, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef, RegisterCtx, TextEvent,
     Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
-use crate::kurbo::{Affine, Axis, BezPath, Cap, Dashes, Join, Rect, Size, Stroke};
+use crate::kurbo::{Affine, Axis, BezPath, Cap, Dashes, Join, Point, Rect, Size, Stroke};
 use crate::layout::{LayoutSize, LenReq, SizeDef};
 use crate::properties::{
     ActiveBackground, Background, BorderColor, BorderWidth, CheckmarkColor, CheckmarkStrokeWidth,
@@ -274,10 +274,14 @@ impl Widget for Checkbox {
 
         let label_size = ctx.compute_size(&mut self.label, SizeDef::fit(space), space.into());
         ctx.run_layout(&mut self.label, label_size);
-        ctx.place_child(&mut self.label, (check_side + check_padding, 0.0).into());
 
-        let baseline = ctx.child_baseline_offset(&self.label) + (size.height - label_size.height);
-        ctx.set_baseline_offset(baseline);
+        let label_origin = Point::new(check_side + check_padding, 0.);
+        ctx.place_child(&mut self.label, label_origin);
+
+        let label_baseline = ctx.child_baseline_offset(&self.label);
+        let label_bottom = label_origin.y + label_size.height;
+        let bottom_gap = size.height - label_bottom;
+        ctx.set_baseline_offset(label_baseline + bottom_gap);
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {

--- a/masonry/src/widgets/indexed_stack.rs
+++ b/masonry/src/widgets/indexed_stack.rs
@@ -316,10 +316,12 @@ impl Widget for IndexedStack {
         let child_origin = padding.origin_down(child_origin, scale);
         ctx.place_child(&mut self.children[self.active_child], child_origin);
 
-        let baseline = ctx.child_baseline_offset(&self.children[self.active_child]);
-        let baseline = border.baseline_up(baseline, scale);
-        let baseline = padding.baseline_up(baseline, scale);
-        ctx.set_baseline_offset(baseline);
+        let child_baseline = ctx.child_baseline_offset(&self.children[self.active_child]);
+        let child_baseline = border.baseline_up(child_baseline, scale);
+        let child_baseline = padding.baseline_up(child_baseline, scale);
+        let child_bottom = child_origin.y + child_size.height;
+        let bottom_gap = size.height - child_bottom;
+        ctx.set_baseline_offset(child_baseline + bottom_gap);
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {

--- a/masonry/src/widgets/passthrough.rs
+++ b/masonry/src/widgets/passthrough.rs
@@ -104,8 +104,8 @@ impl Widget for Passthrough {
         ctx.run_layout(&mut self.inner, size);
         ctx.place_child(&mut self.inner, Point::ORIGIN);
 
-        let baseline = ctx.child_baseline_offset(&self.inner);
-        ctx.set_baseline_offset(baseline);
+        let child_baseline = ctx.child_baseline_offset(&self.inner);
+        ctx.set_baseline_offset(child_baseline);
     }
 
     fn paint(&mut self, _ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, _scene: &mut Scene) {}

--- a/masonry/src/widgets/resize_observer.rs
+++ b/masonry/src/widgets/resize_observer.rs
@@ -125,8 +125,8 @@ impl Widget for ResizeObserver {
         ctx.run_layout(&mut self.child, size);
         ctx.place_child(&mut self.child, Point::ORIGIN);
 
-        let baseline = ctx.child_baseline_offset(&self.child);
-        ctx.set_baseline_offset(baseline);
+        let child_baseline = ctx.child_baseline_offset(&self.child);
+        ctx.set_baseline_offset(child_baseline);
 
         if self.last_size.is_none_or(|it| it != size) {
             self.last_size = Some(size);

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -315,10 +315,10 @@ impl Widget for SizedBox {
         let child_origin = padding.origin_down(child_origin, scale);
         ctx.place_child(child, child_origin);
 
-        let baseline = ctx.child_baseline_offset(child);
-        let baseline = border.baseline_up(baseline, scale);
-        let baseline = padding.baseline_up(baseline, scale);
-        ctx.set_baseline_offset(baseline);
+        let child_baseline = ctx.child_baseline_offset(child);
+        let child_baseline = border.baseline_up(child_baseline, scale);
+        let child_baseline = padding.baseline_up(child_baseline, scale);
+        ctx.set_baseline_offset(child_baseline);
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {

--- a/masonry/src/widgets/text_input.rs
+++ b/masonry/src/widgets/text_input.rs
@@ -314,10 +314,10 @@ impl Widget for TextInput {
 
         ctx.place_child(&mut self.text, child_origin);
 
-        let baseline = ctx.child_baseline_offset(&self.text);
-        let baseline = border.baseline_up(baseline, scale);
-        let baseline = padding.baseline_up(baseline, scale);
-        ctx.set_baseline_offset(baseline);
+        let child_baseline = ctx.child_baseline_offset(&self.text);
+        let child_baseline = border.baseline_up(child_baseline, scale);
+        let child_baseline = padding.baseline_up(child_baseline, scale);
+        ctx.set_baseline_offset(child_baseline);
 
         let text_is_empty = ctx.get_raw(&mut self.text).0.is_empty();
         ctx.set_stashed(&mut self.placeholder, !text_is_empty);

--- a/masonry/src/widgets/variable_label.rs
+++ b/masonry/src/widgets/variable_label.rs
@@ -242,8 +242,8 @@ impl Widget for VariableLabel {
         ctx.run_layout(&mut self.label, size);
         ctx.place_child(&mut self.label, Point::ORIGIN);
 
-        let baseline = ctx.child_baseline_offset(&self.label);
-        ctx.set_baseline_offset(baseline);
+        let child_baseline = ctx.child_baseline_offset(&self.label);
+        ctx.set_baseline_offset(child_baseline);
     }
 
     fn paint(&mut self, _ctx: &mut PaintCtx<'_>, _props: &PropertiesRef<'_>, _scene: &mut Scene) {}

--- a/masonry_testing/src/wrapper_widget.rs
+++ b/masonry_testing/src/wrapper_widget.rs
@@ -112,10 +112,14 @@ impl Widget for WrapperWidget {
     fn layout(&mut self, ctx: &mut LayoutCtx<'_>, _props: &PropertiesRef<'_>, size: Size) {
         let child_size = ctx.compute_size(&mut self.child, SizeDef::fit(size), size.into());
         ctx.run_layout(&mut self.child, child_size);
-        ctx.place_child(&mut self.child, Point::ORIGIN);
 
-        let baseline = ctx.child_baseline_offset(&self.child);
-        ctx.set_baseline_offset(baseline);
+        let child_origin = Point::ORIGIN;
+        ctx.place_child(&mut self.child, child_origin);
+
+        let child_baseline = ctx.child_baseline_offset(&self.child);
+        let child_bottom = child_origin.y + child_size.height;
+        let bottom_gap = size.height - child_bottom;
+        ctx.set_baseline_offset(child_baseline + bottom_gap);
     }
 
     fn compose(&mut self, _ctx: &mut ComposeCtx<'_>) {}


### PR DESCRIPTION
A bunch of widgets had incorrect logic for converting their child's baseline into their own baseline. Most commonly that they didn't account for a potential gap between the child's bottom and their own bottom.

This PR adds that missing gap addition.