### PR TITLE
Extract masonry_imaging backend adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +641,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +673,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -697,6 +737,9 @@ name = "color"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18ef4657441fb193b65f34dc39b3781f0dfec23d3bd94d0eeb4e88cde421edb"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "color_quant"
@@ -1016,6 +1059,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "elm"
 version = "0.0.0"
 dependencies = [
@@ -1071,7 +1120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1126,6 +1175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fearless_simd"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76258897e51fd156ee03b6246ea53f3e0eb395d0b327e9961c4fc4c8b2fa151a"
+
+[[package]]
 name = "fetch"
 version = "0.0.0"
 dependencies = [
@@ -1137,6 +1192,17 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "xilem_web",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1178,6 +1244,12 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
 
 [[package]]
 name = "font-types"
@@ -1454,6 +1526,12 @@ dependencies = [
  "log",
  "xml-rs",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-events"
@@ -1974,22 +2052,62 @@ checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 [[package]]
 name = "imaging"
 version = "0.0.1"
-source = "git+https://github.com/forest-rs/imaging.git?rev=850af057d4c56cf644f37aaa644c7814a7a03a4b#850af057d4c56cf644f37aaa644c7814a7a03a4b"
+source = "git+https://github.com/forest-rs/imaging.git?rev=0eea0499d2666195103b9837ac4c3ee474176a5b#0eea0499d2666195103b9837ac4c3ee474176a5b"
 dependencies = [
  "kurbo",
  "peniko",
 ]
 
 [[package]]
+name = "imaging_skia"
+version = "0.0.1"
+source = "git+https://github.com/forest-rs/imaging.git?rev=0eea0499d2666195103b9837ac4c3ee474176a5b#0eea0499d2666195103b9837ac4c3ee474176a5b"
+dependencies = [
+ "ash",
+ "foreign-types-shared",
+ "imaging",
+ "kurbo",
+ "oaty",
+ "peniko",
+ "skia-safe",
+ "wgpu",
+ "windows",
+]
+
+[[package]]
 name = "imaging_vello"
 version = "0.0.1"
-source = "git+https://github.com/forest-rs/imaging.git?rev=850af057d4c56cf644f37aaa644c7814a7a03a4b#850af057d4c56cf644f37aaa644c7814a7a03a4b"
+source = "git+https://github.com/forest-rs/imaging.git?rev=0eea0499d2666195103b9837ac4c3ee474176a5b#0eea0499d2666195103b9837ac4c3ee474176a5b"
 dependencies = [
  "imaging",
  "kurbo",
  "peniko",
- "pollster",
  "vello",
+]
+
+[[package]]
+name = "imaging_vello_cpu"
+version = "0.0.1"
+source = "git+https://github.com/forest-rs/imaging.git?rev=0eea0499d2666195103b9837ac4c3ee474176a5b#0eea0499d2666195103b9837ac4c3ee474176a5b"
+dependencies = [
+ "imaging",
+ "kurbo",
+ "peniko",
+ "vello_common",
+ "vello_cpu",
+]
+
+[[package]]
+name = "imaging_vello_hybrid"
+version = "0.0.1"
+source = "git+https://github.com/forest-rs/imaging.git?rev=0eea0499d2666195103b9837ac4c3ee474176a5b#0eea0499d2666195103b9837ac4c3ee474176a5b"
+dependencies = [
+ "imaging",
+ "kurbo",
+ "peniko",
+ "vello_common",
+ "vello_hybrid",
+ "wgpu",
 ]
 
 [[package]]
@@ -2030,6 +2148,15 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2323,6 +2450,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "masonry_imaging"
+version = "0.4.0"
+dependencies = [
+ "imaging",
+ "imaging_skia",
+ "imaging_vello",
+ "imaging_vello_cpu",
+ "imaging_vello_hybrid",
+ "kurbo",
+ "peniko",
+ "vello",
+ "wgpu",
+]
+
+[[package]]
 name = "masonry_testing"
 version = "0.4.0"
 dependencies = [
@@ -2330,8 +2472,8 @@ dependencies = [
  "assert_matches",
  "futures-intrusive",
  "image",
- "imaging_vello",
  "masonry_core",
+ "masonry_imaging",
  "oxipng",
  "profiling",
  "tracing",
@@ -2343,9 +2485,9 @@ version = "0.4.0"
 dependencies = [
  "accesskit_winit",
  "copypasta",
- "imaging_vello",
  "masonry",
  "masonry_core",
+ "masonry_imaging",
  "pollster",
  "tracing",
  "tracing-tracy",
@@ -2462,6 +2604,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2549,12 +2697,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2602,6 +2760,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "oaty"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7890d4a4c9205ee57a5e200658e78ed7d51c9cd48d0f7066596a19cc20e5d2"
+dependencies = [
+ "font-types 0.10.1",
 ]
 
 [[package]]
@@ -3026,6 +3193,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
 dependencies = [
+ "bytemuck",
  "color",
  "kurbo",
  "linebender_resource_handle",
@@ -3489,7 +3657,7 @@ checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
 dependencies = [
  "bytemuck",
  "core_maths",
- "font-types",
+ "font-types 0.11.1",
 ]
 
 [[package]]
@@ -3692,7 +3860,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3910,6 +4078,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3994,6 +4171,48 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "skia-bindings"
+version = "0.93.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2359f7e30c9da3f322f8ca3d4ec0abbc12a40035ce758309db0cdab07b5d4476"
+dependencies = [
+ "bindgen",
+ "cc",
+ "flate2",
+ "heck",
+ "pkg-config",
+ "regex",
+ "serde_json",
+ "tar",
+ "toml",
+]
+
+[[package]]
+name = "skia-safe"
+version = "0.93.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9e837ea9d531c9efee8f980bfcdb7226b21db0285b0c3171d8be745829f940"
+dependencies = [
+ "base64",
+ "bitflags 2.11.0",
+ "percent-encoding",
+ "skia-bindings",
+ "skia-svg-macros",
+ "windows",
+]
+
+[[package]]
+name = "skia-svg-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "044dd2233c9717a74f75197f3e7f0a966db2127c0ffb5e05013b480a9b75b2c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "skrifa"
@@ -4105,7 +4324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4230,6 +4449,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4239,7 +4469,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4513,6 +4743,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.0.7+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.0",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4541,6 +4786,12 @@ checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
  "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -4763,7 +5014,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4958,6 +5209,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "vello_api"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5088cd0113bc5332c753f24503825e3bc93e26c7883c9dc3ad9637bb62c4634"
+dependencies = [
+ "bytemuck",
+ "peniko",
+]
+
+[[package]]
+name = "vello_common"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986dc49a501a683477614bf07b8e7b6c79ae4828efce3bf22e51850f4a0a8a4c"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown 0.16.1",
+ "log",
+ "peniko",
+ "png",
+ "skrifa",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a678f91c7524a3a9ac9a19df9f83552866ec70b2ca26441b916a6b219b6aa2de"
+dependencies = [
+ "bytemuck",
+ "hashbrown 0.16.1",
+ "vello_api",
+ "vello_common",
+]
+
+[[package]]
 name = "vello_encoding"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4968,6 +5259,22 @@ dependencies = [
  "peniko",
  "skrifa",
  "smallvec",
+]
+
+[[package]]
+name = "vello_hybrid"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2b295a72c9fb73be9679c0d468c64d4f97ef09b91ce6d16d309747719c6ff2"
+dependencies = [
+ "bytemuck",
+ "hashbrown 0.16.1",
+ "log",
+ "thiserror 2.0.18",
+ "vello_api",
+ "vello_common",
+ "vello_sparse_shaders",
+ "wgpu",
 ]
 
 [[package]]
@@ -4982,6 +5289,12 @@ dependencies = [
  "thiserror 2.0.18",
  "vello_encoding",
 ]
+
+[[package]]
+name = "vello_sparse_shaders"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afd2601f1c8cc1e16807aaf1a66dd182eb6f895df095a48fb353fe49377a9ce"
 
 [[package]]
 name = "version_check"
@@ -5476,7 +5789,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6034,6 +6347,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "xcursor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "xilem_masonry",
     "masonry",
     "masonry_core",
+    "masonry_imaging",
     "masonry_testing",
     "masonry_winit",
 
@@ -28,7 +29,7 @@ members = [
 
 [workspace.package]
 # Xilem version, also used by other packages which want to mimic Xilem's version.
-# Right now those packages include: xilem_core, xilem_masonry, xilem_web, masonry, masonry_core, masonry_testing, masonry_winit.
+# Right now those packages include: xilem_core, xilem_masonry, xilem_web, masonry, masonry_core, masonry_imaging, masonry_testing, masonry_winit.
 #
 # NOTE: When bumping this, remember to also bump the aforementioned other packages'
 #       version in the dependencies section of this file.
@@ -44,6 +45,7 @@ repository = "https://github.com/linebender/xilem"
 
 masonry = { version = "0.4.0", path = "masonry", default-features = false }
 masonry_core = { version = "0.4.0", path = "masonry_core", default-features = false }
+masonry_imaging = { version = "0.4.0", path = "masonry_imaging", default-features = false }
 masonry_testing = { version = "0.4.0", path = "masonry_testing", default-features = false }
 masonry_winit = { version = "0.4.0", path = "masonry_winit", default-features = false }
 xilem_core = { version = "0.4.0", path = "xilem_core" }
@@ -53,9 +55,15 @@ tree_arena = { version = "0.2.0", path = "tree_arena" }
 include_doc_path = { version = "0.1.0", path = "include_doc_path", package = "linebender_include_doc_path" }
 
 anymore = "1.0.0"
-imaging = { git = "https://github.com/forest-rs/imaging.git", rev = "850af057d4c56cf644f37aaa644c7814a7a03a4b" }
-imaging_vello = { git = "https://github.com/forest-rs/imaging.git", rev = "850af057d4c56cf644f37aaa644c7814a7a03a4b" }
+imaging = { git = "https://github.com/forest-rs/imaging.git", rev = "0eea0499d2666195103b9837ac4c3ee474176a5b" }
+imaging_vello = { git = "https://github.com/forest-rs/imaging.git", rev = "0eea0499d2666195103b9837ac4c3ee474176a5b" }
+imaging_vello_hybrid = { git = "https://github.com/forest-rs/imaging.git", rev = "0eea0499d2666195103b9837ac4c3ee474176a5b" }
+imaging_vello_cpu = { git = "https://github.com/forest-rs/imaging.git", rev = "0eea0499d2666195103b9837ac4c3ee474176a5b" }
+imaging_skia = { git = "https://github.com/forest-rs/imaging.git", rev = "0eea0499d2666195103b9837ac4c3ee474176a5b", features = [
+    "gpu",
+] }
 vello = { version = "0.8.0", default-features = false, features = ["wgpu"] }
+wgpu = "28.0.0"
 kurbo = "0.13.0"
 parley = { version = "0.8.0", features = ["accesskit"] }
 # TODO: Use no_std correctly in Xilem Web.

--- a/masonry/Cargo.toml
+++ b/masonry/Cargo.toml
@@ -17,14 +17,20 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [features]
-default = ["masonry_core/default", "masonry_testing?/default"]
+default = ["masonry_core/default", "imaging_vello"]
+imaging_vello = ["masonry_testing?/imaging_vello", "masonry_winit/imaging_vello"]
+imaging_vello_hybrid = [
+    "masonry_testing?/imaging_vello_hybrid",
+    "masonry_winit/imaging_vello_hybrid",
+]
+imaging_skia = ["masonry_testing?/imaging_skia", "masonry_winit/imaging_skia"]
 tracy = ["masonry_core/tracy"]
 testing = ["dep:masonry_testing"]
 
 [dependencies]
 accesskit.workspace = true
 masonry_core.workspace = true
-masonry_testing = { workspace = true, optional = true }
+masonry_testing = { workspace = true, optional = true, default-features = false }
 smallvec.workspace = true
 tracing = { workspace = true, features = ["default"] }
 include_doc_path.workspace = true
@@ -37,8 +43,8 @@ divan.workspace = true
 float-cmp = { version = "0.10.0", features = ["std"], default-features = false }
 image = { workspace = true, features = ["png"] }
 insta = { version = "1.46.3" }
-masonry_testing = { workspace = true, features = ["default"] }
-masonry_winit = { workspace = true, features = ["default"] }
+masonry_testing = { workspace = true, default-features = false }
+masonry_winit = { workspace = true, default-features = false }
 
 # Make wgpu use tracing for its spans.
 profiling = { version = "1.0.17", features = ["profile-with-tracing"] }

--- a/masonry_imaging/Cargo.toml
+++ b/masonry_imaging/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "masonry_imaging"
+version.workspace = true # We mimic Xilem's version
+description = "Backend adapters for rendering Masonry retained imaging scenes."
+keywords = ["gui", "ui", "toolkit"]
+categories = ["gui", "internationalization", "accessibility"]
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+
+[package.metadata.docs.rs]
+all-features = true
+# There are no platform specific docs.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
+
+[features]
+default = ["imaging_vello"]
+imaging_vello = ["dep:imaging_vello", "dep:vello"]
+imaging_vello_hybrid = ["dep:imaging_vello_hybrid"]
+imaging_vello_cpu = ["dep:imaging_vello_cpu"]
+imaging_skia = ["dep:imaging_skia"]
+
+[dependencies]
+imaging.workspace = true
+imaging_vello = { workspace = true, optional = true }
+imaging_vello_hybrid = { workspace = true, optional = true }
+imaging_vello_cpu = { workspace = true, optional = true }
+kurbo.workspace = true
+peniko.workspace = true
+wgpu.workspace = true
+vello = { workspace = true, optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+imaging_skia = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/masonry_imaging/README.md
+++ b/masonry_imaging/README.md
@@ -1,0 +1,11 @@
+# Masonry Imaging
+
+Masonry-owned imaging helpers and backend adapters.
+
+This crate currently provides:
+
+- shared helpers for preparing retained scenes from Masonry-style base content plus overlays
+- a `vello` module backed by `imaging_vello`
+- a `vello_hybrid` module backed by `imaging_vello_hybrid`
+- a `vello_cpu` module backed by `imaging_vello_cpu`
+- a `skia` module backed by `imaging_skia`

--- a/masonry_imaging/src/headless_wgpu.rs
+++ b/masonry_imaging/src/headless_wgpu.rs
@@ -1,0 +1,72 @@
+// Copyright 2026 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::future::Future;
+use std::sync::Arc;
+use std::task::{Context, Poll, Wake, Waker};
+
+/// Errors that can occur while creating a headless WGPU device.
+#[derive(Debug)]
+pub(crate) enum InitError {
+    NoAdapter,
+    RequestDevice(wgpu::RequestDeviceError),
+}
+
+impl core::fmt::Display for InitError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NoAdapter => write!(f, "no compatible WGPU adapter found"),
+            Self::RequestDevice(err) => write!(f, "requesting WGPU device failed: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for InitError {}
+
+pub(crate) fn try_init_device_and_queue() -> Result<(wgpu::Device, wgpu::Queue), InitError> {
+    block_on(async {
+        let instance = wgpu::Instance::default();
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::default(),
+                force_fallback_adapter: false,
+                compatible_surface: None,
+            })
+            .await
+            .map_err(|_| InitError::NoAdapter)?;
+
+        adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("masonry_imaging headless device"),
+                required_features: wgpu::Features::empty(),
+                ..Default::default()
+            })
+            .await
+            .map_err(InitError::RequestDevice)
+    })
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    struct ThreadWaker(std::thread::Thread);
+
+    impl Wake for ThreadWaker {
+        fn wake(self: Arc<Self>) {
+            self.0.unpark();
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.unpark();
+        }
+    }
+
+    let waker = Waker::from(Arc::new(ThreadWaker(std::thread::current())));
+    let mut context = Context::from_waker(&waker);
+    let mut future = std::pin::pin!(future);
+
+    loop {
+        match future.as_mut().poll(&mut context) {
+            Poll::Ready(value) => return value,
+            Poll::Pending => std::thread::park(),
+        }
+    }
+}

--- a/masonry_imaging/src/lib.rs
+++ b/masonry_imaging/src/lib.rs
@@ -1,0 +1,354 @@
+// Copyright 2026 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/linebender/xilem/main/docs/assets/masonry-logo.svg"
+)]
+//! Imaging helpers owned by Masonry.
+//!
+//! `masonry_imaging` owns the bridge between Masonry paint output and concrete imaging backends.
+//! In this first slice that means:
+//!
+//! - preparing flattened Masonry frame content from base content plus overlays
+//! - exposing backend-specific renderer modules for `imaging_vello`,
+//!   `imaging_vello_hybrid`, `imaging_vello_cpu`, and `imaging_skia`
+//! - exposing host-neutral texture rendering helpers for writing into caller-provided WGPU
+//!   targets
+//!
+//! This crate does not own window integration, surfaces, or compositor policy.
+//!
+//! # Feature flags
+//!
+//! - `default`: Enables the `vello` module.
+//! - `imaging_vello`: Enables the `vello` module and texture rendering support.
+//! - `imaging_vello_hybrid`: Enables the `vello_hybrid` module and texture rendering support.
+//! - `imaging_vello_cpu`: Enables the `vello_cpu` module for headless image rendering only.
+//! - `imaging_skia`: Enables the `skia` module and texture rendering support on non-wasm targets.
+
+// LINEBENDER LINT SET - lib.rs - v3
+// See https://linebender.org/wiki/canonical-lints/
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+#![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
+// END LINEBENDER LINT SET
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+use imaging::record::{Scene, ValidateError, replay_transformed};
+use imaging::render::RenderSource;
+use imaging::{PaintSink, Painter};
+use kurbo::{Affine, Rect};
+use peniko::Color;
+
+#[cfg(any(feature = "imaging_vello", feature = "imaging_vello_hybrid"))]
+mod headless_wgpu;
+
+/// Masonry helpers for rendering retained scenes with `imaging_skia`.
+#[cfg(all(feature = "imaging_skia", not(target_arch = "wasm32")))]
+pub mod skia;
+/// Host-neutral texture rendering helpers for texture-capable backends.
+pub mod texture_render;
+/// Masonry helpers for rendering retained scenes with `imaging_vello`.
+#[cfg(feature = "imaging_vello")]
+pub mod vello;
+/// Masonry helpers for rendering retained scenes with `imaging_vello_cpu`.
+#[cfg(feature = "imaging_vello_cpu")]
+pub mod vello_cpu;
+/// Masonry helpers for rendering retained scenes with `imaging_vello_hybrid`.
+#[cfg(feature = "imaging_vello_hybrid")]
+pub mod vello_hybrid;
+
+pub use imaging::render::{ImageRenderer, TextureRenderer};
+
+/// Backend-selected helpers for headless image rendering.
+pub mod image_render {
+    #[cfg(all(
+        not(feature = "imaging_vello"),
+        feature = "imaging_skia",
+        not(target_arch = "wasm32")
+    ))]
+    pub use crate::skia::{BACKEND_NAME, Renderer, new_headless_renderer};
+    #[cfg(feature = "imaging_vello")]
+    pub use crate::vello::{BACKEND_NAME, Renderer, new_headless_renderer};
+    #[cfg(all(
+        not(feature = "imaging_vello"),
+        not(feature = "imaging_skia"),
+        not(feature = "imaging_vello_hybrid"),
+        feature = "imaging_vello_cpu"
+    ))]
+    pub use crate::vello_cpu::{BACKEND_NAME, Renderer, new_headless_renderer};
+    #[cfg(all(
+        not(feature = "imaging_vello"),
+        not(feature = "imaging_skia"),
+        feature = "imaging_vello_hybrid"
+    ))]
+    pub use crate::vello_hybrid::{BACKEND_NAME, Renderer, new_headless_renderer};
+
+    #[cfg(not(any(
+        feature = "imaging_vello",
+        feature = "imaging_vello_hybrid",
+        feature = "imaging_vello_cpu",
+        all(feature = "imaging_skia", not(target_arch = "wasm32"))
+    )))]
+    pub use self::no_backend::{BACKEND_NAME, Error, Renderer, new_headless_renderer};
+
+    #[cfg(not(any(
+        feature = "imaging_vello",
+        feature = "imaging_vello_hybrid",
+        feature = "imaging_vello_cpu",
+        all(feature = "imaging_skia", not(target_arch = "wasm32"))
+    )))]
+    mod no_backend {
+        use imaging::{RgbaImage, render::RenderSource};
+
+        /// Error returned when no image-render backend feature is enabled.
+        #[derive(Debug)]
+        pub struct Error;
+
+        impl core::fmt::Display for Error {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.write_str("no imaging backend feature selected")
+            }
+        }
+
+        impl std::error::Error for Error {}
+
+        /// Placeholder renderer used when no image-render backend feature is enabled.
+        #[derive(Debug)]
+        pub struct Renderer;
+
+        /// Stable diagnostics name for the backend-less stub renderer.
+        pub const BACKEND_NAME: &str = "no_backend";
+
+        /// Create the backend-less stub renderer.
+        pub fn new_headless_renderer() -> Result<Renderer, Error> {
+            Err(Error)
+        }
+
+        impl imaging::render::ImageRenderer for Renderer {
+            type Error = Error;
+
+            fn render_source_into<S: RenderSource + ?Sized>(
+                &mut self,
+                _: &mut S,
+                _: u32,
+                _: u32,
+                _: &mut RgbaImage,
+            ) -> Result<(), Self::Error> {
+                Err(Error)
+            }
+        }
+    }
+}
+
+/// A Masonry overlay layer ready to be composited into window space.
+#[derive(Clone, Copy)]
+pub struct Layer<'a> {
+    /// The retained scene for this layer in layer-local coordinates.
+    pub scene: &'a Scene,
+    /// Transform from layer-local coordinates into window coordinates.
+    pub transform: Affine,
+}
+
+impl core::fmt::Debug for Layer<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Layer")
+            .field("scene", &"(Scene)")
+            .field("transform", &self.transform)
+            .finish()
+    }
+}
+
+/// A flattened Masonry frame ready to be adapted to a concrete render target.
+///
+/// This is intentionally a single-target convenience type for Masonry's current rendering paths.
+/// Future compositor-oriented work is expected to preserve more layer structure above this level.
+#[derive(Clone, Copy, Debug)]
+pub struct PreparedFrame<'a> {
+    /// Frame width in physical pixels.
+    pub width: u32,
+    /// Frame height in physical pixels.
+    pub height: u32,
+    /// Window scale factor.
+    pub scale_factor: f64,
+    /// Background color to paint before replaying scene content.
+    pub background_color: Color,
+    /// Base retained scene in root coordinates.
+    pub base: &'a Scene,
+    /// Overlay layers in painter order.
+    pub overlays: &'a [Layer<'a>],
+}
+
+impl<'a> PreparedFrame<'a> {
+    /// Create a flattened Masonry frame from base content plus overlays.
+    pub fn new(
+        width: u32,
+        height: u32,
+        scale_factor: f64,
+        background_color: Color,
+        base: &'a Scene,
+        overlays: &'a [Layer<'a>],
+    ) -> Self {
+        Self {
+            width,
+            height,
+            scale_factor,
+            background_color,
+            base,
+            overlays,
+        }
+    }
+
+    /// Create a render source for window output in physical pixels.
+    pub fn window_source(self) -> WindowSource<'a> {
+        WindowSource { frame: self }
+    }
+
+    /// Create a screenshot render source with optional root padding.
+    pub fn snapshot_source(self, root_padding: u32) -> SnapshotSource<'a> {
+        SnapshotSource::new(self, root_padding)
+    }
+}
+
+/// Masonry render source for a window-sized frame.
+#[derive(Clone, Copy, Debug)]
+pub struct WindowSource<'a> {
+    frame: PreparedFrame<'a>,
+}
+
+impl<'a> WindowSource<'a> {
+    /// Create a render source for window output in physical pixels.
+    pub fn new(frame: PreparedFrame<'a>) -> Self {
+        Self { frame }
+    }
+}
+
+impl RenderSource for WindowSource<'_> {
+    fn validate(&self) -> Result<(), ValidateError> {
+        validate_layers(self.frame.base, self.frame.overlays)
+    }
+
+    fn paint_into(&mut self, sink: &mut dyn PaintSink) {
+        {
+            let mut painter = Painter::new(sink);
+            painter.fill_rect(
+                Rect::new(
+                    0.0,
+                    0.0,
+                    f64::from(self.frame.width),
+                    f64::from(self.frame.height),
+                ),
+                self.frame.background_color,
+            );
+        }
+
+        let scale = Affine::scale(self.frame.scale_factor);
+        replay_transformed(self.frame.base, sink, scale);
+        for layer in self.frame.overlays {
+            replay_transformed(layer.scene, sink, scale * layer.transform);
+        }
+    }
+}
+
+/// Masonry render source for screenshot-style output with optional root padding.
+#[derive(Clone, Copy, Debug)]
+pub struct SnapshotSource<'a> {
+    frame: PreparedFrame<'a>,
+    width: u32,
+    height: u32,
+    root_padding: u32,
+}
+
+impl<'a> SnapshotSource<'a> {
+    /// Create a screenshot render source.
+    pub fn new(frame: PreparedFrame<'a>, root_padding: u32) -> Self {
+        let (width, height) = padded_dimensions(frame.width, frame.height, root_padding);
+        Self {
+            frame,
+            width,
+            height,
+            root_padding,
+        }
+    }
+
+    /// Output width in pixels.
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Output height in pixels.
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+}
+
+impl RenderSource for SnapshotSource<'_> {
+    fn validate(&self) -> Result<(), ValidateError> {
+        validate_layers(self.frame.base, self.frame.overlays)
+    }
+
+    fn paint_into(&mut self, sink: &mut dyn PaintSink) {
+        {
+            let mut painter = Painter::new(sink);
+            painter.fill_rect(
+                Rect::new(0.0, 0.0, f64::from(self.width), f64::from(self.height)),
+                self.frame.background_color,
+            );
+
+            if self.root_padding != 0 {
+                // 25% opacity of 50% grey provides a border of where the actual widget content is.
+                // Alternatively, maybe we should use a stronger color here?
+                let padding_color = Color::from_rgba8(127, 127, 127, 64);
+                // We draw the border first, so that any content is above the background color.
+                for [x0, y0, x1, y1] in padding_rects(self.width, self.height, self.root_padding) {
+                    painter.fill_rect(
+                        Rect::new(x0 as f64, y0 as f64, x1 as f64, y1 as f64),
+                        padding_color,
+                    );
+                }
+            }
+        }
+
+        let padding_transform =
+            Affine::translate((f64::from(self.root_padding), f64::from(self.root_padding)));
+        replay_transformed(self.frame.base, sink, padding_transform);
+        for layer in self.frame.overlays {
+            replay_transformed(layer.scene, sink, padding_transform * layer.transform);
+        }
+    }
+}
+
+/// Compute the output dimensions for a padded render target.
+fn padded_dimensions(content_width: u32, content_height: u32, root_padding: u32) -> (u32, u32) {
+    // Avoid having a zero-sized image.
+    let width = content_width.max(1) + root_padding * 2;
+    let height = content_height.max(1) + root_padding * 2;
+    (width, height)
+}
+
+fn padding_rects(width: u32, height: u32, padding: u32) -> [[u32; 4]; 4] {
+    [
+        [0, 0, padding, height],                              // Left edge
+        [width - padding, 0, width, height],                  // Right edge
+        [padding, 0, width - padding, padding],               // Top edge
+        [padding, height - padding, width - padding, height], // Bottom edge
+    ]
+}
+
+fn validate_layers(base: &Scene, overlays: &[Layer<'_>]) -> Result<(), ValidateError> {
+    base.validate()?;
+    for layer in overlays {
+        layer.scene.validate()?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::padded_dimensions;
+
+    #[test]
+    fn padded_dimensions_avoid_zero() {
+        assert_eq!(padded_dimensions(0, 0, 0), (1, 1));
+        assert_eq!(padded_dimensions(0, 2, 5), (11, 12));
+    }
+}

--- a/masonry_imaging/src/skia.rs
+++ b/masonry_imaging/src/skia.rs
@@ -1,0 +1,47 @@
+// Copyright 2026 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use core::fmt;
+
+/// Errors that can occur while creating or using a Skia renderer.
+#[derive(Debug)]
+pub enum Error {
+    /// Creating or using the underlying `imaging_skia` renderer failed.
+    Backend(imaging_skia::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Backend(err) => write!(f, "Skia render failed: {err:?}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Stable backend name for diagnostics.
+pub const BACKEND_NAME: &str = "imaging_skia";
+
+/// Masonry alias for the selected Skia image renderer type.
+pub type Renderer = imaging_skia::SkiaRenderer;
+
+/// Masonry alias for the selected Skia texture renderer type.
+pub type TargetRenderer = imaging_skia::SkiaGpuTargetRenderer;
+
+/// Masonry alias for the selected Skia texture target wrapper.
+pub type TextureTarget<'a> = imaging_skia::TextureTarget<'a>;
+
+/// Create a reusable headless Skia renderer.
+pub fn new_headless_renderer() -> Result<Renderer, Error> {
+    Ok(imaging_skia::SkiaRenderer::new())
+}
+
+/// Create a reusable GPU Skia target renderer bound to an existing WGPU adapter, device, and queue.
+pub fn new_target_renderer(
+    adapter: wgpu::Adapter,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+) -> Result<TargetRenderer, Error> {
+    imaging_skia::SkiaGpuTargetRenderer::new(adapter, device, queue).map_err(Error::Backend)
+}

--- a/masonry_imaging/src/texture_render.rs
+++ b/masonry_imaging/src/texture_render.rs
@@ -1,0 +1,528 @@
+// Copyright 2026 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Host-neutral texture rendering helpers.
+//!
+//! This module owns backend state for rendering Masonry paint output into a caller-provided WGPU
+//! texture target. It does not own window surfaces or presentation.
+
+use wgpu;
+
+use crate::PreparedFrame;
+
+/// GPU target that Masonry content should be rendered into.
+#[derive(Clone, Copy, Debug)]
+pub struct RenderTarget<'a> {
+    /// Adapter used to create the device.
+    pub adapter: &'a wgpu::Adapter,
+    /// Device used for rendering commands.
+    pub device: &'a wgpu::Device,
+    /// Queue used for submitting rendering commands and uploads.
+    pub queue: &'a wgpu::Queue,
+    /// Texture backing the render target.
+    pub texture: &'a wgpu::Texture,
+    /// View of the render target texture.
+    pub view: &'a wgpu::TextureView,
+}
+
+/// Masonry paint output prepared for texture rendering.
+#[derive(Clone, Copy, Debug)]
+pub struct RenderInput<'a> {
+    /// Flattened Masonry frame content prepared for rendering.
+    pub frame: PreparedFrame<'a>,
+}
+
+/// Errors that can occur while rendering Masonry content into a target texture.
+#[derive(Debug)]
+pub struct Error(imp::Error);
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Backend-selected texture renderer for Masonry paint output.
+#[derive(Debug)]
+pub struct Renderer(imp::Renderer);
+
+impl Renderer {
+    /// Stable backend name for diagnostics.
+    pub const BACKEND_NAME: &str = imp::Renderer::BACKEND_NAME;
+
+    /// Create an empty renderer state.
+    pub fn new() -> Self {
+        Self(imp::Renderer::new())
+    }
+
+    /// Render the given Masonry paint output into the provided target texture.
+    pub fn render_to_texture(
+        &mut self,
+        target: RenderTarget<'_>,
+        input: RenderInput<'_>,
+    ) -> Result<(), Error> {
+        self.0.render_to_texture(target, input).map_err(Error)
+    }
+}
+
+impl Default for Renderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(all(
+    not(feature = "imaging_vello"),
+    any(
+        all(feature = "imaging_skia", not(target_arch = "wasm32")),
+        feature = "imaging_vello_hybrid"
+    )
+))]
+mod non_vello {
+    use imaging::render::TextureRenderer;
+
+    use crate::PreparedFrame;
+
+    #[derive(Debug)]
+    pub(super) struct CachedRenderer<R, K> {
+        key: Option<K>,
+        inner: Option<R>,
+    }
+
+    impl<R, K> CachedRenderer<R, K>
+    where
+        K: Copy + Eq,
+    {
+        pub(super) fn new() -> Self {
+            Self {
+                key: None,
+                inner: None,
+            }
+        }
+
+        pub(super) fn get_or_try_init<E>(
+            &mut self,
+            key: K,
+            create: impl FnOnce() -> Result<R, E>,
+        ) -> Result<&mut R, E> {
+            if self.key != Some(key) {
+                self.inner = Some(create()?);
+                self.key = Some(key);
+            }
+
+            Ok(self
+                .inner
+                .as_mut()
+                .expect("cached renderer should be initialized"))
+        }
+    }
+
+    pub(super) fn render_window_source_to_texture<R>(
+        renderer: &mut R,
+        frame: PreparedFrame<'_>,
+        target: R::TextureTarget<'_>,
+    ) -> Result<(), R::Error>
+    where
+        R: TextureRenderer,
+    {
+        let mut source = frame.window_source();
+        renderer.render_source_to_texture(&mut source, target)
+    }
+}
+
+#[cfg(not(any(
+    feature = "imaging_vello",
+    feature = "imaging_vello_hybrid",
+    all(feature = "imaging_skia", not(target_arch = "wasm32"))
+)))]
+mod imp {
+    #[derive(Debug)]
+    pub(super) enum Error {}
+
+    impl core::fmt::Display for Error {
+        fn fmt(&self, _: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            match *self {}
+        }
+    }
+
+    impl std::error::Error for Error {}
+
+    #[derive(Debug)]
+    pub(super) struct Renderer;
+
+    impl Renderer {
+        pub(super) const BACKEND_NAME: &str = "";
+
+        pub(super) fn new() -> Self {
+            Self
+        }
+
+        pub(super) fn render_to_texture(
+            &mut self,
+            _: super::RenderTarget<'_>,
+            _: super::RenderInput<'_>,
+        ) -> Result<(), Error> {
+            unreachable!("a renderer backend feature is required")
+        }
+    }
+}
+
+#[cfg(all(
+    not(feature = "imaging_vello"),
+    feature = "imaging_skia",
+    not(target_arch = "wasm32")
+))]
+mod imp {
+    use super::non_vello::{CachedRenderer, render_window_source_to_texture};
+    use crate::skia::{TargetRenderer, TextureTarget, new_target_renderer};
+
+    use super::{RenderInput, RenderTarget};
+
+    /// Errors that can occur while rendering Masonry content with Skia.
+    #[derive(Debug)]
+    pub(super) enum Error {
+        /// Creating the Skia renderer failed.
+        CreateRenderer(crate::skia::Error),
+        /// Rendering the Masonry source failed.
+        Render(imaging_skia::Error),
+    }
+
+    impl core::fmt::Display for Error {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            match self {
+                Self::CreateRenderer(err) => write!(f, "creating Skia renderer failed: {err}"),
+                Self::Render(err) => write!(f, "rendering with Skia failed: {err:?}"),
+            }
+        }
+    }
+
+    impl std::error::Error for Error {}
+
+    /// Runtime renderer state for the Skia backend.
+    #[derive(Debug)]
+    pub(super) struct Renderer {
+        inner: CachedRenderer<TargetRenderer, (usize, usize, usize)>,
+    }
+
+    impl Renderer {
+        /// Stable backend name for diagnostics.
+        pub(super) const BACKEND_NAME: &str = crate::skia::BACKEND_NAME;
+
+        /// Create an empty renderer state.
+        pub(super) fn new() -> Self {
+            Self {
+                inner: CachedRenderer::new(),
+            }
+        }
+
+        /// Render the given Masonry paint output into the provided target texture.
+        pub(super) fn render_to_texture(
+            &mut self,
+            target: RenderTarget<'_>,
+            input: RenderInput<'_>,
+        ) -> Result<(), Error> {
+            let renderer = self.inner.get_or_try_init(
+                (
+                    target.adapter as *const _ as usize,
+                    target.device as *const _ as usize,
+                    target.queue as *const _ as usize,
+                ),
+                || {
+                    new_target_renderer(
+                        target.adapter.clone(),
+                        target.device.clone(),
+                        target.queue.clone(),
+                    )
+                    .map_err(Error::CreateRenderer)
+                },
+            )?;
+
+            render_window_source_to_texture(
+                renderer,
+                input.frame,
+                TextureTarget::new(target.texture),
+            )
+            .map_err(Error::Render)
+        }
+    }
+}
+
+#[cfg(feature = "imaging_vello")]
+impl Renderer {
+    /// Set a persistent image override for the Vello backend.
+    pub fn set_image_override(&mut self, image: peniko::ImageData, texture: wgpu::Texture) {
+        self.0.set_image_override(image, texture);
+    }
+
+    /// Clear a previously-set Vello image override.
+    pub fn clear_image_override(&mut self, image: &peniko::ImageData) {
+        self.0.clear_image_override(image);
+    }
+}
+
+#[cfg(feature = "imaging_vello")]
+mod imp {
+    use std::collections::HashMap;
+
+    use vello::{AaConfig, AaSupport, RenderParams, Renderer as VelloRenderer, RendererOptions};
+
+    use crate::vello::build_scene_from_source;
+
+    use super::{RenderInput, RenderTarget};
+
+    /// Errors that can occur while rendering Masonry content with Vello.
+    #[derive(Debug)]
+    pub(super) enum Error {
+        /// Building the native Vello scene failed.
+        BuildScene(crate::vello::Error),
+        /// Creating the Vello renderer failed.
+        CreateRenderer(vello::Error),
+        /// Rendering the scene to the texture failed.
+        Render(vello::Error),
+    }
+
+    impl core::fmt::Display for Error {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            match self {
+                Self::BuildScene(err) => write!(f, "building Vello scene failed: {err}"),
+                Self::CreateRenderer(err) => write!(f, "creating Vello renderer failed: {err}"),
+                Self::Render(err) => write!(f, "rendering with Vello failed: {err}"),
+            }
+        }
+    }
+
+    impl std::error::Error for Error {}
+
+    #[derive(Debug)]
+    struct ImageOverrideState {
+        image: peniko::ImageData,
+        texture: wgpu::Texture,
+        applied: bool,
+        prev: Option<wgpu::TexelCopyTextureInfoBase<wgpu::Texture>>,
+    }
+
+    /// Runtime renderer state for the Vello backend.
+    pub(super) struct Renderer {
+        inner: Option<VelloRenderer>,
+        image_overrides: HashMap<u64, ImageOverrideState>,
+    }
+
+    impl core::fmt::Debug for Renderer {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.debug_struct("Renderer")
+                .field("inner", &self.inner.as_ref().map(|_| "(VelloRenderer)"))
+                .field("image_overrides", &self.image_overrides)
+                .finish()
+        }
+    }
+
+    impl Renderer {
+        /// Stable backend name for diagnostics.
+        pub(super) const BACKEND_NAME: &str = crate::vello::BACKEND_NAME;
+
+        /// Create an empty renderer state.
+        pub(super) fn new() -> Self {
+            Self {
+                inner: None,
+                image_overrides: HashMap::new(),
+            }
+        }
+
+        /// Render the given Masonry paint output into the provided target texture.
+        pub(super) fn render_to_texture(
+            &mut self,
+            target: RenderTarget<'_>,
+            input: RenderInput<'_>,
+        ) -> Result<(), Error> {
+            let mut source = input.frame.window_source();
+            let scene = build_scene_from_source(&mut source, input.frame.width, input.frame.height)
+                .map_err(Error::BuildScene)?;
+
+            if self.inner.is_none() {
+                let renderer_options = RendererOptions {
+                    antialiasing_support: AaSupport::area_only(),
+                    ..Default::default()
+                };
+                self.inner = Some(
+                    VelloRenderer::new(target.device, renderer_options)
+                        .map_err(Error::CreateRenderer)?,
+                );
+            }
+            let renderer = self.inner.as_mut().unwrap();
+
+            for state in self.image_overrides.values_mut() {
+                if state.applied {
+                    continue;
+                }
+                state.prev = renderer.override_image(
+                    &state.image,
+                    Some(wgpu::TexelCopyTextureInfoBase {
+                        texture: state.texture.clone(),
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    }),
+                );
+                state.applied = true;
+            }
+
+            let render_params = RenderParams {
+                // WindowSource already paints the background into the scene, so keep
+                // Vello's target clear transparent here instead of applying the base color twice.
+                base_color: peniko::Color::from_rgba8(0, 0, 0, 0),
+                width: input.frame.width,
+                height: input.frame.height,
+                antialiasing_method: AaConfig::Area,
+            };
+            renderer
+                .render_to_texture(
+                    target.device,
+                    target.queue,
+                    &scene,
+                    target.view,
+                    &render_params,
+                )
+                .map_err(Error::Render)
+        }
+
+        /// Set a persistent image override for the Vello backend.
+        pub(super) fn set_image_override(
+            &mut self,
+            image: peniko::ImageData,
+            texture: wgpu::Texture,
+        ) {
+            let image_id = image.data.id();
+
+            if let Some(existing) = self.image_overrides.get_mut(&image_id) {
+                existing.texture = texture;
+                if existing.applied {
+                    if let Some(renderer) = &mut self.inner {
+                        renderer.override_image(
+                            &existing.image,
+                            Some(wgpu::TexelCopyTextureInfoBase {
+                                texture: existing.texture.clone(),
+                                mip_level: 0,
+                                origin: wgpu::Origin3d::ZERO,
+                                aspect: wgpu::TextureAspect::All,
+                            }),
+                        );
+                    } else {
+                        existing.applied = false;
+                    }
+                }
+                return;
+            }
+
+            let mut state = ImageOverrideState {
+                image,
+                texture,
+                applied: false,
+                prev: None,
+            };
+
+            if let Some(renderer) = &mut self.inner {
+                state.prev = renderer.override_image(
+                    &state.image,
+                    Some(wgpu::TexelCopyTextureInfoBase {
+                        texture: state.texture.clone(),
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
+                    }),
+                );
+                state.applied = true;
+            }
+
+            self.image_overrides.insert(image_id, state);
+        }
+
+        /// Clear a previously-set Vello image override.
+        pub(super) fn clear_image_override(&mut self, image: &peniko::ImageData) {
+            let image_id = image.data.id();
+            let Some(state) = self.image_overrides.remove(&image_id) else {
+                return;
+            };
+            if state.applied
+                && let Some(renderer) = &mut self.inner
+            {
+                renderer.override_image(&state.image, state.prev);
+            }
+        }
+    }
+}
+
+#[cfg(all(
+    not(feature = "imaging_vello"),
+    not(all(feature = "imaging_skia", not(target_arch = "wasm32"))),
+    feature = "imaging_vello_hybrid"
+))]
+mod imp {
+    use super::non_vello::{CachedRenderer, render_window_source_to_texture};
+    use crate::vello_hybrid::{TargetRenderer, TextureTarget, new_target_renderer};
+
+    use super::{RenderInput, RenderTarget};
+
+    /// Errors that can occur while rendering Masonry content with Vello Hybrid.
+    #[derive(Debug)]
+    pub(super) enum Error {
+        /// Rendering the Masonry source failed.
+        Render(imaging_vello_hybrid::Error),
+    }
+
+    impl core::fmt::Display for Error {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            match self {
+                Self::Render(err) => write!(f, "rendering with Vello Hybrid failed: {err:?}"),
+            }
+        }
+    }
+
+    impl std::error::Error for Error {}
+
+    /// Runtime renderer state for the Vello Hybrid backend.
+    #[derive(Debug)]
+    pub(super) struct Renderer {
+        inner: CachedRenderer<TargetRenderer, (usize, usize)>,
+    }
+
+    impl Renderer {
+        /// Stable backend name for diagnostics.
+        pub(super) const BACKEND_NAME: &str = crate::vello_hybrid::BACKEND_NAME;
+
+        /// Create an empty renderer state.
+        pub(super) fn new() -> Self {
+            Self {
+                inner: CachedRenderer::new(),
+            }
+        }
+
+        /// Render the given Masonry paint output into the provided target texture.
+        pub(super) fn render_to_texture(
+            &mut self,
+            target: RenderTarget<'_>,
+            input: RenderInput<'_>,
+        ) -> Result<(), Error> {
+            let renderer = self.inner.get_or_try_init(
+                (
+                    target.device as *const _ as usize,
+                    target.queue as *const _ as usize,
+                ),
+                || {
+                    Ok(new_target_renderer(
+                        target.device.clone(),
+                        target.queue.clone(),
+                    ))
+                },
+            )?;
+
+            render_window_source_to_texture(
+                renderer,
+                input.frame,
+                TextureTarget::new(target.view, input.frame.width, input.frame.height),
+            )
+            .map_err(Error::Render)
+        }
+    }
+}

