### PR TITLE
Refactor NewWidget constructors

### DIFF
--- a/masonry/README.md
+++ b/masonry/README.md
@@ -124,22 +124,20 @@ impl AppDriver for Driver {
 
 /// Return initial to-do-list without items.
 pub fn make_widget_tree() -> NewWidget<impl Widget> {
-    let text_input = NewWidget::new_with_tag(
+    let text_input = NewWidget::new(
         TextInput::new("").with_placeholder("ex: 'Do the dishes', 'File my taxes', ..."),
-        TEXT_INPUT_TAG,
-    );
+    )
+    .with_tag(TEXT_INPUT_TAG);
     let button = NewWidget::new(Button::with_text("Add task"));
 
     let list = Flex::column()
-        .with_fixed(NewWidget::new_with_props(
-            Flex::row()
-                .with(text_input, 1.0)
-                .with_fixed(button),
-            PropertySet::new().with(Padding::all(WIDGET_SPACING.get())),
-        ))
+        .with_fixed(
+            NewWidget::new(Flex::row().with(text_input, 1.0).with_fixed(button))
+                .with_props(PropertySet::new().with(Padding::all(WIDGET_SPACING.get()))),
+        )
         .with_fixed_spacer(WIDGET_SPACING);
 
-    NewWidget::new(Portal::new(NewWidget::new_with_tag(list, LIST_TAG)))
+    NewWidget::new(Portal::new(NewWidget::new(list).with_tag(LIST_TAG)))
 }
 
 fn main() {

--- a/masonry/examples/calc_masonry.rs
+++ b/masonry/examples/calc_masonry.rs
@@ -190,7 +190,7 @@ fn op_button_with_label(op: char, label: String) -> NewWidget<Button> {
             .with_style(StyleProperty::FontSize(24.))
             .with_auto_id(),
     );
-    let mut button = NewWidget::new_with_props(button, CalcAction::Op(op));
+    let mut button = NewWidget::new(button).with_props(CalcAction::Op(op));
     button.classes.insert("op_button".to_string());
 
     button
@@ -207,7 +207,7 @@ fn digit_button(digit: u8) -> NewWidget<Button> {
             .with_auto_id(),
     );
 
-    let mut button = NewWidget::new_with_props(button, CalcAction::Digit(digit));
+    let mut button = NewWidget::new(button).with_props(CalcAction::Digit(digit));
     button.classes.insert("digit_button".to_string());
 
     button
@@ -252,8 +252,7 @@ pub fn build_calc() -> NewWidget<impl Widget> {
         .with(op_button('.'), button_params(2, 5))
         .with(op_button('='), button_params(3, 5));
 
-    NewWidget::new_with_props(
-        root_widget,
+    NewWidget::new(root_widget).with_props(
         PropertySet::new()
             .with(Background::Color(AlphaColor::from_str("#794869").unwrap()))
             .with(Padding::all(2.0))

--- a/masonry/examples/gallery/badge.rs
+++ b/masonry/examples/gallery/badge.rs
@@ -83,13 +83,11 @@ impl DemoPage for BadgeDemo {
 
         let new_badge = Badge::with_text("New");
 
-        let beta_badge = NewWidget::new_with_props(
-            Badge::with_text("Beta"),
+        let beta_badge = NewWidget::new(Badge::with_text("Beta")).with_props(
             PropertySet::new().with(Background::Color(Color::from_rgb8(0xd9, 0x77, 0x06))),
         );
 
-        let outline_badge = NewWidget::new_with_props(
-            Badge::with_text("99+"),
+        let outline_badge = NewWidget::new(Badge::with_text("99+")).with_props(
             PropertySet::new()
                 .with(Background::Color(Color::TRANSPARENT))
                 .with(BorderWidth { width: 1.0 })
@@ -122,24 +120,24 @@ impl DemoPage for BadgeDemo {
         .with_badge_offset(Vec2::new(2.0, -2.0))
         .with_auto_id();
 
-        let interactive_inbox = NewWidget::new_with_tag(
+        let interactive_inbox = NewWidget::new(
             Badged::new_optional(
                 Button::with_text("Interactive inbox").with_auto_id(),
                 Self::make_count_badge(self.count),
             )
             .with_badge_placement(BadgePlacement::TopRight)
             .with_badge_offset(Vec2::new(2.0, -2.0)),
-            self.inbox_badged,
-        );
+        )
+        .with_tag(self.inbox_badged);
 
-        let decrement_btn = NewWidget::new_with_tag(Button::with_text("−"), self.decrement_btn);
-        let increment_btn = NewWidget::new_with_tag(Button::with_text("+"), self.increment_btn);
-        let count_label = NewWidget::new_with_tag(
+        let decrement_btn = NewWidget::new(Button::with_text("−")).with_tag(self.decrement_btn);
+        let increment_btn = NewWidget::new(Button::with_text("+")).with_tag(self.increment_btn);
+        let count_label = NewWidget::new(
             Label::new(format!("count: {}", self.count)).with_style(StyleProperty::FontSize(13.0)),
-            self.count_label,
-        );
+        )
+        .with_tag(self.count_label);
 
-        let avatar = NewWidget::new_with_props(
+        let avatar = NewWidget::new(
             SizedBox::new(
                 Align::centered(
                     Label::new("AB")
@@ -150,18 +148,20 @@ impl DemoPage for BadgeDemo {
                 .with_auto_id(),
             )
             .size(Length::const_px(72.0), Length::const_px(72.0)),
+        )
+        .with_props(
             PropertySet::new()
                 .with(Background::Color(Color::from_rgb8(0x3f, 0x3f, 0x46)))
                 .with(CornerRadius { radius: 999.0 })
                 .with(Padding::all(0.0)),
         );
 
-        let online_dot = NewWidget::new_with_props(
-            Badge::new(
-                SizedBox::empty()
-                    .size(Length::const_px(10.0), Length::const_px(10.0))
-                    .with_auto_id(),
-            ),
+        let online_dot = NewWidget::new(Badge::new(
+            SizedBox::empty()
+                .size(Length::const_px(10.0), Length::const_px(10.0))
+                .with_auto_id(),
+        ))
+        .with_props(
             PropertySet::new()
                 .with(Padding::all(0.0))
                 .with(CornerRadius { radius: 999.0 })

--- a/masonry/examples/gallery/checkbox.rs
+++ b/masonry/examples/gallery/checkbox.rs
@@ -34,14 +34,16 @@ impl DemoPage for CheckboxDemo {
     }
 
     fn build(&self) -> NewWidget<dyn Widget> {
-        let checkbox = NewWidget::new_with_tag(Checkbox::new(false, "Check me"), self.checkbox);
+        let checkbox = NewWidget::new(Checkbox::new(false, "Check me")).with_tag(self.checkbox);
 
         let body = Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_fixed(NewWidget::new_with_tag(
-                Label::new("Checked: false").with_style(StyleProperty::FontSize(13.0)),
-                self.state_label,
-            ))
+            .with_fixed(
+                NewWidget::new(
+                    Label::new("Checked: false").with_style(StyleProperty::FontSize(13.0)),
+                )
+                .with_tag(self.state_label),
+            )
             .with_fixed_spacer(CONTENT_GAP)
             .with_fixed(checkbox);
 

--- a/masonry/examples/gallery/demo.rs
+++ b/masonry/examples/gallery/demo.rs
@@ -88,13 +88,13 @@ pub(crate) fn wrap_in_shell(
     body: NewWidget<dyn Widget>,
 ) -> NewWidget<dyn Widget> {
     let disabled_toggle =
-        NewWidget::new_with_tag(Checkbox::new(false, "Disabled"), shell.disabled_toggle);
+        NewWidget::new(Checkbox::new(false, "Disabled")).with_tag(shell.disabled_toggle);
 
     let header = Flex::row()
         .cross_axis_alignment(CrossAxisAlignment::Center)
         .with_fixed(disabled_toggle);
 
-    let content = NewWidget::new_with_tag(SizedBox::new(body), shell.content_wrapper);
+    let content = NewWidget::new(SizedBox::new(body)).with_tag(shell.content_wrapper);
 
     NewWidget::new(
         Flex::column()
@@ -117,5 +117,5 @@ pub(crate) fn build_sidebar_button(
     tag: WidgetTag<Button>,
     name: &'static str,
 ) -> NewWidget<Button> {
-    NewWidget::new_with_tag(Button::with_text(name), tag)
+    NewWidget::new(Button::with_text(name)).with_tag(tag)
 }

--- a/masonry/examples/gallery/image.rs
+++ b/masonry/examples/gallery/image.rs
@@ -43,10 +43,8 @@ impl DemoPage for ImageDemo {
     }
 
     fn build(&self) -> NewWidget<dyn Widget> {
-        let image = NewWidget::new_with_props(
-            Image::new(make_image_data()),
-            PropertySet::one(ObjectFit::Contain),
-        );
+        let image = NewWidget::new(Image::new(make_image_data()))
+            .with_props(PropertySet::one(ObjectFit::Contain));
 
         let body = Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Stretch)

--- a/masonry/examples/gallery/kitchen_sink.rs
+++ b/masonry/examples/gallery/kitchen_sink.rs
@@ -52,15 +52,13 @@ impl DemoPage for KitchenSinkDemo {
                 GridParams::new(1, 1, 1, 1),
             );
 
-        let grid = NewWidget::new_with_props(
-            SizedBox::new(grid.with_auto_id()),
+        let grid = NewWidget::new(SizedBox::new(grid.with_auto_id())).with_props(
             PropertySet::new()
                 .with(Background::Color(Color::from_rgb8(0x24, 0x24, 0x24)))
                 .with(Padding::all(12.0)),
         );
 
-        let bg = NewWidget::new_with_props(
-            SizedBox::empty().size(220.0.px(), 120.0.px()),
+        let bg = NewWidget::new(SizedBox::empty().size(220.0.px(), 120.0.px())).with_props(
             PropertySet::one(Background::Color(Color::from_rgb8(0x44, 0x22, 0x66))),
         );
 

--- a/masonry/examples/gallery/main.rs
+++ b/masonry/examples/gallery/main.rs
@@ -337,15 +337,12 @@ fn main() {
 
     // Padding so the first item isn't flush with the window, and a right inset so an overlay
     // scrollbar doesn't sit on top of the buttons.
-    let list = NewWidget::new_with_props(
-        SizedBox::new(list.with_auto_id()),
-        Padding {
-            top: LEFT_PANE_TOP_PADDING,
-            bottom: 0.0,
-            left: LEFT_PANE_LEFT_PADDING,
-            right: SIDEBAR_SCROLLBAR_INSET,
-        },
-    );
+    let list = NewWidget::new(SizedBox::new(list.with_auto_id())).with_props(Padding {
+        top: LEFT_PANE_TOP_PADDING,
+        bottom: 0.0,
+        left: LEFT_PANE_LEFT_PADDING,
+        right: SIDEBAR_SCROLLBAR_INSET,
+    });
 
     let sidebar = SizedBox::new(Portal::new(list).constrain_horizontal(true).with_auto_id())
         .width(SIDEBAR_WIDTH);
@@ -359,18 +356,18 @@ fn main() {
 
     let right_panel = Flex::column()
         .cross_axis_alignment(CrossAxisAlignment::Stretch)
-        .with_fixed(NewWidget::new_with_tag(
-            Label::new(demos[0].name())
-                .with_style(StyleProperty::FontSize(DEMO_TITLE_FONT_SIZE))
-                .with_style(StyleProperty::FontWeight(FontWeight::BOLD)),
-            title_tag,
-        ))
-        .with(NewWidget::new_with_tag(stack, stack_tag), 1.0);
+        .with_fixed(
+            NewWidget::new(
+                Label::new(demos[0].name())
+                    .with_style(StyleProperty::FontSize(DEMO_TITLE_FONT_SIZE))
+                    .with_style(StyleProperty::FontWeight(FontWeight::BOLD)),
+            )
+            .with_tag(title_tag),
+        )
+        .with(NewWidget::new(stack).with_tag(stack_tag), 1.0);
 
-    let right_panel = NewWidget::new_with_props(
-        SizedBox::new(right_panel.with_auto_id()),
-        Padding::all(RIGHT_PANE_PADDING),
-    );
+    let right_panel = NewWidget::new(SizedBox::new(right_panel.with_auto_id()))
+        .with_props(Padding::all(RIGHT_PANE_PADDING));
 
     let root = Flex::row()
         .cross_axis_alignment(CrossAxisAlignment::Stretch)

--- a/masonry/examples/gallery/pagination.rs
+++ b/masonry/examples/gallery/pagination.rs
@@ -140,10 +140,8 @@ impl DemoPage for PaginationDemo {
                 Flex::row()
                     .with(Label::new("Total pages").with_auto_id(), 1.)
                     .with(
-                        NewWidget::new_with_tag(
-                            StepInput::new(20, 1, 0, 1000),
-                            self.tag_page_count,
-                        ),
+                        NewWidget::new(StepInput::new(20, 1, 0, 1000))
+                            .with_tag(self.tag_page_count),
                         1.,
                     )
                     .with_auto_id(),
@@ -152,10 +150,8 @@ impl DemoPage for PaginationDemo {
                 Flex::row()
                     .with(Label::new("Active page").with_auto_id(), 1.)
                     .with(
-                        NewWidget::new_with_tag(
-                            StepInput::new(1, 1, 1, 1000),
-                            self.tag_page_active,
-                        ),
+                        NewWidget::new(StepInput::new(1, 1, 1, 1000))
+                            .with_tag(self.tag_page_active),
                         1.,
                     )
                     .with_auto_id(),
@@ -164,10 +160,8 @@ impl DemoPage for PaginationDemo {
                 Flex::row()
                     .with(Label::new("Buttons start").with_auto_id(), 1.)
                     .with(
-                        NewWidget::new_with_tag(
-                            StepInput::new(1, 1, 0, 255),
-                            self.tag_buttons_start,
-                        ),
+                        NewWidget::new(StepInput::new(1, 1, 0, 255))
+                            .with_tag(self.tag_buttons_start),
                         1.,
                     )
                     .with_auto_id(),
@@ -176,7 +170,7 @@ impl DemoPage for PaginationDemo {
                 Flex::row()
                     .with(Label::new("Buttons end").with_auto_id(), 1.)
                     .with(
-                        NewWidget::new_with_tag(StepInput::new(1, 1, 0, 255), self.tag_buttons_end),
+                        NewWidget::new(StepInput::new(1, 1, 0, 255)).with_tag(self.tag_buttons_end),
                         1.,
                     )
                     .with_auto_id(),
@@ -185,22 +179,14 @@ impl DemoPage for PaginationDemo {
                 Flex::row()
                     .with(Label::new("Buttons total").with_auto_id(), 1.)
                     .with(
-                        NewWidget::new_with_tag(
-                            StepInput::new(9, 1, 0, 255),
-                            self.tag_buttons_total,
-                        ),
+                        NewWidget::new(StepInput::new(9, 1, 0, 255))
+                            .with_tag(self.tag_buttons_total),
                         1.,
                     )
                     .with_auto_id(),
             )
-            .with_fixed(NewWidget::new_with_tag(
-                Label::new("Some data here .."),
-                self.tag_content,
-            ))
-            .with_fixed(NewWidget::new_with_tag(
-                Pagination::new(20),
-                self.tag_pagination,
-            ));
+            .with_fixed(NewWidget::new(Label::new("Some data here ..")).with_tag(self.tag_content))
+            .with_fixed(NewWidget::new(Pagination::new(20)).with_tag(self.tag_pagination));
 
         wrap_in_shell(self.shell, NewWidget::new(body).erased())
     }

--- a/masonry/examples/gallery/progress.rs
+++ b/masonry/examples/gallery/progress.rs
@@ -69,23 +69,18 @@ impl DemoPage for ProgressDemo {
     }
 
     fn build(&self) -> NewWidget<dyn Widget> {
-        let slider = NewWidget::new_with_tag(
-            Slider::new(0.0, 1.0, self.value).with_step(0.01),
-            self.slider,
-        );
+        let slider =
+            NewWidget::new(Slider::new(0.0, 1.0, self.value).with_step(0.01)).with_tag(self.slider);
         let indeterminate =
-            NewWidget::new_with_tag(Checkbox::new(false, "Indeterminate"), self.indeterminate);
+            NewWidget::new(Checkbox::new(false, "Indeterminate")).with_tag(self.indeterminate);
 
         let body = Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_fixed(NewWidget::new_with_tag(
-                ProgressBar::new(Some(self.value)),
-                self.bar,
-            ))
-            .with_fixed(NewWidget::new_with_tag(
-                Label::new("Value: 35%").with_style(StyleProperty::FontSize(13.0)),
-                self.value_label,
-            ))
+            .with_fixed(NewWidget::new(ProgressBar::new(Some(self.value))).with_tag(self.bar))
+            .with_fixed(
+                NewWidget::new(Label::new("Value: 35%").with_style(StyleProperty::FontSize(13.0)))
+                    .with_tag(self.value_label),
+            )
             .with_fixed_spacer(CONTENT_GAP)
             .with_fixed(slider)
             .with_fixed_spacer(CONTENT_GAP)

--- a/masonry/examples/gallery/radio_buttons.rs
+++ b/masonry/examples/gallery/radio_buttons.rs
@@ -46,10 +46,12 @@ impl DemoPage for RadioButtonsDemo {
 
         let body = Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_fixed(NewWidget::new_with_tag(
-                Label::new("No button selected").with_style(StyleProperty::FontSize(13.0)),
-                self.state_label,
-            ))
+            .with_fixed(
+                NewWidget::new(
+                    Label::new("No button selected").with_style(StyleProperty::FontSize(13.0)),
+                )
+                .with_tag(self.state_label),
+            )
             .with_fixed_spacer(CONTENT_GAP)
             .with_fixed(NewWidget::new(group));
 

--- a/masonry/examples/gallery/slider.rs
+++ b/masonry/examples/gallery/slider.rs
@@ -35,14 +35,16 @@ impl DemoPage for SliderDemo {
 
     fn build(&self) -> NewWidget<dyn Widget> {
         let slider =
-            NewWidget::new_with_tag(Slider::new(-1.0, 1.0, 0.0).with_step(0.001), self.slider);
+            NewWidget::new(Slider::new(-1.0, 1.0, 0.0).with_step(0.001)).with_tag(self.slider);
 
         let body = Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_fixed(NewWidget::new_with_tag(
-                Label::new("Value: 0.000").with_style(StyleProperty::FontSize(13.0)),
-                self.value_label,
-            ))
+            .with_fixed(
+                NewWidget::new(
+                    Label::new("Value: 0.000").with_style(StyleProperty::FontSize(13.0)),
+                )
+                .with_tag(self.value_label),
+            )
             .with_fixed_spacer(CONTENT_GAP)
             .with_fixed(slider);
 

--- a/masonry/examples/gallery/split.rs
+++ b/masonry/examples/gallery/split.rs
@@ -29,23 +29,23 @@ impl DemoPage for SplitDemo {
     }
 
     fn build(&self) -> NewWidget<dyn Widget> {
-        let left = NewWidget::new_with_props(
-            SizedBox::new(
-                Label::new("Left pane (drag the divider)")
-                    .with_style(StyleProperty::FontSize(14.0))
-                    .with_auto_id(),
-            ),
+        let left = NewWidget::new(SizedBox::new(
+            Label::new("Left pane (drag the divider)")
+                .with_style(StyleProperty::FontSize(14.0))
+                .with_auto_id(),
+        ))
+        .with_props(
             PropertySet::new()
                 .with(Background::Color(Color::from_rgb8(0x1f, 0x2a, 0x44)))
                 .with(Padding::all(12.0)),
         );
 
-        let right = NewWidget::new_with_props(
-            SizedBox::new(
-                Label::new("Right pane")
-                    .with_style(StyleProperty::FontSize(14.0))
-                    .with_auto_id(),
-            ),
+        let right = NewWidget::new(SizedBox::new(
+            Label::new("Right pane")
+                .with_style(StyleProperty::FontSize(14.0))
+                .with_auto_id(),
+        ))
+        .with_props(
             PropertySet::new()
                 .with(Background::Color(Color::from_rgb8(0x2b, 0x3c, 0x2f)))
                 .with(Padding::all(12.0)),

--- a/masonry/examples/gallery/step_input.rs
+++ b/masonry/examples/gallery/step_input.rs
@@ -3,7 +3,7 @@
 
 use masonry::app::RenderRoot;
 use masonry::core::{
-    NewWidget, PropertyStack, Selector, StyleProperty, Widget, WidgetId, WidgetOptions, WidgetTag,
+    NewWidget, PropertyStack, Selector, StyleProperty, Widget, WidgetId, WidgetTag,
 };
 use masonry::layout::AsUnit;
 use masonry::peniko::color::AlphaColor;
@@ -155,25 +155,19 @@ impl DemoPage for StepInputDemo {
                 Flex::row()
                     .with_fixed(desc("There are two styles"))
                     .with(
-                        NewWidget::new_with(
-                            StepInput::new(BALANCE_TOTAL / 2, 1, 0, BALANCE_TOTAL),
-                            Some(self.tag_left),
-                            WidgetOptions::default(),
-                            StepInputStyle::Basic,
-                        ),
+                        NewWidget::new(StepInput::new(BALANCE_TOTAL / 2, 1, 0, BALANCE_TOTAL))
+                            .with_tag(self.tag_left)
+                            .with_props(StepInputStyle::Basic),
                         3.,
                     )
                     .with(
-                        NewWidget::new_with_tag(Button::with_text("Balance"), self.tag_balance),
+                        NewWidget::new(Button::with_text("Balance")).with_tag(self.tag_balance),
                         2.,
                     )
                     .with(
-                        NewWidget::new_with(
-                            StepInput::new(BALANCE_TOTAL / 2, 1, 0, BALANCE_TOTAL),
-                            Some(self.tag_right),
-                            WidgetOptions::default(),
-                            StepInputStyle::Flow,
-                        ),
+                        NewWidget::new(StepInput::new(BALANCE_TOTAL / 2, 1, 0, BALANCE_TOTAL))
+                            .with_tag(self.tag_right)
+                            .with_props(StepInputStyle::Flow),
                         3.,
                     )
                     .with_auto_id(),
@@ -243,13 +237,10 @@ impl DemoPage for StepInputDemo {
                 Flex::row()
                     .with_fixed(desc("Visuals can be customized"))
                     .with(
-                        NewWidget::new_with(
-                            StepInput::new(u16::MAX / 2, 1, 0, u16::MAX),
-                            Some(self.tag_custom),
-                            WidgetOptions::default(),
-                            StepInputStyle::Flow,
-                        )
-                        .with_class("custom"),
+                        NewWidget::new(StepInput::new(u16::MAX / 2, 1, 0, u16::MAX))
+                            .with_tag(self.tag_custom)
+                            .with_props(StepInputStyle::Flow)
+                            .with_class("custom"),
                         1.,
                     )
                     .with_auto_id(),

--- a/masonry/examples/gallery/switch.rs
+++ b/masonry/examples/gallery/switch.rs
@@ -34,14 +34,14 @@ impl DemoPage for SwitchDemo {
     }
 
     fn build(&self) -> NewWidget<dyn Widget> {
-        let switch = NewWidget::new_with_tag(Switch::new(false), self.switch);
+        let switch = NewWidget::new(Switch::new(false)).with_tag(self.switch);
 
         let body = Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_fixed(NewWidget::new_with_tag(
-                Label::new("On: false").with_style(StyleProperty::FontSize(13.0)),
-                self.state_label,
-            ))
+            .with_fixed(
+                NewWidget::new(Label::new("On: false").with_style(StyleProperty::FontSize(13.0)))
+                    .with_tag(self.state_label),
+            )
             .with_fixed_spacer(CONTENT_GAP)
             .with_fixed(switch);
 

--- a/masonry/examples/gallery/tooltip.rs
+++ b/masonry/examples/gallery/tooltip.rs
@@ -34,7 +34,7 @@ impl DemoPage for TooltipDemo {
     }
 
     fn build(&self) -> NewWidget<dyn Widget> {
-        let show = NewWidget::new_with_tag(Button::with_text("Show tooltip"), self.show_btn);
+        let show = NewWidget::new(Button::with_text("Show tooltip")).with_tag(self.show_btn);
 
         let body = Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Stretch)

--- a/masonry/examples/gallery/transforms.rs
+++ b/masonry/examples/gallery/transforms.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use masonry::app::RenderRoot;
-use masonry::core::{
-    NewWidget, PropertySet, StyleProperty, Widget, WidgetId, WidgetOptions, WidgetTag,
-};
+use masonry::core::{NewWidget, PropertySet, StyleProperty, Widget, WidgetId, WidgetTag};
 use masonry::kurbo::{Affine, Vec2};
 use masonry::layout::AsUnit as _;
 use masonry::peniko::Color;
@@ -85,47 +83,33 @@ impl DemoPage for TransformsDemo {
     }
 
     fn build(&self) -> NewWidget<dyn Widget> {
-        let state = NewWidget::new_with_tag(
+        let state = NewWidget::new(
             Label::new("angle: 0°   scale: 1.00").with_style(StyleProperty::FontSize(13.0)),
-            self.state_label,
-        );
+        )
+        .with_tag(self.state_label);
 
         let controls = Flex::row()
             .cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_fixed(NewWidget::new_with_tag(
-                Button::with_text("⟲"),
-                self.btn_rotate_left,
-            ))
+            .with_fixed(NewWidget::new(Button::with_text("⟲")).with_tag(self.btn_rotate_left))
             .with_fixed_spacer(SIDEBAR_GAP)
-            .with_fixed(NewWidget::new_with_tag(
-                Button::with_text("⟳"),
-                self.btn_rotate_right,
-            ))
+            .with_fixed(NewWidget::new(Button::with_text("⟳")).with_tag(self.btn_rotate_right))
             .with_fixed_spacer(SIDEBAR_GAP)
-            .with_fixed(NewWidget::new_with_tag(
-                Button::with_text("−"),
-                self.btn_scale_down,
-            ))
+            .with_fixed(NewWidget::new(Button::with_text("−")).with_tag(self.btn_scale_down))
             .with_fixed_spacer(SIDEBAR_GAP)
-            .with_fixed(NewWidget::new_with_tag(
-                Button::with_text("+"),
-                self.btn_scale_up,
-            ))
+            .with_fixed(NewWidget::new(Button::with_text("+")).with_tag(self.btn_scale_up))
             .with_fixed_spacer(SIDEBAR_GAP)
-            .with_fixed(NewWidget::new_with_tag(
-                Button::with_text("Reset"),
-                self.btn_reset,
-            ));
+            .with_fixed(NewWidget::new(Button::with_text("Reset")).with_tag(self.btn_reset));
 
-        let target = NewWidget::new_with(
+        let target = NewWidget::new(
             SizedBox::new(
                 Label::new("Transform me\nand\nsee what happens")
                     .with_style(StyleProperty::FontSize(14.0))
                     .with_auto_id(),
             )
             .size(160.0.px(), 160.0.px()),
-            Some(self.target),
-            WidgetOptions::default(),
+        )
+        .with_tag(self.target)
+        .with_props(
             PropertySet::new()
                 .with(Background::Color(Color::from_rgb8(0x35, 0x35, 0x35)))
                 .with(Padding::all(12.0)),

--- a/masonry/examples/grid_masonry.rs
+++ b/masonry/examples/grid_masonry.rs
@@ -70,7 +70,7 @@ pub fn make_grid(grid_gap: f64) -> NewWidget<Grid> {
     let props = PropertySet::new()
         .with(BorderColor::new(Color::from_rgb8(40, 40, 80)))
         .with(BorderWidth::all(1.0));
-    let label = SizedBox::new(NewWidget::new_with_props(label, props));
+    let label = SizedBox::new(NewWidget::new(label).with_props(props));
 
     let button_inputs = vec![
         GridParams {
@@ -125,10 +125,7 @@ pub fn make_grid(grid_gap: f64) -> NewWidget<Grid> {
         main_widget = main_widget.with(button.with_auto_id(), button_input);
     }
 
-    NewWidget::new_with_props(
-        main_widget,
-        PropertySet::one(Gap::new(Length::px(grid_gap))),
-    )
+    NewWidget::new(main_widget).with_props(PropertySet::one(Gap::new(Length::px(grid_gap))))
 }
 
 fn main() {

--- a/masonry/examples/layers.rs
+++ b/masonry/examples/layers.rs
@@ -173,17 +173,15 @@ fn main() {
         .with_style(StyleProperty::FontWeight(FontWeight::BOLD));
 
     let overlayer = || {
-        let tooltip = NewWidget::new_with_props(
-            Tooltip::new(NewWidget::new_with_props(
-                Label::new("Tooltip!!!"),
-                PropertySet::one(ContentColor::new(Color::BLACK)),
-            )),
-            PropertySet::from((
-                BorderWidth::all(1.),
-                BorderColor::new(Color::BLACK),
-                Background::Color(Color::WHITE),
-            )),
-        )
+        let tooltip = NewWidget::new(Tooltip::new(
+            NewWidget::new(Label::new("Tooltip!!!"))
+                .with_props(PropertySet::one(ContentColor::new(Color::BLACK))),
+        ))
+        .with_props(PropertySet::from((
+            BorderWidth::all(1.),
+            BorderColor::new(Color::BLACK),
+            Background::Color(Color::WHITE),
+        )))
         .erased();
         (tooltip, LayerType::Tooltip("Tooltip!!!".to_string()))
     };

--- a/masonry/examples/simple_image.rs
+++ b/masonry/examples/simple_image.rs
@@ -44,7 +44,7 @@ pub fn make_image() -> NewWidget<Image> {
         height,
     };
 
-    NewWidget::new_with_props(Image::new(png_data), PropertySet::one(ObjectFit::Contain))
+    NewWidget::new(Image::new(png_data)).with_props(PropertySet::one(ObjectFit::Contain))
 }
 
 fn main() {

--- a/masonry/examples/split_playground.rs
+++ b/masonry/examples/split_playground.rs
@@ -94,27 +94,16 @@ fn make_widget_tree() -> NewWidget<impl masonry::core::Widget> {
     const SPACING: Length = Length::const_px(8.0);
 
     let controls = Flex::row()
-        .with_fixed(NewWidget::new_with_tag(
-            Button::with_text("Fraction"),
-            FRACTION_BTN,
-        ))
+        .with_fixed(NewWidget::new(Button::with_text("Fraction")).with_tag(FRACTION_BTN))
         .with_fixed_spacer(SPACING)
-        .with_fixed(NewWidget::new_with_tag(
-            Button::with_text("From start"),
-            START_BTN,
-        ))
+        .with_fixed(NewWidget::new(Button::with_text("From start")).with_tag(START_BTN))
         .with_fixed_spacer(SPACING)
-        .with_fixed(NewWidget::new_with_tag(
-            Button::with_text("From end"),
-            END_BTN,
-        ));
+        .with_fixed(NewWidget::new(Button::with_text("From end")).with_tag(END_BTN));
 
-    let status = NewWidget::new_with_tag(
-        Label::new(
-            "Click the divider, then use arrow keys (Shift = bigger step), Home/End to jump.",
-        ),
-        STATUS_TAG,
-    );
+    let status = NewWidget::new(Label::new(
+        "Click the divider, then use arrow keys (Shift = bigger step), Home/End to jump.",
+    ))
+    .with_tag(STATUS_TAG);
 
     let left = Flex::column()
         .with_fixed(
@@ -132,12 +121,12 @@ fn make_widget_tree() -> NewWidget<impl masonry::core::Widget> {
         )
         .with_fixed(Label::new("Try switching split-point modes.").with_auto_id());
 
-    let split = NewWidget::new_with_tag(
+    let split = NewWidget::new(
         Split::new(NewWidget::new(left), NewWidget::new(right))
             .min_lengths(80.px(), 80.px())
             .min_bar_area(12.px()),
-        SPLIT_TAG,
-    );
+    )
+    .with_tag(SPLIT_TAG);
 
     NewWidget::new(
         Flex::column()

--- a/masonry/examples/to_do_list.rs
+++ b/masonry/examples/to_do_list.rs
@@ -62,23 +62,23 @@ impl AppDriver for Driver {
 
 /// Return initial to-do-list without items.
 pub fn make_widget_tree() -> NewWidget<impl Widget> {
-    let text_input = NewWidget::new_with_tag(
+    let text_input = NewWidget::new(
         TextInput::new("").with_placeholder("ex: 'Do the dishes', 'File my taxes', ..."),
-        TEXT_INPUT_TAG,
-    );
+    )
+    .with_tag(TEXT_INPUT_TAG);
     let button = NewWidget::new(Button::with_text("Add task"));
 
-    let portal = Portal::new(NewWidget::new_with_tag(
-        Flex::column().cross_axis_alignment(CrossAxisAlignment::Start),
-        LIST_TAG,
-    ))
+    let portal = Portal::new(
+        NewWidget::new(Flex::column().cross_axis_alignment(CrossAxisAlignment::Start))
+            .with_tag(LIST_TAG),
+    )
     .with_auto_id();
 
     let root = Flex::column()
-        .with_fixed(NewWidget::new_with_props(
-            Flex::row().with(text_input, 1.0).with_fixed(button),
-            PropertySet::new().with(Padding::all(WIDGET_SPACING.get())),
-        ))
+        .with_fixed(
+            NewWidget::new(Flex::row().with(text_input, 1.0).with_fixed(button))
+                .with_props(PropertySet::new().with(Padding::all(WIDGET_SPACING.get()))),
+        )
         .with_fixed_spacer(WIDGET_SPACING)
         .with(portal, 1.0);
 

--- a/masonry/examples/virtual_fizzbuzz.rs
+++ b/masonry/examples/virtual_fizzbuzz.rs
@@ -90,7 +90,7 @@ impl AppDriver for Driver {
 
 fn main() {
     let scroll_tag = WidgetTag::unique();
-    let main_widget = NewWidget::new_with_tag(init(), scroll_tag).erased();
+    let main_widget = NewWidget::new(init()).with_tag(scroll_tag).erased();
     let driver = Driver {
         scroll_tag,
         fizz: "Fizz".into(),

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -94,22 +94,20 @@
 //!
 //! /// Return initial to-do-list without items.
 //! pub fn make_widget_tree() -> NewWidget<impl Widget> {
-//!     let text_input = NewWidget::new_with_tag(
+//!     let text_input = NewWidget::new(
 //!         TextInput::new("").with_placeholder("ex: 'Do the dishes', 'File my taxes', ..."),
-//!         TEXT_INPUT_TAG,
-//!     );
+//!     )
+//!     .with_tag(TEXT_INPUT_TAG);
 //!     let button = NewWidget::new(Button::with_text("Add task"));
 //!
 //!     let list = Flex::column()
-//!         .with_fixed(NewWidget::new_with_props(
-//!             Flex::row()
-//!                 .with(text_input, 1.0)
-//!                 .with_fixed(button),
-//!             PropertySet::new().with(Padding::all(WIDGET_SPACING.get())),
-//!         ))
+//!         .with_fixed(
+//!             NewWidget::new(Flex::row().with(text_input, 1.0).with_fixed(button))
+//!                 .with_props(PropertySet::new().with(Padding::all(WIDGET_SPACING.get()))),
+//!         )
 //!         .with_fixed_spacer(WIDGET_SPACING);
 //!
-//!     NewWidget::new(Portal::new(NewWidget::new_with_tag(list, LIST_TAG)))
+//!     NewWidget::new(Portal::new(NewWidget::new(list).with_tag(LIST_TAG)))
 //! }
 //!
 //! fn main() {

--- a/masonry/src/tests/accessibility.rs
+++ b/masonry/src/tests/accessibility.rs
@@ -13,8 +13,8 @@ use crate::widgets::SizedBox;
 fn request_accessibility() {
     let target_tag = WidgetTag::named("target");
     let parent_tag = WidgetTag::named("parent");
-    let child = NewWidget::new_with_tag(SizedBox::empty().record(), target_tag);
-    let parent = NewWidget::new_with_tag(ModularWidget::new_parent(child).record(), parent_tag);
+    let child = NewWidget::new(SizedBox::empty().record()).with_tag(target_tag);
+    let parent = NewWidget::new(ModularWidget::new_parent(child).record()).with_tag(parent_tag);
     let grandparent = NewWidget::new(ModularWidget::new_parent(parent));
 
     let mut harness = TestHarness::create(test_property_set(), grandparent);
@@ -49,10 +49,10 @@ fn access_node_children() {
     let child_2 = NewWidget::new(SizedBox::empty());
     let child_3 = NewWidget::new(SizedBox::empty());
 
-    let parent = NewWidget::new_with_tag(
-        ModularWidget::new_multi_parent(vec![child_1, child_2, child_3]),
-        parent_tag,
-    );
+    let parent = NewWidget::new(ModularWidget::new_multi_parent(vec![
+        child_1, child_2, child_3,
+    ]))
+    .with_tag(parent_tag);
     let grandparent = NewWidget::new(ModularWidget::new_parent(parent));
 
     let mut harness = TestHarness::create(test_property_set(), grandparent);

--- a/masonry/src/tests/anim.rs
+++ b/masonry/src/tests/anim.rs
@@ -12,8 +12,8 @@ use crate::widgets::SizedBox;
 fn needs_anim_flag() {
     let target_tag = WidgetTag::named("target");
     let parent_tag = WidgetTag::named("parent");
-    let child = NewWidget::new_with_tag(SizedBox::empty().record(), target_tag);
-    let parent = NewWidget::new_with_tag(ModularWidget::new_parent(child).record(), parent_tag);
+    let child = NewWidget::new(SizedBox::empty().record()).with_tag(target_tag);
+    let parent = NewWidget::new(ModularWidget::new_parent(child).record()).with_tag(parent_tag);
     let grandparent = NewWidget::new(ModularWidget::new_parent(parent));
 
     let mut harness = TestHarness::create(test_property_set(), grandparent);

--- a/masonry/src/tests/compose.rs
+++ b/masonry/src/tests/compose.rs
@@ -20,7 +20,7 @@ fn request_compose() {
 
     let child_tag = WidgetTag::named("child");
     let parent_tag = WidgetTag::named("parent");
-    let child = NewWidget::new_with_tag(SizedBox::empty().record(), child_tag);
+    let child = NewWidget::new(SizedBox::empty().record()).with_tag(child_tag);
 
     let child = ChildAndPos {
         child: child.erased().to_pod(),
@@ -42,7 +42,7 @@ fn request_compose() {
             ctx.register_child(&mut state.child);
         })
         .children_fn(|state| ChildrenIds::from_slice(&[state.child.id()]));
-    let parent = NewWidget::new_with_tag(parent.record(), parent_tag);
+    let parent = NewWidget::new(parent.record()).with_tag(parent_tag);
 
     let mut harness = TestHarness::create(test_property_set(), parent);
     harness.flush_records_of(parent_tag);
@@ -81,7 +81,7 @@ fn request_compose() {
 #[test]
 fn scroll_pixel_snap() {
     let child_tag = WidgetTag::named("child");
-    let child = NewWidget::new_with_tag(SizedBox::empty(), child_tag);
+    let child = NewWidget::new(SizedBox::empty()).with_tag(child_tag);
 
     let parent = ModularWidget::new_parent(child)
         .compose_fn(|state, ctx| {

--- a/masonry/src/tests/event.rs
+++ b/masonry/src/tests/event.rs
@@ -35,7 +35,7 @@ fn create_capture_target() -> ModularWidget<()> {
 fn pointer_event() {
     let button_tag = WidgetTag::named("button");
 
-    let button = NewWidget::new_with_tag(Button::with_text("button").record(), button_tag);
+    let button = NewWidget::new(Button::with_text("button").record()).with_tag(button_tag);
 
     let mut harness = TestHarness::create(test_property_set(), button);
     let button_id = harness.get_widget(button_tag).id();
@@ -55,10 +55,10 @@ fn pointer_event_bubbling() {
     let parent_tag = WidgetTag::named("parent");
     let grandparent_tag = WidgetTag::named("grandparent");
 
-    let button = NewWidget::new_with_tag(Button::with_text("button").record(), button_tag);
-    let parent = NewWidget::new_with_tag(ModularWidget::new_parent(button).record(), parent_tag);
+    let button = NewWidget::new(Button::with_text("button").record()).with_tag(button_tag);
+    let parent = NewWidget::new(ModularWidget::new_parent(button).record()).with_tag(parent_tag);
     let grandparent =
-        NewWidget::new_with_tag(ModularWidget::new_parent(parent).record(), grandparent_tag);
+        NewWidget::new(ModularWidget::new_parent(parent).record()).with_tag(grandparent_tag);
 
     let mut harness = TestHarness::create(test_property_set(), grandparent);
     let button_id = harness.get_widget(button_tag).id();
@@ -80,7 +80,7 @@ fn pointer_capture_and_cancel() {
     let target_tag = WidgetTag::named("target");
 
     let target = create_capture_target();
-    let target = NewWidget::new_with_tag(target, target_tag);
+    let target = NewWidget::new(target).with_tag(target_tag);
 
     let mut harness = TestHarness::create(test_property_set(), target);
 
@@ -103,7 +103,7 @@ fn synthetic_cancel() {
     let target_tag = WidgetTag::named("target");
 
     let target = create_capture_target();
-    let target = NewWidget::new_with_tag(target.record(), target_tag);
+    let target = NewWidget::new(target.record()).with_tag(target_tag);
 
     let mut harness = TestHarness::create(test_property_set(), target);
 
@@ -129,10 +129,10 @@ fn pointer_capture_suppresses_neighbors() {
     let other_tag = WidgetTag::named("other");
 
     let target = create_capture_target();
-    let target = NewWidget::new_with_tag(target, target_tag);
+    let target = NewWidget::new(target).with_tag(target_tag);
 
     let other = Button::with_text("");
-    let other = NewWidget::new_with_tag(other.record(), other_tag);
+    let other = NewWidget::new(other.record()).with_tag(other_tag);
 
     let parent = Flex::column()
         .with_fixed(target)
@@ -205,7 +205,7 @@ fn pointer_cancel_on_window_blur() {
     let target_tag = WidgetTag::named("target");
 
     let target = create_capture_target();
-    let target = NewWidget::new_with_tag(target.record(), target_tag);
+    let target = NewWidget::new(target.record()).with_tag(target_tag);
 
     let mut harness = TestHarness::create(test_property_set(), target);
 
@@ -231,17 +231,11 @@ fn click_anchors_focus() {
     let other = WidgetTag::named("other");
 
     let parent = Flex::column()
-        .with_fixed(NewWidget::new_with_tag(
-            SizedBox::empty().size(5.px(), 5.px()),
-            other,
-        ))
+        .with_fixed(NewWidget::new(SizedBox::empty().size(5.px(), 5.px())).with_tag(other))
         .with_fixed(NewWidget::new(Button::with_text("")))
         .with_fixed(NewWidget::new(Button::with_text("")))
-        .with_fixed(NewWidget::new_with_tag(
-            Button::with_text("Click me!"),
-            child_3,
-        ))
-        .with_fixed(NewWidget::new_with_tag(Button::with_text(""), child_4))
+        .with_fixed(NewWidget::new(Button::with_text("Click me!")).with_tag(child_3))
+        .with_fixed(NewWidget::new(Button::with_text("")).with_tag(child_4))
         .with_fixed(NewWidget::new(Button::with_text("")))
         .with_auto_id();
 
@@ -328,16 +322,16 @@ fn multi_pointers_hover() {
     let button_2_tag = WidgetTag::named("button_2");
     let flex_tag = WidgetTag::named("flex");
 
-    let button_1 = NewWidget::new_with_tag(Button::with_text("Button 1").record(), button_1_tag);
-    let button_2 = NewWidget::new_with_tag(Button::with_text("Button 2").record(), button_2_tag);
+    let button_1 = NewWidget::new(Button::with_text("Button 1").record()).with_tag(button_1_tag);
+    let button_2 = NewWidget::new(Button::with_text("Button 2").record()).with_tag(button_2_tag);
 
-    let flex = NewWidget::new_with_tag(
+    let flex = NewWidget::new(
         Flex::row()
             .with_fixed(button_1)
             .with_fixed(button_2)
             .record(),
-        flex_tag,
-    );
+    )
+    .with_tag(flex_tag);
     let mut harness = TestHarness::create(test_property_set(), flex);
 
     let button_1_rect = harness.get_widget(button_1_tag).ctx().bounding_box();
@@ -412,16 +406,16 @@ fn multi_pointers_capture() {
     let button_2_tag = WidgetTag::named("button_2");
     let flex_tag = WidgetTag::named("flex");
 
-    let button_1 = NewWidget::new_with_tag(Button::with_text("Button 1").record(), button_1_tag);
-    let button_2 = NewWidget::new_with_tag(Button::with_text("Button 2").record(), button_2_tag);
+    let button_1 = NewWidget::new(Button::with_text("Button 1").record()).with_tag(button_1_tag);
+    let button_2 = NewWidget::new(Button::with_text("Button 2").record()).with_tag(button_2_tag);
 
-    let flex = NewWidget::new_with_tag(
+    let flex = NewWidget::new(
         Flex::row()
             .with_fixed(button_1)
             .with_fixed(button_2)
             .record(),
-        flex_tag,
-    );
+    )
+    .with_tag(flex_tag);
     let mut harness = TestHarness::create(test_property_set(), flex);
 
     let button_1_rect = harness.get_widget(button_1_tag).ctx().bounding_box();
@@ -487,7 +481,7 @@ fn multi_pointers_capture() {
 fn text_event() {
     let target_tag = WidgetTag::named("target");
 
-    let target = NewWidget::new_with_tag(TextArea::new_editable("").record(), target_tag);
+    let target = NewWidget::new(TextArea::new_editable("").record()).with_tag(target_tag);
 
     let mut harness = TestHarness::create(test_property_set(), target);
     let target_id = harness.get_widget(target_tag).id();
@@ -510,13 +504,11 @@ fn text_event_bubbling() {
     let parent_tag = WidgetTag::named("parent");
     let grandparent_tag = WidgetTag::named("grandparent");
 
-    let target = NewWidget::new_with_tag(
-        ModularWidget::new(()).accepts_focus(true).record(),
-        target_tag,
-    );
-    let parent = NewWidget::new_with_tag(ModularWidget::new_parent(target).record(), parent_tag);
+    let target =
+        NewWidget::new(ModularWidget::new(()).accepts_focus(true).record()).with_tag(target_tag);
+    let parent = NewWidget::new(ModularWidget::new_parent(target).record()).with_tag(parent_tag);
     let grandparent =
-        NewWidget::new_with_tag(ModularWidget::new_parent(parent).record(), grandparent_tag);
+        NewWidget::new(ModularWidget::new_parent(parent).record()).with_tag(grandparent_tag);
 
     let mut harness = TestHarness::create(test_property_set(), grandparent);
     let target_id = harness.get_widget(target_tag).id();
@@ -538,8 +530,8 @@ fn text_event_fallback() {
     let target_tag = WidgetTag::named("target");
     let other_tag = WidgetTag::named("other");
 
-    let target = NewWidget::new_with_tag(TextArea::new_editable("").record(), target_tag);
-    let other = NewWidget::new_with_tag(TextArea::new_editable(""), other_tag);
+    let target = NewWidget::new(TextArea::new_editable("").record()).with_tag(target_tag);
+    let other = NewWidget::new(TextArea::new_editable("")).with_tag(other_tag);
     let parent = Flex::row()
         .with_fixed(target)
         .with_fixed(other)
@@ -576,11 +568,11 @@ fn tab_focus() {
     let child_5 = WidgetTag::named("child_5");
 
     let parent = Flex::column()
-        .with_fixed(NewWidget::new_with_tag(Button::with_text(""), child_1))
-        .with_fixed(NewWidget::new_with_tag(Button::with_text(""), child_2))
-        .with_fixed(NewWidget::new_with_tag(Button::with_text(""), child_3))
-        .with_fixed(NewWidget::new_with_tag(Button::with_text(""), child_4))
-        .with_fixed(NewWidget::new_with_tag(Button::with_text(""), child_5))
+        .with_fixed(NewWidget::new(Button::with_text("")).with_tag(child_1))
+        .with_fixed(NewWidget::new(Button::with_text("")).with_tag(child_2))
+        .with_fixed(NewWidget::new(Button::with_text("")).with_tag(child_3))
+        .with_fixed(NewWidget::new(Button::with_text("")).with_tag(child_4))
+        .with_fixed(NewWidget::new(Button::with_text("")).with_tag(child_5))
         .with_auto_id();
 
     let mut harness = TestHarness::create(test_property_set(), parent);
@@ -622,10 +614,10 @@ fn access_event_bubbling() {
     let parent_tag = WidgetTag::named("parent");
     let grandparent_tag = WidgetTag::named("grandparent");
 
-    let target = NewWidget::new_with_tag(ModularWidget::new(()).record(), target_tag);
-    let parent = NewWidget::new_with_tag(ModularWidget::new_parent(target).record(), parent_tag);
+    let target = NewWidget::new(ModularWidget::new(()).record()).with_tag(target_tag);
+    let parent = NewWidget::new(ModularWidget::new_parent(target).record()).with_tag(parent_tag);
     let grandparent =
-        NewWidget::new_with_tag(ModularWidget::new_parent(parent).record(), grandparent_tag);
+        NewWidget::new(ModularWidget::new_parent(parent).record()).with_tag(grandparent_tag);
 
     let mut harness = TestHarness::create(test_property_set(), grandparent);
     let target_id = harness.get_widget(target_tag).id();
@@ -660,8 +652,8 @@ fn accessibility_focus() {
 
     let parent = Flex::column()
         .with_fixed(NewWidget::new(Button::with_text("")))
-        .with_fixed(NewWidget::new_with_tag(Button::with_text(""), child_2))
-        .with_fixed(NewWidget::new_with_tag(Button::with_text(""), child_3))
+        .with_fixed(NewWidget::new(Button::with_text("")).with_tag(child_2))
+        .with_fixed(NewWidget::new(Button::with_text("")).with_tag(child_3))
         .with_fixed(NewWidget::new(Button::with_text("")))
         .with_auto_id();
 
@@ -708,7 +700,7 @@ fn downcast_untyped_action() {
         ctx.submit_untyped_action(Box::new(ArbitraryAction));
     });
 
-    let widget = NewWidget::new_with_tag(arbitrary_submitter, target_tag);
+    let widget = NewWidget::new(arbitrary_submitter).with_tag(target_tag);
 
     let mut harness = TestHarness::create(test_property_set(), widget);
     let target_id = harness.get_widget(target_tag).id();

--- a/masonry/src/tests/layout.rs
+++ b/masonry/src/tests/layout.rs
@@ -3,7 +3,7 @@
 
 use assert_matches::assert_matches;
 
-use crate::core::{NewWidget, Widget, WidgetOptions, WidgetTag};
+use crate::core::{NewWidget, Widget, WidgetTag};
 use crate::kurbo::{Insets, Point, Rect, Size};
 use crate::layout::{AsUnit, Length, SizeDef};
 use crate::properties::{BorderWidth, Dimensions, Padding};
@@ -22,14 +22,14 @@ fn layout_simple() {
     let widget = Flex::column()
         .with_fixed(
             Flex::row()
-                .with_fixed(NewWidget::new_with_tag(
-                    SizedBox::empty().width(box_side).height(box_side),
-                    tag_1,
-                ))
-                .with_fixed(NewWidget::new_with_tag(
-                    SizedBox::empty().width(box_side).height(box_side),
-                    tag_2,
-                ))
+                .with_fixed(
+                    NewWidget::new(SizedBox::empty().width(box_side).height(box_side))
+                        .with_tag(tag_1),
+                )
+                .with_fixed(
+                    NewWidget::new(SizedBox::empty().width(box_side).height(box_side))
+                        .with_tag(tag_2),
+                )
                 .with_spacer(1.0)
                 .with_auto_id(),
         )
@@ -104,7 +104,7 @@ fn run_layout_on_stashed() {
             ctx.run_layout(child, size);
             ctx.place_child(child, Point::ZERO);
         });
-    let widget = NewWidget::new_with_tag(widget, parent_tag);
+    let widget = NewWidget::new(widget).with_tag(parent_tag);
 
     let mut harness = TestHarness::create(test_property_set(), widget);
 
@@ -128,7 +128,7 @@ fn stash_then_run_layout() {
             ctx.run_layout(child, size);
             ctx.place_child(child, Point::ZERO);
         });
-    let widget = NewWidget::new_with_tag(widget, parent_tag);
+    let widget = NewWidget::new(widget).with_tag(parent_tag);
 
     assert_debug_panics!(
         TestHarness::create(test_property_set(), widget),
@@ -147,7 +147,7 @@ fn unstash_then_run_layout() {
             ctx.run_layout(child, size);
             ctx.place_child(child, Point::ZERO);
         });
-    let widget = NewWidget::new_with_tag(widget, parent_tag);
+    let widget = NewWidget::new(widget).with_tag(parent_tag);
 
     let mut harness = TestHarness::create(test_property_set(), widget);
 
@@ -162,11 +162,9 @@ fn skip_layout_when_cached() {
     let button_tag = WidgetTag::named("button");
     let sibling_tag = WidgetTag::named("sibling");
 
-    let button = NewWidget::new_with_tag(Button::with_text("Foobar").record(), button_tag);
-    let sibling = NewWidget::new_with_tag(
-        SizedBox::empty().width(20.px()).height(20.px()),
-        sibling_tag,
-    );
+    let button = NewWidget::new(Button::with_text("Foobar").record()).with_tag(button_tag);
+    let sibling =
+        NewWidget::new(SizedBox::empty().width(20.px()).height(20.px())).with_tag(sibling_tag);
 
     // We choose a ZStack, because it should pass down the same constraints no matter what.
     let parent = NewWidget::new(
@@ -199,7 +197,7 @@ fn skip_layout_when_cached() {
 #[test]
 fn pixel_snapping() {
     let child_tag = WidgetTag::named("child");
-    let child = NewWidget::new_with_tag(SizedBox::empty().size(10.3.px(), 10.3.px()), child_tag);
+    let child = NewWidget::new(SizedBox::empty().size(10.3.px(), 10.3.px())).with_tag(child_tag);
     let pos = Point::new(5.1, 5.3);
     let parent = ModularWidget::new_parent(child).layout_fn(move |child, ctx, _, size| {
         let child_size = ctx.compute_size(child, SizeDef::fit(size), size.into());
@@ -208,7 +206,7 @@ fn pixel_snapping() {
         ctx.set_baselines(2.4, 2.6);
     });
     let parent_tag = WidgetTag::named("parent");
-    let parent = NewWidget::new_with_tag(parent, parent_tag);
+    let parent = NewWidget::new(parent).with_tag(parent_tag);
 
     let harness = TestHarness::create(test_property_set(), parent);
 
@@ -237,10 +235,10 @@ fn layout_insets() {
             ctx.set_paint_insets(Insets::uniform_xy(0., 20.));
         });
 
-    let parent_widget = NewWidget::new_with_tag(
-        SizedBox::new(NewWidget::new_with_tag(child_widget, child_tag)),
-        parent_tag,
-    );
+    let parent_widget = NewWidget::new(SizedBox::new(
+        NewWidget::new(child_widget).with_tag(child_tag),
+    ))
+    .with_tag(parent_tag);
 
     let root_widget = Portal::new(parent_widget).with_auto_id();
 
@@ -284,12 +282,9 @@ fn content_box() {
         BorderWidth::all(1.),
     );
 
-    let hero = NewWidget::new_with(
-        Button::with_text("Hero"),
-        Some(tag),
-        WidgetOptions::default(),
-        props,
-    );
+    let hero = NewWidget::new(Button::with_text("Hero"))
+        .with_tag(tag)
+        .with_props(props);
 
     let harness = TestHarness::create(test_property_set(), hero);
 

--- a/masonry/src/tests/mutate.rs
+++ b/masonry/src/tests/mutate.rs
@@ -13,7 +13,7 @@ use crate::widgets::SizedBox;
 fn mutate_order() {
     let parent_tag = WidgetTag::named("parent");
     let child = NewWidget::new(SizedBox::empty());
-    let parent = NewWidget::new_with_tag(ModularWidget::new_parent(child), parent_tag);
+    let parent = NewWidget::new(ModularWidget::new_parent(child)).with_tag(parent_tag);
     let grandparent = NewWidget::new(ModularWidget::new_parent(parent));
 
     let (sender, receiver) = mpsc::channel::<u32>();
@@ -44,7 +44,7 @@ fn mutate_order() {
 fn cancel_mutate() {
     let parent_tag = WidgetTag::named("parent");
     let child = NewWidget::new(SizedBox::empty());
-    let parent = NewWidget::new_with_tag(SizedBox::new(child), parent_tag);
+    let parent = NewWidget::new(SizedBox::new(child)).with_tag(parent_tag);
 
     let mut harness = TestHarness::create(test_property_set(), parent);
     harness.edit_widget(parent_tag, move |mut parent| {

--- a/masonry/src/tests/paint.rs
+++ b/masonry/src/tests/paint.rs
@@ -19,8 +19,8 @@ use crate::widgets::{Align, ChildAlignment, Flex, Grid, GridParams, Label, Sized
 fn request_paint() {
     let target_tag = WidgetTag::named("target");
     let parent_tag = WidgetTag::named("parent");
-    let child = NewWidget::new_with_tag(SizedBox::empty().record(), target_tag);
-    let parent = NewWidget::new_with_tag(ModularWidget::new_parent(child).record(), parent_tag);
+    let child = NewWidget::new(SizedBox::empty().record()).with_tag(target_tag);
+    let parent = NewWidget::new(ModularWidget::new_parent(child).record()).with_tag(parent_tag);
     let grandparent = NewWidget::new(ModularWidget::new_parent(parent));
 
     let mut harness = TestHarness::create(test_property_set(), grandparent);
@@ -61,18 +61,12 @@ fn request_paint() {
 fn paint_order() {
     const SQUARE_SIZE: f64 = 30.;
     const SQUARE_LENGTH: Length = Length::const_px(SQUARE_SIZE);
-    let child1 = NewWidget::new_with_props(
-        SizedBox::empty().width(SQUARE_LENGTH).height(SQUARE_LENGTH),
-        Background::Color(RED),
-    );
-    let child2 = NewWidget::new_with_props(
-        SizedBox::empty().width(SQUARE_LENGTH).height(SQUARE_LENGTH),
-        Background::Color(GREEN),
-    );
-    let child3 = NewWidget::new_with_props(
-        SizedBox::empty().width(SQUARE_LENGTH).height(SQUARE_LENGTH),
-        Background::Color(BLUE),
-    );
+    let child1 = NewWidget::new(SizedBox::empty().width(SQUARE_LENGTH).height(SQUARE_LENGTH))
+        .with_props(Background::Color(RED));
+    let child2 = NewWidget::new(SizedBox::empty().width(SQUARE_LENGTH).height(SQUARE_LENGTH))
+        .with_props(Background::Color(GREEN));
+    let child3 = NewWidget::new(SizedBox::empty().width(SQUARE_LENGTH).height(SQUARE_LENGTH))
+        .with_props(Background::Color(BLUE));
     let children = vec![child1, child2, child3];
     let parent = NewWidget::new(
         ModularWidget::new_multi_parent(children)

--- a/masonry/src/tests/transforms.rs
+++ b/masonry/src/tests/transforms.rs
@@ -34,8 +34,7 @@ fn blue_box(inner: impl Widget) -> impl Widget {
 #[test]
 fn transforms_translation_rotation() {
     let translation = Vec2::new(100.0, 50.0);
-    let transformed_widget = NewWidget::new_with_options(
-        blue_box(Label::new("Background")),
+    let transformed_widget = NewWidget::new(blue_box(Label::new("Background"))).with_options(
         // Currently there's no support for changing the transform-origin, which is currently at the top left.
         // This rotates around the center of the widget
         WidgetOptions {
@@ -55,16 +54,14 @@ fn transforms_translation_rotation() {
 
 #[test]
 fn transforms_pointer_events() {
-    let transformed_widget = NewWidget::new_with_options(
-        blue_box(ZStack::new().with_fixed(
-            Button::with_text("Should be pressed").with_auto_id(),
-            UnitPoint::BOTTOM_RIGHT,
-        )),
-        WidgetOptions {
-            transform: Affine::rotate(PI * 0.125).then_translate(Vec2::new(100.0, 50.0)),
-            ..Default::default()
-        },
-    );
+    let transformed_widget = NewWidget::new(blue_box(ZStack::new().with_fixed(
+        Button::with_text("Should be pressed").with_auto_id(),
+        UnitPoint::BOTTOM_RIGHT,
+    )))
+    .with_options(WidgetOptions {
+        transform: Affine::rotate(PI * 0.125).then_translate(Vec2::new(100.0, 50.0)),
+        ..Default::default()
+    });
     let widget = ZStack::new()
         .with_fixed(transformed_widget, ChildAlignment::ParentAligned)
         .with_auto_id();

--- a/masonry/src/tests/update.rs
+++ b/masonry/src/tests/update.rs
@@ -23,7 +23,7 @@ use crate::widgets::{Button, Flex, Label, SizedBox, TextArea};
 #[test]
 fn app_creation() {
     let widget_tag = WidgetTag::named("widget");
-    let widget = NewWidget::new_with_tag(SizedBox::empty().record(), widget_tag);
+    let widget = NewWidget::new(SizedBox::empty().record()).with_tag(widget_tag);
 
     let harness = TestHarness::create(test_property_set(), widget);
 
@@ -51,7 +51,7 @@ fn new_widget() {
 
     let widget_tag = WidgetTag::named("widget");
     harness.edit_root_widget(|mut flex| {
-        let widget = NewWidget::new_with_tag(SizedBox::empty().record(), widget_tag);
+        let widget = NewWidget::new(SizedBox::empty().record()).with_tag(widget_tag);
 
         Flex::add_fixed(&mut flex, widget);
     });
@@ -100,8 +100,8 @@ fn register_invalid_child() {
 fn disabled_widget_gets_no_event() {
     let button_tag = WidgetTag::named("button");
     let parent_tag = WidgetTag::named("parent");
-    let child = NewWidget::new_with_tag(Button::with_text("").record(), button_tag);
-    let parent = NewWidget::new_with_tag(ModularWidget::new_parent(child), parent_tag);
+    let child = NewWidget::new(Button::with_text("").record()).with_tag(button_tag);
+    let parent = NewWidget::new(ModularWidget::new_parent(child)).with_tag(parent_tag);
 
     let mut harness = TestHarness::create(test_property_set(), parent);
     let button_id = harness.get_widget(button_tag).id();
@@ -131,9 +131,9 @@ fn disable_parent() {
     let button_tag = WidgetTag::named("button");
     let parent_tag = WidgetTag::named("parent");
     let grandparent_tag = WidgetTag::named("grandparent_tag");
-    let child = NewWidget::new_with_tag(Button::with_text("").record(), button_tag);
-    let parent = NewWidget::new_with_tag(ModularWidget::new_parent(child), parent_tag);
-    let grandparent = NewWidget::new_with_tag(ModularWidget::new_parent(parent), grandparent_tag);
+    let child = NewWidget::new(Button::with_text("").record()).with_tag(button_tag);
+    let parent = NewWidget::new(ModularWidget::new_parent(child)).with_tag(parent_tag);
+    let grandparent = NewWidget::new(ModularWidget::new_parent(parent)).with_tag(grandparent_tag);
 
     let mut harness = TestHarness::create(test_property_set(), grandparent);
     harness.flush_records_of(button_tag);
@@ -175,8 +175,8 @@ fn disable_parent() {
 fn stashed_widget_loses_focus() {
     let button_tag = WidgetTag::named("button");
     let parent_tag = WidgetTag::named("parent");
-    let child = NewWidget::new_with_tag(Button::with_text("").record(), button_tag);
-    let parent = NewWidget::new_with_tag(ModularWidget::new_parent(child), parent_tag);
+    let child = NewWidget::new(Button::with_text("").record()).with_tag(button_tag);
+    let parent = NewWidget::new(ModularWidget::new_parent(child)).with_tag(parent_tag);
 
     let mut harness = TestHarness::create(test_property_set(), parent);
     let button_id = harness.get_widget(button_tag).id();
@@ -205,9 +205,9 @@ fn stash_parent() {
     let button_tag = WidgetTag::named("button");
     let parent_tag = WidgetTag::named("parent");
     let grandparent_tag = WidgetTag::named("grandparent_tag");
-    let child = NewWidget::new_with_tag(Button::with_text("").record(), button_tag);
-    let parent = NewWidget::new_with_tag(ModularWidget::new_parent(child), parent_tag);
-    let grandparent = NewWidget::new_with_tag(ModularWidget::new_parent(parent), grandparent_tag);
+    let child = NewWidget::new(Button::with_text("").record()).with_tag(button_tag);
+    let parent = NewWidget::new(ModularWidget::new_parent(child)).with_tag(parent_tag);
+    let grandparent = NewWidget::new(ModularWidget::new_parent(parent)).with_tag(grandparent_tag);
 
     let mut harness = TestHarness::create(test_property_set(), grandparent);
     harness.flush_records_of(button_tag);
@@ -259,20 +259,16 @@ fn stash_parent() {
 // FOCUSABLE
 
 fn focusable_child(name: &'static str) -> NewWidget<impl Widget> {
-    NewWidget::new_with_props(
-        ModularWidget::new(()).accepts_focus(true),
-        PropertySet::one(DebugName(name.to_string())),
-    )
+    NewWidget::new(ModularWidget::new(()).accepts_focus(true))
+        .with_props(PropertySet::one(DebugName(name.to_string())))
 }
 
 fn focusable_parent(
     name: &'static str,
     children: Vec<NewWidget<impl Widget + ?Sized>>,
 ) -> NewWidget<impl Widget> {
-    NewWidget::new_with_props(
-        ModularWidget::new_multi_parent(children).accepts_focus(true),
-        PropertySet::one(DebugName(name.to_string())),
-    )
+    NewWidget::new(ModularWidget::new_multi_parent(children).accepts_focus(true))
+        .with_props(PropertySet::one(DebugName(name.to_string())))
 }
 
 #[test]
@@ -385,9 +381,9 @@ fn disable_focusable() {
     let button2_tag = WidgetTag::named("button2");
     let button3_tag = WidgetTag::named("button3");
 
-    let button1 = NewWidget::new_with_tag(Button::with_text(""), button1_tag);
-    let button2 = NewWidget::new_with_tag(Button::with_text(""), button2_tag);
-    let button3 = NewWidget::new_with_tag(Button::with_text(""), button3_tag);
+    let button1 = NewWidget::new(Button::with_text("")).with_tag(button1_tag);
+    let button2 = NewWidget::new(Button::with_text("")).with_tag(button2_tag);
+    let button3 = NewWidget::new(Button::with_text("")).with_tag(button3_tag);
 
     let parent = NewWidget::new(ModularWidget::new_multi_parent(vec![
         button1, button2, button3,
@@ -418,9 +414,9 @@ fn stash_focusable() {
     let button2_tag = WidgetTag::named("button2");
     let button3_tag = WidgetTag::named("button3");
 
-    let button1 = NewWidget::new_with_tag(Button::with_text(""), button1_tag);
-    let button2 = NewWidget::new_with_tag(Button::with_text(""), button2_tag);
-    let button3 = NewWidget::new_with_tag(Button::with_text(""), button3_tag);
+    let button1 = NewWidget::new(Button::with_text("")).with_tag(button1_tag);
+    let button2 = NewWidget::new(Button::with_text("")).with_tag(button2_tag);
+    let button3 = NewWidget::new(Button::with_text("")).with_tag(button3_tag);
 
     let parent = NewWidget::new(ModularWidget::new_multi_parent(vec![
         button1, button2, button3,
@@ -454,9 +450,9 @@ fn remove_focusable() {
     let button2_tag = WidgetTag::named("button2");
     let button3_tag = WidgetTag::named("button3");
 
-    let button1 = NewWidget::new_with_tag(Button::with_text(""), button1_tag);
-    let button2 = NewWidget::new_with_tag(Button::with_text(""), button2_tag);
-    let button3 = NewWidget::new_with_tag(Button::with_text(""), button3_tag);
+    let button1 = NewWidget::new(Button::with_text("")).with_tag(button1_tag);
+    let button2 = NewWidget::new(Button::with_text("")).with_tag(button2_tag);
+    let button3 = NewWidget::new(Button::with_text("")).with_tag(button3_tag);
 
     let parent = NewWidget::new(ModularWidget::new_multi_parent(vec![
         button1, button2, button3,
@@ -489,7 +485,7 @@ fn remove_focusable() {
 #[test]
 fn ime_commit() {
     let textbox_tag = WidgetTag::named("textbox");
-    let textbox = NewWidget::new_with_tag(TextArea::new_editable(""), textbox_tag);
+    let textbox = NewWidget::new(TextArea::new_editable("")).with_tag(textbox_tag);
 
     let mut harness = TestHarness::create(test_property_set(), textbox);
     let textbox_id = harness.get_widget(textbox_tag).id();
@@ -509,7 +505,7 @@ fn ime_commit() {
 #[test]
 fn ime_removed() {
     let textbox_tag = WidgetTag::named("textbox");
-    let textbox = NewWidget::new_with_tag(TextArea::new_editable(""), textbox_tag);
+    let textbox = NewWidget::new(TextArea::new_editable("")).with_tag(textbox_tag);
     let parent = NewWidget::new(SizedBox::new(textbox));
 
     let mut harness = TestHarness::create(test_property_set(), parent);
@@ -528,7 +524,7 @@ fn ime_removed() {
 #[test]
 fn ime_start_stop() {
     let textbox_tag = WidgetTag::named("textbox");
-    let textbox = NewWidget::new_with_tag(TextArea::new_editable("").record(), textbox_tag);
+    let textbox = NewWidget::new(TextArea::new_editable("").record()).with_tag(textbox_tag);
     let parent = NewWidget::new(ModularWidget::new_parent(textbox));
 
     let mut harness = TestHarness::create(test_property_set(), parent);
@@ -568,7 +564,7 @@ fn create_icon_widget() -> ModularWidget<()> {
 fn cursor_icon() {
     let icon_tag = WidgetTag::named("icon");
     let label = NewWidget::new(Button::with_text("hello"));
-    let icon_widget = NewWidget::new_with_tag(create_icon_widget(), icon_tag);
+    let icon_widget = NewWidget::new(create_icon_widget()).with_tag(icon_tag);
     let parent = NewWidget::new(Flex::row().with_fixed(label).with_fixed(icon_widget));
 
     let mut harness = TestHarness::create(test_property_set(), parent);
@@ -584,8 +580,8 @@ fn cursor_icon() {
 fn pointer_capture_affects_pointer_icon() {
     let label_tag = WidgetTag::named("label");
     let icon_tag = WidgetTag::named("icon");
-    let label = NewWidget::new_with_tag(Button::with_text("hello"), label_tag);
-    let icon_widget = NewWidget::new_with_tag(create_icon_widget(), icon_tag);
+    let label = NewWidget::new(Button::with_text("hello")).with_tag(label_tag);
+    let icon_widget = NewWidget::new(create_icon_widget()).with_tag(icon_tag);
     let parent = NewWidget::new(Flex::row().with_fixed(label).with_fixed(icon_widget));
 
     let mut harness = TestHarness::create(test_property_set(), parent);
@@ -608,7 +604,7 @@ fn pointer_capture_affects_pointer_icon() {
 fn lose_hovered_on_pointer_leave_or_cancel() {
     let button_tag = WidgetTag::named("button");
 
-    let button = NewWidget::new_with_tag(Button::with_text("button").record(), button_tag);
+    let button = NewWidget::new(Button::with_text("button").record()).with_tag(button_tag);
 
     let mut harness = TestHarness::create(test_property_set(), button);
     let button_id = harness.get_widget(button_tag).id();
@@ -651,14 +647,13 @@ fn change_hovered_when_widget_changes() {
     let child_tag = WidgetTag::named("child");
     let parent_tag = WidgetTag::named("parent");
 
-    let child = NewWidget::new_with_tag(
-        ModularWidget::new(BOX_SIZE).measure_fn(|size, _, _, _, _, _| size.get()),
-        child_tag,
-    );
-    let parent = NewWidget::new_with_tag(
+    let child =
+        NewWidget::new(ModularWidget::new(BOX_SIZE).measure_fn(|size, _, _, _, _, _| size.get()))
+            .with_tag(child_tag);
+    let parent = NewWidget::new(
         ModularWidget::new_parent(child).measure_fn(|_, _, _, _, _, _| BOX_SIZE.get()),
-        parent_tag,
-    );
+    )
+    .with_tag(parent_tag);
 
     let mut harness = TestHarness::create(test_property_set(), parent);
     let child_id = harness.get_widget(child_tag).id();
@@ -718,7 +713,7 @@ fn status_flag_update_order() {
     let parent1_tag = WidgetTag::named("parent1");
 
     let child = NewWidget::new(Label::new(""));
-    let parent1 = NewWidget::new_with_tag(make_reporter_parent(child, sender1, 1), parent1_tag);
+    let parent1 = NewWidget::new(make_reporter_parent(child, sender1, 1)).with_tag(parent1_tag);
     let parent2 = NewWidget::new(make_reporter_parent(parent1, sender2, 2));
     let parent3 = NewWidget::new(make_reporter_parent(parent2, sender3, 3));
 

--- a/masonry/src/tests/widget_tag.rs
+++ b/masonry/src/tests/widget_tag.rs
@@ -11,14 +11,14 @@ use crate::widgets::{Flex, SizedBox};
 fn duplicate_widget_tag() {
     let tag = WidgetTag::named("hello");
 
-    let target = NewWidget::new_with_tag(SizedBox::empty(), tag);
+    let target = NewWidget::new(SizedBox::empty()).with_tag(tag);
     let parent = NewWidget::new(Flex::row().with_fixed(target));
 
     let mut harness = TestHarness::create(test_property_set(), parent);
 
     assert_debug_panics!(
         harness.edit_root_widget(|mut flex| {
-            let new_child = NewWidget::new_with_tag(SizedBox::empty(), tag);
+            let new_child = NewWidget::new(SizedBox::empty()).with_tag(tag);
             Flex::add_fixed(&mut flex, new_child);
         }),
         "already exists in the widget tree"

--- a/masonry/src/widgets/align.rs
+++ b/masonry/src/widgets/align.rs
@@ -210,7 +210,7 @@ impl Widget for Align {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{WidgetOptions, WidgetTag};
+    use crate::core::WidgetTag;
     use crate::layout::AsUnit;
     use crate::palette;
     use crate::peniko::color::AlphaColor;
@@ -254,16 +254,13 @@ mod tests {
             Dimensions::fixed(100.px(), 100.px()),
             Background::Color(AlphaColor::from_rgba8(127, 0, 0, 127)),
         ));
-        let align = NewWidget::new_with(
-            Align::new(UnitPoint::CENTER, child),
-            Some(align_tag),
-            WidgetOptions::default(),
-            (
+        let align = NewWidget::new(Align::new(UnitPoint::CENTER, child))
+            .with_tag(align_tag)
+            .with_props((
                 Dimensions::fixed(50.px(), 50.px()),
                 BorderWidth::all(2.),
                 BorderColor::new(palette::css::BLACK),
-            ),
-        );
+            ));
         let root = Align::centered(align).with_auto_id();
 
         let window_size = Size::new(200.0, 200.0);

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -332,10 +332,8 @@ mod tests {
         let image_1 = {
             let label = Label::new("The quick brown fox jumps over the lazy dog")
                 .with_style(StyleProperty::FontSize(20.0));
-            let label = NewWidget::new_with_props(
-                label,
-                PropertySet::new().with(ContentColor::new(ACCENT_COLOR)),
-            );
+            let label = NewWidget::new(label)
+                .with_props(PropertySet::new().with(ContentColor::new(ACCENT_COLOR)));
 
             let button = NewWidget::new(Button::new(label));
 
@@ -410,8 +408,7 @@ mod tests {
                 Button::with_text("D").with_auto_id(),
                 GridParams::new(1, 1, 1, 1),
             );
-        let root_widget = NewWidget::new_with_props(
-            grid,
+        let root_widget = NewWidget::new(grid).with_props(
             PropertySet::new()
                 .with(Padding::all(20.0))
                 .with(Gap::new(40.px())),

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -443,10 +443,8 @@ mod tests {
         let image_1 = {
             let label = Label::new("The quick brown fox jumps over the lazy dog")
                 .with_style(StyleProperty::FontSize(20.0));
-            let label = NewWidget::new_with_props(
-                label,
-                PropertySet::new().with(ContentColor::new(ACCENT_COLOR)),
-            );
+            let label = NewWidget::new(label)
+                .with_props(PropertySet::new().with(ContentColor::new(ACCENT_COLOR)));
             let checkbox = NewWidget::new(Checkbox::from_label(true, label));
 
             let mut harness =

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -1250,7 +1250,7 @@ impl Widget for Flex {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{WidgetOptions, WidgetTag};
+    use crate::core::WidgetTag;
     use crate::kurbo::{Cap, Line, Stroke};
     use crate::layout::AsUnit;
     use crate::palette;
@@ -1385,14 +1385,14 @@ mod tests {
 
     #[test]
     fn flex_row_fixed_size_only() {
-        let widget = NewWidget::new_with_props(
+        let widget = NewWidget::new(
             Flex::row()
                 .with_fixed(Label::new("hello").with_auto_id())
                 .with_fixed(Label::new("world").with_auto_id())
                 .with_fixed(Label::new("foo").with_auto_id())
                 .with_fixed(Label::new("bar").with_auto_id()),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)),
-        );
+        )
+        .with_props((BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)));
 
         let window_size = Size::new(200.0, 150.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -1431,7 +1431,7 @@ mod tests {
     // TODO - Reduce copy-pasting?
     #[test]
     fn flex_row_cross_axis_snapshots() {
-        let widget = NewWidget::new_with_props(
+        let widget = NewWidget::new(
             Flex::row()
                 .with_fixed(Label::new("hello").with_auto_id())
                 .with(Label::new("world").with_auto_id(), 1.0)
@@ -1440,8 +1440,8 @@ mod tests {
                     Label::new("bar").with_auto_id(),
                     FlexParams::new(2.0, None, CrossAxisAlignment::Start),
                 ),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)),
-        );
+        )
+        .with_props((BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)));
 
         let window_size = Size::new(200.0, 150.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -1482,14 +1482,14 @@ mod tests {
     #[test]
     fn flex_row_main_axis_snapshots() {
         // ALl children need to be fixed, otherwise a flexible child will use up all the space.
-        let widget = NewWidget::new_with_props(
+        let widget = NewWidget::new(
             Flex::row()
                 .with_fixed(Label::new("hello").with_auto_id())
                 .with_fixed(Label::new("world").with_auto_id())
                 .with_fixed(Label::new("foo").with_auto_id())
                 .with(Label::new("bar").with_auto_id(), CrossAxisAlignment::Start),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)),
-        );
+        )
+        .with_props((BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)));
 
         let window_size = Size::new(200.0, 150.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -1529,7 +1529,7 @@ mod tests {
 
     #[test]
     fn flex_col_cross_axis_snapshots() {
-        let widget = NewWidget::new_with_props(
+        let widget = NewWidget::new(
             Flex::column()
                 .with_fixed(Label::new("hello").with_auto_id())
                 .with(Label::new("world").with_auto_id(), 1.0)
@@ -1538,8 +1538,8 @@ mod tests {
                     Label::new("bar").with_auto_id(),
                     FlexParams::new(2.0, None, CrossAxisAlignment::Start),
                 ),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)),
-        );
+        )
+        .with_props((BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)));
 
         let window_size = Size::new(200.0, 150.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -1580,14 +1580,14 @@ mod tests {
     #[test]
     fn flex_col_main_axis_snapshots() {
         // ALl children need to be fixed, otherwise a flexible child will use up all the space.
-        let widget = NewWidget::new_with_props(
+        let widget = NewWidget::new(
             Flex::column()
                 .with_fixed(Label::new("hello").with_auto_id())
                 .with_fixed(Label::new("world").with_auto_id())
                 .with_fixed(Label::new("foo").with_auto_id())
                 .with(Label::new("bar").with_auto_id(), CrossAxisAlignment::Start),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)),
-        );
+        )
+        .with_props((BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)));
 
         let window_size = Size::new(200.0, 150.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -1642,7 +1642,7 @@ mod tests {
 
         let flex_tag = WidgetTag::unique();
 
-        let flex = NewWidget::new_with(
+        let flex = NewWidget::new(
             Flex::row()
                 .cross_axis_alignment(CrossAxisAlignment::Center)
                 .with_fixed(Label::new("Left").with_props(props(0., 0.)))
@@ -1651,10 +1651,9 @@ mod tests {
                 .with_fixed(Label::new("F\nG\nH\nI").with_props(props(20., 20.)))
                 .with_fixed(Label::new("J\nK\nL\nM\nN").with_props(props(0., 30.)))
                 .with_fixed(Label::new("Right\nToo").with_props(props(50., 50.))),
-            Some(flex_tag),
-            WidgetOptions::default(),
-            (BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)),
-        );
+        )
+        .with_tag(flex_tag)
+        .with_props((BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)));
 
         let root = Flex::row()
             .cross_axis_alignment(CrossAxisAlignment::FirstBaseline)

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -476,13 +476,11 @@ mod tests {
     #[test]
     fn test_grid_basics() {
         // Start with a 1x1 grid
-        let widget = NewWidget::new_with_props(
-            Grid::with_dimensions(1, 1).with(
-                Button::with_text("A").with_auto_id(),
-                GridParams::new(0, 0, 1, 1),
-            ),
-            Dimensions::STRETCH,
-        );
+        let widget = NewWidget::new(Grid::with_dimensions(1, 1).with(
+            Button::with_text("A").with_auto_id(),
+            GridParams::new(0, 0, 1, 1),
+        ))
+        .with_props(Dimensions::STRETCH);
         let window_size = Size::new(200.0, 200.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
         // Snapshot with the single widget.

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -747,7 +747,7 @@ mod tests {
             .with(label4, CrossAxisAlignment::Center)
             .with(label5, CrossAxisAlignment::Center)
             .with(label6, CrossAxisAlignment::Center);
-        let flex = NewWidget::new_with_props(flex, Gap::ZERO);
+        let flex = NewWidget::new(flex).with_props(Gap::ZERO);
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), flex, Size::new(200.0, 200.0));

--- a/masonry/src/widgets/pagination.rs
+++ b/masonry/src/widgets/pagination.rs
@@ -9,7 +9,7 @@ use tracing::{Span, trace_span};
 use crate::core::{
     AccessCtx, ActionCtx, ChildrenIds, ErasedAction, FromDynWidget, LayoutCtx, MeasureCtx,
     MutateCtx, NewWidget, PaintCtx, PropertiesMut, PropertiesRef, RegisterCtx, Update, UpdateCtx,
-    Widget, WidgetId, WidgetMut, WidgetOptions, WidgetPod,
+    Widget, WidgetId, WidgetMut, WidgetPod,
 };
 use crate::imaging::Painter;
 use crate::kurbo::{Axis, Point, Size};
@@ -249,14 +249,7 @@ impl Pagination {
             let text = format!("{}", page_idx + 1);
             let disabled = page_idx == self.active_page;
             let button = Button::with_text(text);
-            let button = NewWidget::new_with_options(
-                button,
-                WidgetOptions {
-                    disabled,
-                    ..WidgetOptions::default()
-                },
-            )
-            .to_pod();
+            let button = NewWidget::new(button).disabled(disabled).to_pod();
             self.buttons.push(PageButton {
                 widget: button,
                 disabled,

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -859,8 +859,8 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::WidgetTag;
     use crate::core::keyboard::{Key, NamedKey};
-    use crate::core::{WidgetOptions, WidgetTag};
     use crate::layout::AsUnit;
     use crate::properties::Dimensions;
     use crate::testing::{ModularWidget, TestHarness, assert_render_snapshot};
@@ -872,12 +872,9 @@ mod tests {
         top_pad: f64,
         tag: Option<WidgetTag<Button>>,
     ) -> NewWidget<ModularWidget<WidgetPod<Button>>> {
-        let btn = NewWidget::new_with(
-            Button::with_text(text),
-            tag,
-            WidgetOptions::default(),
-            Dimensions::fixed(70.px(), 40.px()),
-        );
+        let btn = NewWidget::new(Button::with_text(text))
+            .with_tag(tag.unwrap_or_else(WidgetTag::unique))
+            .with_props(Dimensions::fixed(70.px(), 40.px()));
 
         ModularWidget::new_parent(btn)
             .measure_fn(move |child, ctx, _props, axis, len_req, cross_length| {
@@ -951,10 +948,7 @@ mod tests {
         let widget = Portal::new(
             Flex::column()
                 .with_fixed_spacer(500.px())
-                .with_fixed(NewWidget::new_with_tag(
-                    Button::with_text("Fully visible"),
-                    button_tag,
-                ))
+                .with_fixed(NewWidget::new(Button::with_text("Fully visible")).with_tag(button_tag))
                 .with_fixed_spacer(500.px())
                 .with_auto_id(),
         )
@@ -972,7 +966,7 @@ mod tests {
     fn portal_accessibility_node_exposes_scroll() {
         let portal_tag = WidgetTag::named("portal");
         let content = SizedBox::empty().size(300.px(), 300.px()).with_auto_id();
-        let portal = NewWidget::new_with_tag(Portal::new(content), portal_tag);
+        let portal = NewWidget::new(Portal::new(content)).with_tag(portal_tag);
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), portal, Size::new(100.0, 100.0));
@@ -1006,7 +1000,7 @@ mod tests {
     fn portal_keyboard_scroll_updates_access_tree() {
         let portal_tag = WidgetTag::named("portal");
         let content = SizedBox::empty().size(300.px(), 300.px()).with_auto_id();
-        let portal = NewWidget::new_with_tag(Portal::new(content), portal_tag);
+        let portal = NewWidget::new(Portal::new(content)).with_tag(portal_tag);
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), portal, Size::new(100.0, 100.0));

--- a/masonry/src/widgets/progress_bar.rs
+++ b/masonry/src/widgets/progress_bar.rs
@@ -49,8 +49,9 @@ impl ProgressBar {
     pub fn new(progress: Option<f64>) -> Self {
         let progress = clamp_progress(progress);
         let label_props = PropertySet::one(LineBreaking::Overflow);
-        let label =
-            NewWidget::new_with_props(Label::new(Self::value(progress)), label_props).to_pod();
+        let label = NewWidget::new(Label::new(Self::value(progress)))
+            .with_props(label_props)
+            .to_pod();
         Self { progress, label }
     }
 }

--- a/masonry/src/widgets/prose.rs
+++ b/masonry/src/widgets/prose.rs
@@ -265,7 +265,7 @@ mod tests {
             .with(prose4.with_auto_id(), CrossAxisAlignment::Center)
             .with(prose5.with_auto_id(), CrossAxisAlignment::Center)
             .with(prose6.with_auto_id(), CrossAxisAlignment::Center);
-        let flex = NewWidget::new_with_props(flex, PropertySet::one(Gap::ZERO));
+        let flex = NewWidget::new(flex).with_props(PropertySet::one(Gap::ZERO));
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), flex, Size::new(200.0, 120.0));

--- a/masonry/src/widgets/radio_button.rs
+++ b/masonry/src/widgets/radio_button.rs
@@ -423,7 +423,7 @@ mod tests {
     #[test]
     fn simple_radio_button() {
         let radio_tag = WidgetTag::unique();
-        let widget = NewWidget::new_with_tag(RadioButton::new(false, "Hello"), radio_tag);
+        let widget = NewWidget::new(RadioButton::new(false, "Hello")).with_tag(radio_tag);
         let widget = NewWidget::new(RadioGroup::new(widget));
 
         let window_size = Size::new(100.0, 40.0);
@@ -486,7 +486,7 @@ mod tests {
         let image_1 = {
             let label = Label::new("The quick brown fox jumps over the lazy dog")
                 .with_style(StyleProperty::FontSize(20.0));
-            let label = NewWidget::new_with_props(label, ContentColor::new(ACCENT_COLOR));
+            let label = NewWidget::new(label).with_props(ContentColor::new(ACCENT_COLOR));
             let radio = NewWidget::new(RadioButton::from_label(true, label));
             let group = NewWidget::new(RadioGroup::new(radio));
 

--- a/masonry/src/widgets/resize_observer.rs
+++ b/masonry/src/widgets/resize_observer.rs
@@ -184,7 +184,7 @@ mod tests {
     fn detects_inner_resizing() {
         let tag = WidgetTag::named("inner_box");
         let inner_box =
-            NewWidget::new_with_tag(SizedBox::empty().width(100.px()).height(100.px()), tag);
+            NewWidget::new(SizedBox::empty().width(100.px()).height(100.px())).with_tag(tag);
         let observer = ResizeObserver::new(inner_box).with_props(Dimensions::MAX);
         let observer_id = observer.id();
         // We use a flex here as the inner `SizedBox` will take up the full space available in this case.

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -474,10 +474,8 @@ mod tests {
 
     #[test]
     fn simple_scrollbar() {
-        let widget = NewWidget::new_with_props(
-            ScrollBar::new(Axis::Vertical, 200.0, 600.0),
-            Dimensions::FIT,
-        );
+        let widget = NewWidget::new(ScrollBar::new(Axis::Vertical, 200.0, 600.0))
+            .with_props(Dimensions::FIT);
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(50.0, 200.0));
@@ -504,10 +502,8 @@ mod tests {
 
     #[test]
     fn horizontal_scrollbar() {
-        let widget = NewWidget::new_with_props(
-            ScrollBar::new(Axis::Horizontal, 200.0, 600.0),
-            Dimensions::FIT,
-        );
+        let widget = NewWidget::new(ScrollBar::new(Axis::Horizontal, 200.0, 600.0))
+            .with_props(Dimensions::FIT);
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(200.0, 50.0));
@@ -526,10 +522,8 @@ mod tests {
 
     #[test]
     fn keyboard_scroll_updates_access_tree() {
-        let widget = NewWidget::new_with_props(
-            ScrollBar::new(Axis::Vertical, 200.0, 600.0),
-            Dimensions::FIT,
-        );
+        let widget = NewWidget::new(ScrollBar::new(Axis::Vertical, 200.0, 600.0))
+            .with_props(Dimensions::FIT);
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(50.0, 200.0));
         let _ = harness.render();

--- a/masonry/src/widgets/step_input.rs
+++ b/masonry/src/widgets/step_input.rs
@@ -1838,7 +1838,7 @@ mod tests {
     use std::fmt::Display;
 
     use super::*;
-    use crate::core::{NewWidget, PropertySet, WidgetOptions, WidgetTag};
+    use crate::core::{NewWidget, PropertySet, WidgetTag};
     use crate::layout::AsUnit;
     use crate::properties::types::CrossAxisAlignment;
     use crate::properties::{Dimensions, Padding};
@@ -2384,12 +2384,9 @@ mod tests {
     #[test]
     fn speed_lines() {
         let si = |tag| {
-            NewWidget::new_with(
-                StepInput::new(5000, 1, 0, usize::MAX),
-                Some(tag),
-                WidgetOptions::default(),
-                (StepInputStyle::Flow, Dimensions::fixed(250.px(), 85.px())),
-            )
+            NewWidget::new(StepInput::new(5000, 1, 0, usize::MAX))
+                .with_tag(tag)
+                .with_props((StepInputStyle::Flow, Dimensions::fixed(250.px(), 85.px())))
         };
 
         let tag_backward = WidgetTag::unique();

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -1178,10 +1178,8 @@ mod tests {
         test_params.window_size = Size::new(200.0, 20.0);
 
         let base_target = {
-            let area = NewWidget::new_with_props(
-                TextArea::new_immutable("Test string"),
-                PropertySet::new().with(ContentColor::new(palette::css::AZURE)),
-            );
+            let area = NewWidget::new(TextArea::new_immutable("Test string"))
+                .with_props(PropertySet::new().with(ContentColor::new(palette::css::AZURE)));
 
             let mut harness = TestHarness::create_with(test_property_set(), area, test_params);
 
@@ -1189,10 +1187,8 @@ mod tests {
         };
 
         {
-            let area = NewWidget::new_with_props(
-                TextArea::new_immutable("Different string"),
-                PropertySet::new().with(ContentColor::new(palette::css::AZURE)),
-            );
+            let area = NewWidget::new(TextArea::new_immutable("Different string"))
+                .with_props(PropertySet::new().with(ContentColor::new(palette::css::AZURE)));
 
             let mut harness = TestHarness::create_with(test_property_set(), area, test_params);
 

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -336,19 +336,17 @@ mod tests {
 
         let widget = ZStack::new()
             .with(
-                NewWidget::new_with_props(
+                NewWidget::new(
                     SizedBox::new(Label::new("Background").with_auto_id())
                         .width(200.px())
                         .height(100.px()),
-                    bg_props,
-                ),
+                )
+                .with_props(bg_props),
                 ChildAlignment::ParentAligned,
             )
             .with(
-                NewWidget::new_with_props(
-                    SizedBox::new(Label::new("Foreground").with_auto_id()),
-                    fg_props,
-                ),
+                NewWidget::new(SizedBox::new(Label::new("Foreground").with_auto_id()))
+                    .with_props(fg_props),
                 ChildAlignment::ParentAligned,
             )
             .with_auto_id();

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -38,7 +38,7 @@ use crate::layout::LenReq;
 ///
 /// You can't create a widget with a pre-allocated `WidgetId`.
 /// If you want to create a widget in a way that lets you refer to it later,
-/// see [`NewWidget::new_with_tag`](crate::core::NewWidget::new_with_tag).
+/// see [`NewWidget::with_tag`](crate::core::NewWidget::with_tag).
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct WidgetId(pub(crate) NonZeroU64);
 
@@ -584,7 +584,7 @@ pub trait Widget: AsDynWidget + Any {
     where
         Self: Sized,
     {
-        NewWidget::new_with_props(self, props)
+        NewWidget::new(self).with_props(props)
     }
 }
 

--- a/masonry_core/src/core/widget_pod.rs
+++ b/masonry_core/src/core/widget_pod.rs
@@ -89,58 +89,18 @@ impl<W: Widget> NewWidget<W> {
     /// You can also get the same result with [`Widget::with_auto_id()`].
     #[inline(always)]
     pub fn new(inner: W) -> Self {
-        Self::new_with(
-            inner,
-            None,
-            WidgetOptions::default(),
-            PropertySet::default(),
-        )
-    }
-
-    /// Creates a new widget with a potential [`WidgetTag`],
-    /// custom [`WidgetOptions`] and custom [`PropertySet`].
-    pub fn new_with(
-        inner: W,
-        tag: Option<WidgetTag<W>>,
-        options: WidgetOptions,
-        props: impl Into<PropertySet>,
-    ) -> Self {
         Self {
             widget: Box::new(inner),
             id: WidgetId::next(),
             action_type: TypeId::of::<W::Action>(),
             #[cfg(debug_assertions)]
             action_type_name: std::any::type_name::<W::Action>(),
-            options,
-            properties: props.into(),
+            options: WidgetOptions::default(),
+            properties: PropertySet::default(),
             property_stack_id: None,
             classes: HashSet::new(),
-            tag: tag.map(|tag| tag.inner),
+            tag: None,
         }
-    }
-
-    /// Creates a new widget with a [`WidgetTag`].
-    #[inline(always)]
-    pub fn new_with_tag(inner: W, tag: WidgetTag<W>) -> Self {
-        Self::new_with(
-            inner,
-            Some(tag),
-            WidgetOptions::default(),
-            PropertySet::default(),
-        )
-    }
-
-    // TODO - Replace with builder methods? More allocations then though?
-    /// Creates a new widget with custom [`PropertySet`].
-    #[inline(always)]
-    pub fn new_with_props(inner: W, props: impl Into<PropertySet>) -> Self {
-        Self::new_with(inner, None, WidgetOptions::default(), props)
-    }
-
-    /// Creates a new widget with custom [`WidgetOptions`].
-    #[inline(always)]
-    pub fn new_with_options(inner: W, options: WidgetOptions) -> Self {
-        Self::new_with(inner, None, options, PropertySet::default())
     }
 }
 
@@ -162,6 +122,24 @@ impl<W: Widget + ?Sized> NewWidget<W> {
         }
     }
 
+    /// Sets the [`WidgetTag`] to this widget.
+    pub fn with_tag(mut self, tag: WidgetTag<W>) -> Self {
+        self.tag = Some(tag.inner);
+        self
+    }
+
+    /// Sets the [`PropertySet`] for this widget.
+    pub fn with_props(mut self, props: impl Into<PropertySet>) -> Self {
+        self.properties = props.into();
+        self
+    }
+
+    /// Sets the [`Affine`] transform for this widget.
+    pub fn with_transform(mut self, transform: Affine) -> Self {
+        self.options.transform = transform;
+        self
+    }
+
     /// Assigns a [`PropertyStack`](crate::core::PropertyStack) to this widget.
     pub fn with_property_stack(mut self, id: PropertyStackId) -> Self {
         self.property_stack_id = Some(id);
@@ -181,6 +159,14 @@ impl<W: Widget + ?Sized> NewWidget<W> {
     /// [classes]: crate::doc::masonry_concepts#classes
     pub fn with_classes(mut self, classes: impl IntoIterator<Item = String>) -> Self {
         self.classes.extend(classes);
+        self
+    }
+
+    /// Set whether the widget will be created in a [disabled] state.
+    ///
+    /// [disabled]: crate::doc::masonry_concepts#disabled
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.options.disabled = disabled;
         self
     }
 

--- a/masonry_testing/src/modular_widget.rs
+++ b/masonry_testing/src/modular_widget.rs
@@ -591,6 +591,6 @@ impl<S: 'static> Widget for ModularWidget<S> {
     where
         Self: Sized,
     {
-        NewWidget::new_with_props(self, props)
+        NewWidget::new(self).with_props(props)
     }
 }

--- a/masonry_testing/src/recorder_widget.rs
+++ b/masonry_testing/src/recorder_widget.rs
@@ -354,6 +354,6 @@ impl<W: Widget> Widget for Recorder<W> {
     where
         Self: Sized,
     {
-        NewWidget::new_with_props(self, props)
+        NewWidget::new(self).with_props(props)
     }
 }

--- a/xilem_masonry/src/pod.rs
+++ b/xilem_masonry/src/pod.rs
@@ -37,7 +37,7 @@ impl<W: Widget + FromDynWidget> Pod<W> {
     /// Creates a new [`Pod`] with the given `widget` and `props`.
     pub fn new_with_props(widget: W, props: impl Into<PropertySet>) -> Self {
         Self {
-            new_widget: NewWidget::new_with_props(widget, props),
+            new_widget: NewWidget::new(widget).with_props(props),
         }
     }
 }

--- a/xilem_masonry/src/view/prose.rs
+++ b/xilem_masonry/src/view/prose.rs
@@ -106,7 +106,7 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Prose<Sta
         if let Some(color) = self.text_color {
             props.insert(ContentColor { color });
         }
-        let text_area = NewWidget::new_with_props(text_area, props);
+        let text_area = NewWidget::new(text_area).with_props(props);
 
         let pod = ctx.create_pod(
             widgets::Prose::from_text_area(text_area)

--- a/xilem_masonry/src/view/text_input.rs
+++ b/xilem_masonry/src/view/text_input.rs
@@ -243,7 +243,7 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for TextInput
         }
 
         let text_input =
-            widgets::TextInput::from_text_area(NewWidget::new_with_props(text_area, props))
+            widgets::TextInput::from_text_area(NewWidget::new(text_area).with_props(props))
                 .with_text_alignment(self.text_alignment)
                 .with_clip(self.clip)
                 .with_placeholder(self.placeholder.clone());


### PR DESCRIPTION
Use a single `NewNewidget::new` constructor with builder methods for the other variants.

The changes in `widget_pod.rs` were made by hand. Almost everything else was AI-generated. I did go through each diff chunk to check the edits made sense.