### PR TITLE
Disable font hinting during IME composition to fix text jitter

### DIFF
--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -201,7 +201,6 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
     /// To modify this on an active text area, use [`set_hint`](Self::set_hint).
     /// You should do so as an animation starts and ends.
     // TODO: Should we tell each widget if smooth scrolling is ongoing so they can disable their hinting?
-    // Alternatively, we should automate disabling hinting at the Vello layer when composing.
     pub fn with_hint(mut self, hint: bool) -> Self {
         self.hint = hint;
         self
@@ -1032,7 +1031,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
             Affine::IDENTITY,
             layout,
             &[text_color.color.into()],
-            self.hint,
+            self.hint && !self.editor.is_composing(),
         );
     }
 


### PR DESCRIPTION
## Summary

- Disable font hinting in `TextArea::paint` when the IME is actively composing (i.e., `editor.is_composing()` returns true)
- Remove the now-resolved TODO about automating hinting disable during composition

## Problem

When typing with an input method editor (CJK languages), font hinting causes visible text jitter. Each time the preedit text updates (every keystroke), the glyph layout changes and the hinting algorithm snaps positions to different pixel boundaries, producing a shaking effect. This is especially noticeable with Chinese input methods where the preedit string changes rapidly (e.g., pinyin → character conversion).

This was also confirmed to affect the xilem native `TextInput` widget, not just custom text input implementations.

## Test plan

- [x] `cargo check -p masonry` passes
- [ ] Manual test: type Chinese/Japanese/Korean text in a `TextInput` and verify no jitter during composition
- [ ] Verify that hinting is still active for normal (non-IME) text input (Latin characters should look the same)

🤖 Generated with [Claude Code](https://claude.com/claude-code)