### PR TITLE
Give focus to TextArea when clicking TextInput padding

### DIFF
--- a/masonry/src/widgets/text_input.rs
+++ b/masonry/src/widgets/text_input.rs
@@ -4,16 +4,15 @@
 use std::any::TypeId;
 
 use accesskit::{Node, Role};
-use masonry_core::core::{PointerButton, PointerButtonEvent};
 use tracing::{Span, trace_span};
 use vello::Scene;
 
 use crate::TextAlign;
 use crate::core::{
     AccessCtx, ArcStr, ChildrenIds, EventCtx, HasProperty, LayoutCtx, MeasureCtx, NewWidget,
-    NoAction, PaintCtx, PointerEvent, PrePaintProps, PropertiesMut, PropertiesRef, RegisterCtx,
-    Update, UpdateCtx, Widget, WidgetId, WidgetMut, WidgetPod, paint_background, paint_border,
-    paint_box_shadow,
+    NoAction, PaintCtx, PointerButton, PointerButtonEvent, PointerEvent, PrePaintProps,
+    PropertiesMut, PropertiesRef, RegisterCtx, Update, UpdateCtx, Widget, WidgetId, WidgetMut,
+    WidgetPod, paint_background, paint_border, paint_box_shadow,
 };
 use crate::kurbo::{Axis, Point, Size};
 use crate::layout::{LayoutSize, LenReq};


### PR DESCRIPTION
Fixes part of #1639.

It's not a perfect fix (mouse cursor isn't changed, click-and-dragging won't start a text selection) but it's makes the jank less user-visible.