### PR TITLE
Improve `Label` text layout caching.

### DIFF
--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -149,6 +149,9 @@ impl TextLayout {
     ///
     /// That is if they have the same number of line breaks with the same reason at the same places.
     fn equals(&self, other: &Self) -> bool {
+        if self.layout.len() != other.layout.len() {
+            return false;
+        }
         let mut a = self.layout.lines();
         let mut b = other.layout.lines();
         loop {


### PR DESCRIPTION
The previous cache had a capacity of one and was isolated between `measure` and `layout` meaning that every layout pass tended to have at least two identical text layouts. The new caching system improves things quite a bit.

* `Widget::layout` can now reuse the cache primed by `Widget::measure`.
* The cache now has a capacity of `5`. Perhaps not the ideal number, but definitely better than `1`. Especially for cases where a `Label` gets measured for e.g. both `MinContent` and `MaxContent`.
* Gradually reducing the available space (e.g. reducing the window size) is handled extremely well by the new cache. It knows the exact `max_advance` threshold where a cache entry is still valid and so has perfect layout re-use without recalculation.
* Gradually increasing the available space is a harder problem and would need Parley cooperation that doesn't exist right now. Which means we have no idea if `cached_max_advance + 1px` will result in a different text layout. So for now the system just makes sure to not trash the cache. After calculating the text layout, if the result is the same as an already cached one then the new entry is discarded. Otherwise the cache would be quickly filled with identical results at slightly different constraints.