--- a/masonry_imaging/src/vello.rs
+++ b/masonry_imaging/src/vello.rs
@@ -1,0 +1,60 @@
+// Copyright 2026 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use core::fmt;
+
+use imaging::render::RenderSource;
+use kurbo::Rect;
+
+use crate::headless_wgpu;
+
+/// Errors that can occur while creating or using a Vello renderer.
+#[derive(Debug)]
+pub enum Error {
+    /// Headless WGPU initialization failed.
+    Init,
+    /// The underlying `imaging_vello` renderer failed.
+    Backend(imaging_vello::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Init => write!(f, "Vello renderer initialization failed"),
+            Self::Backend(err) => write!(f, "Vello render failed: {err:?}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Stable backend name for diagnostics.
+pub const BACKEND_NAME: &str = "imaging_vello";
+
+/// Masonry alias for the selected Vello renderer type.
+pub type Renderer = imaging_vello::VelloRenderer;
+
+/// Create a reusable headless Vello renderer.
+pub fn new_headless_renderer() -> Result<Renderer, Error> {
+    let (device, queue) = headless_wgpu::try_init_device_and_queue().map_err(|_| Error::Init)?;
+    imaging_vello::VelloRenderer::new(device, queue).map_err(Error::Backend)
+}
+
+/// Build a native Vello scene from any render source.
+pub fn build_scene_from_source<S: RenderSource + ?Sized>(
+    source: &mut S,
+    width: u32,
+    height: u32,
+) -> Result<vello::Scene, Error> {
+    source
+        .validate()
+        .map_err(imaging_vello::Error::InvalidScene)
+        .map_err(Error::Backend)?;
+
+    let mut native = vello::Scene::new();
+    let bounds = Rect::new(0.0, 0.0, f64::from(width), f64::from(height));
+    let mut sink = imaging_vello::VelloSceneSink::new(&mut native, bounds);
+    source.paint_into(&mut sink);
+    sink.finish().map_err(Error::Backend)?;
+    Ok(native)
+}

--- a/masonry_imaging/src/vello_cpu.rs
+++ b/masonry_imaging/src/vello_cpu.rs
@@ -1,0 +1,32 @@
+// Copyright 2026 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use core::fmt;
+
+/// Errors that can occur while creating or using a Vello CPU renderer.
+#[derive(Debug)]
+pub enum Error {
+    /// The underlying `imaging_vello_cpu` renderer failed.
+    Backend(imaging_vello_cpu::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Backend(err) => write!(f, "Vello CPU render failed: {err:?}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Stable backend name for diagnostics.
+pub const BACKEND_NAME: &str = "imaging_vello_cpu";
+
+/// Masonry alias for the selected Vello CPU renderer type.
+pub type Renderer = imaging_vello_cpu::VelloCpuRenderer;
+
+/// Create a reusable headless Vello CPU renderer.
+pub fn new_headless_renderer() -> Result<Renderer, Error> {
+    Ok(imaging_vello_cpu::VelloCpuRenderer::new(1, 1))
+}

--- a/masonry_imaging/src/vello_hybrid.rs
+++ b/masonry_imaging/src/vello_hybrid.rs
@@ -1,0 +1,51 @@
+// Copyright 2026 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use core::fmt;
+
+use crate::headless_wgpu;
+
+/// Errors that can occur while creating or using a Vello Hybrid renderer.
+#[derive(Debug)]
+pub enum Error {
+    /// Headless WGPU initialization failed.
+    Init,
+    /// The underlying `imaging_vello_hybrid` renderer failed.
+    Backend(imaging_vello_hybrid::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Init => write!(f, "Vello Hybrid renderer initialization failed"),
+            Self::Backend(err) => write!(f, "Vello Hybrid render failed: {err:?}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Stable backend name for diagnostics.
+pub const BACKEND_NAME: &str = "imaging_vello_hybrid";
+
+/// Masonry alias for the selected Vello Hybrid renderer type.
+pub type Renderer = imaging_vello_hybrid::VelloHybridRenderer;
+
+/// Masonry alias for the selected Vello Hybrid texture renderer type.
+pub type TargetRenderer = imaging_vello_hybrid::VelloHybridTargetRenderer;
+
+/// Masonry alias for the selected Vello Hybrid texture target wrapper.
+pub type TextureTarget<'a> = imaging_vello_hybrid::TextureTarget<'a>;
+
+/// Create a reusable headless Vello Hybrid renderer.
+pub fn new_headless_renderer() -> Result<Renderer, Error> {
+    let (device, queue) = headless_wgpu::try_init_device_and_queue().map_err(|_| Error::Init)?;
+    Ok(imaging_vello_hybrid::VelloHybridRenderer::new(
+        device, queue,
+    ))
+}
+
+/// Create a reusable Vello Hybrid target renderer bound to an existing WGPU device and queue.
+pub fn new_target_renderer(device: wgpu::Device, queue: wgpu::Queue) -> TargetRenderer {
+    imaging_vello_hybrid::VelloHybridTargetRenderer::new(device, queue)
+}

--- a/masonry_testing/Cargo.toml
+++ b/masonry_testing/Cargo.toml
@@ -16,13 +16,17 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [features]
-default = []
+default = ["imaging_vello"]
+imaging_vello = ["masonry_imaging/imaging_vello"]
+imaging_vello_hybrid = ["masonry_imaging/imaging_vello_hybrid"]
+imaging_vello_cpu = ["masonry_imaging/imaging_vello_cpu"]
+imaging_skia = ["masonry_imaging/imaging_skia"]
 
 [dependencies]
 accesskit_consumer.workspace = true
 futures-intrusive = "0.5.0"
 image = { workspace = true, features = ["png"] }
-imaging_vello.workspace = true
+masonry_imaging = { workspace = true, default-features = false }
 masonry_core.workspace = true
 oxipng = { version = "9.1.5", default-features = false }
 tracing = { workspace = true, features = ["default"] }

--- a/masonry_testing/README.md
+++ b/masonry_testing/README.md
@@ -67,6 +67,16 @@ UI screenshots compress well, so we expect this to be scalable.
 For repositories hosted on GitHub, this scheme also allows for including screenshots of your app or
 widgets in hosted documentation, although we haven't documented this publicly yet.
 
+## Feature flags
+
+Screenshot rendering is backend-driven:
+
+- `default`: Enables screenshot rendering via `imaging_vello`.
+- `imaging_vello`: Enables screenshot rendering via `imaging_vello`.
+- `imaging_vello_hybrid`: Enables screenshot rendering via `imaging_vello_hybrid`.
+- `imaging_vello_cpu`: Enables screenshot rendering via `imaging_vello_cpu`.
+- `imaging_skia`: Enables screenshot rendering via `imaging_skia`.
+
 ## Examples
 
 For examples of this crate in use

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -12,7 +12,11 @@ use std::sync::{Arc, mpsc};
 use std::time::UNIX_EPOCH;
 
 use image::{DynamicImage, ImageFormat, ImageReader, Rgba, RgbaImage};
-use imaging_vello::VelloRenderer;
+use masonry_imaging::ImageRenderer as _;
+use masonry_imaging::image_render::{
+    BACKEND_NAME as IMAGING_BACKEND_NAME, Renderer as ImagingRenderer, new_headless_renderer,
+};
+use masonry_imaging::{Layer as ImagingLayer, PreparedFrame};
 use oxipng::{Options, optimize_from_memory};
 use tracing::debug;
 
@@ -29,9 +33,7 @@ use masonry_core::core::{
     WidgetId, WidgetMut, WidgetRef, WidgetTag, WindowEvent,
 };
 use masonry_core::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
-use masonry_core::imaging::Painter;
-use masonry_core::imaging::record::{Scene, replay_transformed};
-use masonry_core::kurbo::{Affine, Point, Rect, Size, Vec2};
+use masonry_core::kurbo::{Point, Size, Vec2};
 use masonry_core::peniko::{Blob, Color};
 use masonry_core::util::Duration;
 
@@ -130,8 +132,7 @@ pub struct TestHarness<W: Widget> {
     signal_receiver: mpsc::Receiver<RenderRootSignal>,
     render_root: RenderRoot,
     access_tree: accesskit_consumer::Tree,
-    renderer: Option<VelloRenderer>,
-    renderer_size: Option<(u16, u16)>,
+    renderer: Option<ImagingRenderer>,
     mouse_state: PointerState,
     window_size: PhysicalSize<u32>,
     root_padding: u32,
@@ -354,7 +355,6 @@ impl<W: Widget> TestHarness<W> {
             ),
             access_tree: accesskit_consumer::Tree::new(dummy_tree_update, false),
             renderer: None,
-            renderer_size: None,
             mouse_state,
             window_size,
             background_color: params.background_color,
@@ -492,53 +492,40 @@ impl<W: Widget> TestHarness<W> {
             return RgbaImage::from_pixel(1, 1, Rgba([255, 255, 255, 255]));
         }
 
-        let (width, height) = padded_dimensions(self.window_size, self.root_padding);
-        let width_u16 = u16::try_from(width).expect("screenshot width exceeds renderer limit");
-        let height_u16 = u16::try_from(height).expect("screenshot height exceeds renderer limit");
-
-        if self.renderer_size != Some((width_u16, height_u16)) {
-            self.renderer = Some(VelloRenderer::new(width_u16, height_u16));
-            self.renderer_size = Some((width_u16, height_u16));
+        let overlays: Vec<_> = paint_result
+            .overlays
+            .iter()
+            .map(|layer| ImagingLayer {
+                scene: &layer.scene,
+                transform: layer.transform,
+            })
+            .collect();
+        let frame = PreparedFrame::new(
+            self.window_size.width,
+            self.window_size.height,
+            1.0,
+            self.background_color,
+            &paint_result.base,
+            &overlays,
+        );
+        let mut source = frame.snapshot_source(self.root_padding);
+        let width = source.width();
+        let height = source.height();
+        if self.renderer.is_none() {
+            self.renderer =
+                Some(new_headless_renderer().expect("create imaging renderer for test harness"));
         }
 
         let renderer = self.renderer.as_mut().unwrap();
-        let mut scene = Scene::new();
-        {
-            let mut painter = Painter::new(&mut scene);
-            painter.fill_rect(
-                Rect::new(0.0, 0.0, f64::from(width), f64::from(height)),
-                self.background_color,
-            );
-
-            if self.root_padding != 0 {
-                // 25% opacity of 50% grey provides a border of where the actual widget content is.
-                // Alternatively, maybe we should use a stronger color here?
-                let padding_color = Color::from_rgba8(127, 127, 127, 64);
-                // We draw the border first, so that any content is above the background color.
-                for [x0, y0, x1, y1] in padding_rects(width, height, self.root_padding) {
-                    painter.fill_rect(
-                        Rect::new(x0 as f64, y0 as f64, x1 as f64, y1 as f64),
-                        padding_color,
-                    );
-                }
-            }
-        }
-
-        let padding_transform =
-            Affine::translate((self.root_padding as f64, self.root_padding as f64));
-        replay_transformed(&paint_result.base, &mut scene, padding_transform);
-        for layer in &paint_result.overlays {
-            replay_transformed(
-                &layer.scene,
-                &mut scene,
-                padding_transform * layer.transform,
-            );
-        }
-
-        let rgba = renderer
-            .render_scene_rgba8(&scene)
-            .expect("render retained imaging scene for Vello");
-        RgbaImage::from_vec(width, height, rgba).expect("failed to create image")
+        let image = renderer
+            .render_source(&mut source, width, height)
+            .unwrap_or_else(|err| {
+                panic!(
+                    "render retained imaging scene for {}: {err:?}",
+                    IMAGING_BACKEND_NAME
+                )
+            });
+        RgbaImage::from_vec(image.width, image.height, image.data).expect("failed to create image")
     }
 
     /// Returns a reference to the current state of the accessibility tree.
@@ -1151,22 +1138,6 @@ impl<W: Widget> TestHarness<W> {
             }
         }
     }
-}
-
-fn padded_dimensions(window_size: PhysicalSize<u32>, root_padding: u32) -> (u32, u32) {
-    // Avoid having a zero-sized image.
-    let width = window_size.width.max(1) + root_padding * 2;
-    let height = window_size.height.max(1) + root_padding * 2;
-    (width, height)
-}
-
-fn padding_rects(width: u32, height: u32, padding: u32) -> [[u32; 4]; 4] {
-    [
-        [0, 0, padding, height],                              // Left edge
-        [width - padding, 0, width, height],                  // Right edge
-        [padding, 0, width - padding, padding],               // Top edge
-        [padding, height - padding, width - padding, height], // Bottom edge
-    ]
 }
 
 struct NoOpTreeChangeHandler;

--- a/masonry_testing/src/lib.rs
+++ b/masonry_testing/src/lib.rs
@@ -44,6 +44,16 @@
 //! For repositories hosted on GitHub, this scheme also allows for including screenshots of your app or
 //! widgets in hosted documentation, although we haven't documented this publicly yet.
 //!
+//! # Feature flags
+//!
+//! Screenshot rendering is backend-driven:
+//!
+//! - `default`: Enables screenshot rendering via `imaging_vello`.
+//! - `imaging_vello`: Enables screenshot rendering via `imaging_vello`.
+//! - `imaging_vello_hybrid`: Enables screenshot rendering via `imaging_vello_hybrid`.
+//! - `imaging_vello_cpu`: Enables screenshot rendering via `imaging_vello_cpu`.
+//! - `imaging_skia`: Enables screenshot rendering via `imaging_skia`.
+//!
 //! # Examples
 //!
 //! For examples of this crate in use

--- a/masonry_winit/Cargo.toml
+++ b/masonry_winit/Cargo.toml
@@ -18,11 +18,15 @@ targets = []
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [features]
-default = ["vello/default"]
+default = ["imaging_vello"]
+imaging_vello = ["masonry_imaging/imaging_vello"]
+imaging_vello_hybrid = ["masonry_imaging/imaging_vello_hybrid"]
+imaging_skia = ["masonry_imaging/imaging_skia"]
 # Enables tracing using tracy if the default Masonry tracing is used.
 # https://github.com/wolfpld/tracy can be connected to when this feature is enabled.
 tracy = [
     "dep:tracing-tracy",
+    "dep:vello",
     "dep:wgpu-profiler",
     "wgpu-profiler/tracy",
     "masonry_core/tracy",
@@ -37,14 +41,15 @@ tracing-tracy = { version = "0.11.4", optional = true }
 ui-events-winit.workspace = true
 pollster = "0.4.0"
 accesskit_winit.workspace = true
-imaging_vello.workspace = true
-vello.workspace = true
+masonry_imaging = { workspace = true, default-features = false }
+vello = { workspace = true, optional = true }
+wgpu.workspace = true
 wgpu-profiler = { optional = true, version = "0.26.0", default-features = false }
 copypasta = "0.10.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-# We need Metal to interact with CoreAnimation during window resizing.  
-wgpu = { version = "28.0.0", default-features = false, features = ["metal"] }
+# We need Metal to interact with CoreAnimation during window resizing.
+wgpu = { workspace = true, features = ["metal"] }
 
 [dev-dependencies]
 # We don't use the "workspace" dependency here, because this makes a loop in publishing.

--- a/masonry_winit/src/app_driver.rs
+++ b/masonry_winit/src/app_driver.rs
@@ -8,9 +8,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use masonry_core::app::RenderRoot;
 use masonry_core::core::{ErasedAction, WidgetId};
+#[cfg(feature = "imaging_vello")]
 use masonry_core::peniko::ImageData;
 use tracing::field::DisplayValue;
-use vello::wgpu;
 use winit::event_loop::ActiveEventLoop;
 
 use crate::app::MasonryState;
@@ -192,6 +192,7 @@ impl DriverCtx<'_, '_> {
     /// `image` is drawn in the UI scene.
     ///
     /// The texture must be `Rgba8Unorm` and include `COPY_SRC` usage.
+    #[cfg(feature = "imaging_vello")]
     pub fn set_image_override(&mut self, image: ImageData, texture: wgpu::Texture) {
         self.state.set_image_override(image, texture);
     }
@@ -199,6 +200,7 @@ impl DriverCtx<'_, '_> {
     /// Clear a previously-set image override for the given `ImageData`.
     ///
     /// Note: overrides are global to the current renderer/device; see [`set_image_override`](Self::set_image_override).
+    #[cfg(feature = "imaging_vello")]
     pub fn clear_image_override(&mut self, image: &ImageData) {
         self.state.clear_image_override(image);
     }

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -9,18 +9,20 @@ use std::sync::{Arc, mpsc};
 use accesskit_winit::Adapter;
 use copypasta::nop_clipboard::NopClipboardContext;
 use copypasta::{ClipboardContext, ClipboardProvider};
-use imaging_vello::VelloSceneSink;
 use masonry_core::app::{RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy};
 use masonry_core::core::keyboard::{Key, KeyState};
 use masonry_core::core::{
     DefaultProperties, ErasedAction, NewWidget, TextEvent, Widget, WindowEvent,
 };
-use masonry_core::kurbo::{Affine, Rect};
 use masonry_core::peniko::Color;
 use masonry_core::util::Instant;
+use masonry_imaging::texture_render::{
+    RenderInput as ImagingRenderInput, RenderTarget as ImagingRenderTarget,
+    Renderer as ImagingRenderer,
+};
+use masonry_imaging::{Layer as ImagingLayer, PreparedFrame};
 use tracing::{info, info_span, trace};
 use ui_events_winit::{WindowEventReducer, WindowEventTranslation};
-use vello::{AaConfig, AaSupport, RenderParams, Renderer, RendererOptions, Scene, wgpu};
 use winit::application::ApplicationHandler;
 use winit::dpi::PhysicalSize;
 use winit::error::EventLoopError;
@@ -193,8 +195,7 @@ pub struct MasonryState<'a> {
     /// See [`ApplicationHandler::suspended()`] for details.
     is_suspended: bool,
     render_cx: RenderContext,
-    renderer: Option<Renderer>,
-    image_overrides: HashMap<u64, ImageOverrideState>,
+    renderer: ImagingRenderer,
     // TODO: Winit doesn't seem to let us create these proxies from within the loop
     // The reasons for this are unclear
     event_loop_proxy: EventLoopProxy,
@@ -221,14 +222,6 @@ pub struct MasonryState<'a> {
     /// Windows that are scheduled to be created in the next resumed event.
     new_windows: Vec<NewWindow>,
     need_first_frame: Vec<HandleId>,
-}
-
-#[derive(Debug)]
-struct ImageOverrideState {
-    image: masonry_core::peniko::ImageData,
-    texture: wgpu::Texture,
-    applied: bool,
-    prev: Option<wgpu::TexelCopyTextureInfoBase<wgpu::Texture>>,
 }
 
 // TODO - Merge into MasonryState?
@@ -365,6 +358,11 @@ impl MasonryState<'_> {
         new_windows: Vec<NewWindow>,
         default_properties: DefaultProperties,
     ) -> Self {
+        tracing::debug!(
+            backend = ImagingRenderer::BACKEND_NAME,
+            "selected Masonry Winit render backend"
+        );
+
         let render_cx = RenderContext::new();
 
         let (signal_sender, signal_receiver) = mpsc::channel::<(WindowId, RenderRootSignal)>();
@@ -382,8 +380,7 @@ impl MasonryState<'_> {
         MasonryState {
             is_suspended: true,
             render_cx,
-            renderer: None,
-            image_overrides: HashMap::new(),
+            renderer: ImagingRenderer::new(),
             event_loop_proxy,
             #[cfg(feature = "tracy")]
             frame: None,
@@ -569,66 +566,18 @@ impl MasonryState<'_> {
         window.handle.set_ime_allowed(false);
     }
 
+    #[cfg(feature = "imaging_vello")]
     pub(crate) fn set_image_override(
         &mut self,
         image: masonry_core::peniko::ImageData,
         texture: wgpu::Texture,
     ) {
-        let image_id = image.data.id();
-
-        if let Some(existing) = self.image_overrides.get_mut(&image_id) {
-            existing.texture = texture;
-            if existing.applied {
-                if let Some(renderer) = &mut self.renderer {
-                    renderer.override_image(
-                        &existing.image,
-                        Some(wgpu::TexelCopyTextureInfoBase {
-                            texture: existing.texture.clone(),
-                            mip_level: 0,
-                            origin: wgpu::Origin3d::ZERO,
-                            aspect: wgpu::TextureAspect::All,
-                        }),
-                    );
-                } else {
-                    existing.applied = false;
-                }
-            }
-            return;
-        }
-
-        let mut state = ImageOverrideState {
-            image,
-            texture,
-            applied: false,
-            prev: None,
-        };
-
-        if let Some(renderer) = &mut self.renderer {
-            state.prev = renderer.override_image(
-                &state.image,
-                Some(wgpu::TexelCopyTextureInfoBase {
-                    texture: state.texture.clone(),
-                    mip_level: 0,
-                    origin: wgpu::Origin3d::ZERO,
-                    aspect: wgpu::TextureAspect::All,
-                }),
-            );
-            state.applied = true;
-        }
-
-        self.image_overrides.insert(image_id, state);
+        self.renderer.set_image_override(image, texture);
     }
 
+    #[cfg(feature = "imaging_vello")]
     pub(crate) fn clear_image_override(&mut self, image: &masonry_core::peniko::ImageData) {
-        let image_id = image.data.id();
-        let Some(state) = self.image_overrides.remove(&image_id) else {
-            return;
-        };
-        if state.applied
-            && let Some(renderer) = &mut self.renderer
-        {
-            renderer.override_image(&state.image, state.prev);
-        }
+        self.renderer.clear_image_override(image);
     }
 
     // --- MARK: REDRAW
@@ -700,22 +649,24 @@ impl MasonryState<'_> {
         }
 
         let (paint_result, tree_update) = window.render_root.redraw();
-        let mut scene = Scene::new();
-        let bounds = Rect::new(0.0, 0.0, f64::from(size.width), f64::from(size.height));
-        let mut sink = VelloSceneSink::new(&mut scene, bounds);
-        paint_result.replay_into(&mut sink);
-        if let Err(err) = sink.finish() {
-            tracing::error!("Couldn't translate retained imaging scene for Vello: {err:?}");
-            return;
-        }
-        Self::render(
-            surface,
-            window,
-            scene,
-            &self.render_cx,
-            &mut self.renderer,
-            &mut self.image_overrides,
+        let overlays: Vec<_> = paint_result
+            .overlays
+            .iter()
+            .map(|layer| ImagingLayer {
+                scene: &layer.scene,
+                transform: layer.transform,
+            })
+            .collect();
+        let size = window.render_root.size();
+        let frame = PreparedFrame::new(
+            size.width,
+            size.height,
+            window.handle.scale_factor(),
+            window.base_color,
+            &paint_result.base,
+            &overlays,
         );
+        Self::render(surface, window, frame, &self.render_cx, &mut self.renderer);
         #[cfg(feature = "tracy")]
         drop(self.frame.take());
         if let Some(tree_update) = tree_update {
@@ -727,112 +678,79 @@ impl MasonryState<'_> {
     fn render(
         surface: &mut RenderSurface<'_>,
         window: &mut Window,
-        scene: Scene,
+        frame: PreparedFrame<'_>,
         render_cx: &RenderContext,
-        renderer: &mut Option<Renderer>,
-        image_overrides: &mut HashMap<u64, ImageOverrideState>,
+        renderer: &mut ImagingRenderer,
     ) {
-        let size = window.render_root.size();
-        let scale_factor = window.handle.scale_factor();
-
-        let transformed_scene = if scale_factor == 1.0 {
-            None
-        } else {
-            let mut new_scene = Scene::new();
-            new_scene.append(&scene, Some(Affine::scale(scale_factor)));
-            Some(new_scene)
-        };
-        let scene_ref = transformed_scene.as_ref().unwrap_or(&scene);
-
         let dev_id = surface.dev_id;
         let device = &render_cx.devices[dev_id].device;
         let queue = &render_cx.devices[dev_id].queue;
-        let renderer_options = RendererOptions {
-            antialiasing_support: AaSupport::area_only(),
-            ..Default::default()
-        };
-        let render_params = RenderParams {
-            base_color: window.base_color,
-            width: size.width,
-            height: size.height,
-            antialiasing_method: AaConfig::Area,
+        let Some(surface_texture) = Self::acquire_surface_texture(surface, window, render_cx)
+        else {
+            return;
         };
 
-        let surface_texture = match surface.surface.get_current_texture() {
-            Ok(texture) => texture,
+        let _render_span = tracing::info_span!(
+            "Rendering Masonry window",
+            backend = ImagingRenderer::BACKEND_NAME
+        )
+        .entered();
+        if let Err(err) = renderer.render_to_texture(
+            ImagingRenderTarget {
+                adapter: &render_cx.devices[dev_id].adapter,
+                device,
+                queue,
+                texture: &surface.target_texture,
+                view: &surface.target_view,
+            },
+            ImagingRenderInput { frame },
+        ) {
+            tracing::error!(
+                backend = ImagingRenderer::BACKEND_NAME,
+                "Couldn't render Masonry content into target texture: {err}"
+            );
+            return;
+        }
+        Self::present_surface(surface, surface_texture, &window.handle, device, queue);
+    }
+
+    fn acquire_surface_texture(
+        surface: &mut RenderSurface<'_>,
+        window: &Window,
+        render_cx: &RenderContext,
+    ) -> Option<wgpu::SurfaceTexture> {
+        match surface.surface.get_current_texture() {
+            Ok(texture) => Some(texture),
             Err(wgpu::SurfaceError::Outdated) => {
                 let size = window.handle.inner_size();
                 render_cx.resize_surface(surface, size.width, size.height);
 
                 match surface.surface.get_current_texture() {
-                    Ok(texture) => texture,
+                    Ok(texture) => Some(texture),
                     Err(err) => {
                         // This is a common occurrence on X11 and Xwayland with NVIDIA drivers
                         // when opening and resizing the window.
                         tracing::error!(
                             "Couldn't get swap chain texture after configuring. Cause: '{err}'"
                         );
-                        return;
+                        None
                     }
                 }
             }
             Err(err) => {
                 tracing::error!("Couldn't get swap chain texture, operation unrecoverable: {err}");
-                return;
+                None
             }
-        };
-
-        let _render_span = tracing::info_span!("Rendering using Vello").entered();
-        let renderer = renderer.get_or_insert_with(|| {
-            #[cfg_attr(not(feature = "tracy"), expect(unused_mut, reason = "cfg"))]
-            let mut renderer = Renderer::new(device, renderer_options).unwrap();
-            #[cfg(feature = "tracy")]
-            {
-                let new_profiler = wgpu_profiler::GpuProfiler::new_with_tracy_client(
-                    wgpu_profiler::GpuProfilerSettings::default(),
-                    // We don't have access to the adapter until we get  https://github.com/linebender/vello/pull/634
-                    // Luckily, this `backend` is only used for visual display in the profiling, so we can just guess here
-                    wgpu::Backend::Vulkan,
-                    device,
-                    queue,
-                )
-                .unwrap_or(renderer.profiler);
-                renderer.profiler = new_profiler;
-            }
-            renderer
-        });
-
-        // Apply any persistent image overrides.
-        //
-        // `Renderer` is shared across windows, so these overrides are global to the current
-        // renderer/device. We apply them once (lazily, when a renderer exists) and only restore
-        // when explicitly cleared.
-        for ovr in image_overrides.values_mut() {
-            if ovr.applied {
-                continue;
-            }
-            ovr.prev = renderer.override_image(
-                &ovr.image,
-                Some(wgpu::TexelCopyTextureInfoBase {
-                    texture: ovr.texture.clone(),
-                    mip_level: 0,
-                    origin: wgpu::Origin3d::ZERO,
-                    aspect: wgpu::TextureAspect::All,
-                }),
-            );
-            ovr.applied = true;
         }
+    }
 
-        renderer
-            .render_to_texture(
-                device,
-                queue,
-                scene_ref,
-                &surface.target_view,
-                &render_params,
-            )
-            .expect("failed to render to surface");
-
+    fn present_surface(
+        surface: &RenderSurface<'_>,
+        surface_texture: wgpu::SurfaceTexture,
+        window: &WindowHandle,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+    ) {
         // Copy the new surface content to the surface.
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("Surface Blit"),
@@ -846,7 +764,7 @@ impl MasonryState<'_> {
                 .create_view(&wgpu::TextureViewDescriptor::default()),
         );
         queue.submit([encoder.finish()]);
-        window.handle.pre_present_notify();
+        window.pre_present_notify();
         surface_texture.present();
         {
             let _render_poll_span =

--- a/masonry_winit/src/lib.rs
+++ b/masonry_winit/src/lib.rs
@@ -86,6 +86,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![expect(missing_debug_implementations, reason = "Deferred: Noisy")]
 
+#[cfg(feature = "tracy")]
+use vello as _;
+
 mod app_driver;
 mod convert_winit_event;
 mod event_loop_runner;

--- a/masonry_winit/src/vello_util.rs
+++ b/masonry_winit/src/vello_util.rs
@@ -6,15 +6,33 @@
 //! This module is based on [`vello::util`] module with modifications
 //! for transparent surfaces.
 
-use vello::Error;
-use vello::wgpu::util::{TextureBlitter, TextureBlitterBuilder};
-use vello::wgpu::{
+use wgpu::util::{TextureBlitter, TextureBlitterBuilder};
+use wgpu::{
     self, BlendComponent, BlendFactor, BlendState, CompositeAlphaMode, Device, Instance,
     MemoryBudgetThresholds, MemoryHints, PresentMode, Surface, SurfaceConfiguration, Texture,
     TextureFormat, TextureUsages, TextureView,
 };
 
 use crate::app_driver::WgpuLimits;
+
+#[derive(Debug)]
+pub(crate) enum RenderSurfaceError {
+    CreateSurface(wgpu::CreateSurfaceError),
+    NoCompatibleDevice,
+    UnsupportedSurfaceFormat,
+}
+
+impl core::fmt::Display for RenderSurfaceError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::CreateSurface(err) => write!(f, "creating surface failed: {err}"),
+            Self::NoCompatibleDevice => write!(f, "no compatible WGPU device found"),
+            Self::UnsupportedSurfaceFormat => write!(f, "unsupported surface format"),
+        }
+    }
+}
+
+impl std::error::Error for RenderSurfaceError {}
 
 /// Simple render context that maintains wgpu state for rendering the pipeline.
 pub(crate) struct RenderContext {
@@ -93,9 +111,11 @@ impl RenderContext {
         width: u32,
         height: u32,
         present_mode: PresentMode,
-    ) -> Result<RenderSurface<'w>, Error> {
+    ) -> Result<RenderSurface<'w>, RenderSurfaceError> {
         self.create_render_surface(
-            self.instance.create_surface(window.into())?,
+            self.instance
+                .create_surface(window.into())
+                .map_err(RenderSurfaceError::CreateSurface)?,
             width,
             height,
             present_mode,
@@ -110,11 +130,11 @@ impl RenderContext {
         width: u32,
         height: u32,
         present_mode: PresentMode,
-    ) -> Result<RenderSurface<'w>, Error> {
+    ) -> Result<RenderSurface<'w>, RenderSurfaceError> {
         let dev_id = self
             .device(Some(&surface))
             .await
-            .ok_or(Error::NoCompatibleDevice)?;
+            .ok_or(RenderSurfaceError::NoCompatibleDevice)?;
 
         let device_handle = &self.devices[dev_id];
         let capabilities = surface.get_capabilities(&device_handle.adapter);
@@ -122,7 +142,7 @@ impl RenderContext {
             .formats
             .into_iter()
             .find(|it| matches!(it, TextureFormat::Rgba8Unorm | TextureFormat::Bgra8Unorm))
-            .ok_or(Error::UnsupportedSurfaceFormat)?;
+            .ok_or(RenderSurfaceError::UnsupportedSurfaceFormat)?;
 
         const PREMUL_BLEND_STATE: BlendState = BlendState {
             alpha: BlendComponent::REPLACE,
@@ -314,10 +334,12 @@ impl RenderContext {
     }
 }
 
-/// Vello uses a compute shader to render to the provided texture, which means that it can't bind the surface
-/// texture in most cases.
+/// Masonry renders into an intermediate texture because surface textures are not suitable for all
+/// backend paths directly.
 ///
-/// Because of this, we need to create an "intermediate" texture which we render to, and then blit to the surface.
+/// The Vello path needs storage binding for compute-based rendering, while the Vello Hybrid path
+/// renders through a color attachment. We therefore provision one intermediate texture that
+/// supports both backends and then blit to the surface.
 fn create_targets(width: u32, height: u32, device: &Device) -> (Texture, TextureView) {
     let target_texture = device.create_texture(&wgpu::TextureDescriptor {
         label: None,
@@ -329,7 +351,10 @@ fn create_targets(width: u32, height: u32, device: &Device) -> (Texture, Texture
         mip_level_count: 1,
         sample_count: 1,
         dimension: wgpu::TextureDimension::D2,
-        usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
+        usage: TextureUsages::STORAGE_BINDING
+            | TextureUsages::TEXTURE_BINDING
+            | TextureUsages::COPY_DST
+            | TextureUsages::RENDER_ATTACHMENT,
         format: TextureFormat::Rgba8Unorm,
         view_formats: &[],
     });


### PR DESCRIPTION
Add masonry_imaging as the Masonry-owned bridge between paint output and concrete imaging backends.

This change:
- extracts shared Masonry render-source and frame helpers into masonry_imaging
- splits backend integration into image rendering and texture rendering capabilities
- supports imaging_vello, imaging_vello_hybrid, imaging_vello_cpu, and imaging_skia
- updates masonry_testing to render through masonry_imaging
- updates masonry_winit to use masonry_imaging for runtime rendering while keeping window and surface management local
- replaces vello::wgpu usage with direct wgpu
- aligns runtime rendering with target-oriented backend renderers where available

The result is a cleaner boundary:
- masonry_core owns paint output
- masonry_imaging owns Masonry-to-backend rendering integration
- host crates such as masonry_winit own presentation and platform integration