### PR TITLE
Document methods related to the window's coordinate space.

### DIFF
--- a/masonry_core/src/app/layer_stack.rs
+++ b/masonry_core/src/app/layer_stack.rs
@@ -70,6 +70,10 @@ impl LayerStack {
 // --- MARK: IMPL WIDGETMUT
 impl LayerStack {
     /// Adds a new layer at the end of the stack, with the given widget as its root, at the given position.
+    ///
+    /// The given `pos` must be in this `LayerStack`'s content-box coordinate space.
+    /// If this `LayerStack` is used as the root widget with no borders, padding, or transforms,
+    /// then that coordinate space will exactly match the window's coordinate space.
     pub(crate) fn add_layer(
         this: &mut WidgetMut<'_, Self>,
         root: NewWidget<impl Widget + ?Sized>,
@@ -122,6 +126,10 @@ impl LayerStack {
     }
 
     /// Repositions the layer with the given widget as root.
+    ///
+    /// The given `new_origin` must be in this `LayerStack`'s content-box coordinate space.
+    /// If this `LayerStack` is used as the root widget with no borders, padding, or transforms,
+    /// then that coordinate space will exactly match the window's coordinate space.
     ///
     /// The base layer cannot be repositioned.
     ///

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -275,11 +275,17 @@ pub enum RenderRootSignal {
     ShowWindowMenu(LogicalPosition<f64>),
     /// The widget picker has selected this widget.
     WidgetSelectedInInspector(WidgetId),
-    /// A new [layer](crate::doc::masonry_concepts#layers) should be created with the widget as root.
+    /// A new [layer] should be created with the widget as root.
+    ///
+    /// The given [`Point`] must be in the window's coordinate space.
+    ///
+    /// [layer]: crate::doc::masonry_concepts#layers
     NewLayer(LayerType, NewWidget<dyn Widget>, Point),
     /// The layer with the given widget as root should be removed.
     RemoveLayer(WidgetId),
     /// The layer with the given widget as root should be repositioned to the specified point.
+    ///
+    /// The given [`Point`] must be in the window's coordinate space.
     RepositionLayer(WidgetId, Point),
 }
 
@@ -674,6 +680,8 @@ impl RenderRoot {
     }
 
     /// Adds a new layer at the end of the stack, with the given widget as its root, at the given position.
+    ///
+    /// The given `pos` must be in the window's coordinate space.
     pub fn add_layer(&mut self, root: NewWidget<impl Widget + ?Sized>, pos: Point) {
         debug!("added layer to stack");
         mutate_widget(self, self.root_id(), |mut layer_stack| {
@@ -702,6 +710,8 @@ impl RenderRoot {
     }
 
     /// Repositions the layer with the given widget as root.
+    ///
+    /// The given `new_origin` must be in the window's coordinate space.
     ///
     /// The base layer cannot be repositioned.
     ///

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -462,8 +462,8 @@ pub trait Widget: AsDynWidget + Any {
     ///
     /// This will be called when the mouse moves or [`request_cursor_icon_change`](crate::core::MutateCtx::request_cursor_icon_change) is called.
     ///
-    /// **pos** - the mouse position in global coordinates (e.g. `(0,0)` is the top-left corner of the
-    /// window).
+    /// **pos** - the mouse position in the window's coordinate space,
+    /// e.g. `(0,0)` is the top-left corner of the window.
     fn get_cursor(&self, ctx: &QueryCtx<'_>, pos: Point) -> CursorIcon {
         CursorIcon::Default
     }
@@ -478,8 +478,8 @@ pub trait Widget: AsDynWidget + Any {
     /// Has a default implementation that can be overridden to search children more efficiently.
     /// Custom implementations must uphold the conditions outlined above.
     ///
-    /// **pos** - the position in global coordinates (e.g. `(0,0)` is the top-left corner of the
-    /// window).
+    /// **pos** - the position is in the window's coordinate space,
+    /// e.g. `(0,0)` is the top-left corner of the window.
     fn find_widget_under_pointer<'c>(
         &'c self,
         ctx: QueryCtx<'c>,

--- a/masonry_core/src/core/widget_pod.rs
+++ b/masonry_core/src/core/widget_pod.rs
@@ -57,7 +57,11 @@ impl<W: ?Sized + Widget> std::fmt::Debug for NewWidget<W> {
 /// The options a new widget will be created with.
 #[derive(Default, Debug)]
 pub struct WidgetOptions {
-    /// The transform the widget will be created with.
+    /// Local transform used during the mapping of this widget's border-box coordinate space
+    /// to the parent's border-box coordinate space.
+    ///
+    /// When calculating the effective border-box of this widget, first this transform
+    /// will be applied and then `scroll_translation` and `origin` applied on top.
     pub transform: Affine,
     /// The disabled state the widget will be created with.
     pub disabled: bool,

--- a/masonry_core/src/core/widget_ref.rs
+++ b/masonry_core/src/core/widget_ref.rs
@@ -168,10 +168,10 @@ impl WidgetRef<'_, dyn Widget> {
 
     /// Recursively finds the innermost widget at the given position, using
     /// [`Widget::find_widget_under_pointer`] to descend the widget tree. If `self` does not contain the
-    /// given position in its layout rect or clip path, this returns `None`.
+    /// given position in its aligned border-box or clip path, this returns `None`.
     ///
-    /// **pos** - the position in global coordinates (e.g. `(0,0)` is the top-left corner of the
-    /// window).
+    /// **pos** - the position is in the window's coordinate space,
+    /// e.g. `(0,0)` is the top-left corner of the window.
     pub fn find_widget_under_pointer(&self, pos: Point) -> Option<Self> {
         self.widget.find_widget_under_pointer(self.ctx, pos)
     }


### PR DESCRIPTION
Made the language a bit more clear and consistent for various methods that talk about the window's coordinate space.