### PR TITLE
Move changed_properties from Masonry to Xilem

### DIFF
--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -23,7 +23,7 @@ use crate::kurbo::{Affine, Axis, Insets, Point, Rect, Size, Vec2};
 use crate::layout::{LayoutSize, LenDef, SizeDef};
 use crate::passes::layout::{place_widget, resolve_length, resolve_size, run_layout_on};
 use crate::peniko::Color;
-use crate::util::{ParentLinkedList, TypeSet, get_debug_color};
+use crate::util::{ParentLinkedList, get_debug_color};
 
 // Note - Most methods defined in this file revolve around `WidgetState` fields.
 // Consider reading `WidgetState` documentation (especially the documented naming scheme)
@@ -54,7 +54,6 @@ pub struct MutateCtx<'a> {
     pub(crate) parent_widget_state: Option<&'a mut WidgetState>,
     pub(crate) widget_state: &'a mut WidgetState,
     pub(crate) properties: PropertiesMut<'a>,
-    pub(crate) changed_properties: &'a mut TypeSet,
     pub(crate) children: ArenaMutList<'a, WidgetArenaNode>,
     pub(crate) property_arena: &'a PropertyArena,
 }
@@ -308,7 +307,6 @@ impl MutateCtx<'_> {
                 stack: child_stack,
                 class_set: &node_mut.item.class_set,
             },
-            changed_properties: &mut node_mut.item.changed_properties,
             children: node_mut.children,
             property_arena: self.property_arena,
         };
@@ -332,7 +330,6 @@ impl MutateCtx<'_> {
                 stack: self.properties.stack,
                 class_set: self.properties.class_set,
             },
-            changed_properties: self.changed_properties,
             children: self.children.reborrow_mut(),
             property_arena: self.property_arena,
         }
@@ -2210,7 +2207,6 @@ impl RegisterCtx<'_> {
             widget: widget.as_box_dyn(),
             state,
             properties,
