### PR TITLE
Add `Update::FontsChanged`.

### DIFF
--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -851,6 +851,13 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
 
     fn update(&mut self, ctx: &mut UpdateCtx<'_>, _props: &mut PropertiesMut<'_>, event: &Update) {
         match event {
+            Update::FontsChanged => {
+                // HACK: We force the editor to relayout by pretending to edit the styles.
+                //       We know that the lifecycle of dirty tracking in Parley's
+                //       editor will need to change eventually anyway...
+                let _ = self.editor.edit_styles();
+                ctx.request_layout();
+            }
             Update::FocusChanged(_) => {
                 ctx.request_render();
             }
@@ -920,14 +927,6 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
         //       but that's potentially wasted work for measure.
         //       Should probably split up that PlainEditor method.
 
-        // TODO: Don't trigger style change multiple times per layout pass for font changes,
-        //       by storing some marker that states we've already dealt with it this pass.
-        if ctx.fonts_changed() {
-            // HACK: We force the editor to relayout by pretending to edit the styles.
-            // We know that the lifecycle of dirty tracking in Parley's
-            // editor will need to change eventually anyway...
-            let _ = self.editor.edit_styles();
-        }
         let (fctx, lctx) = ctx.text_contexts();
         let layout = self.editor.layout(fctx, lctx);
         let text_width = max_advance.unwrap_or(layout.full_width());
@@ -969,14 +968,6 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
             self.rendered_generation = new_generation;
         }
 
-        // TODO: Don't trigger style change multiple times per layout pass for font changes,
-        //       by storing some marker that states we've already dealt with it this pass.
-        if ctx.fonts_changed() {
-            // HACK: We force the editor to relayout by pretending to edit the styles.
-            // We know that the lifecycle of dirty tracking in Parley's
-            // editor will need to change eventually anyway...
-            let _ = self.editor.edit_styles();
-        }
         let (fctx, lctx) = ctx.text_contexts();
         self.editor.layout(fctx, lctx);
 

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -355,20 +355,14 @@ impl_context_method!(
         /// as a child for non-interactive text.
         /// These contexts could however be useful for custom text editing, such as for rich text editing.
         ///
-        /// Any cached text layouts should be invalidated in the layout pass when [`Self::fonts_changed`]
-        /// returns `true`.
+        /// Any cached text layouts should be invalidated when receiving [`Update::FontsChanged`].
+        ///
+        /// [`Update::FontsChanged`]: crate::core::Update::FontsChanged
         pub fn text_contexts(&mut self) -> (&mut FontContext, &mut LayoutContext<BrushIndex>) {
             (
                 &mut self.global_state.font_context,
                 &mut self.global_state.text_layout_context,
             )
-        }
-
-        /// Whether the set of loaded fonts has changed since layout was most recently called.
-        ///
-        /// Any cached text layouts should be invalidated in the layout pass when this is `true`.
-        pub fn fonts_changed(&mut self) -> bool {
-            self.global_state.fonts_changed
         }
     }
 );

--- a/masonry_core/src/core/events.rs
+++ b/masonry_core/src/core/events.rs
@@ -143,6 +143,11 @@ pub enum Update {
     ///
     /// [focused]: crate::doc::masonry_concepts#text-focus
     ChildFocusChanged(bool),
+
+    /// Called when available fonts have changed.
+    ///
+    /// Widgets that directly use fonts should recompute their font selection.
+    FontsChanged,
 }
 
 /// An enum for specifying whether an event was handled.
@@ -279,6 +284,7 @@ impl Update {
             Self::FocusChanged(true) => "FocusChanged(true)",
             Self::ChildFocusChanged(true) => "ChildFocusChanged(true)",
             Self::RequestPanToChild(_) => "RequestPanToChild(_)",
+            Self::FontsChanged => "FontsChanged",
         }
     }
 }

--- a/masonry_core/src/doc/pass_system.md
+++ b/masonry_core/src/doc/pass_system.md
@@ -151,6 +151,12 @@ It updates the hovered and [active] status of widgets and sends related events.
 
 It also update the pointer's icon depending on which widget it's hovering.
 
+#### "Update fonts" pass
+
+This pass informs widgets that the available set of fonts has changed.
+
+If the widget uses fonts directly it'll have to invalidate its existing use and re-assess what fonts are available.
+
 
 ### Layout pass
 

--- a/masonry_core/src/passes/layout.rs
+++ b/masonry_core/src/passes/layout.rs
@@ -621,8 +621,6 @@ pub(crate) fn run_layout_pass(root: &mut RenderRoot) {
     );
     place_widget(&mut root_node.item.state, Point::ORIGIN);
 
-    root.global_state.fonts_changed = false;
-
     if let WindowSizePolicy::Content = root.size_policy {
         // We use the aligned border-box size, which means that transforms won't affect window size.
         let size = root_node.item.state.border_box_size();


### PR DESCRIPTION
The existing `ctx.fonts_changed()` method is not efficient because there is no way to know if a widget has already invalidated its cache due to it. That is, a widget can get e.g. four `measure` calls and then a `layout` call and end up re-selecting fonts five times while one would have been enough.

This PR presents a solution by making it an `Update` variant instead. Now only widgets that care about font changes react to that and request the appropriate passes for themselves.

---

Note that the `Label` widget changes are minimal on purpose. The label layout caching needs a larger rework but that will happen in a separate PR.