### PR TITLE
Add or tweak button parameter to Harness methods that simulate clicks

### DIFF
--- a/masonry/src/doc/color_rectangle.rs
+++ b/masonry/src/doc/color_rectangle.rs
@@ -17,9 +17,7 @@ use crate as masonry;
 
 use masonry::peniko::Color;
 // ---
-use masonry::core::{
-    AccessEvent, EventCtx, PointerButton, PointerEvent, PropertiesMut, TextEvent, Widget,
-};
+use masonry::core::{AccessEvent, EventCtx, PointerEvent, PropertiesMut, TextEvent, Widget};
 // ---
 use masonry::core::{Update, UpdateCtx};
 // ---
@@ -75,7 +73,7 @@ impl Widget for ColorRectangle {
         event: &PointerEvent,
     ) {
         match event {
-            PointerEvent::Down(b) if b.button == Some(PointerButton::Primary) => {
+            PointerEvent::Down(_) => {
                 ctx.submit_action::<Self::Action>(ColorRectanglePress);
             }
             _ => {}
@@ -316,7 +314,7 @@ mod tests {
         let mut harness = TestHarness::create(default_property_set(), widget);
         let rect_id = harness.root_id();
 
-        harness.mouse_click_on(rect_id);
+        harness.mouse_click_on(rect_id, None);
         assert!(matches!(
             harness.pop_action::<ColorRectanglePress>(),
             Some((ColorRectanglePress, _))

--- a/masonry/src/doc/implementing_widget.md
+++ b/masonry/src/doc/implementing_widget.md
@@ -88,9 +88,7 @@ First we implement event methods:
 
 ```rust,ignore
 // ...
-use masonry::core::{
-    AccessEvent, EventCtx, PointerButton, PointerEvent, PropertiesMut, TextEvent, Widget
-};
+use masonry::core::{AccessEvent, EventCtx, PointerEvent, PropertiesMut, TextEvent, Widget};
 // ...
 
 #[derive(Debug)]
@@ -101,7 +99,7 @@ impl Widget for ColorRectangle {
 
     fn on_pointer_event(&mut self, ctx: &mut EventCtx<'_>, _props: &mut PropertiesMut<'_>, event: &PointerEvent) {
         match event {
-            PointerEvent::Down { button: Some(PointerButton::Primary), .. } => {
+            PointerEvent::Down(_) => {
                 ctx.submit_action::<Self::Action>(ColorRectanglePress);
             }
             _ => {},
@@ -123,7 +121,7 @@ impl Widget for ColorRectangle {
 }
 ```
 
-We handle pointer events and accessibility events the same way: we check the event type, and if it's a left-click, we submit an action.
+We handle pointer events and accessibility events the same way: we check the event type, and if it's a click, we submit an action.
 
 Submitting an action lets Masonry know that a semantically meaningful event has occurred; Masonry will call `AppDriver::on_action()` with the action before the end of the frame.
 This lets higher-level frameworks like Xilem react to UI events - in this case, the color rectangle being pressed.

--- a/masonry/src/doc/testing_widget.md
+++ b/masonry/src/doc/testing_widget.md
@@ -179,7 +179,7 @@ The `TestHarness` is also capable of reading actions emitted by our widget with 
         let mut harness = TestHarness::create(default_property_set(), widget);
         let rect_id = harness.root_id();
 
-        harness.mouse_click_on(rect_id);
+        harness.mouse_click_on(rect_id, None);
         assert!(matches!(
             harness.pop_action::<ColorRectanglePress>(),
             Some((ColorRectanglePress, _))

--- a/masonry/src/tests/action.rs
+++ b/masonry/src/tests/action.rs
@@ -128,7 +128,7 @@ fn action_propagation() {
 
     let mut harness = TestHarness::create(test_property_set(), parent3);
 
-    harness.mouse_click_on(button_id);
+    harness.mouse_click_on(button_id, None);
 
     // Only the translated action should reach the app driver
     assert_matches!(

--- a/masonry/src/tests/event.rs
+++ b/masonry/src/tests/event.rs
@@ -64,7 +64,7 @@ fn pointer_event_bubbling() {
     let button_id = harness.get_widget(button_tag).id();
 
     harness.flush_records_of(button_tag);
-    harness.mouse_click_on(button_id);
+    harness.mouse_click_on(button_id, None);
 
     fn is_pointer_down(record: Record) -> bool {
         matches!(record, Record::PointerEvent(PointerEvent::Down { .. }))
@@ -87,7 +87,7 @@ fn pointer_capture_and_cancel() {
     let target_id = harness.get_widget(target_tag).id();
 
     harness.mouse_move_to(target_id);
-    harness.mouse_button_press(PointerButton::Primary);
+    harness.mouse_button_press(None);
     assert_eq!(harness.pointer_capture_target_id(), Some(target_id));
 
     harness.process_pointer_event(PointerEvent::Cancel(PointerInfo {
@@ -110,7 +110,7 @@ fn synthetic_cancel() {
     let target_id = harness.get_widget(target_tag).id();
 
     harness.mouse_move_to(target_id);
-    harness.mouse_button_press(PointerButton::Primary);
+    harness.mouse_button_press(None);
     assert_eq!(harness.pointer_capture_target_id(), Some(target_id));
 
     // When we disable a widget with pointer capture, it gets a
@@ -146,7 +146,7 @@ fn pointer_capture_suppresses_neighbors() {
     let other_id = harness.get_widget(other_tag).id();
 
     harness.mouse_move_to(target_id);
-    harness.mouse_button_press(PointerButton::Primary);
+    harness.mouse_button_press(None);
 
     assert_eq!(harness.pointer_capture_target_id(), Some(target_id));
 
@@ -158,7 +158,7 @@ fn pointer_capture_suppresses_neighbors() {
     assert!(!harness.get_widget(other_tag).ctx().is_hovered());
 
     // We end pointer capture.
-    harness.mouse_button_release(PointerButton::Primary);
+    harness.mouse_button_release(None);
     assert_eq!(harness.pointer_capture_target_id(), None);
 
     // Once the capture is released, 'other' should immediately register as hovered.
@@ -212,7 +212,7 @@ fn pointer_cancel_on_window_blur() {
     let target_id = harness.get_widget(target_tag).id();
 
     harness.mouse_move_to(target_id);
-    harness.mouse_button_press(PointerButton::Primary);
+    harness.mouse_button_press(None);
     assert_eq!(harness.pointer_capture_target_id(), Some(target_id));
     harness.flush_records_of(target_tag);
 
@@ -253,7 +253,7 @@ fn click_anchors_focus() {
 
     // Clicking a disabled button doesn't focus it.
     harness.set_disabled(child_3, true);
-    harness.mouse_click_on(child_3_id);
+    harness.mouse_click_on(child_3_id, None);
     assert_eq!(harness.focused_widget_id(), None);
 
     // But the next tab event focuses its neighbor.
@@ -266,8 +266,8 @@ fn click_anchors_focus() {
 
     // Clicking another non-focusable widget clears focus.
     harness.mouse_move_to_unchecked(other_id);
-    harness.mouse_button_press(PointerButton::Primary);
-    harness.mouse_button_release(PointerButton::Primary);
+    harness.mouse_button_press(None);
+    harness.mouse_button_release(None);
     assert_eq!(harness.focused_widget_id(), None);
 }
 
@@ -440,7 +440,7 @@ fn multi_pointers_capture() {
     // Move mouse to button 1, mouse press
     // Check mouse is captured, button 1 is active
     harness.mouse_move_to(button_1_id);
-    harness.mouse_button_press(PointerButton::Primary);
+    harness.mouse_button_press(None);
 
     assert_captured_by(&harness, PointerId::PRIMARY, button_1_id);
     assert!(harness.get_widget(button_1_tag).ctx().is_active());

--- a/masonry/src/tests/transforms.rs
+++ b/masonry/src/tests/transforms.rs
@@ -7,7 +7,7 @@ use std::f64::consts::PI;
 
 use masonry_testing::WrapperWidget;
 
-use crate::core::{NewWidget, PointerButton, PropertySet, Widget, WidgetOptions};
+use crate::core::{NewWidget, PropertySet, Widget, WidgetOptions};
 use crate::kurbo::{Affine, Vec2};
 use crate::layout::AsUnit;
 use crate::peniko::color::palette;
@@ -71,6 +71,6 @@ fn transforms_pointer_events() {
 
     let mut harness = TestHarness::create(default_property_set(), widget);
     harness.mouse_move((335.0, 350.0)); // Should hit the last "d" of the button text
-    harness.mouse_button_press(PointerButton::Primary);
+    harness.mouse_button_press(None);
     assert_render_snapshot!(harness, "transforms_pointer_events");
 }

--- a/masonry/src/tests/update.rs
+++ b/masonry/src/tests/update.rs
@@ -9,7 +9,7 @@ use masonry_testing::{
     assert_debug_panics,
 };
 
-use crate::core::pointer::{PointerButton, PointerEvent};
+use crate::core::pointer::PointerEvent;
 use crate::core::{
     CursorIcon, Ime, NewWidget, PropertySet, TextEvent, Update, Widget, WidgetId, WidgetPod,
     WidgetTag,
@@ -118,7 +118,7 @@ fn disabled_widget_gets_no_event() {
         ]
     );
 
-    harness.mouse_click_on(button_id);
+    harness.mouse_click_on(button_id, None);
     assert_matches!(harness.take_records_of(button_tag)[..], []);
 
     assert_matches!(harness.focused_widget_id(), None);
@@ -593,14 +593,14 @@ fn pointer_capture_affects_pointer_icon() {
     let label_id = harness.get_widget(label_tag).id();
 
     harness.mouse_move_to(icon_id);
-    harness.mouse_button_press(PointerButton::Primary);
+    harness.mouse_button_press(None);
     assert_eq!(harness.cursor_icon(), CursorIcon::Crosshair);
 
     // We keep the Crosshair icon as long as the pointer stays captured.
     harness.mouse_move_to(label_id);
     assert_eq!(harness.cursor_icon(), CursorIcon::Crosshair);
 
-    harness.mouse_button_release(PointerButton::Primary);
+    harness.mouse_button_release(None);
     assert_eq!(harness.cursor_icon(), CursorIcon::Default);
 }
 
@@ -741,7 +741,7 @@ fn status_flag_update_order() {
     assert!(harness.get_widget(parent1_tag).ctx().is_hovered());
     assert!(harness.get_widget(parent1_tag).ctx().has_hovered());
 
-    harness.mouse_button_press(PointerButton::Primary);
+    harness.mouse_button_press(None);
     let events: Vec<_> = receiver.try_iter().collect();
     assert_eq!(
         events,
@@ -755,7 +755,7 @@ fn status_flag_update_order() {
     assert!(harness.get_widget(parent1_tag).ctx().is_active());
     assert!(harness.get_widget(parent1_tag).ctx().has_active());
 
-    harness.mouse_button_release(PointerButton::Primary);
+    harness.mouse_button_release(None);
     let events: Vec<_> = receiver.try_iter().collect();
     assert_eq!(
         events,

--- a/masonry/src/widgets/badge.rs
+++ b/masonry/src/widgets/badge.rs
@@ -234,7 +234,7 @@ mod tests {
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
         let badge_id = harness.root_id();
 
-        harness.mouse_click_on(badge_id);
+        harness.mouse_click_on(badge_id, None);
         assert!(harness.pop_action_erased().is_none());
         assert!(harness.focused_widget().is_none());
     }

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -290,7 +290,7 @@ mod tests {
 
         assert!(harness.pop_action_erased().is_none());
 
-        harness.mouse_click_on(button_id);
+        harness.mouse_click_on(button_id, Some(PointerButton::Primary));
         assert_eq!(
             harness.pop_action::<ButtonPress>(),
             Some((
@@ -322,7 +322,7 @@ mod tests {
 
         harness.focus_on(None);
         harness.mouse_move_to(button_id);
-        harness.mouse_button_press(PointerButton::Primary);
+        harness.mouse_button_press(None);
 
         assert_eq!(harness.focused_widget_id(), Some(button_id));
     }
@@ -479,13 +479,13 @@ mod tests {
             button.ctx().is_hovered(),
             "The child shouldn't prevent hover."
         );
-        harness.mouse_button_press(PointerButton::Primary);
+        harness.mouse_button_press(None);
         let button = harness.get_widget_with_id(button_id);
         assert!(
             button.ctx().is_pointer_capture_target(),
             "A non-interactive child shouldn't prevent pointer capture."
         );
-        harness.mouse_button_release(PointerButton::Primary);
+        harness.mouse_button_release(None);
         let (_, event_id) = harness
             .pop_action::<<Button as Widget>::Action>()
             .expect("There should be an action.");

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -396,7 +396,7 @@ mod tests {
 
         assert!(harness.pop_action_erased().is_none());
 
-        harness.mouse_click_on(checkbox_id);
+        harness.mouse_click_on(checkbox_id, None);
         assert_eq!(
             harness.pop_action::<CheckboxToggled>(),
             Some((CheckboxToggled(true), checkbox_id))

--- a/masonry/src/widgets/radio_button.rs
+++ b/masonry/src/widgets/radio_button.rs
@@ -439,7 +439,7 @@ mod tests {
 
         assert_render_snapshot!(harness, "radio_button_hello_hovered");
 
-        harness.mouse_click_on(radio_id);
+        harness.mouse_click_on(radio_id, None);
         assert_eq!(
             harness.pop_action::<RadioButtonSelected>(),
             Some((RadioButtonSelected, radio_id))

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -467,7 +467,7 @@ mod tests {
     use super::*;
     use crate::core::TextEvent;
     use crate::core::keyboard::{Key, NamedKey};
-    use crate::core::{NewWidget, PointerButton};
+    use crate::core::NewWidget;
     use crate::properties::Dimensions;
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::test_property_set;
@@ -487,13 +487,13 @@ mod tests {
 
         assert!(harness.pop_action_erased().is_none());
 
-        harness.mouse_click_on(scrollbar_id);
+        harness.mouse_click_on(scrollbar_id, None);
         // TODO - Scroll action?
         assert!(harness.pop_action_erased().is_none());
 
         assert_render_snapshot!(harness, "scrollbar_middle");
 
-        harness.mouse_button_press(PointerButton::Primary);
+        harness.mouse_button_press(None);
         harness.mouse_move(Point::new(30.0, 150.0));
 
         assert_render_snapshot!(harness, "scrollbar_down");
@@ -517,7 +517,7 @@ mod tests {
 
         assert!(harness.pop_action_erased().is_none());
 
-        harness.mouse_click_on(scrollbar_id);
+        harness.mouse_click_on(scrollbar_id, None);
         // TODO - Scroll action?
         assert!(harness.pop_action_erased().is_none());
 

--- a/masonry/src/widgets/scroll_bar.rs
+++ b/masonry/src/widgets/scroll_bar.rs
@@ -465,9 +465,8 @@ impl AllowRawMut for ScrollBar {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::TextEvent;
     use crate::core::keyboard::{Key, NamedKey};
-    use crate::core::NewWidget;
+    use crate::core::{NewWidget, TextEvent};
     use crate::properties::Dimensions;
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::test_property_set;

--- a/masonry/src/widgets/slider.rs
+++ b/masonry/src/widgets/slider.rs
@@ -506,7 +506,7 @@ impl Widget for Slider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{PointerButton, TextEvent};
+    use crate::core::TextEvent;
     use crate::kurbo::{Point, Size};
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::test_property_set;
@@ -534,7 +534,7 @@ mod tests {
 
         // 2. Press the mouse button.
         // This should not emit an action because the value does not change.
-        harness.mouse_button_press(PointerButton::Primary);
+        harness.mouse_button_press(None);
         assert!(harness.pop_action::<f64>().is_none());
 
         // 3. Move to the new position (75%).
@@ -545,7 +545,7 @@ mod tests {
         assert_render_snapshot!(harness, "slider_drag_to_75");
 
         // Release the mouse
-        harness.mouse_button_release(PointerButton::Primary);
+        harness.mouse_button_release(None);
         assert_render_snapshot!(harness, "slider_drag_released_at_75");
     }
 

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -826,7 +826,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{PointerButton, TextEvent, WindowEvent};
+    use crate::core::{TextEvent, WindowEvent};
     use crate::dpi::PhysicalSize;
     use crate::properties::Padding;
     use crate::testing::{TestHarness, assert_render_snapshot};
@@ -925,9 +925,9 @@ mod tests {
         // Initial bar center with default settings:
         // split_space = 150 - 6 = 144, child1 = 72, bar center = 72 + 3 = 75.
         harness.mouse_move(Point::new(75.0, 10.0));
-        harness.mouse_button_press(PointerButton::Primary);
+        harness.mouse_button_press(None);
         harness.mouse_move(Point::new(105.0, 10.0));
-        harness.mouse_button_release(PointerButton::Primary);
+        harness.mouse_button_release(None);
 
         let (child1_width, child2_width) = {
             let root = harness.root_widget();

--- a/masonry/src/widgets/switch.rs
+++ b/masonry/src/widgets/switch.rs
@@ -360,7 +360,7 @@ mod tests {
         assert!(harness.pop_action_erased().is_none());
 
         // Click on switch (off -> wants to be on)
-        harness.mouse_click_on(switch_id);
+        harness.mouse_click_on(switch_id, None);
         assert_eq!(harness.focused_widget().map(|w| w.id()), Some(switch_id));
         assert_eq!(
             harness.pop_action::<SwitchToggled>(),
@@ -371,7 +371,7 @@ mod tests {
         harness.edit_root_widget(|mut switch| Switch::set_on(&mut switch, true));
 
         // Click again (on -> wants to be off)
-        harness.mouse_click_on(switch_id);
+        harness.mouse_click_on(switch_id, None);
         assert_eq!(
             harness.pop_action::<SwitchToggled>(),
             Some((SwitchToggled(false), switch_id))
@@ -465,7 +465,7 @@ mod tests {
         assert_render_snapshot!(harness, "switch_off_hovered");
 
         // Now click to switch
-        harness.mouse_click_on(switch_id);
+        harness.mouse_click_on(switch_id, None);
         assert_eq!(
             harness.pop_action::<SwitchToggled>(),
             Some((SwitchToggled(true), switch_id))

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -583,21 +583,25 @@ impl<W: Widget> TestHarness<W> {
     }
 
     /// Sends a [`Down`](PointerEvent::Down) event to the window.
-    pub fn mouse_button_press(&mut self, button: PointerButton) {
-        self.mouse_state.buttons.insert(button);
+    pub fn mouse_button_press(&mut self, button: Option<PointerButton>) {
+        if let Some(button) = button {
+            self.mouse_state.buttons.insert(button);
+        }
         self.process_pointer_event(PointerEvent::Down(PointerButtonEvent {
             pointer: PRIMARY_MOUSE,
-            button: button.into(),
+            button,
             state: self.mouse_state.clone(),
         }));
     }
 
     /// Sends an [`Up`](PointerEvent::Up) event to the window.
-    pub fn mouse_button_release(&mut self, button: PointerButton) {
-        self.mouse_state.buttons.remove(button);
+    pub fn mouse_button_release(&mut self, button: Option<PointerButton>) {
+        if let Some(button) = button {
+            self.mouse_state.buttons.remove(button);
+        }
         self.process_pointer_event(PointerEvent::Up(PointerButtonEvent {
             pointer: PRIMARY_MOUSE,
-            button: button.into(),
+            button,
             state: self.mouse_state.clone(),
         }));
     }
@@ -622,10 +626,10 @@ impl<W: Widget> TestHarness<W> {
     /// - If the widget doesn't accept pointer events.
     /// - If the widget is scrolled out of view.
     #[track_caller]
-    pub fn mouse_click_on(&mut self, id: WidgetId) {
+    pub fn mouse_click_on(&mut self, id: WidgetId, button: Option<PointerButton>) {
         self.mouse_move_to(id);
-        self.mouse_button_press(PointerButton::Primary);
-        self.mouse_button_release(PointerButton::Primary);
+        self.mouse_button_press(button);
+        self.mouse_button_release(button);
     }
 
     /// Uses [`mouse_move`](Self::mouse_move) to set the internal mouse pos to the center of the given widget.


### PR DESCRIPTION
In most cases, we want that button to be None (which helps us check for the footgun where a widget accepts `Some(PointerButton::Primary)` but not `None`).

Update ColorRectangle example to ignore button type for simplicity.
(And also because button-checking code in widgets is really not beginner-friendly right now.)

The changes in `harness.rs` were done by hand. Everything else was generated by Claude Code, with some manual follow-ups.