### PR TITLE
Fix `click_anchors_focus` test and focus anchor behavior

### DIFF
--- a/masonry/src/tests/event.rs
+++ b/masonry/src/tests/event.rs
@@ -232,7 +232,10 @@ fn click_anchors_focus() {
         ))
         .with_fixed(NewWidget::new(Button::with_text("")))
         .with_fixed(NewWidget::new(Button::with_text("")))
-        .with_fixed(NewWidget::new_with_tag(Button::with_text(""), child_3))
+        .with_fixed(NewWidget::new_with_tag(
+            Button::with_text("Click me!"),
+            child_3,
+        ))
         .with_fixed(NewWidget::new_with_tag(Button::with_text(""), child_4))
         .with_fixed(NewWidget::new(Button::with_text("")))
         .with_auto_id();
@@ -243,13 +246,18 @@ fn click_anchors_focus() {
     let child_4_id = harness.get_widget(child_4).id();
     let other_id = harness.get_widget(other).id();
 
-    // Clicking a button doesn't focus it.
+    // Clicking a disabled button doesn't focus it.
+    harness.set_disabled(child_3, true);
     harness.mouse_click_on(child_3_id);
     assert_eq!(harness.focused_widget_id(), None);
 
     // But the next tab event focuses its neighbor.
     harness.process_text_event(TextEvent::key_down(Key::Named(NamedKey::Tab)));
     assert_eq!(harness.focused_widget_id(), Some(child_4_id));
+
+    // TODO - Remove use of mouse_move_to_unchecked after
+    // https://github.com/linebender/xilem/issues/1620
+    // is resolved.
 
     // Clicking another non-focusable widget clears focus.
     harness.mouse_move_to_unchecked(other_id);

--- a/masonry_core/src/passes/event.rs
+++ b/masonry_core/src/passes/event.rs
@@ -207,7 +207,7 @@ pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEv
     if matches!(event, PointerEvent::Down { .. })
         && let Some(target_widget_id) = target_widget_id
     {
-        // The next tab event assign focus around this widget.
+        // The next tab event will assign focus around this widget.
         root.global_state.focus_anchor = Some(target_widget_id);
 
         // If we click outside of the focused widget, we clear the focus.

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -445,7 +445,7 @@ pub(crate) fn find_next_focusable(root: &mut RenderRoot, forward: bool) -> Optio
     let mut focus_anchor_id = root.global_state.focus_anchor;
 
     if let Some(id) = focus_anchor_id
-        && !root.is_still_interactive(id)
+        && !root.has_widget(id)
     {
         focus_anchor_id = None;
     }
@@ -559,9 +559,9 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
     {
         root.global_state.next_focused_widget = None;
     }
-    // Same thing for the anchor.
+    // We are more permissive with the anchor.
     if let Some(id) = root.global_state.focus_anchor
-        && !root.is_still_interactive(id)
+        && !root.has_widget(id)
     {
         root.global_state.focus_anchor = None;
     }


### PR DESCRIPTION
- Allow disabled/stashed widgets as focus anchors.
- Use a disabled button as the focus anchor in `click_anchors_focus`

Unblocks #1609.