### PR TITLE
Check keep_running after Action state mutations

### DIFF
--- a/xilem/src/app.rs
+++ b/xilem/src/app.rs
@@ -120,8 +120,7 @@ impl<State>
 pub trait AppState {
     /// Returns whether the application should keep running or exit.
     ///
-    /// Is currently only checked after a close request.
-    // TODO: check this after every state mutation
+    /// Checked after every state mutation (actions, close requests, etc.).
     fn keep_running(&self) -> bool;
 }
 

--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -260,6 +260,10 @@ where
             //     avoiding infinite loops.
             MessageResult::Action(()) => {
                 self.run_logic(masonry_ctx);
+                // Check if the app wants to exit after this state mutation.
+                if !self.state.keep_running() {
+                    masonry_ctx.exit();
+                }
             }
             MessageResult::RequestRebuild => {
                 window.view.masonry_root.rebuild(


### PR DESCRIPTION
\`keep_running\` was only checked after close requests. Actions that set \`keep_running\` to false (e.g. a quit button) would close all windows but leave the event loop hanging. This is needed to cleanly exit when spawning a xilem UI from a parent process.

Mirrors the existing check in \`on_close_requested\`. Resolves the TODO on \`AppState::keep_running\`.