### PR TITLE
Use pseudo-class properties only when explicitly defined.

### DIFF
--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -309,10 +309,11 @@ impl Widget for Checkbox {
 
         let border_rect = border_width.border_rect(check_size.to_rect(), border_radius);
 
-        let border_color = if is_focused {
-            &props.get::<FocusedBorderColor>().0
-        } else if is_hovered {
-            &props.get::<HoveredBorderColor>().0
+        let border_color = if is_focused && let Some(fb) = props.get_defined::<FocusedBorderColor>()
+        {
+            &fb.0
+        } else if is_hovered && let Some(hb) = props.get_defined::<HoveredBorderColor>() {
+            &hb.0
         } else {
             props.get::<BorderColor>()
         };
@@ -323,8 +324,10 @@ impl Widget for Checkbox {
         // Paint the checkmark if checked
         if self.checked {
             let checkmark_width = props.get::<CheckmarkStrokeWidth>();
-            let brush = if ctx.is_disabled() {
-                &props.get::<DisabledCheckmarkColor>().0
+            let brush = if ctx.is_disabled()
+                && let Some(dc) = props.get_defined::<DisabledCheckmarkColor>()
+            {
+                &dc.0
             } else {
                 props.get::<CheckmarkColor>()
             };

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -439,8 +439,10 @@ impl Widget for Label {
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
-        let text_color = if ctx.is_disabled() {
-            &props.get::<DisabledContentColor>().0
+        let text_color = if ctx.is_disabled()
+            && let Some(dc) = props.get_defined::<DisabledContentColor>()
+        {
+            &dc.0
         } else {
             props.get::<ContentColor>()
         };

--- a/masonry/src/widgets/slider.rs
+++ b/masonry/src/widgets/slider.rs
@@ -358,13 +358,13 @@ impl Widget for Slider {
     fn paint(&mut self, ctx: &mut PaintCtx<'_>, props: &PropertiesRef<'_>, scene: &mut Scene) {
         // Get parameters and resolve colors
         // TODO: Create a dedicated TrackColor property
-        let track_color = if props.contains::<Background>() {
-            props.get::<Background>()
+        let track_color = if let Some(b) = props.get_defined::<Background>() {
+            b
         } else {
             &Background::Color(theme::ZYNC_800)
         };
-        let active_track_color = if props.contains::<BarColor>() {
-            props.get::<BarColor>().0
+        let active_track_color = if let Some(bc) = props.get_defined::<BarColor>() {
+            bc.0
         } else {
             theme::ACCENT_COLOR
         };

--- a/masonry/src/widgets/switch.rs
+++ b/masonry/src/widgets/switch.rs
@@ -248,12 +248,14 @@ impl Widget for Switch {
         ) - ctx.border_box_translation();
 
         // Determine track background color
-        let track_bg = if is_disabled {
-            &props.get::<DisabledBackground>().0
-        } else if is_pressed {
-            &props.get::<ActiveBackground>().0
-        } else if self.on {
-            &props.get::<ToggledBackground>().0
+        let track_bg = if is_disabled && let Some(db) = props.get_defined::<DisabledBackground>() {
+            &db.0
+        } else if is_pressed && let Some(ab) = props.get_defined::<ActiveBackground>() {
+            &ab.0
+        } else if self.on
+            && let Some(tb) = props.get_defined::<ToggledBackground>()
+        {
+            &tb.0
         } else {
             props.get::<Background>()
         };
@@ -265,10 +267,11 @@ impl Widget for Switch {
         fill(scene, &track_rounded, &brush);
 
         // Determine border color
-        let border_color = if is_focused {
-            &props.get::<FocusedBorderColor>().0
-        } else if is_hovered {
-            &props.get::<HoveredBorderColor>().0
+        let border_color = if is_focused && let Some(fb) = props.get_defined::<FocusedBorderColor>()
+        {
+            &fb.0
+        } else if is_hovered && let Some(hb) = props.get_defined::<HoveredBorderColor>() {
+            &hb.0
         } else {
             props.get::<BorderColor>()
         };

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -995,10 +995,12 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
         };
         if ctx.is_focus_target() {
             let caret_color = props.get::<CaretColor>().color;
-            let selection_color = if ctx.is_window_focused() {
-                props.get::<SelectionColor>().color
+            let selection_color = if !ctx.is_window_focused()
+                && let Some(us) = props.get_defined::<UnfocusedSelectionColor>()
+            {
+                us.0.color
             } else {
-                props.get::<UnfocusedSelectionColor>().0.color
+                props.get::<SelectionColor>().color
             };
             for (rect, _) in self.editor.selection_geometry().iter() {
                 scene.fill(
@@ -1023,8 +1025,10 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
             };
         }
 
-        let text_color = if ctx.is_disabled() {
-            &props.get::<DisabledContentColor>().0
+        let text_color = if ctx.is_disabled()
+            && let Some(dc) = props.get_defined::<DisabledContentColor>()
+        {
+            &dc.0
         } else {
             props.get::<ContentColor>()
         };

--- a/masonry/src/widgets/text_input.rs
+++ b/masonry/src/widgets/text_input.rs
@@ -287,8 +287,10 @@ impl Widget for TextInput {
         let mut p = PrePaintProps::fetch(ctx, props);
 
         // We want to show a focus border if our child TextArea is focused
-        if ctx.has_focus_target() {
-            p.border_color = &props.get::<FocusedBorderColor>().0;
+        if ctx.has_focus_target()
+            && let Some(fb) = props.get_defined::<FocusedBorderColor>()
+        {
+            p.border_color = &fb.0;
         }
 
         paint_box_shadow(scene, bbox, p.box_shadow, p.corner_radius);

--- a/masonry_core/src/core/properties.rs
+++ b/masonry_core/src/core/properties.rs
@@ -181,6 +181,14 @@ impl PropertiesRef<'_> {
             P::static_default()
         }
     }
+
+    /// Returns the defined value of property `P`.
+    ///
+    /// If the widget has an explicit entry, or the default property map has an explicit entry,
+    /// then this will return a value. Otherwise it will return `None`.
+    pub fn get_defined<P: Property>(&self) -> Option<&P> {
+        self.map.get::<P>().or_else(|| self.default_map.get::<P>())
+    }
 }
 
 impl PropertiesMut<'_> {
@@ -204,6 +212,14 @@ impl PropertiesMut<'_> {
         } else {
             P::static_default()
         }
+    }
+
+    /// Returns the defined value of property `P`.
+    ///
+    /// If the widget has an explicit entry, or the default property map has an explicit entry,
+    /// then this will return a value. Otherwise it will return `None`.
+    pub fn get_defined<P: Property>(&self) -> Option<&P> {
+        self.map.get::<P>().or_else(|| self.default_map.get::<P>())
     }
 
     /// Sets local property `P` to given value. Returns the previous value if `P` was already set.

--- a/masonry_core/src/core/widget_paint.rs
+++ b/masonry_core/src/core/widget_paint.rs
@@ -33,21 +33,29 @@ impl<'a> PrePaintProps<'a> {
     /// Returns common pre-paint properties based on widget state.
     pub fn fetch(ctx: &mut PaintCtx<'_>, props: &'a PropertiesRef<'_>) -> Self {
         let box_shadow = props.get::<BoxShadow>();
-        let background = if ctx.is_disabled() {
-            &props.get::<DisabledBackground>().0
-        } else if ctx.is_active() {
-            &props.get::<ActiveBackground>().0
+        let background = if ctx.is_disabled()
+            && let Some(db) = props.get_defined::<DisabledBackground>()
+        {
+            &db.0
+        } else if ctx.is_active()
+            && let Some(ab) = props.get_defined::<ActiveBackground>()
+        {
+            &ab.0
         } else {
             props.get::<Background>()
         };
-        let border_width = props.get::<BorderWidth>();
-        let border_color = if ctx.is_focus_target() {
-            &props.get::<FocusedBorderColor>().0
-        } else if ctx.is_hovered() {
-            &props.get::<HoveredBorderColor>().0
+        let border_color = if ctx.is_focus_target()
+            && let Some(fb) = props.get_defined::<FocusedBorderColor>()
+        {
+            &fb.0
+        } else if ctx.is_hovered()
+            && let Some(hb) = props.get_defined::<HoveredBorderColor>()
+        {
+            &hb.0
         } else {
             props.get::<BorderColor>()
         };
+        let border_width = props.get::<BorderWidth>();
         let corner_radius = props.get::<CornerRadius>();
 
         Self {


### PR DESCRIPTION
By pseudo-class I mean properties like `HoveredBorderColor`, `FocusedBorderColor`, `ActiveBackground`, etc. Currently they will be used when the the pseudo-class is active (i.e. widget is hovered) regardless if the property was defined.

This means that widgets that don't have an explicitly defined hover border (*and there isn't a theme entry in the default propmap*) will default to a transparent hover border. So for example a button with a blue border will suddenly have no visual border at all when hovered.

This PR makes it possible to check whether there is an explicitly defined property, either directly on the widget or in the theme for that widget type. Then, all pseudo-class prop references make use of this and fall back to the regular property, e.g. regular `BorderColor`.