### PR TITLE
fix: correct copy-paste error in Svg view error message

### DIFF
--- a/xilem_masonry/src/view/svg.rs
+++ b/xilem_masonry/src/view/svg.rs
@@ -106,7 +106,7 @@ impl<State: 'static, Action> View<State, Action, ViewCtx> for Svg {
     ) -> MessageResult<Action> {
         tracing::error!(
             ?message,
-            "Message arrived in Svg::message, but Image doesn't consume any messages, this is a bug."
+            "Message arrived in Svg::message, but Svg doesn't consume any messages, this is a bug."
         );
         MessageResult::Stale
     }


### PR DESCRIPTION
## Summary

The error message in `Svg::message` (`xilem_masonry/src/view/svg.rs:109`) incorrectly said "Image doesn't consume any messages" instead of "Svg doesn't consume any messages". This was a copy-paste error introduced when the SVG view was created from the Image view in #1708.

## Test plan

- [x] `cargo check -p xilem_masonry` passes
- [ ] String literal grep confirms all other `*::message` error messages are self-referential

🤖 Generated with [Claude Code](https://claude.com/claude-code)