-            changed_properties: TypeSet::default(),
             class_set: ClassSet {
                 classes,
                 ..ClassSet::default()

--- a/masonry_core/src/core/widget_arena.rs
+++ b/masonry_core/src/core/widget_arena.rs
@@ -4,7 +4,6 @@
 use tree_arena::{ArenaMut, ArenaRef, TreeArena};
 
 use crate::core::{ClassSet, PropertySet, Widget, WidgetId, WidgetState};
-use crate::util::TypeSet;
 
 pub(crate) struct WidgetArena {
     pub(crate) nodes: TreeArena<WidgetArenaNode>,
@@ -14,7 +13,6 @@ pub(crate) struct WidgetArenaNode {
     pub(crate) widget: Box<dyn Widget>,
     pub(crate) state: WidgetState,
     pub(crate) properties: PropertySet,
-    pub(crate) changed_properties: TypeSet,
     pub(crate) class_set: ClassSet,
 }
 

--- a/masonry_core/src/core/widget_mut.rs
+++ b/masonry_core/src/core/widget_mut.rs
@@ -66,15 +66,6 @@ impl<W: Widget + ?Sized> WidgetMut<'_, W> {
         self.ctx.properties.contains::<T>()
     }
 
-    /// Whether the property `P` of this widget has been modified in this pass.
-    ///
-    /// This is useful when composing units which might mutate a property value.
-    /// In these cases, the "strongest" of these will want to check if it has been
-    /// changed by a different unit, to overwrite this change.
-    pub fn prop_has_changed<P: Property>(&self) -> bool {
-        self.ctx.changed_properties.contains(&TypeId::of::<P>())
-    }
-
     /// Returns the value of property `T`.
     ///
     /// If the widget has an entry for `P`, returns that entry.
@@ -92,7 +83,6 @@ impl<W: Widget + ?Sized> WidgetMut<'_, W> {
     ///
     /// This also calls [`Widget::property_changed`] with the matching type id.
     pub fn insert_prop<P: Property>(&mut self, value: P) -> Option<P> {
-        self.ctx.changed_properties.insert(TypeId::of::<P>());
         let value = self.ctx.properties.insert(value);
         let mut ctx = self.ctx.update_mut();
         let property_type = TypeId::of::<P>();
@@ -107,7 +97,6 @@ impl<W: Widget + ?Sized> WidgetMut<'_, W> {
     ///
     /// This also calls [`Widget::property_changed`] with the matching type id.
     pub fn remove_prop<P: Property>(&mut self) -> Option<P> {
-        self.ctx.changed_properties.insert(TypeId::of::<P>());
         let value = self.ctx.properties.remove::<P>();
         let mut ctx = self.ctx.update_mut();
         let property_type = TypeId::of::<P>();

--- a/masonry_core/src/passes/mutate.rs
+++ b/masonry_core/src/passes/mutate.rs
@@ -19,7 +19,6 @@ pub(crate) fn mutate_widget<R>(
     let widget = &mut *node.item.widget;
     let state = &mut node.item.state;
     let properties = &mut node.item.properties;
-    let changed_properties = &mut node.item.changed_properties;
     let class_set = &node.item.class_set;
     let id = state.id;
     let stack = root
@@ -27,8 +26,6 @@ pub(crate) fn mutate_widget<R>(
         .get(state.property_stack_id, widget.type_id());
 
     let _span = info_span!("mutate_widget", name = widget.short_type_name()).entered();
-
-    changed_properties.clear();
 
     // NOTE - we can set parent_widget_state to None here, because the loop below will merge the
     // states up to the root.
@@ -47,7 +44,6 @@ pub(crate) fn mutate_widget<R>(
                 stack,
                 class_set,
             },
-            changed_properties,
             children,
             property_arena: &root.property_arena,
         },

--- a/masonry_core/src/util.rs
+++ b/masonry_core/src/util.rs
@@ -107,10 +107,6 @@ impl Sanitize for Option<f64> {
 // ---
 
 pub(crate) type AnyMap = anymap3::Map<dyn anymap3::CloneAny + Send + Sync>;
-pub(crate) type TypeSet = std::collections::HashSet<
-    std::any::TypeId,
-    std::hash::BuildHasherDefault<anymap3::TypeIdHasher>,
->;
 
 /// Convert a 2d rectangle from Parley to one used for drawing in Vello and other maths.
 pub fn bounding_box_to_rect(bb: parley::BoundingBox) -> kurbo::Rect {

--- a/xilem_masonry/src/masonry_root.rs
+++ b/xilem_masonry/src/masonry_root.rs
@@ -53,6 +53,7 @@ impl<State> View<State, (), ViewCtx> for MasonryRoot<State> {
         let mut root_id = None;
         render_root.edit_base_layer(|mut root| {
             let mut root = root.downcast();
+            ctx.reset_changed_props();
             self.root_widget_view.rebuild(
                 &prev.root_widget_view,
                 root_widget_view_state,

--- a/xilem_masonry/src/view/prop.rs
+++ b/xilem_masonry/src/view/prop.rs
@@ -56,8 +56,12 @@ where
             element.reborrow_mut(),
             app_state,
         );
+        // TODO - This is kind of a hack. We shouldn't allow stacking `Prop` views.
         // If a child view changed the property, we know we're out of date.
-        if self.property != prev.property || element.prop_has_changed::<P>() {
+        let prop_has_changed = ctx.prop_has_changed::<P>(element.id());
+
+        if self.property != prev.property || prop_has_changed {
+            ctx.mark_prop_changed::<P>(element.id());
             element.insert_prop(self.property.clone());
         }
     }

--- a/xilem_masonry/src/view_ctx.rs
+++ b/xilem_masonry/src/view_ctx.rs
@@ -1,10 +1,11 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::any::TypeId;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use masonry::core::{FromDynWidget, Widget, WidgetId, WidgetMut};
+use masonry::core::{FromDynWidget, Property, Widget, WidgetId, WidgetMut};
 
 use crate::Pod;
 use crate::core::{Environment, RawProxy, ViewId, ViewPathTracker};
@@ -18,6 +19,7 @@ pub struct ViewCtx {
     id_path: Vec<ViewId>,
     proxy: Arc<dyn RawProxy>,
     runtime: Arc<tokio::runtime::Runtime>,
+    props_changed: HashSet<(WidgetId, TypeId)>,
     environment: Environment,
 }
 
@@ -82,6 +84,29 @@ impl ViewCtx {
         &self.runtime
     }
 
+    /// Marks the property `P` of the widget with the given id as changed.
+    ///
+    /// This is used to avoid bugs when multiple `Prop` views are stacked on the same widget.
+    ///
+    /// This should be reset at the end of each rebuild.
+    pub fn mark_prop_changed<P: Property>(&mut self, id: WidgetId) {
+        self.props_changed.insert((id, TypeId::of::<P>()));
+    }
+
+    /// Checks if the property `P` of the widget with the given id has changed during this rebuild.
+    ///
+    /// This is used to avoid bugs when multiple `Prop` views are stacked on the same widget.
+    pub fn prop_has_changed<P: Property>(&self, id: WidgetId) -> bool {
+        self.props_changed.contains(&(id, TypeId::of::<P>()))
+    }
+
+    /// Resets the changed properties for all widgets.
+    ///
+    /// This should be called at the start of each rebuild.
+    pub fn reset_changed_props(&mut self) {
+        self.props_changed.clear();
+    }
+
     /// Returns an event queue to which [`SendMessage`](crate::core::SendMessage)s can be submitted.
     pub fn proxy(&self) -> Arc<dyn RawProxy + 'static> {
         self.proxy.clone()
@@ -96,6 +121,7 @@ impl ViewCtx {
             id_path: Vec::new(),
             proxy,
             runtime,
+            props_changed: HashSet::default(),
             environment: Environment::new(),
         }
     }


### PR DESCRIPTION
This feature was only added to Masonry to cover for a quirk of how Xilem handles properties, and wasn't expected to be very useful to other users of Masonry. This PR makes Xilem fix its own quirk.