### PR TITLE
Rename `Widget::with_auto_id()` to `prepare()`

### DIFF
--- a/masonry/README.md
+++ b/masonry/README.md
@@ -107,7 +107,7 @@ impl AppDriver for Driver {
                 TextArea::reset_text(&mut text_area, "");
             });
             render_root.edit_widget_with_tag(LIST_TAG, |mut list| {
-                let child = Label::new(self.next_task.clone()).with_auto_id();
+                let child = Label::new(self.next_task.clone()).prepare();
                 Flex::add_fixed(&mut list, child);
             });
         } else if action.is::<TextAction>() {

--- a/masonry/examples/calc_masonry.rs
+++ b/masonry/examples/calc_masonry.rs
@@ -188,7 +188,7 @@ fn op_button_with_label(op: char, label: String) -> NewWidget<Button> {
     let button = Button::new(
         Label::new(label)
             .with_style(StyleProperty::FontSize(24.))
-            .with_auto_id(),
+            .prepare(),
     );
     let mut button = NewWidget::new(button).with_props(CalcAction::Op(op));
     button.classes.insert("op_button".to_string());
@@ -204,7 +204,7 @@ fn digit_button(digit: u8) -> NewWidget<Button> {
     let button = Button::new(
         Label::new(format!("{digit}"))
             .with_style(StyleProperty::FontSize(24.))
-            .with_auto_id(),
+            .prepare(),
     );
 
     let mut button = NewWidget::new(button).with_props(CalcAction::Digit(digit));
@@ -218,7 +218,7 @@ pub fn build_calc() -> NewWidget<impl Widget> {
     let display = Label::new(String::new()).with_style(StyleProperty::FontSize(32.));
     let display = Flex::column()
         .with_spacer(1.)
-        .with_fixed(display.with_auto_id())
+        .with_fixed(display.prepare())
         .with_spacer(1.)
         .cross_axis_alignment(CrossAxisAlignment::End);
 
@@ -227,7 +227,7 @@ pub fn build_calc() -> NewWidget<impl Widget> {
     }
 
     let root_widget = Grid::with_dimensions(4, 6)
-        .with(display.with_auto_id(), GridParams::new(0, 0, 4, 1))
+        .with(display.prepare(), GridParams::new(0, 0, 4, 1))
         .with(
             op_button_with_label('c', "CE".to_string()),
             button_params(0, 1),

--- a/masonry/examples/gallery/badge.rs
+++ b/masonry/examples/gallery/badge.rs
@@ -48,7 +48,7 @@ impl BadgeDemo {
                     show_plus: true,
                 },
             )
-            .with_auto_id()
+            .prepare()
             .erased(),
         )
     }
@@ -97,32 +97,32 @@ impl DemoPage for BadgeDemo {
         );
 
         let inbox = Badged::new(
-            Button::with_text("Inbox").with_auto_id(),
-            Badge::count(3).with_auto_id(),
+            Button::with_text("Inbox").prepare(),
+            Badge::count(3).prepare(),
         )
         .with_badge_placement(BadgePlacement::TopRight)
         .with_badge_offset(Vec2::new(2.0, -2.0))
-        .with_auto_id();
+        .prepare();
 
         let inbox_zero = Badged::new_optional(
-            Button::with_text("Empty inbox").with_auto_id(),
-            Badge::count_nonzero(0).map(|b| b.with_auto_id().erased()),
+            Button::with_text("Empty inbox").prepare(),
+            Badge::count_nonzero(0).map(|b| b.prepare().erased()),
         )
         .with_badge_placement(BadgePlacement::TopRight)
         .with_badge_offset(Vec2::new(2.0, -2.0))
-        .with_auto_id();
+        .prepare();
 
         let inbox_overflow = Badged::new(
-            Button::with_text("Big inbox").with_auto_id(),
-            Badge::count(120).with_auto_id(),
+            Button::with_text("Big inbox").prepare(),
+            Badge::count(120).prepare(),
         )
         .with_badge_placement(BadgePlacement::TopRight)
         .with_badge_offset(Vec2::new(2.0, -2.0))
-        .with_auto_id();
+        .prepare();
 
         let interactive_inbox = NewWidget::new(
             Badged::new_optional(
-                Button::with_text("Interactive inbox").with_auto_id(),
+                Button::with_text("Interactive inbox").prepare(),
                 Self::make_count_badge(self.count),
             )
             .with_badge_placement(BadgePlacement::TopRight)
@@ -143,9 +143,9 @@ impl DemoPage for BadgeDemo {
                     Label::new("AB")
                         .with_style(StyleProperty::FontSize(22.0))
                         .with_style(StyleProperty::FontWeight(FontWeight::BOLD))
-                        .with_auto_id(),
+                        .prepare(),
                 )
-                .with_auto_id(),
+                .prepare(),
             )
             .size(Length::const_px(72.0), Length::const_px(72.0)),
         )
@@ -159,7 +159,7 @@ impl DemoPage for BadgeDemo {
         let online_dot = NewWidget::new(Badge::new(
             SizedBox::empty()
                 .size(Length::const_px(10.0), Length::const_px(10.0))
-                .with_auto_id(),
+                .prepare(),
         ))
         .with_props(
             PropertySet::new()
@@ -172,24 +172,24 @@ impl DemoPage for BadgeDemo {
         let avatar_with_status = Badged::new(avatar.erased(), online_dot.erased())
             .with_badge_placement(BadgePlacement::BottomRight)
             .with_badge_offset(Vec2::new(-2.0, -2.0))
-            .with_auto_id();
+            .prepare();
 
         let body = Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Start)
             .with_fixed(
                 Label::new("Badges are non-interactive, decorative labels.")
                     .with_style(StyleProperty::FontSize(14.0))
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed_spacer(GAP)
             .with_fixed(
                 Flex::row()
-                    .with_fixed(new_badge.with_auto_id())
+                    .with_fixed(new_badge.prepare())
                     .with_fixed_spacer(GAP)
                     .with_fixed(beta_badge)
                     .with_fixed_spacer(GAP)
                     .with_fixed(outline_badge)
-                    .with_auto_id(),
+                    .prepare(),
             );
 
         let body = body
@@ -197,7 +197,7 @@ impl DemoPage for BadgeDemo {
             .with_fixed(
                 Label::new("Decorate other widgets with Badged:")
                     .with_style(StyleProperty::FontSize(14.0))
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed_spacer(GAP)
             .with_fixed(
@@ -210,7 +210,7 @@ impl DemoPage for BadgeDemo {
                     .with_fixed(inbox_overflow)
                     .with_fixed_spacer(Length::const_px(18.0))
                     .with_fixed(avatar_with_status)
-                    .with_auto_id(),
+                    .prepare(),
             );
 
         let body = body
@@ -218,7 +218,7 @@ impl DemoPage for BadgeDemo {
             .with_fixed(
                 Label::new("Interactive count (0 hides, 10 shows 9+):")
                     .with_style(StyleProperty::FontSize(14.0))
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed_spacer(GAP)
             .with_fixed(
@@ -231,7 +231,7 @@ impl DemoPage for BadgeDemo {
                     .with_fixed(count_label)
                     .with_fixed_spacer(Length::const_px(18.0))
                     .with_fixed(interactive_inbox)
-                    .with_auto_id(),
+                    .prepare(),
             );
 
         wrap_in_shell(self.shell, NewWidget::new(body).erased())

--- a/masonry/examples/gallery/basics.rs
+++ b/masonry/examples/gallery/basics.rs
@@ -33,12 +33,12 @@ impl DemoPage for BasicsDemo {
             .with_fixed(
                 Label::new("This is a Masonry widget gallery.")
                     .with_style(StyleProperty::FontSize(18.0))
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed_spacer(Length::const_px(12.0))
-            .with_fixed(Button::with_text("A button").with_auto_id())
+            .with_fixed(Button::with_text("A button").prepare())
             .with_fixed_spacer(Length::const_px(6.0))
-            .with_fixed(Button::with_text("Another button").with_auto_id());
+            .with_fixed(Button::with_text("Another button").prepare());
 
         wrap_in_shell(self.shell, NewWidget::new(body).erased())
     }

--- a/masonry/examples/gallery/demo.rs
+++ b/masonry/examples/gallery/demo.rs
@@ -99,7 +99,7 @@ pub(crate) fn wrap_in_shell(
     NewWidget::new(
         Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_fixed(header.with_auto_id())
+            .with_fixed(header.prepare())
             .with_fixed_spacer(CONTENT_GAP)
             .with(content, 1.0),
     )

--- a/masonry/examples/gallery/divider.rs
+++ b/masonry/examples/gallery/divider.rs
@@ -25,7 +25,7 @@ impl DividerDemo {
 fn desc(text: &str) -> NewWidget<Label> {
     Label::new(text)
         .with_style(StyleProperty::FontSize(14.0))
-        .with_auto_id()
+        .prepare()
 }
 
 impl DemoPage for DividerDemo {
@@ -43,21 +43,24 @@ impl DemoPage for DividerDemo {
                 .thickness(2.px())
                 .dash_pattern(&[10.px(), 10.px()])
                 .dash_fit(dash_fit)
+                .prepare()
                 .with_props(ContentColor::new(palette::css::DARK_CYAN))
         };
         let divider_label = |text: &str, placement: Placement| {
             Divider::horizontal()
                 .label(text)
                 .placement(placement)
-                .with_auto_id()
+                .prepare()
         };
 
-        let img = Image::new(make_image_data()).with_props(Dimensions::fixed(30.px(), 30.px()));
+        let img = Image::new(make_image_data())
+            .prepare()
+            .with_props(Dimensions::fixed(30.px(), 30.px()));
 
         let main = Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Stretch)
             .with_fixed(desc("It can be simple"))
-            .with_fixed(Divider::horizontal().with_auto_id())
+            .with_fixed(Divider::horizontal().prepare())
             .with_fixed(desc("It can be stylish"))
             .with_fixed(
                 Divider::horizontal()
@@ -65,6 +68,7 @@ impl DemoPage for DividerDemo {
                     .dash_pattern(&[1.px(), 10.px()])
                     .dash_fit(DashFit::Stretch)
                     .cap(Cap::Round)
+                    .prepare()
                     .with_props(ContentColor::new(palette::css::DARK_ORANGE)),
             )
             .with_fixed(desc(
@@ -89,8 +93,8 @@ impl DemoPage for DividerDemo {
             .with_fixed(divider_label("In the middle", Placement::Center))
             .with_fixed(divider_label("At the end", Placement::End))
             .with_fixed(desc("It even supports arbitrary content!"))
-            .with_fixed(Divider::horizontal().content(img).with_auto_id())
-            .with_auto_id();
+            .with_fixed(Divider::horizontal().content(img).prepare())
+            .prepare();
 
         let sidebar = Flex::column()
             .with_fixed(desc("🔍"))
@@ -98,7 +102,7 @@ impl DemoPage for DividerDemo {
             .with_fixed(desc("💾"))
             .with_fixed(desc("✂️"))
             .with_fixed(desc("🏷️"))
-            .with_auto_id();
+            .prepare();
 
         let body = Flex::row()
             .with_fixed(sidebar)
@@ -106,6 +110,7 @@ impl DemoPage for DividerDemo {
                 Divider::vertical()
                     .thickness(3.px())
                     .label("👉")
+                    .prepare()
                     .with_props(ContentColor::new(palette::css::DARK_SEA_GREEN)),
             )
             .with(main, 1.0);

--- a/masonry/examples/gallery/image.rs
+++ b/masonry/examples/gallery/image.rs
@@ -51,14 +51,10 @@ impl DemoPage for ImageDemo {
             .with_fixed(
                 Label::new("An `Image` widget (ObjectFit::Contain).")
                     .with_style(StyleProperty::FontSize(14.0))
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed_spacer(CONTENT_GAP)
-            .with_fixed(
-                SizedBox::new(image)
-                    .size(420.0.px(), 280.0.px())
-                    .with_auto_id(),
-            );
+            .with_fixed(SizedBox::new(image).size(420.0.px(), 280.0.px()).prepare());
 
         wrap_in_shell(self.shell, NewWidget::new(body).erased())
     }

--- a/masonry/examples/gallery/kitchen_sink.rs
+++ b/masonry/examples/gallery/kitchen_sink.rs
@@ -32,27 +32,15 @@ impl DemoPage for KitchenSinkDemo {
     fn build(&self) -> NewWidget<dyn Widget> {
         let header = Label::new("A few widgets composed together.")
             .with_style(StyleProperty::FontSize(14.0))
-            .with_auto_id();
+            .prepare();
 
         let grid = Grid::with_dimensions(2, 2)
-            .with(
-                Label::new("Grid 0").with_auto_id(),
-                GridParams::new(0, 0, 1, 1),
-            )
-            .with(
-                Label::new("Grid 1").with_auto_id(),
-                GridParams::new(1, 0, 1, 1),
-            )
-            .with(
-                Label::new("Grid 2").with_auto_id(),
-                GridParams::new(0, 1, 1, 1),
-            )
-            .with(
-                Label::new("Grid 3").with_auto_id(),
-                GridParams::new(1, 1, 1, 1),
-            );
+            .with(Label::new("Grid 0").prepare(), GridParams::new(0, 0, 1, 1))
+            .with(Label::new("Grid 1").prepare(), GridParams::new(1, 0, 1, 1))
+            .with(Label::new("Grid 2").prepare(), GridParams::new(0, 1, 1, 1))
+            .with(Label::new("Grid 3").prepare(), GridParams::new(1, 1, 1, 1));
 
-        let grid = NewWidget::new(SizedBox::new(grid.with_auto_id())).with_props(
+        let grid = NewWidget::new(SizedBox::new(grid.prepare())).with_props(
             PropertySet::new()
                 .with(Background::Color(Color::from_rgb8(0x24, 0x24, 0x24)))
                 .with(Padding::all(12.0)),
@@ -65,14 +53,14 @@ impl DemoPage for KitchenSinkDemo {
         let fg = Align::centered(
             Label::new("ZStack overlay")
                 .with_style(StyleProperty::FontSize(14.0))
-                .with_auto_id(),
+                .prepare(),
         )
-        .with_auto_id();
+        .prepare();
 
         let stack = ZStack::new()
             .with(bg, ChildAlignment::ParentAligned)
             .with(fg, ChildAlignment::SelfAligned(UnitPoint::CENTER))
-            .with_auto_id();
+            .prepare();
 
         let body = Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Stretch)

--- a/masonry/examples/gallery/main.rs
+++ b/masonry/examples/gallery/main.rs
@@ -337,15 +337,15 @@ fn main() {
 
     // Padding so the first item isn't flush with the window, and a right inset so an overlay
     // scrollbar doesn't sit on top of the buttons.
-    let list = NewWidget::new(SizedBox::new(list.with_auto_id())).with_props(Padding {
+    let list = NewWidget::new(SizedBox::new(list.prepare())).with_props(Padding {
         top: LEFT_PANE_TOP_PADDING,
         bottom: 0.0,
         left: LEFT_PANE_LEFT_PADDING,
         right: SIDEBAR_SCROLLBAR_INSET,
     });
 
-    let sidebar = SizedBox::new(Portal::new(list).constrain_horizontal(true).with_auto_id())
-        .width(SIDEBAR_WIDTH);
+    let sidebar =
+        SizedBox::new(Portal::new(list).constrain_horizontal(true).prepare()).width(SIDEBAR_WIDTH);
 
     let stack = demos
         .iter()
@@ -366,12 +366,12 @@ fn main() {
         )
         .with(NewWidget::new(stack).with_tag(stack_tag), 1.0);
 
-    let right_panel = NewWidget::new(SizedBox::new(right_panel.with_auto_id()))
+    let right_panel = NewWidget::new(SizedBox::new(right_panel.prepare()))
         .with_props(Padding::all(RIGHT_PANE_PADDING));
 
     let root = Flex::row()
         .cross_axis_alignment(CrossAxisAlignment::Stretch)
-        .with_fixed(sidebar.with_auto_id())
+        .with_fixed(sidebar.prepare())
         .with(right_panel, 1.0);
 
     let driver = Driver {

--- a/masonry/examples/gallery/pagination.rs
+++ b/masonry/examples/gallery/pagination.rs
@@ -138,52 +138,52 @@ impl DemoPage for PaginationDemo {
         let body = Flex::column()
             .with_fixed(
                 Flex::row()
-                    .with(Label::new("Total pages").with_auto_id(), 1.)
+                    .with(Label::new("Total pages").prepare(), 1.)
                     .with(
                         NewWidget::new(StepInput::new(20, 1, 0, 1000))
                             .with_tag(self.tag_page_count),
                         1.,
                     )
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed(
                 Flex::row()
-                    .with(Label::new("Active page").with_auto_id(), 1.)
+                    .with(Label::new("Active page").prepare(), 1.)
                     .with(
                         NewWidget::new(StepInput::new(1, 1, 1, 1000))
                             .with_tag(self.tag_page_active),
                         1.,
                     )
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed(
                 Flex::row()
-                    .with(Label::new("Buttons start").with_auto_id(), 1.)
+                    .with(Label::new("Buttons start").prepare(), 1.)
                     .with(
                         NewWidget::new(StepInput::new(1, 1, 0, 255))
                             .with_tag(self.tag_buttons_start),
                         1.,
                     )
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed(
                 Flex::row()
-                    .with(Label::new("Buttons end").with_auto_id(), 1.)
+                    .with(Label::new("Buttons end").prepare(), 1.)
                     .with(
                         NewWidget::new(StepInput::new(1, 1, 0, 255)).with_tag(self.tag_buttons_end),
                         1.,
                     )
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed(
                 Flex::row()
-                    .with(Label::new("Buttons total").with_auto_id(), 1.)
+                    .with(Label::new("Buttons total").prepare(), 1.)
                     .with(
                         NewWidget::new(StepInput::new(9, 1, 0, 255))
                             .with_tag(self.tag_buttons_total),
                         1.,
                     )
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed(NewWidget::new(Label::new("Some data here ..")).with_tag(self.tag_content))
             .with_fixed(NewWidget::new(Pagination::new(20)).with_tag(self.tag_pagination));

--- a/masonry/examples/gallery/spinner.rs
+++ b/masonry/examples/gallery/spinner.rs
@@ -31,9 +31,9 @@ impl DemoPage for SpinnerDemo {
         let body = Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Center)
             .with_fixed(
-                SizedBox::new(Spinner::new().with_auto_id())
+                SizedBox::new(Spinner::new().prepare())
                     .size(80.0.px(), 80.0.px())
-                    .with_auto_id(),
+                    .prepare(),
             );
 
         wrap_in_shell(self.shell, NewWidget::new(body).erased())

--- a/masonry/examples/gallery/split.rs
+++ b/masonry/examples/gallery/split.rs
@@ -32,7 +32,7 @@ impl DemoPage for SplitDemo {
         let left = NewWidget::new(SizedBox::new(
             Label::new("Left pane (drag the divider)")
                 .with_style(StyleProperty::FontSize(14.0))
-                .with_auto_id(),
+                .prepare(),
         ))
         .with_props(
             PropertySet::new()
@@ -43,7 +43,7 @@ impl DemoPage for SplitDemo {
         let right = NewWidget::new(SizedBox::new(
             Label::new("Right pane")
                 .with_style(StyleProperty::FontSize(14.0))
-                .with_auto_id(),
+                .prepare(),
         ))
         .with_props(
             PropertySet::new()
@@ -51,7 +51,7 @@ impl DemoPage for SplitDemo {
                 .with(Padding::all(12.0)),
         );
 
-        let body = SizedBox::new(Split::new(left, right).split_fraction(0.33).with_auto_id())
+        let body = SizedBox::new(Split::new(left, right).split_fraction(0.33).prepare())
             .height(260.0.px());
 
         wrap_in_shell(self.shell, NewWidget::new(body).erased())

--- a/masonry/examples/gallery/step_input.rs
+++ b/masonry/examples/gallery/step_input.rs
@@ -49,6 +49,7 @@ impl StepInputDemo {
 fn desc(text: &str) -> NewWidget<Label> {
     Label::new(text)
         .with_style(StyleProperty::FontSize(14.0))
+        .prepare()
         .with_props(Dimensions::width(250.px()))
 }
 
@@ -170,16 +171,18 @@ impl DemoPage for StepInputDemo {
                             .with_props(StepInputStyle::Flow),
                         3.,
                     )
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed(
                 Flex::row()
                     .with_fixed(desc("Step size 100"))
                     .with(
-                        StepInput::new(0, 100, i16::MIN, i16::MAX).with_props(StepInputStyle::Flow),
+                        StepInput::new(0, 100, i16::MIN, i16::MAX)
+                            .prepare()
+                            .with_props(StepInputStyle::Flow),
                         1.,
                     )
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed(
                 Flex::row()
@@ -187,19 +190,22 @@ impl DemoPage for StepInputDemo {
                     .with(
                         StepInput::new(50., 0.01, 0., 100.)
                             .with_snap(2.)
+                            .prepare()
                             .with_props(StepInputStyle::Flow),
                         1.,
                     )
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed(
                 Flex::row()
                     .with_fixed(desc("Hold Shift for 10x, Alt for 0.1x speed"))
                     .with(
-                        StepInput::new(0, 1, i32::MIN, i32::MAX).with_props(StepInputStyle::Flow),
+                        StepInput::new(0, 1, i32::MIN, i32::MAX)
+                            .prepare()
+                            .with_props(StepInputStyle::Flow),
                         1.,
                     )
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed(
                 Flex::row()
@@ -207,10 +213,11 @@ impl DemoPage for StepInputDemo {
                     .with(
                         StepInput::new(0, 1, u8::MIN, u8::MAX)
                             .with_wrap(true)
+                            .prepare()
                             .with_props(StepInputStyle::Flow),
                         1.,
                     )
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed(
                 Flex::row()
@@ -228,10 +235,11 @@ impl DemoPage for StepInputDemo {
                                     format!("{}", ctx.value)
                                 }
                             })
+                            .prepare()
                             .with_props(StepInputStyle::Flow),
                         1.,
                     )
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed(
                 Flex::row()
@@ -243,7 +251,7 @@ impl DemoPage for StepInputDemo {
                             .with_class("custom"),
                         1.,
                     )
-                    .with_auto_id(),
+                    .prepare(),
             );
 
         wrap_in_shell(self.shell, NewWidget::new(main).erased())

--- a/masonry/examples/gallery/svg.rs
+++ b/masonry/examples/gallery/svg.rs
@@ -36,14 +36,14 @@ impl DemoPage for SvgDemo {
     }
 
     fn build(&self) -> NewWidget<dyn Widget> {
-        let svg = Svg::new(tiger()).with_auto_id();
+        let svg = Svg::new(tiger()).prepare();
 
         let body = Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Stretch)
             .with_fixed(
                 Label::new("SVG widget")
                     .with_style(StyleProperty::FontSize(14.0))
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed_spacer(CONTENT_GAP)
             .with(svg, 1.0);

--- a/masonry/examples/gallery/text_input.rs
+++ b/masonry/examples/gallery/text_input.rs
@@ -33,17 +33,17 @@ impl DemoPage for TextInputDemo {
             .with_fixed(
                 Label::new("Type in the text box:")
                     .with_style(StyleProperty::FontSize(14.0))
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed_spacer(Length::const_px(8.0))
             .with_fixed(
                 SizedBox::new(
                     TextInput::new("")
                         .with_placeholder("Hello from Masonry…")
-                        .with_auto_id(),
+                        .prepare(),
                 )
                 .height(Length::const_px(40.0))
-                .with_auto_id(),
+                .prepare(),
             );
 
         wrap_in_shell(self.shell, NewWidget::new(body).erased())

--- a/masonry/examples/gallery/tooltip.rs
+++ b/masonry/examples/gallery/tooltip.rs
@@ -41,7 +41,7 @@ impl DemoPage for TooltipDemo {
             .with_fixed(
                 Label::new("Click the button to create a tooltip layer.")
                     .with_style(StyleProperty::FontSize(14.0))
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed_spacer(CONTENT_GAP)
             .with_fixed(show);
@@ -58,7 +58,7 @@ impl DemoPage for TooltipDemo {
         let tooltip = NewWidget::new(Tooltip::new(
             Label::new("Hello from a tooltip layer!")
                 .with_style(StyleProperty::FontSize(14.0))
-                .with_auto_id(),
+                .prepare(),
         ));
         render_root.add_layer(tooltip.erased(), Point::new(320.0, 120.0));
         true

--- a/masonry/examples/gallery/transforms.rs
+++ b/masonry/examples/gallery/transforms.rs
@@ -104,7 +104,7 @@ impl DemoPage for TransformsDemo {
             SizedBox::new(
                 Label::new("Transform me\nand\nsee what happens")
                     .with_style(StyleProperty::FontSize(14.0))
-                    .with_auto_id(),
+                    .prepare(),
             )
             .size(160.0.px(), 160.0.px()),
         )
@@ -119,7 +119,7 @@ impl DemoPage for TransformsDemo {
             .cross_axis_alignment(CrossAxisAlignment::Stretch)
             .with_fixed(state)
             .with_fixed_spacer(CONTENT_GAP)
-            .with_fixed(controls.with_auto_id())
+            .with_fixed(controls.prepare())
             .with_fixed_spacer(CONTENT_GAP)
             .with_fixed(target);
 

--- a/masonry/examples/grid_masonry.rs
+++ b/masonry/examples/grid_masonry.rs
@@ -63,9 +63,9 @@ pub fn make_grid(grid_gap: f64) -> NewWidget<Grid> {
         TextArea::new_immutable("Change spacing by right and left clicking on the buttons")
             .with_style(StyleProperty::FontSize(14.0))
             .with_text_alignment(TextAlign::Center)
-            .with_auto_id(),
+            .prepare(),
     );
-    let label = SizedBox::new(label.with_auto_id());
+    let label = SizedBox::new(label.prepare());
 
     let props = PropertySet::new()
         .with(BorderColor::new(Color::from_rgb8(40, 40, 80)))
@@ -119,10 +119,10 @@ pub fn make_grid(grid_gap: f64) -> NewWidget<Grid> {
 
     // Arrange widgets in a 4 by 4 grid.
     let mut main_widget =
-        Grid::with_dimensions(4, 4).with(label.with_auto_id(), GridParams::new(1, 0, 1, 1));
+        Grid::with_dimensions(4, 4).with(label.prepare(), GridParams::new(1, 0, 1, 1));
     for button_input in button_inputs {
         let button = grid_button(button_input);
-        main_widget = main_widget.with(button.with_auto_id(), button_input);
+        main_widget = main_widget.with(button.prepare(), button_input);
     }
 
     NewWidget::new(main_widget).with_props(PropertySet::one(Gap::new(Length::px(grid_gap))))

--- a/masonry/examples/hello_masonry.rs
+++ b/masonry/examples/hello_masonry.rs
@@ -50,9 +50,9 @@ fn main() {
 
     // Arrange the two widgets vertically, with some padding
     let main_widget = Flex::column()
-        .with_fixed(label.with_auto_id())
+        .with_fixed(label.prepare())
         .with_fixed_spacer(VERTICAL_WIDGET_SPACING)
-        .with_fixed(button.with_auto_id());
+        .with_fixed(button.prepare());
 
     let window_size = LogicalSize::new(400.0, 400.0);
     let window_attributes = Window::default_attributes()

--- a/masonry/examples/layers.rs
+++ b/masonry/examples/layers.rs
@@ -186,16 +186,16 @@ fn main() {
         (tooltip, LayerType::Tooltip("Tooltip!!!".to_string()))
     };
 
-    let overlay_box = OverlayBox::new(label.with_auto_id(), Box::new(overlayer));
+    let overlay_box = OverlayBox::new(label.prepare(), Box::new(overlayer));
 
     let selector = Selector::new(vec!["A".to_string(), "B".to_string(), "C".to_string()]);
 
     // Arrange the two widgets vertically, with some padding
     let main_widget = Flex::column()
         .with_spacer(1.)
-        .with_fixed(overlay_box.with_auto_id())
+        .with_fixed(overlay_box.prepare())
         .with_fixed_spacer(80.px())
-        .with_fixed(selector.with_auto_id())
+        .with_fixed(selector.prepare())
         .with_spacer(1.);
 
     let driver = Driver {};
@@ -203,7 +203,7 @@ fn main() {
     masonry_winit::app::run(
         vec![NewWindow::new(
             Window::default_attributes().with_title("Hello Layers!"),
-            main_widget.with_auto_id().erased(),
+            main_widget.prepare().erased(),
         )],
         driver,
         default_property_set(),

--- a/masonry/examples/split_playground.rs
+++ b/masonry/examples/split_playground.rs
@@ -109,17 +109,17 @@ fn make_widget_tree() -> NewWidget<impl masonry::core::Widget> {
         .with_fixed(
             Label::new("Left pane")
                 .with_style(masonry::core::StyleProperty::FontSize(18.0))
-                .with_auto_id(),
+                .prepare(),
         )
-        .with_fixed(Label::new("Drag / keyboard-resize the divider.").with_auto_id());
+        .with_fixed(Label::new("Drag / keyboard-resize the divider.").prepare());
 
     let right = Flex::column()
         .with_fixed(
             Label::new("Right pane")
                 .with_style(masonry::core::StyleProperty::FontSize(18.0))
-                .with_auto_id(),
+                .prepare(),
         )
-        .with_fixed(Label::new("Try switching split-point modes.").with_auto_id());
+        .with_fixed(Label::new("Try switching split-point modes.").prepare());
 
     let split = NewWidget::new(
         Split::new(NewWidget::new(left), NewWidget::new(right))
@@ -130,7 +130,7 @@ fn make_widget_tree() -> NewWidget<impl masonry::core::Widget> {
 
     NewWidget::new(
         Flex::column()
-            .with_fixed(controls.with_auto_id())
+            .with_fixed(controls.prepare())
             .with_fixed_spacer(SPACING)
             .with_fixed(status)
             .with_fixed_spacer(SPACING)

--- a/masonry/examples/to_do_list.rs
+++ b/masonry/examples/to_do_list.rs
@@ -45,7 +45,7 @@ impl AppDriver for Driver {
                 TextArea::reset_text(&mut text_area, "");
             });
             render_root.edit_widget_with_tag(LIST_TAG, |mut list| {
-                let child = Label::new(self.next_task.clone()).with_auto_id();
+                let child = Label::new(self.next_task.clone()).prepare();
                 Flex::add_fixed(&mut list, child);
             });
         } else if action.is::<TextAction>() {
@@ -72,7 +72,7 @@ pub fn make_widget_tree() -> NewWidget<impl Widget> {
         NewWidget::new(Flex::column().cross_axis_alignment(CrossAxisAlignment::Start))
             .with_tag(LIST_TAG),
     )
-    .with_auto_id();
+    .prepare();
 
     let root = Flex::column()
         .with_fixed(

--- a/masonry/src/doc/color_rectangle.rs
+++ b/masonry/src/doc/color_rectangle.rs
@@ -264,7 +264,9 @@ mod tests {
 
     #[test]
     fn simple_rect() {
-        let widget = ColorRectangle::new(BLUE).with_props(Dimensions::fixed(20.px(), 20.px()));
+        let widget = ColorRectangle::new(BLUE)
+            .prepare()
+            .with_props(Dimensions::fixed(20.px(), 20.px()));
 
         let mut harness = TestHarness::create(default_property_set(), widget);
 
@@ -279,7 +281,9 @@ mod tests {
 
     #[test]
     fn hovered() {
-        let widget = ColorRectangle::new(BLUE).with_props(Dimensions::fixed(20.px(), 20.px()));
+        let widget = ColorRectangle::new(BLUE)
+            .prepare()
+            .with_props(Dimensions::fixed(20.px(), 20.px()));
 
         let mut harness = TestHarness::create(default_property_set(), widget);
         let rect_id = harness.root_id();
@@ -295,7 +299,9 @@ mod tests {
     #[test]
     fn edit_rect() {
         const RED: Color = Color::from_rgb8(u8::MAX, 0, 0);
-        let widget = ColorRectangle::new(BLUE).with_props(Dimensions::fixed(20.px(), 20.px()));
+        let widget = ColorRectangle::new(BLUE)
+            .prepare()
+            .with_props(Dimensions::fixed(20.px(), 20.px()));
 
         let mut harness = TestHarness::create(default_property_set(), widget);
 
@@ -311,7 +317,9 @@ mod tests {
 
     #[test]
     fn on_click() {
-        let widget = ColorRectangle::new(BLUE).with_props(Dimensions::fixed(20.px(), 20.px()));
+        let widget = ColorRectangle::new(BLUE)
+            .prepare()
+            .with_props(Dimensions::fixed(20.px(), 20.px()));
 
         let mut harness = TestHarness::create(default_property_set(), widget);
         let rect_id = harness.root_id();

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -77,7 +77,7 @@
 //!                 TextArea::reset_text(&mut text_area, "");
 //!             });
 //!             render_root.edit_widget_with_tag(LIST_TAG, |mut list| {
-//!                 let child = Label::new(self.next_task.clone()).with_auto_id();
+//!                 let child = Label::new(self.next_task.clone()).prepare();
 //!                 Flex::add_fixed(&mut list, child);
 //!             });
 //!         } else if action.is::<TextAction>() {

--- a/masonry/src/tests/action.rs
+++ b/masonry/src/tests/action.rs
@@ -32,6 +32,7 @@ fn action_source_removed() {
             ctx.submit_untyped_action(Box::new(ArbitraryAction));
             ok.store(true, Ordering::Release);
         })
+        .prepare()
         .with_props(Dimensions::fixed(50.px(), 50.px()))
         .to_pod();
     let action_source_id = action_source.id();
@@ -76,7 +77,7 @@ fn action_source_removed() {
             }
             ids
         })
-        .with_auto_id();
+        .prepare();
 
     let mut harness = TestHarness::create(test_property_set(), parent);
 
@@ -94,7 +95,7 @@ fn action_propagation() {
     #[derive(Debug)]
     struct TranslatedAction;
 
-    let button = Button::with_text("Click me!").with_auto_id();
+    let button = Button::with_text("Click me!").prepare();
     let button_id = button.id();
 
     let parent1 = ModularWidget::new_parent(button)
@@ -103,7 +104,7 @@ fn action_propagation() {
             assert_eq!(source, button_id, "unexpected action source");
             assert!(action.is::<ButtonPress>(), "unexpected action type");
         })
-        .with_auto_id();
+        .prepare();
 
     let parent2 = ModularWidget::new_parent(parent1)
         .action_fn(move |_, ctx, _, action, source| {
@@ -115,7 +116,7 @@ fn action_propagation() {
             // Translate it into our own action
             ctx.submit_untyped_action(Box::new(TranslatedAction));
         })
-        .with_auto_id();
+        .prepare();
     let parent2_id = parent2.id();
 
     let parent3 = ModularWidget::new_parent(parent2)
@@ -124,7 +125,7 @@ fn action_propagation() {
             assert_eq!(source, parent2_id, "unexpected action source");
             assert!(action.is::<TranslatedAction>(), "unexpected action type");
         })
-        .with_auto_id();
+        .prepare();
 
     let mut harness = TestHarness::create(test_property_set(), parent3);
 

--- a/masonry/src/tests/compose.rs
+++ b/masonry/src/tests/compose.rs
@@ -89,7 +89,7 @@ fn scroll_pixel_snap() {
 
             ctx.set_child_scroll_translation(state, offset);
         })
-        .with_auto_id();
+        .prepare();
 
     let harness = TestHarness::create(test_property_set(), parent);
 

--- a/masonry/src/tests/event.rs
+++ b/masonry/src/tests/event.rs
@@ -137,7 +137,7 @@ fn pointer_capture_suppresses_neighbors() {
     let parent = Flex::column()
         .with_fixed(target)
         .with_fixed(other)
-        .with_auto_id();
+        .prepare();
 
     let mut harness = TestHarness::create(test_property_set(), parent);
     harness.flush_records_of(other_tag);
@@ -171,7 +171,7 @@ fn try_capture_pointer_on_pointer_move() {
         .pointer_event_fn(|_, ctx, _, _event| {
             ctx.capture_pointer();
         })
-        .with_auto_id();
+        .prepare();
 
     let mut harness = TestHarness::create(test_property_set(), widget);
 
@@ -188,7 +188,7 @@ fn try_capture_pointer_on_text_event() {
         .text_event_fn(|_, ctx, _, _event| {
             ctx.capture_pointer();
         })
-        .with_auto_id();
+        .prepare();
 
     let mut harness = TestHarness::create(test_property_set(), widget);
     let id = harness.root_id();
@@ -237,7 +237,7 @@ fn click_anchors_focus() {
         .with_fixed(NewWidget::new(Button::with_text("Click me!")).with_tag(child_3))
         .with_fixed(NewWidget::new(Button::with_text("")).with_tag(child_4))
         .with_fixed(NewWidget::new(Button::with_text("")))
-        .with_auto_id();
+        .prepare();
 
     let mut harness = TestHarness::create(test_property_set(), parent);
 
@@ -532,10 +532,7 @@ fn text_event_fallback() {
 
     let target = NewWidget::new(TextArea::new_editable("").record()).with_tag(target_tag);
     let other = NewWidget::new(TextArea::new_editable("")).with_tag(other_tag);
-    let parent = Flex::row()
-        .with_fixed(target)
-        .with_fixed(other)
-        .with_auto_id();
+    let parent = Flex::row().with_fixed(target).with_fixed(other).prepare();
 
     let mut harness = TestHarness::create(test_property_set(), parent);
     let target_id = harness.get_widget(target_tag).id();
@@ -573,7 +570,7 @@ fn tab_focus() {
         .with_fixed(NewWidget::new(Button::with_text("")).with_tag(child_3))
         .with_fixed(NewWidget::new(Button::with_text("")).with_tag(child_4))
         .with_fixed(NewWidget::new(Button::with_text("")).with_tag(child_5))
-        .with_auto_id();
+        .prepare();
 
     let mut harness = TestHarness::create(test_property_set(), parent);
 
@@ -655,7 +652,7 @@ fn accessibility_focus() {
         .with_fixed(NewWidget::new(Button::with_text("")).with_tag(child_2))
         .with_fixed(NewWidget::new(Button::with_text("")).with_tag(child_3))
         .with_fixed(NewWidget::new(Button::with_text("")))
-        .with_auto_id();
+        .prepare();
 
     let mut harness = TestHarness::create(test_property_set(), parent);
     let child_2_id = harness.get_widget(child_2).id();

--- a/masonry/src/tests/layout.rs
+++ b/masonry/src/tests/layout.rs
@@ -31,10 +31,10 @@ fn layout_simple() {
                         .with_tag(tag_2),
                 )
                 .with_spacer(1.0)
-                .with_auto_id(),
+                .prepare(),
         )
         .with_spacer(1.0)
-        .with_auto_id();
+        .prepare();
 
     let harness = TestHarness::create(test_property_set(), widget);
 
@@ -52,12 +52,12 @@ fn layout_simple() {
 
 #[test]
 fn forget_to_recurse_layout() {
-    let widget = ModularWidget::new_parent(Flex::row().with_auto_id())
+    let widget = ModularWidget::new_parent(Flex::row().prepare())
         .measure_fn(|_, _, _, _, _, _| 0.)
         .layout_fn(|_child, _ctx, _, _| {
             // We forget to call ctx.run_layout();
         })
-        .with_auto_id();
+        .prepare();
 
     assert_debug_panics!(
         TestHarness::create(test_property_set(), widget),
@@ -67,12 +67,12 @@ fn forget_to_recurse_layout() {
 
 #[test]
 fn forget_to_call_place_child() {
-    let widget = ModularWidget::new_parent(Flex::row().with_auto_id())
+    let widget = ModularWidget::new_parent(Flex::row().prepare())
         .layout_fn(|child, ctx, _, size| {
             // We call ctx.run_layout(), but forget place_child
             ctx.run_layout(child, size);
         })
-        .with_auto_id();
+        .prepare();
 
     assert_debug_panics!(
         TestHarness::create(test_property_set(), widget),
@@ -82,13 +82,13 @@ fn forget_to_call_place_child() {
 
 #[test]
 fn call_place_child_before_layout() {
-    let widget = ModularWidget::new_parent(Flex::row().with_auto_id())
+    let widget = ModularWidget::new_parent(Flex::row().prepare())
         .measure_fn(|_, _, _, _, _, _| 0.)
         .layout_fn(|child, ctx, _, _| {
             // We call ctx.place_child(), but forget run_layout
             ctx.place_child(child, Point::ORIGIN);
         })
-        .with_auto_id();
+        .prepare();
 
     assert_debug_panics!(
         TestHarness::create(test_property_set(), widget),
@@ -100,7 +100,7 @@ fn call_place_child_before_layout() {
 fn run_layout_on_stashed() {
     let parent_tag = WidgetTag::named("parent");
     let widget =
-        ModularWidget::new_parent(Flex::row().with_auto_id()).layout_fn(|child, ctx, _, size| {
+        ModularWidget::new_parent(Flex::row().prepare()).layout_fn(|child, ctx, _, size| {
             ctx.run_layout(child, size);
             ctx.place_child(child, Point::ZERO);
         });
@@ -121,7 +121,7 @@ fn run_layout_on_stashed() {
 fn stash_then_run_layout() {
     let parent_tag = WidgetTag::named("parent");
     let widget =
-        ModularWidget::new_parent(Flex::row().with_auto_id()).layout_fn(|child, ctx, _, size| {
+        ModularWidget::new_parent(Flex::row().prepare()).layout_fn(|child, ctx, _, size| {
             // We check that stashing a widget is effective "immediately"
             // and triggers an error.
             ctx.set_stashed(child, true);
@@ -140,7 +140,7 @@ fn stash_then_run_layout() {
 fn unstash_then_run_layout() {
     let parent_tag = WidgetTag::named("parent");
     let widget =
-        ModularWidget::new_parent(Flex::row().with_auto_id()).layout_fn(|child, ctx, _, size| {
+        ModularWidget::new_parent(Flex::row().prepare()).layout_fn(|child, ctx, _, size| {
             // We check that unstashing a widget is effective "immediately"
             // and avoids an error.
             ctx.set_stashed(child, false);
@@ -240,7 +240,7 @@ fn layout_insets() {
     ))
     .with_tag(parent_tag);
 
-    let root_widget = Portal::new(parent_widget).with_auto_id();
+    let root_widget = Portal::new(parent_widget).prepare();
 
     let harness = TestHarness::create(test_property_set(), root_widget);
 

--- a/masonry/src/tests/paint.rs
+++ b/masonry/src/tests/paint.rs
@@ -164,7 +164,7 @@ fn paint_transparency() {
     ) -> NewWidget<Align> {
         let bg_color = bg_color.into();
 
-        let label = Label::new(text).with_props((
+        let label = Label::new(text).prepare().with_props((
             Background::Color(Color::TRANSPARENT),
             Dimensions::fixed(20.px(), 20.px()),
         ));
@@ -174,7 +174,7 @@ fn paint_transparency() {
             props = props.with(Background::Color(bg_color));
         }
 
-        Align::new(align, label).with_props(props)
+        Align::new(align, label).prepare().with_props(props)
     }
 
     let align_a = UnitPoint::TOP_LEFT;
@@ -213,18 +213,15 @@ fn paint_transparency() {
     );
 
     let props = (Padding::all(20.), Gap::new(10.px()));
-    let grid_a = grid_a.with_props(props);
-    let grid_b = grid_b.with_props(props);
+    let grid_a = grid_a.prepare().with_props(props);
+    let grid_b = grid_b.prepare().with_props(props);
 
     let mut root = ZStack::new();
     root = root.with(grid_a, ChildAlignment::ParentAligned);
     root = root.with(grid_b, ChildAlignment::ParentAligned);
 
-    let mut harness = TestHarness::create_with_size(
-        test_property_set(),
-        root.with_auto_id(),
-        Size::new(350., 80.),
-    );
+    let mut harness =
+        TestHarness::create_with_size(test_property_set(), root.prepare(), Size::new(350., 80.));
 
     assert_render_snapshot!(harness, "paint_transparency");
 }

--- a/masonry/src/tests/transforms.rs
+++ b/masonry/src/tests/transforms.rs
@@ -24,7 +24,7 @@ fn blue_box(inner: impl Widget) -> impl Widget {
     box_props.insert(BorderWidth::all(2.0));
 
     WrapperWidget::new(
-        SizedBox::new(inner.with_auto_id())
+        SizedBox::new(inner.prepare())
             .width(200.px())
             .height(100.px())
             .with_props(box_props),
@@ -46,7 +46,7 @@ fn transforms_translation_rotation() {
     );
     let widget = ZStack::new()
         .with_fixed(transformed_widget, ChildAlignment::ParentAligned)
-        .with_auto_id();
+        .prepare();
 
     let mut harness = TestHarness::create(default_property_set(), widget);
     assert_render_snapshot!(harness, "transforms_translation_rotation");
@@ -55,7 +55,7 @@ fn transforms_translation_rotation() {
 #[test]
 fn transforms_pointer_events() {
     let transformed_widget = NewWidget::new(blue_box(ZStack::new().with_fixed(
-        Button::with_text("Should be pressed").with_auto_id(),
+        Button::with_text("Should be pressed").prepare(),
         UnitPoint::BOTTOM_RIGHT,
     )))
     .with_options(WidgetOptions {
@@ -64,7 +64,7 @@ fn transforms_pointer_events() {
     });
     let widget = ZStack::new()
         .with_fixed(transformed_widget, ChildAlignment::ParentAligned)
-        .with_auto_id();
+        .prepare();
 
     let mut harness = TestHarness::create(default_property_set(), widget);
     harness.mouse_move((335.0, 350.0)); // Should hit the last "d" of the button text

--- a/masonry/src/tests/update.rs
+++ b/masonry/src/tests/update.rs
@@ -67,11 +67,11 @@ fn new_widget() {
 
 #[test]
 fn forget_register_child() {
-    let widget = ModularWidget::new_parent(Flex::row().with_auto_id())
+    let widget = ModularWidget::new_parent(Flex::row().prepare())
         .register_children_fn(|_child, _ctx| {
             // We forget to call ctx.register_child();
         })
-        .with_auto_id();
+        .prepare();
 
     assert_debug_panics!(
         TestHarness::create(test_property_set(), widget),
@@ -81,12 +81,12 @@ fn forget_register_child() {
 
 #[test]
 fn register_invalid_child() {
-    let widget = ModularWidget::new_parent(Flex::row().with_auto_id())
+    let widget = ModularWidget::new_parent(Flex::row().prepare())
         .register_children_fn(|child, ctx| {
             ctx.register_child(child);
             ctx.register_child(&mut WidgetPod::new(Flex::row()));
         })
-        .with_auto_id();
+        .prepare();
 
     assert_debug_panics!(
         TestHarness::create(test_property_set(), widget),

--- a/masonry/src/widgets/align.rs
+++ b/masonry/src/widgets/align.rs
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn centered() {
-        let widget = Align::centered(Label::new("hello").with_auto_id()).with_auto_id();
+        let widget = Align::centered(Label::new("hello").prepare()).prepare();
 
         let mut harness = TestHarness::create(test_property_set(), widget);
 
@@ -230,7 +230,7 @@ mod tests {
 
     #[test]
     fn right() {
-        let widget = Align::right(Label::new("hello").with_auto_id()).with_auto_id();
+        let widget = Align::right(Label::new("hello").prepare()).prepare();
 
         let mut harness = TestHarness::create(test_property_set(), widget);
 
@@ -239,7 +239,7 @@ mod tests {
 
     #[test]
     fn left() {
-        let widget = Align::left(Label::new("hello").with_auto_id()).with_auto_id();
+        let widget = Align::left(Label::new("hello").prepare()).prepare();
 
         let mut harness = TestHarness::create(test_property_set(), widget);
 
@@ -250,7 +250,7 @@ mod tests {
     fn oversized() {
         let align_tag = WidgetTag::unique();
 
-        let child = SizedBox::empty().with_props((
+        let child = SizedBox::empty().prepare().with_props((
             Dimensions::fixed(100.px(), 100.px()),
             Background::Color(AlphaColor::from_rgba8(127, 0, 0, 127)),
         ));
@@ -261,7 +261,7 @@ mod tests {
                 BorderWidth::all(2.),
                 BorderColor::new(palette::css::BLACK),
             ));
-        let root = Align::centered(align).with_auto_id();
+        let root = Align::centered(align).prepare();
 
         let window_size = Size::new(200.0, 200.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), root, window_size);

--- a/masonry/src/widgets/badge.rs
+++ b/masonry/src/widgets/badge.rs
@@ -36,7 +36,7 @@ use crate::widgets::Label;
 /// use masonry::core::Widget;
 /// use masonry::widgets::{Badge, Label};
 ///
-/// let badge = Badge::new(Label::new("New").with_auto_id());
+/// let badge = Badge::new(Label::new("New").prepare());
 /// ```
 ///
 /// [`Background`]: crate::properties::Background
@@ -92,7 +92,7 @@ impl Badge {
         let label = Label::new(text)
             .with_style(StyleProperty::FontSize(12.0))
             .with_style(StyleProperty::FontWeight(FontWeight::BOLD))
-            .with_auto_id();
+            .prepare();
 
         Self::new(label)
     }
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn badge_is_non_interactive() {
-        let widget = Badge::new(Label::new("New").with_auto_id()).with_auto_id();
+        let widget = Badge::new(Label::new("New").prepare()).prepare();
         let window_size = Size::new(80.0, 40.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
         let badge_id = harness.root_id();
@@ -241,7 +241,7 @@ mod tests {
 
     #[test]
     fn badge_with_text() {
-        let widget = Badge::with_text("New").with_auto_id();
+        let widget = Badge::with_text("New").prepare();
         let mut params = TestHarnessParams::DEFAULT;
         params.window_size = Size::new(120.0, 60.0);
         params.root_padding = TestHarnessParams::ROOT_PADDING;
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn badge_count_overflow() {
-        let widget = Badge::count(120).with_auto_id();
+        let widget = Badge::count(120).prepare();
         let mut params = TestHarnessParams::DEFAULT;
         params.window_size = Size::new(120.0, 60.0);
         params.root_padding = TestHarnessParams::ROOT_PADDING;

--- a/masonry/src/widgets/badged.rs
+++ b/masonry/src/widgets/badged.rs
@@ -263,12 +263,12 @@ mod tests {
     fn badged_button() {
         let widget = Align::centered(
             Badged::new(
-                Button::with_text("Inbox").with_auto_id(),
-                Badge::with_text("3").with_auto_id(),
+                Button::with_text("Inbox").prepare(),
+                Badge::with_text("3").prepare(),
             )
-            .with_auto_id(),
+            .prepare(),
         )
-        .with_auto_id();
+        .prepare();
 
         let mut params = TestHarnessParams::DEFAULT;
         params.window_size = Size::new(240.0, 120.0);
@@ -281,9 +281,9 @@ mod tests {
     #[test]
     fn badged_button_optional_badge() {
         let widget = Align::centered(
-            Badged::new_optional(Button::with_text("Inbox").with_auto_id(), None).with_auto_id(),
+            Badged::new_optional(Button::with_text("Inbox").prepare(), None).prepare(),
         )
-        .with_auto_id();
+        .prepare();
 
         let mut params = TestHarnessParams::DEFAULT;
         params.window_size = Size::new(240.0, 120.0);

--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -48,7 +48,7 @@ impl Button {
     /// use masonry::widgets::{Button, Label};
     /// use masonry::core::Widget;
     ///
-    /// let button = Button::new(Label::new("Increment").with_auto_id());
+    /// let button = Button::new(Label::new("Increment").prepare());
     /// ```
     pub fn new(child: NewWidget<impl Widget + ?Sized>) -> Self {
         Self {
@@ -67,7 +67,7 @@ impl Button {
     /// let button = Button::with_text("Increment");
     /// ```
     pub fn with_text(text: impl Into<Arc<str>>) -> Self {
-        Self::new(Label::new(text).with_auto_id())
+        Self::new(Label::new(text).prepare())
     }
 }
 
@@ -393,19 +393,19 @@ mod tests {
 
         let grid = Grid::with_dimensions(2, 2)
             .with(
-                Button::with_text("A").with_auto_id(),
+                Button::with_text("A").prepare(),
                 GridParams::new(0, 0, 1, 1),
             )
             .with(
-                Button::with_text("B").with_auto_id(),
+                Button::with_text("B").prepare(),
                 GridParams::new(1, 0, 1, 1),
             )
             .with(
-                Button::with_text("C").with_auto_id(),
+                Button::with_text("C").prepare(),
                 GridParams::new(0, 1, 1, 1),
             )
             .with(
-                Button::with_text("D").with_auto_id(),
+                Button::with_text("D").prepare(),
                 GridParams::new(1, 1, 1, 1),
             );
         let root_widget = NewWidget::new(grid).with_props(
@@ -465,7 +465,7 @@ mod tests {
     /// We validate that each of these actually are correctly supported.
     fn validate_noninteractive_child<W: Widget>(child: NewWidget<W>) {
         let child_id = child.id();
-        let mut button = Button::new(child).with_auto_id();
+        let mut button = Button::new(child).prepare();
         button.properties.insert(Padding::all(10.));
         let button_id = button.id();
         let mut harness = TestHarness::create(test_property_set(), button);
@@ -494,24 +494,21 @@ mod tests {
 
     #[test]
     fn label_child() {
-        let child = Label::new("Some text").with_auto_id();
+        let child = Label::new("Some text").prepare();
         validate_noninteractive_child(child);
     }
 
     #[test]
     fn sized_box_child() {
-        let child = SizedBox::empty()
-            .width(50.px())
-            .height(50.px())
-            .with_auto_id();
+        let child = SizedBox::empty().width(50.px()).height(50.px()).prepare();
         validate_noninteractive_child(child);
     }
 
     #[test]
     fn flex_child() {
         let child = Flex::row()
-            .with_fixed(Label::new("Some text").with_auto_id())
-            .with_auto_id();
+            .with_fixed(Label::new("Some text").prepare())
+            .prepare();
         validate_noninteractive_child(child);
     }
     // We could imagine more involved tests, e.g. a button with an icon

--- a/masonry/src/widgets/canvas.rs
+++ b/masonry/src/widgets/canvas.rs
@@ -172,7 +172,7 @@ mod tests {
 
         let mut harness = TestHarness::create(
             DefaultProperties::default(),
-            canvas.with_props(PropertySet::default()),
+            canvas.prepare().with_props(PropertySet::default()),
         );
 
         harness.edit_root_widget(|mut canvas| {
@@ -204,7 +204,7 @@ mod tests {
         harness_params.window_size = Size::new(200., 200.);
         let mut harness = TestHarness::create_with(
             DefaultProperties::default(),
-            canvas.with_props(PropertySet::default()),
+            canvas.prepare().with_props(PropertySet::default()),
             harness_params,
         );
 

--- a/masonry/src/widgets/collapse_panel.rs
+++ b/masonry/src/widgets/collapse_panel.rs
@@ -66,6 +66,7 @@ impl CollapsePanel {
 
     fn disclosure_button(collapse: bool) -> WidgetPod<DisclosureButton> {
         DisclosureButton::new(!collapse)
+            .prepare()
             .with_props(
                 // TODO - Move to DefaultProperties
                 Dimensions::fixed(BUTTON_LENGTH, BUTTON_LENGTH),

--- a/masonry/src/widgets/divider.rs
+++ b/masonry/src/widgets/divider.rs
@@ -284,7 +284,7 @@ impl Divider {
     ///
     /// [`content`]: Self::content
     pub fn label(self, text: impl Into<ArcStr>) -> Self {
-        self.content(Label::new(text).with_auto_id())
+        self.content(Label::new(text).prepare())
     }
 
     /// Returns `self` with the given `pad`.
@@ -816,23 +816,29 @@ mod tests {
             .cross_axis_alignment(CrossAxisAlignment::Stretch)
             .with_fixed(
                 Flex::column()
-                    .with_fixed(Label::new("Above").with_auto_id())
-                    .with_fixed(Divider::horizontal().with_auto_id())
-                    .with_fixed(Label::new("Below").with_auto_id())
-                    .with_auto_id(),
+                    .with_fixed(Label::new("Above").prepare())
+                    .with_fixed(Divider::horizontal().prepare())
+                    .with_fixed(Label::new("Below").prepare())
+                    .prepare(),
             )
             .with_fixed(
                 Divider::vertical()
                     .thickness(5.px())
+                    .prepare()
                     .with_props(ContentColor::new(palette::css::DARK_SALMON)),
             )
             .with(
                 Flex::column()
-                    .with_fixed(Label::new("Another above").with_props(Dimensions::height(50.px())))
-                    .with_fixed(Divider::horizontal().with_auto_id())
-                    .with_auto_id(),
+                    .with_fixed(
+                        Label::new("Another above")
+                            .prepare()
+                            .with_props(Dimensions::height(50.px())),
+                    )
+                    .with_fixed(Divider::horizontal().prepare())
+                    .prepare(),
                 1.,
             )
+            .prepare()
             .with_props(Gap::ZERO);
 
         let mut harness =
@@ -851,12 +857,14 @@ mod tests {
                         .thickness(5.px())
                         .dash_pattern(&pattern(&[1, 10, 5, 20]))
                         .cap(Cap::Round)
+                        .prepare()
                         .with_props(ContentColor::new(palette::css::BLANCHED_ALMOND)),
                 )
                 .with_fixed(
                     Divider::horizontal()
                         .thickness(10.px())
                         .dash_pattern(&pattern(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+                        .prepare()
                         .with_props(ContentColor::new(palette::css::LAVENDER)),
                 )
                 .with_fixed(
@@ -865,12 +873,14 @@ mod tests {
                         .dash_pattern(&pattern(&[5, 20]))
                         .start_cap(Cap::Round)
                         .end_cap(Cap::Square)
+                        .prepare()
                         .with_props(ContentColor::new(palette::css::ORANGE)),
                 )
                 .with_fixed(
                     Divider::horizontal()
                         .hairline()
                         .dash_pattern(&pattern(&[5, 1]))
+                        .prepare()
                         .with_props(ContentColor::new(palette::css::CRIMSON)),
                 )
                 .with_fixed(
@@ -878,6 +888,7 @@ mod tests {
                         .thickness(3.px())
                         .dash_pattern(&pattern(&[1, 6, 1, 12]))
                         .cap(Cap::Round)
+                        .prepare()
                         .with_props(ContentColor::new(palette::css::GOLD)),
                 )
                 .with_fixed(
@@ -887,10 +898,12 @@ mod tests {
                         .dash_fit(DashFit::Stretch)
                         .pad(20.px())
                         .label("O")
+                        .prepare()
                         .with_props(ContentColor::new(palette::css::HOT_PINK)),
                 )
-                .with_auto_id(),
+                .prepare(),
         )
+        .prepare()
         .with_props(Padding::all(10.));
 
         let mut harness =
@@ -906,6 +919,7 @@ mod tests {
                 .thickness(5.px())
                 .dash_pattern(&pattern(&[20, 10, 10, 20]))
                 .dash_fit(fit)
+                .prepare()
                 .with_props(ContentColor::new(palette::css::MAGENTA))
         };
 
@@ -918,8 +932,10 @@ mod tests {
                 .with_fixed(divider_fit(DashFit::Start))
                 .with_fixed(divider_fit(DashFit::Center))
                 .with_fixed(divider_fit(DashFit::End))
+                .prepare()
                 .with_props(Background::Color(palette::css::MIDNIGHT_BLUE)),
         )
+        .prepare()
         .with_props(Padding::all(10.));
 
         let mut harness =
@@ -936,19 +952,19 @@ mod tests {
                 Divider::horizontal()
                     .label("Start")
                     .placement(Placement::Start)
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed(
                 Divider::horizontal()
                     .label("Center")
                     .placement(Placement::Center)
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_fixed(
                 Divider::horizontal()
                     .label("End")
                     .placement(Placement::End)
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with(
                 Flex::row()
@@ -958,24 +974,24 @@ mod tests {
                         Divider::vertical()
                             .label("Start")
                             .placement(Placement::Start)
-                            .with_auto_id(),
+                            .prepare(),
                     )
                     .with_fixed(
                         Divider::vertical()
                             .label("Center")
                             .placement(Placement::Center)
-                            .with_auto_id(),
+                            .prepare(),
                     )
                     .with_fixed(
                         Divider::vertical()
                             .label("End")
                             .placement(Placement::End)
-                            .with_auto_id(),
+                            .prepare(),
                     )
-                    .with_auto_id(),
+                    .prepare(),
                 1.,
             )
-            .with_auto_id();
+            .prepare();
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), root, Size::new(200., 200.));
@@ -985,9 +1001,12 @@ mod tests {
 
     #[test]
     fn content() {
-        let content = Spinner::new().with_props(Dimensions::fixed(30.px(), 30.px()));
+        let content = Spinner::new()
+            .prepare()
+            .with_props(Dimensions::fixed(30.px(), 30.px()));
         let root = Divider::horizontal()
             .content(content)
+            .prepare()
             .with_props(Dimensions::STRETCH);
 
         let mut harness =

--- a/masonry/src/widgets/flex.rs
+++ b/masonry/src/widgets/flex.rs
@@ -1387,10 +1387,10 @@ mod tests {
     fn flex_row_fixed_size_only() {
         let widget = NewWidget::new(
             Flex::row()
-                .with_fixed(Label::new("hello").with_auto_id())
-                .with_fixed(Label::new("world").with_auto_id())
-                .with_fixed(Label::new("foo").with_auto_id())
-                .with_fixed(Label::new("bar").with_auto_id()),
+                .with_fixed(Label::new("hello").prepare())
+                .with_fixed(Label::new("world").prepare())
+                .with_fixed(Label::new("foo").prepare())
+                .with_fixed(Label::new("bar").prepare()),
         )
         .with_props((BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)));
 
@@ -1433,11 +1433,11 @@ mod tests {
     fn flex_row_cross_axis_snapshots() {
         let widget = NewWidget::new(
             Flex::row()
-                .with_fixed(Label::new("hello").with_auto_id())
-                .with(Label::new("world").with_auto_id(), 1.0)
-                .with_fixed(Label::new("foo").with_auto_id())
+                .with_fixed(Label::new("hello").prepare())
+                .with(Label::new("world").prepare(), 1.0)
+                .with_fixed(Label::new("foo").prepare())
                 .with(
-                    Label::new("bar").with_auto_id(),
+                    Label::new("bar").prepare(),
                     FlexParams::new(2.0, None, CrossAxisAlignment::Start),
                 ),
         )
@@ -1484,10 +1484,10 @@ mod tests {
         // ALl children need to be fixed, otherwise a flexible child will use up all the space.
         let widget = NewWidget::new(
             Flex::row()
-                .with_fixed(Label::new("hello").with_auto_id())
-                .with_fixed(Label::new("world").with_auto_id())
-                .with_fixed(Label::new("foo").with_auto_id())
-                .with(Label::new("bar").with_auto_id(), CrossAxisAlignment::Start),
+                .with_fixed(Label::new("hello").prepare())
+                .with_fixed(Label::new("world").prepare())
+                .with_fixed(Label::new("foo").prepare())
+                .with(Label::new("bar").prepare(), CrossAxisAlignment::Start),
         )
         .with_props((BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)));
 
@@ -1531,11 +1531,11 @@ mod tests {
     fn flex_col_cross_axis_snapshots() {
         let widget = NewWidget::new(
             Flex::column()
-                .with_fixed(Label::new("hello").with_auto_id())
-                .with(Label::new("world").with_auto_id(), 1.0)
-                .with_fixed(Label::new("foo").with_auto_id())
+                .with_fixed(Label::new("hello").prepare())
+                .with(Label::new("world").prepare(), 1.0)
+                .with_fixed(Label::new("foo").prepare())
                 .with(
-                    Label::new("bar").with_auto_id(),
+                    Label::new("bar").prepare(),
                     FlexParams::new(2.0, None, CrossAxisAlignment::Start),
                 ),
         )
@@ -1582,10 +1582,10 @@ mod tests {
         // ALl children need to be fixed, otherwise a flexible child will use up all the space.
         let widget = NewWidget::new(
             Flex::column()
-                .with_fixed(Label::new("hello").with_auto_id())
-                .with_fixed(Label::new("world").with_auto_id())
-                .with_fixed(Label::new("foo").with_auto_id())
-                .with(Label::new("bar").with_auto_id(), CrossAxisAlignment::Start),
+                .with_fixed(Label::new("hello").prepare())
+                .with_fixed(Label::new("world").prepare())
+                .with_fixed(Label::new("foo").prepare())
+                .with(Label::new("bar").prepare(), CrossAxisAlignment::Start),
         )
         .with_props((BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)));
 
@@ -1645,20 +1645,33 @@ mod tests {
         let flex = NewWidget::new(
             Flex::row()
                 .cross_axis_alignment(CrossAxisAlignment::Center)
-                .with_fixed(Label::new("Left").with_props(props(0., 0.)))
-                .with_fixed(Label::new("A\nB").with_props(props(30., 10.)))
-                .with_fixed(Label::new("C\nD\nE").with_props(props(20., 115.)))
-                .with_fixed(Label::new("F\nG\nH\nI").with_props(props(20., 20.)))
-                .with_fixed(Label::new("J\nK\nL\nM\nN").with_props(props(0., 30.)))
-                .with_fixed(Label::new("Right\nToo").with_props(props(50., 50.))),
+                .with_fixed(Label::new("Left").prepare().with_props(props(0., 0.)))
+                .with_fixed(Label::new("A\nB").prepare().with_props(props(30., 10.)))
+                .with_fixed(Label::new("C\nD\nE").prepare().with_props(props(20., 115.)))
+                .with_fixed(
+                    Label::new("F\nG\nH\nI")
+                        .prepare()
+                        .with_props(props(20., 20.)),
+                )
+                .with_fixed(
+                    Label::new("J\nK\nL\nM\nN")
+                        .prepare()
+                        .with_props(props(0., 30.)),
+                )
+                .with_fixed(
+                    Label::new("Right\nToo")
+                        .prepare()
+                        .with_props(props(50., 50.)),
+                ),
         )
         .with_tag(flex_tag)
         .with_props((BorderWidth::all(2.0), BorderColor::new(ACCENT_COLOR)));
 
         let root = Flex::row()
             .cross_axis_alignment(CrossAxisAlignment::FirstBaseline)
-            .with_fixed(Label::new("Out").with_props(props(10., 10.)))
+            .with_fixed(Label::new("Out").prepare().with_props(props(10., 10.)))
             .with(flex, 1.0)
+            .prepare()
             .with_props((Gap::new(0.px()), Padding::all(20.)));
 
         let window_size = Size::new(240.0, 240.0);
@@ -1757,7 +1770,7 @@ mod tests {
                     scene.fill(border_box, bg_color).draw();
                     scene.stroke(line, &style, line_color).draw();
                 })
-                .with_auto_id()
+                .prepare()
         };
 
         let mut first = Flex::row().main_axis_alignment(MainAxisAlignment::Center);
@@ -1797,8 +1810,9 @@ mod tests {
 
         let root = Flex::column()
             .main_axis_alignment(MainAxisAlignment::SpaceBetween)
-            .with_fixed(first.with_props(props))
-            .with_fixed(last.with_props(props))
+            .with_fixed(first.prepare().with_props(props))
+            .with_fixed(last.prepare().with_props(props))
+            .prepare()
             .with_props((Gap::new(2.px()), Padding::all(10.)));
 
         let window_size = Size::new(450.0, 50.0);
@@ -1813,34 +1827,34 @@ mod tests {
 
         let image_1 = {
             let widget = Flex::column()
-                .with_fixed(Label::new("q").with_auto_id())
-                .with_fixed(Label::new("b").with_auto_id())
-                .with_fixed(Label::new("w").with_auto_id())
-                .with_fixed(Label::new("d").with_auto_id())
-                .with_auto_id();
+                .with_fixed(Label::new("q").prepare())
+                .with_fixed(Label::new("b").prepare())
+                .with_fixed(Label::new("w").prepare())
+                .with_fixed(Label::new("d").prepare())
+                .prepare();
             // -> qbwd
 
             let mut harness =
                 TestHarness::create_with_size(test_property_set(), widget, window_size);
 
             harness.edit_root_widget(|mut flex| {
-                Flex::set_fixed(&mut flex, 0, Label::new("a").with_auto_id());
+                Flex::set_fixed(&mut flex, 0, Label::new("a").prepare());
                 // -> abwd
-                Flex::set(&mut flex, 2, Label::new("c").with_auto_id(), 0.);
+                Flex::set(&mut flex, 2, Label::new("c").prepare(), 0.);
                 // -> abcd
                 Flex::remove(&mut flex, 1);
                 // -> acd
-                Flex::add_fixed(&mut flex, Label::new("x").with_auto_id());
+                Flex::add_fixed(&mut flex, Label::new("x").prepare());
                 // -> acdx
-                Flex::add(&mut flex, Label::new("y").with_auto_id(), 2.0);
+                Flex::add(&mut flex, Label::new("y").prepare(), 2.0);
                 // -> acdxy
                 Flex::add_fixed_spacer(&mut flex, 5.px());
                 // -> acdxy_
                 Flex::add_spacer(&mut flex, 1.0);
                 // -> acdxy__
-                Flex::insert_fixed(&mut flex, 2, Label::new("i").with_auto_id());
+                Flex::insert_fixed(&mut flex, 2, Label::new("i").prepare());
                 // -> acidxy__
-                Flex::insert(&mut flex, 2, Label::new("j").with_auto_id(), 2.0);
+                Flex::insert(&mut flex, 2, Label::new("j").prepare(), 2.0);
                 // -> acjidxy__
                 Flex::insert_fixed_spacer(&mut flex, 2, 5.px());
                 // -> ac_jidxy__
@@ -1853,18 +1867,18 @@ mod tests {
 
         let image_2 = {
             let widget = Flex::column()
-                .with_fixed(Label::new("a").with_auto_id())
-                .with_fixed(Label::new("c").with_auto_id())
+                .with_fixed(Label::new("a").prepare())
+                .with_fixed(Label::new("c").prepare())
                 .with_spacer(1.0)
                 .with_fixed_spacer(5.px())
-                .with(Label::new("j").with_auto_id(), 2.0)
-                .with_fixed(Label::new("i").with_auto_id())
-                .with_fixed(Label::new("d").with_auto_id())
-                .with_fixed(Label::new("x").with_auto_id())
-                .with(Label::new("y").with_auto_id(), 2.0)
+                .with(Label::new("j").prepare(), 2.0)
+                .with_fixed(Label::new("i").prepare())
+                .with_fixed(Label::new("d").prepare())
+                .with_fixed(Label::new("x").prepare())
+                .with(Label::new("y").prepare(), 2.0)
                 .with_fixed_spacer(5.px())
                 .with_spacer(1.0)
-                .with_auto_id();
+                .prepare();
 
             let mut harness =
                 TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -1878,10 +1892,10 @@ mod tests {
     #[test]
     fn get_flex_child() {
         let widget = Flex::column()
-            .with_fixed(Label::new("hello").with_auto_id())
-            .with_fixed(Label::new("world").with_auto_id())
+            .with_fixed(Label::new("hello").prepare())
+            .with_fixed(Label::new("world").prepare())
             .with_fixed_spacer(1.px())
-            .with_auto_id();
+            .prepare();
 
         let window_size = Size::new(200.0, 150.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -1904,7 +1918,7 @@ mod tests {
 
     #[test]
     fn divide_by_zero() {
-        let widget = Flex::column().with_spacer(0.0).with_auto_id();
+        let widget = Flex::column().with_spacer(0.0).prepare();
 
         // Running layout should not panic when the flex sum is zero.
         let window_size = Size::new(200.0, 150.0);

--- a/masonry/src/widgets/grid.rs
+++ b/masonry/src/widgets/grid.rs
@@ -477,7 +477,7 @@ mod tests {
     fn test_grid_basics() {
         // Start with a 1x1 grid
         let widget = NewWidget::new(Grid::with_dimensions(1, 1).with(
-            Button::with_text("A").with_auto_id(),
+            Button::with_text("A").prepare(),
             GridParams::new(0, 0, 1, 1),
         ))
         .with_props(Dimensions::STRETCH);
@@ -501,7 +501,7 @@ mod tests {
         harness.edit_root_widget(|mut grid| {
             Grid::add(
                 &mut grid,
-                Button::with_text("B").with_auto_id(),
+                Button::with_text("B").prepare(),
                 GridParams::new(1, 0, 3, 1),
             );
         });
@@ -511,7 +511,7 @@ mod tests {
         harness.edit_root_widget(|mut grid| {
             Grid::add(
                 &mut grid,
-                Button::with_text("C").with_auto_id(),
+                Button::with_text("C").prepare(),
                 GridParams::new(0, 1, 1, 3),
             );
         });
@@ -521,7 +521,7 @@ mod tests {
         harness.edit_root_widget(|mut grid| {
             Grid::add(
                 &mut grid,
-                Button::with_text("D").with_auto_id(),
+                Button::with_text("D").prepare(),
                 GridParams::new(1, 1, 2, 2),
             );
         });
@@ -537,7 +537,7 @@ mod tests {
     #[test]
     fn test_widget_removal_and_modification() {
         let widget = NewWidget::new(Grid::with_dimensions(2, 2).with(
-            Button::with_text("A").with_auto_id(),
+            Button::with_text("A").prepare(),
             GridParams::new(0, 0, 1, 1),
         ));
         let window_size = Size::new(200.0, 200.0);
@@ -555,7 +555,7 @@ mod tests {
         harness.edit_root_widget(|mut grid| {
             Grid::add(
                 &mut grid,
-                Button::with_text("A").with_auto_id(),
+                Button::with_text("A").prepare(),
                 GridParams::new(0, 0, 1, 1),
             );
         });
@@ -566,7 +566,7 @@ mod tests {
             Grid::remove(&mut grid, 0);
             Grid::add(
                 &mut grid,
-                Button::with_text("X").with_auto_id(),
+                Button::with_text("X").prepare(),
                 GridParams::new(0, 0, 1, 1),
             );
         });
@@ -574,7 +574,7 @@ mod tests {
             Grid::set(
                 &mut grid,
                 0,
-                Button::with_text("A").with_auto_id(),
+                Button::with_text("A").prepare(),
                 GridParams::new(0, 0, 1, 1),
             );
         });
@@ -596,7 +596,7 @@ mod tests {
     #[test]
     fn test_widget_order() {
         let widget = NewWidget::new(Grid::with_dimensions(2, 2).with(
-            Button::with_text("A").with_auto_id(),
+            Button::with_text("A").prepare(),
             GridParams::new(0, 0, 1, 1),
         ));
         let window_size = Size::new(200.0, 200.0);
@@ -608,7 +608,7 @@ mod tests {
         harness.edit_root_widget(|mut grid| {
             Grid::add(
                 &mut grid,
-                Button::with_text("B").with_auto_id(),
+                Button::with_text("B").prepare(),
                 GridParams::new(0, 0, 1, 1),
             );
         });
@@ -620,7 +620,7 @@ mod tests {
             Grid::insert(
                 &mut grid,
                 0,
-                Button::with_text("C").with_auto_id(),
+                Button::with_text("C").prepare(),
                 GridParams::new(0, 0, 2, 1),
             );
         });
@@ -631,39 +631,41 @@ mod tests {
     fn grid_baselines() {
         let grid = Grid::with_dimensions(3, 3)
             .with(
-                Label::new("A\nB").with_props((
+                Label::new("A\nB").prepare().with_props((
                     Padding::from_vh(0., 0.),
                     Background::Color(palette::css::ORANGE),
                 )),
                 GridParams::new(1, 0, 1, 1),
             )
             .with(
-                Label::new("C\nD").with_props((
+                Label::new("C\nD").prepare().with_props((
                     Padding::from_vh(8., 0.),
                     Background::Color(palette::css::DARK_BLUE),
                 )),
                 GridParams::new(0, 0, 1, 2),
             )
             .with(
-                Label::new("E\nF").with_props((
+                Label::new("E\nF").prepare().with_props((
                     Padding::from_vh(16., 0.),
                     Background::Color(palette::css::DARK_SALMON),
                 )),
                 GridParams::new(2, 0, 1, 3),
             )
             .with(
-                Label::new("G\nH").with_props((
+                Label::new("G\nH").prepare().with_props((
                     Padding::from_vh(24., 0.),
                     Background::Color(palette::css::DARK_SLATE_BLUE),
                 )),
                 GridParams::new(1, 1, 1, 2),
             )
+            .prepare()
             .with_props(Dimensions::width(80.px()));
 
         let root = Flex::row()
             .cross_axis_alignment(CrossAxisAlignment::FirstBaseline)
-            .with_fixed(Label::new("Out").with_auto_id())
+            .with_fixed(Label::new("Out").prepare())
             .with_fixed(grid)
+            .prepare()
             .with_props(Padding::all(10.));
 
         let window_size = Size::new(150.0, 200.0);

--- a/masonry/src/widgets/indexed_stack.rs
+++ b/masonry/src/widgets/indexed_stack.rs
@@ -313,7 +313,7 @@ mod tests {
 
     #[test]
     fn test_indexed_stack_basics() {
-        let widget = IndexedStack::new().with_auto_id();
+        let widget = IndexedStack::new().prepare();
         let window_size = Size::new(50.0, 50.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
 
@@ -322,7 +322,9 @@ mod tests {
         harness.edit_root_widget(|mut stack| {
             IndexedStack::add(
                 &mut stack,
-                Button::with_text("A").with_props(Dimensions::STRETCH),
+                Button::with_text("A")
+                    .prepare()
+                    .with_props(Dimensions::STRETCH),
                 (),
             );
         });
@@ -331,17 +333,23 @@ mod tests {
         harness.edit_root_widget(|mut stack| {
             IndexedStack::add(
                 &mut stack,
-                Button::with_text("B").with_props(Dimensions::STRETCH),
+                Button::with_text("B")
+                    .prepare()
+                    .with_props(Dimensions::STRETCH),
                 (),
             );
             IndexedStack::add(
                 &mut stack,
-                Button::with_text("C").with_props(Dimensions::STRETCH),
+                Button::with_text("C")
+                    .prepare()
+                    .with_props(Dimensions::STRETCH),
                 (),
             );
             IndexedStack::add(
                 &mut stack,
-                Button::with_text("D").with_props(Dimensions::STRETCH),
+                Button::with_text("D")
+                    .prepare()
+                    .with_props(Dimensions::STRETCH),
                 (),
             );
         });
@@ -356,11 +364,23 @@ mod tests {
     #[test]
     fn test_widget_removal_and_modification() {
         let widget = IndexedStack::new()
-            .with(Button::with_text("A").with_props(Dimensions::STRETCH))
-            .with(Button::with_text("B").with_props(Dimensions::STRETCH))
-            .with(Button::with_text("C").with_props(Dimensions::STRETCH))
+            .with(
+                Button::with_text("A")
+                    .prepare()
+                    .with_props(Dimensions::STRETCH),
+            )
+            .with(
+                Button::with_text("B")
+                    .prepare()
+                    .with_props(Dimensions::STRETCH),
+            )
+            .with(
+                Button::with_text("C")
+                    .prepare()
+                    .with_props(Dimensions::STRETCH),
+            )
             .with_active_child(1)
-            .with_auto_id();
+            .prepare();
         let window_size = Size::new(50.0, 50.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
         // Snapshot with the single widget.
@@ -382,7 +402,9 @@ mod tests {
         harness.edit_root_widget(|mut stack| {
             IndexedStack::add(
                 &mut stack,
-                Button::with_text("D").with_props(Dimensions::STRETCH),
+                Button::with_text("D")
+                    .prepare()
+                    .with_props(Dimensions::STRETCH),
                 (),
             );
         });
@@ -399,13 +421,17 @@ mod tests {
             IndexedStack::insert(
                 &mut stack,
                 0,
-                Button::with_text("A").with_props(Dimensions::STRETCH),
+                Button::with_text("A")
+                    .prepare()
+                    .with_props(Dimensions::STRETCH),
                 (),
             );
             IndexedStack::insert(
                 &mut stack,
                 1,
-                Button::with_text("B").with_props(Dimensions::STRETCH),
+                Button::with_text("B")
+                    .prepare()
+                    .with_props(Dimensions::STRETCH),
                 (),
             );
         });
@@ -422,7 +448,9 @@ mod tests {
             IndexedStack::set(
                 &mut stack,
                 1,
-                Button::with_text("D").with_props(Dimensions::STRETCH),
+                Button::with_text("D")
+                    .prepare()
+                    .with_props(Dimensions::STRETCH),
                 (),
             );
         });

--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -672,7 +672,7 @@ mod tests {
 
     #[test]
     fn simple_label() {
-        let label = Label::new("Hello").with_auto_id();
+        let label = Label::new("Hello").prepare();
 
         let window_size = Size::new(100.0, 40.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), label, window_size);
@@ -688,6 +688,7 @@ mod tests {
             )))
             .with_style(StyleProperty::FontSize(20.0))
             .with_text_alignment(TextAlign::Center)
+            .prepare()
             .with_props(
                 PropertySet::new()
                     .with(ContentColor::new(ACCENT_COLOR))
@@ -704,6 +705,7 @@ mod tests {
     fn underline_label() {
         let label = Label::new("Emphasis")
             .with_style(StyleProperty::Underline(true))
+            .prepare()
             .with_props(PropertySet::new().with(LineBreaking::WordWrap));
 
         let window_size = Size::new(100.0, 40.0);
@@ -716,6 +718,7 @@ mod tests {
         let label = Label::new("Tpyo")
             .with_style(StyleProperty::Strikethrough(true))
             .with_style(StyleProperty::StrikethroughSize(Some(4.)))
+            .prepare()
             .with_props(PropertySet::new().with(LineBreaking::WordWrap));
 
         let window_size = Size::new(100.0, 40.0);
@@ -732,6 +735,7 @@ mod tests {
             Label::new("Hello")
                 .with_style(StyleProperty::FontSize(20.0))
                 .with_text_alignment(text_alignment)
+                .prepare()
                 .with_props(Dimensions::width(Dim::Stretch))
         }
         let label1 = base_label(TextAlign::Start);
@@ -762,31 +766,34 @@ mod tests {
             .with_fixed(
                 SizedBox::new(
                     Label::new("The quick brown fox jumps over the lazy dog")
+                        .prepare()
                         .with_props(PropertySet::new().with(LineBreaking::WordWrap)),
                 )
                 .width(180.px())
-                .with_auto_id(),
+                .prepare(),
             )
             .with_fixed_spacer(20.px())
             .with_fixed(
                 SizedBox::new(
                     Label::new("The quick brown fox jumps over the lazy dog")
+                        .prepare()
                         .with_props(PropertySet::new().with(LineBreaking::Clip)),
                 )
                 .width(180.px())
-                .with_auto_id(),
+                .prepare(),
             )
             .with_fixed_spacer(20.px())
             .with_fixed(
                 SizedBox::new(
                     Label::new("The quick brown fox jumps over the lazy dog")
+                        .prepare()
                         .with_props(PropertySet::new().with(LineBreaking::Overflow)),
                 )
                 .width(180.px())
-                .with_auto_id(),
+                .prepare(),
             )
             .with_spacer(1.0)
-            .with_auto_id();
+            .prepare();
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(200.0, 200.0));
@@ -803,6 +810,7 @@ mod tests {
                 )))
                 .with_style(StyleProperty::FontSize(20.0))
                 .with_text_alignment(TextAlign::Center)
+                .prepare()
                 .with_props(
                     PropertySet::new()
                         .with(ContentColor::new(ACCENT_COLOR))
@@ -818,7 +826,7 @@ mod tests {
         let image_2 = {
             let label = Label::new("Hello world")
                 .with_style(StyleProperty::FontSize(40.0))
-                .with_auto_id();
+                .prepare();
 
             let mut harness =
                 TestHarness::create_with_size(test_property_set(), label, Size::new(50.0, 50.0));

--- a/masonry/src/widgets/passthrough.rs
+++ b/masonry/src/widgets/passthrough.rs
@@ -32,11 +32,11 @@ use crate::layout::LenReq;
 /// use masonry::widgets::{Passthrough, Label};
 ///
 /// // Create a host around a label
-/// let host = Passthrough::new(Label::new("Hello").with_auto_id()).with_props(Dimensions::MAX);
+/// let host = Passthrough::new(Label::new("Hello").prepare()).prepare().with_props(Dimensions::MAX);
 ///
 /// // ... in an edit callback, mutate the widget tree
 /// # fn edit(mut host: masonry::core::WidgetMut<'_, Passthrough>) {
-/// Passthrough::set_child(&mut host, Label::new("World").with_auto_id());
+/// Passthrough::set_child(&mut host, Label::new("World").prepare());
 /// # }
 /// ```
 ///
@@ -146,7 +146,9 @@ mod tests {
     #[test]
     fn passthrough_replaces_child() {
         // Start with a label
-        let widget = Passthrough::new(Label::new("A").with_auto_id()).with_props(Dimensions::MAX);
+        let widget = Passthrough::new(Label::new("A").prepare())
+            .prepare()
+            .with_props(Dimensions::MAX);
         let window_size = Size::new(30.0, 30.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
 
@@ -161,7 +163,7 @@ mod tests {
 
         // Replace with a label with different text
         harness.edit_root_widget(|mut host| {
-            Passthrough::set_child(&mut host, Label::new("B").with_auto_id());
+            Passthrough::set_child(&mut host, Label::new("B").prepare());
         });
 
         assert_render_snapshot!(harness, "passthrough_replaced_label_B");

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -895,7 +895,7 @@ mod tests {
                 // Because if we were at (0,0) it would be effectively the same as no parent.
                 ctx.place_child(child, Point::new(0., top_pad));
             })
-            .with_auto_id()
+            .prepare()
     }
 
     #[test]
@@ -921,7 +921,7 @@ mod tests {
                 .with_fixed(button("Item 14", 20., None))
                 .with_fixed_spacer(10.px()),
         ))
-        .with_auto_id();
+        .prepare();
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(400., 400.));
@@ -950,9 +950,9 @@ mod tests {
                 .with_fixed_spacer(500.px())
                 .with_fixed(NewWidget::new(Button::with_text("Fully visible")).with_tag(button_tag))
                 .with_fixed_spacer(500.px())
-                .with_auto_id(),
+                .prepare(),
         )
-        .with_auto_id();
+        .prepare();
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(200., 200.));
@@ -965,7 +965,7 @@ mod tests {
     #[test]
     fn portal_accessibility_node_exposes_scroll() {
         let portal_tag = WidgetTag::named("portal");
-        let content = SizedBox::empty().size(300.px(), 300.px()).with_auto_id();
+        let content = SizedBox::empty().size(300.px(), 300.px()).prepare();
         let portal = NewWidget::new(Portal::new(content)).with_tag(portal_tag);
 
         let mut harness =
@@ -999,7 +999,7 @@ mod tests {
     #[test]
     fn portal_keyboard_scroll_updates_access_tree() {
         let portal_tag = WidgetTag::named("portal");
-        let content = SizedBox::empty().size(300.px(), 300.px()).with_auto_id();
+        let content = SizedBox::empty().size(300.px(), 300.px()).prepare();
         let portal = NewWidget::new(Portal::new(content)).with_tag(portal_tag);
 
         let mut harness =

--- a/masonry/src/widgets/progress_bar.rs
+++ b/masonry/src/widgets/progress_bar.rs
@@ -292,7 +292,7 @@ mod tests {
 
     #[test]
     fn _5_percent_styled_progressbar() {
-        let widget = ProgressBar::new(Some(0.05)).with_props((
+        let widget = ProgressBar::new(Some(0.05)).prepare().with_props((
             CornerRadius::all(50.),
             BorderWidth::all(10.),
             BorderColor::new(palette::css::PINK),
@@ -305,7 +305,7 @@ mod tests {
 
     #[test]
     fn _95_percent_styled_progressbar() {
-        let widget = ProgressBar::new(Some(0.95)).with_props((
+        let widget = ProgressBar::new(Some(0.95)).prepare().with_props((
             CornerRadius::all(50.),
             BorderWidth::all(10.),
             BorderColor::new(palette::css::PINK),
@@ -365,6 +365,7 @@ mod tests {
     fn edit_progressbar() {
         let image_1 = {
             let bar = ProgressBar::new(Some(0.5))
+                .prepare()
                 .with_props(PropertySet::new().with(BarColor(palette::css::PURPLE)));
 
             let mut harness =

--- a/masonry/src/widgets/prose.rs
+++ b/masonry/src/widgets/prose.rs
@@ -47,7 +47,7 @@ impl Prose {
     ///
     /// To use non-default text properties, use [`from_text_area`](Self::from_text_area) instead.
     pub fn new(text: &str) -> Self {
-        Self::from_text_area(TextArea::new_immutable(text).with_auto_id())
+        Self::from_text_area(TextArea::new_immutable(text).prepare())
     }
 
     /// Creates a new `Prose` from a styled text area.
@@ -223,14 +223,14 @@ mod tests {
             TextArea::new_immutable("Truncated text - you should not see this")
                 .with_style(StyleProperty::FontSize(14.0))
                 .with_word_wrap(false)
-                .with_auto_id(),
+                .prepare(),
         )
         .with_clip(true)
-        .with_auto_id();
+        .prepare();
 
         let root_widget = Flex::row()
-            .with_fixed(SizedBox::new(prose).width(60.px()).with_auto_id())
-            .with_auto_id();
+            .with_fixed(SizedBox::new(prose).width(60.px()).prepare())
+            .prepare();
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), root_widget, Size::new(200.0, 40.0));
@@ -249,7 +249,7 @@ mod tests {
                     .with_style(StyleProperty::FontSize(14.0))
                     .with_text_alignment(text_alignment)
                     .with_word_wrap(true)
-                    .with_auto_id(),
+                    .prepare(),
             )
         }
         let prose1 = base_prose(TextAlign::Start);
@@ -259,12 +259,12 @@ mod tests {
         let prose5 = base_prose(TextAlign::Center);
         let prose6 = base_prose(TextAlign::End);
         let flex = Flex::column()
-            .with(prose1.with_auto_id(), CrossAxisAlignment::Start)
-            .with(prose2.with_auto_id(), CrossAxisAlignment::Start)
-            .with(prose3.with_auto_id(), CrossAxisAlignment::Start)
-            .with(prose4.with_auto_id(), CrossAxisAlignment::Center)
-            .with(prose5.with_auto_id(), CrossAxisAlignment::Center)
-            .with(prose6.with_auto_id(), CrossAxisAlignment::Center);
+            .with(prose1.prepare(), CrossAxisAlignment::Start)
+            .with(prose2.prepare(), CrossAxisAlignment::Start)
+            .with(prose3.prepare(), CrossAxisAlignment::Start)
+            .with(prose4.prepare(), CrossAxisAlignment::Center)
+            .with(prose5.prepare(), CrossAxisAlignment::Center)
+            .with(prose6.prepare(), CrossAxisAlignment::Center);
         let flex = NewWidget::new(flex).with_props(PropertySet::one(Gap::ZERO));
 
         let mut harness =

--- a/masonry/src/widgets/resize_observer.rs
+++ b/masonry/src/widgets/resize_observer.rs
@@ -185,12 +185,14 @@ mod tests {
         let tag = WidgetTag::named("inner_box");
         let inner_box =
             NewWidget::new(SizedBox::empty().width(100.px()).height(100.px())).with_tag(tag);
-        let observer = ResizeObserver::new(inner_box).with_props(Dimensions::MAX);
+        let observer = ResizeObserver::new(inner_box)
+            .prepare()
+            .with_props(Dimensions::MAX);
         let observer_id = observer.id();
         // We use a flex here as the inner `SizedBox` will take up the full space available in this case.
         // This doesn't run into the caveat because the size of the inner widget is *not* based on the
         // size of the flex.
-        let flex = Flex::column().with_fixed(observer).with_auto_id();
+        let flex = Flex::column().with_fixed(observer).prepare();
         let mut harness = TestHarness::create(default_property_set(), flex);
         // There will be an initial layout.
         let (LayoutChanged, action_id) = harness.pop_action::<LayoutChanged>().unwrap();
@@ -234,8 +236,10 @@ mod tests {
 
     #[test]
     fn detects_window_resizing() {
-        let inner_box = SizedBox::empty().with_props(Dimensions::STRETCH);
-        let observer = ResizeObserver::new(inner_box).with_props(Dimensions::MAX);
+        let inner_box = SizedBox::empty().prepare().with_props(Dimensions::STRETCH);
+        let observer = ResizeObserver::new(inner_box)
+            .prepare()
+            .with_props(Dimensions::MAX);
         let observer_id = observer.id();
         let mut harness = TestHarness::create_with_size(
             default_property_set(),

--- a/masonry/src/widgets/sized_box.rs
+++ b/masonry/src/widgets/sized_box.rs
@@ -339,6 +339,7 @@ mod tests {
         let widget = SizedBox::empty()
             .width(20.px())
             .height(20.px())
+            .prepare()
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -354,7 +355,9 @@ mod tests {
         box_props.insert(BorderWidth::all(5.0));
         box_props.insert(CornerRadius::all(5.0));
 
-        let widget = SizedBox::new(Label::new("hello").with_auto_id()).with_props(box_props);
+        let widget = SizedBox::new(Label::new("hello").prepare())
+            .prepare()
+            .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -369,9 +372,10 @@ mod tests {
         box_props.insert(BorderWidth::all(5.0));
         box_props.insert(CornerRadius::all(5.0));
 
-        let widget = SizedBox::new(Label::new("hello").with_auto_id())
+        let widget = SizedBox::new(Label::new("hello").prepare())
             .width(20.px())
             .height(20.px())
+            .prepare()
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -388,7 +392,9 @@ mod tests {
         box_props.insert(CornerRadius::all(5.0));
         box_props.insert(Padding::from_vh(15., 10.));
 
-        let widget = SizedBox::new(Label::new("hello").with_auto_id()).with_props(box_props);
+        let widget = SizedBox::new(Label::new("hello").prepare())
+            .prepare()
+            .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -401,9 +407,10 @@ mod tests {
         let mut box_props = PropertySet::new();
         box_props.insert(Background::Color(palette::css::PLUM));
 
-        let widget = SizedBox::new(Label::new("hello").with_auto_id())
+        let widget = SizedBox::new(Label::new("hello").prepare())
             .width(20.px())
             .height(20.px())
+            .prepare()
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -431,6 +438,7 @@ mod tests {
         let widget = SizedBox::empty()
             .width(20.px())
             .height(20.px())
+            .prepare()
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -458,6 +466,7 @@ mod tests {
         let widget = SizedBox::empty()
             .width(20.px())
             .height(20.px())
+            .prepare()
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -485,6 +494,7 @@ mod tests {
         let widget = SizedBox::empty()
             .width(20.px())
             .height(20.px())
+            .prepare()
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -501,9 +511,10 @@ mod tests {
         box_props.insert(BorderWidth::all(5.0));
         box_props.insert(Padding::all(25.));
 
-        let widget = SizedBox::new(Label::new("hello").with_auto_id())
+        let widget = SizedBox::new(Label::new("hello").prepare())
             .width(20.px())
             .height(20.px())
+            .prepare()
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);
@@ -528,6 +539,7 @@ mod tests {
         let widget = SizedBox::empty()
             .width(20.px())
             .height(20.px())
+            .prepare()
             .with_props(box_props);
 
         let window_size = Size::new(100.0, 100.0);

--- a/masonry/src/widgets/slider.rs
+++ b/masonry/src/widgets/slider.rs
@@ -513,7 +513,7 @@ mod tests {
 
     #[test]
     fn slider_initial_state() {
-        let widget = Slider::new(0.0, 100.0, 25.0).with_auto_id();
+        let widget = Slider::new(0.0, 100.0, 25.0).prepare();
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(200.0, 32.0));
 
@@ -522,7 +522,7 @@ mod tests {
 
     #[test]
     fn slider_drag_interaction() {
-        let widget = Slider::new(0.0, 100.0, 25.0).with_auto_id();
+        let widget = Slider::new(0.0, 100.0, 25.0).prepare();
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(200.0, 32.0));
         let slider_id = harness.root_id();
@@ -551,7 +551,7 @@ mod tests {
 
     #[test]
     fn slider_keyboard_interaction() {
-        let widget = Slider::new(0.0, 100.0, 50.0).with_step(10.0).with_auto_id();
+        let widget = Slider::new(0.0, 100.0, 50.0).with_step(10.0).prepare();
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(200.0, 32.0));
         let slider_id = harness.root_id();
@@ -568,7 +568,7 @@ mod tests {
 
     #[test]
     fn slider_disabled_state() {
-        let mut widget = Slider::new(0.0, 100.0, 50.0).with_auto_id();
+        let mut widget = Slider::new(0.0, 100.0, 50.0).prepare();
         widget.options.disabled = true;
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(200.0, 32.0));

--- a/masonry/src/widgets/spinner.rs
+++ b/masonry/src/widgets/spinner.rs
@@ -187,6 +187,7 @@ mod tests {
     fn edit_spinner() {
         let image_1 = {
             let spinner = Spinner::new()
+                .prepare()
                 .with_props(PropertySet::one(ContentColor::new(palette::css::PURPLE)));
 
             let mut harness =

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -837,9 +837,9 @@ mod tests {
     fn columns() {
         #[rustfmt::skip]
         let widget = Split::new(
-            Label::new("Hello").with_auto_id(),
-            Label::new("World").with_auto_id(),
-        ).split_axis(Axis::Horizontal).draggable(false).with_auto_id();
+            Label::new("Hello").prepare(),
+            Label::new("World").prepare(),
+        ).split_axis(Axis::Horizontal).draggable(false).prepare();
 
         let window_size = Size::new(150.0, 150.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -851,9 +851,9 @@ mod tests {
     fn rows() {
         #[rustfmt::skip]
         let widget = Split::new(
-            Label::new("Hello").with_auto_id(),
-            Label::new("World").with_auto_id(),
-        ).split_axis(Axis::Vertical).draggable(false).with_auto_id();
+            Label::new("Hello").prepare(),
+            Label::new("World").prepare(),
+        ).split_axis(Axis::Vertical).draggable(false).prepare();
 
         let window_size = Size::new(150.0, 150.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -864,16 +864,13 @@ mod tests {
     #[test]
     fn edit_splitter() {
         let image_1 = {
-            let widget = Split::new(
-                Label::new("Hello").with_auto_id(),
-                Label::new("World").with_auto_id(),
-            )
-            .split_fraction(0.3)
-            .min_lengths(40.px(), 10.px())
-            .bar_thickness(12.px())
-            .draggable(true)
-            .solid_bar(true)
-            .with_auto_id();
+            let widget = Split::new(Label::new("Hello").prepare(), Label::new("World").prepare())
+                .split_fraction(0.3)
+                .min_lengths(40.px(), 10.px())
+                .bar_thickness(12.px())
+                .draggable(true)
+                .solid_bar(true)
+                .prepare();
 
             let mut harness =
                 TestHarness::create_with_size(test_property_set(), widget, Size::new(100.0, 100.0));
@@ -882,11 +879,8 @@ mod tests {
         };
 
         let image_2 = {
-            let widget = Split::new(
-                Label::new("Hello").with_auto_id(),
-                Label::new("World").with_auto_id(),
-            )
-            .with_auto_id();
+            let widget =
+                Split::new(Label::new("Hello").prepare(), Label::new("World").prepare()).prepare();
 
             let mut harness =
                 TestHarness::create_with_size(test_property_set(), widget, Size::new(100.0, 100.0));
@@ -908,11 +902,8 @@ mod tests {
 
     #[test]
     fn drag_moves_split_point() {
-        let widget = Split::new(
-            Label::new("Hello").with_auto_id(),
-            Label::new("World").with_auto_id(),
-        )
-        .with_auto_id();
+        let widget =
+            Split::new(Label::new("Hello").prepare(), Label::new("World").prepare()).prepare();
 
         let window_size = Size::new(150.0, 100.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -945,11 +936,8 @@ mod tests {
 
     #[test]
     fn keyboard_moves_split_point() {
-        let widget = Split::new(
-            Label::new("Hello").with_auto_id(),
-            Label::new("World").with_auto_id(),
-        )
-        .with_auto_id();
+        let widget =
+            Split::new(Label::new("Hello").prepare(), Label::new("World").prepare()).prepare();
 
         let window_size = Size::new(150.0, 100.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -974,12 +962,9 @@ mod tests {
 
     #[test]
     fn from_start_keeps_pixel_size_on_resize() {
-        let widget = Split::new(
-            Label::new("Hello").with_auto_id(),
-            Label::new("World").with_auto_id(),
-        )
-        .split_point(SplitPoint::FromStart(50.px()))
-        .with_auto_id();
+        let widget = Split::new(Label::new("Hello").prepare(), Label::new("World").prepare())
+            .split_point(SplitPoint::FromStart(50.px()))
+            .prepare();
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(200.0, 100.0));
@@ -1000,12 +985,9 @@ mod tests {
 
     #[test]
     fn from_end_keeps_pixel_size_on_resize() {
-        let widget = Split::new(
-            Label::new("Hello").with_auto_id(),
-            Label::new("World").with_auto_id(),
-        )
-        .split_point(SplitPoint::FromEnd(50.px()))
-        .with_auto_id();
+        let widget = Split::new(Label::new("Hello").prepare(), Label::new("World").prepare())
+            .split_point(SplitPoint::FromEnd(50.px()))
+            .prepare();
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(200.0, 100.0));
@@ -1027,10 +1009,10 @@ mod tests {
     #[test]
     fn fraction_clamps_when_set() {
         let widget = Split::new(
-            Label::new("Hello").with_props(Padding::all(0.)),
-            Label::new("World").with_props(Padding::all(0.)),
+            Label::new("Hello").prepare().with_props(Padding::all(0.)),
+            Label::new("World").prepare().with_props(Padding::all(0.)),
         )
-        .with_auto_id();
+        .prepare();
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(150.0, 100.0));

--- a/masonry/src/widgets/step_input.rs
+++ b/masonry/src/widgets/step_input.rs
@@ -1292,7 +1292,12 @@ impl<T: Steppable> Widget for StepInput<T> {
                 let color = props.get::<ContentColor>(cache);
 
                 let display_value = self.display_value(self.value);
-                self.label = Some(Label::new(display_value).with_props(*color).to_pod());
+                self.label = Some(
+                    Label::new(display_value)
+                        .prepare()
+                        .with_props(*color)
+                        .to_pod(),
+                );
                 ctx.children_changed();
             }
             Update::ActiveChanged(active) => {
@@ -2354,7 +2359,11 @@ mod tests {
 
     #[test]
     fn basics() {
-        let si = |base, props| StepInput::new(base, 1, 0, usize::MAX).with_props(props);
+        let si = |base, props| {
+            StepInput::new(base, 1, 0, usize::MAX)
+                .prepare()
+                .with_props(props)
+        };
 
         let root = Flex::column()
             .cross_axis_alignment(CrossAxisAlignment::Start)
@@ -2373,6 +2382,7 @@ mod tests {
                 (StepInputStyle::Basic, Dimensions::width(100.px())),
             ))
             .with_fixed(si(500, (StepInputStyle::Flow, Dimensions::width(100.px()))))
+            .prepare()
             .with_props(Padding::all(10.));
 
         let window_size = Size::new(150.0, 525.0);
@@ -2399,6 +2409,7 @@ mod tests {
             .cross_axis_alignment(CrossAxisAlignment::Start)
             .with_fixed(lines_backward)
             .with_fixed(lines_forward)
+            .prepare()
             .with_props(Padding::all(10.));
 
         let window_size = Size::new(270.0, 200.0);
@@ -2423,11 +2434,15 @@ mod tests {
     fn awkward_layout() {
         let basic = |base, props: PropertySet| {
             let props = props.with(StepInputStyle::Basic);
-            StepInput::new(base, 1, 0, usize::MAX).with_props(props)
+            StepInput::new(base, 1, 0, usize::MAX)
+                .prepare()
+                .with_props(props)
         };
         let flow = |base, props: PropertySet| {
             let props = props.with(StepInputStyle::Flow);
-            StepInput::new(base, 1, 0, usize::MAX).with_props(props)
+            StepInput::new(base, 1, 0, usize::MAX)
+                .prepare()
+                .with_props(props)
         };
 
         let root = Flex::column()
@@ -2450,6 +2465,7 @@ mod tests {
             // Extra high widget to test that controls remain reasonably sized.
             .with_fixed(basic(1234, (Dimensions::fixed(100.px(), 200.px())).into()))
             .with_fixed(flow(1234, (Dimensions::fixed(100.px(), 200.px())).into()))
+            .prepare()
             .with_props(Padding::all(10.));
 
         let window_size = Size::new(320.0, 650.0);

--- a/masonry/src/widgets/svg.rs
+++ b/masonry/src/widgets/svg.rs
@@ -270,7 +270,7 @@ mod tests {
     fn empty_tree() {
         let xml = r#"<svg xmlns="http://www.w3.org/2000/svg"/>"#;
         let tree = Tree::from_str(xml, &usvg::Options::default()).unwrap();
-        let svg = Svg::new(Arc::new(tree)).with_auto_id();
+        let svg = Svg::new(Arc::new(tree)).prepare();
         let mut harness = TestHarness::create(test_property_set(), svg);
         let _ = harness.render();
     }
@@ -344,7 +344,7 @@ mod tests {
         };
 
         let tree = Tree::from_str(xml, &opts).unwrap();
-        let svg = Svg::new(Arc::new(tree)).with_auto_id();
+        let svg = Svg::new(Arc::new(tree)).prepare();
 
         let window_size = Size::new(852., 320.);
         let mut harness = TestHarness::create_with_size(test_property_set(), svg, window_size);

--- a/masonry/src/widgets/switch.rs
+++ b/masonry/src/widgets/switch.rs
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn click_emits_action_and_focuses() {
-        let widget = Switch::new(false).with_auto_id();
+        let widget = Switch::new(false).prepare();
         let window_size = Size::new(60.0, 40.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
         let switch_id = harness.root_id();
@@ -380,7 +380,7 @@ mod tests {
 
     #[test]
     fn space_emits_action_when_focused() {
-        let widget = Switch::new(false).with_auto_id();
+        let widget = Switch::new(false).prepare();
         let window_size = Size::new(60.0, 40.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
         let switch_id = harness.root_id();
@@ -416,7 +416,7 @@ mod tests {
         // Theme defaults: ThumbRadius(8.0), TrackThickness(20.0), BorderWidth(1.0)
         // Expected: track_height = max(20, 8*2) = 20, track_width = 20*2 = 40
         // With borders: width = 42, height = 22
-        let switch = Switch::new(false).with_auto_id();
+        let switch = Switch::new(false).prepare();
         let switch_id = switch.id();
 
         // Wrap in Flex with Start alignment so it doesn't stretch the switch
@@ -428,7 +428,7 @@ mod tests {
         // Give it much more space than needed
         let window_size = Size::new(200.0, 100.0);
         let harness =
-            TestHarness::create_with_size(test_property_set(), flex.with_auto_id(), window_size);
+            TestHarness::create_with_size(test_property_set(), flex.prepare(), window_size);
 
         let size = harness
             .get_widget_with_id(switch_id)
@@ -450,7 +450,7 @@ mod tests {
 
     #[test]
     fn simple_switch() {
-        let widget = Switch::new(false).with_auto_id();
+        let widget = Switch::new(false).prepare();
 
         let window_size = Size::new(60.0, 40.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -479,7 +479,7 @@ mod tests {
 
     #[test]
     fn focus_visual() {
-        let widget = Switch::new(false).with_auto_id();
+        let widget = Switch::new(false).prepare();
 
         let window_size = Size::new(60.0, 40.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);
@@ -494,7 +494,7 @@ mod tests {
 
     #[test]
     fn on_state() {
-        let widget = Switch::new(true).with_auto_id();
+        let widget = Switch::new(true).prepare();
 
         let window_size = Size::new(60.0, 40.0);
         let mut harness = TestHarness::create_with_size(test_property_set(), widget, window_size);

--- a/masonry/src/widgets/text_input.rs
+++ b/masonry/src/widgets/text_input.rs
@@ -58,14 +58,17 @@ impl TextInput {
     ///
     /// To use non-default text properties, use [`from_text_area`](Self::from_text_area) instead.
     pub fn new(text: &str) -> Self {
-        Self::from_text_area(TextArea::new_editable(text).with_auto_id())
+        Self::from_text_area(TextArea::new_editable(text).prepare())
     }
 
     /// Creates a new `TextInput` from a styled text area.
     pub fn from_text_area(text: NewWidget<TextArea<true>>) -> Self {
         Self {
             text: text.to_pod(),
-            placeholder: Label::new("").with_props(LineBreaking::Clip).to_pod(),
+            placeholder: Label::new("")
+                .prepare()
+                .with_props(LineBreaking::Clip)
+                .to_pod(),
             placeholder_text: "".into(),
             text_alignment: TextAlign::default(),
             clip: false,
@@ -84,7 +87,7 @@ impl TextInput {
     pub fn with_placeholder(mut self, placeholder_text: impl Into<ArcStr>) -> Self {
         let placeholder_text = placeholder_text.into();
         let label = Label::new(placeholder_text.clone()).with_text_alignment(self.text_alignment);
-        self.placeholder = label.with_props(LineBreaking::Clip).to_pod();
+        self.placeholder = label.prepare().with_props(LineBreaking::Clip).to_pod();
         self.placeholder_text = placeholder_text;
         self
     }
@@ -388,7 +391,7 @@ mod tests {
         let text_input = NewWidget::new(TextInput::from_text_area(
             TextArea::new_editable("TextInput contents")
                 .with_style(StyleProperty::FontSize(14.0))
-                .with_auto_id(),
+                .prepare(),
         ));
         let mut harness = TestHarness::create_with(test_property_set(), text_input, HARNESS_PARAMS);
 
@@ -421,7 +424,7 @@ mod tests {
             TextInput::from_text_area(
                 TextArea::new_editable("")
                     .with_style(StyleProperty::FontSize(14.0))
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_placeholder("HELLO WORLD"),
         );
@@ -438,7 +441,7 @@ mod tests {
                 TextArea::new_editable("TextInput contents which should be clipped")
                     .with_style(StyleProperty::FontSize(14.0))
                     .with_word_wrap(false)
-                    .with_auto_id(),
+                    .prepare(),
             )
             .with_clip(true),
         );

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -1122,7 +1122,7 @@ mod tests {
 
     #[test]
     fn sensible_driver() {
-        let widget = VirtualScroll::new(0).with_auto_id();
+        let widget = VirtualScroll::new(0).prepare();
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(100., 200.));
@@ -1165,7 +1165,7 @@ mod tests {
     /// We shouldn't panic or loop if there are small gaps in the items provided by the driver.
     /// Again, this isn't valid code for a user to write, but we should just warn and deal with it
     fn small_gaps() {
-        let widget = VirtualScroll::new(0).with_auto_id();
+        let widget = VirtualScroll::new(0).prepare();
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(100., 200.));
@@ -1205,7 +1205,7 @@ mod tests {
     /// We shouldn't panic or loop if there are big gaps in the items provided by the driver.
     /// Note that we don't test rendering in this case, because this is a driver which breaks our contract.
     fn big_gaps() {
-        let widget = VirtualScroll::new(0).with_auto_id();
+        let widget = VirtualScroll::new(0).prepare();
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(100., 200.));
@@ -1245,7 +1245,7 @@ mod tests {
     /// We shouldn't panic or loop if the driver is very poorly written (doesn't set `valid_range` correctly)
     /// Note that we don't test rendering in this case, because this is a driver which breaks our contract.
     fn degenerate_driver() {
-        let widget = VirtualScroll::new(0).with_auto_id();
+        let widget = VirtualScroll::new(0).prepare();
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(100., 200.));
@@ -1287,7 +1287,7 @@ mod tests {
         const MIN: i64 = 10;
         let widget = VirtualScroll::new(0)
             .with_valid_range(MIN..i64::MAX)
-            .with_auto_id();
+            .prepare();
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(100., 200.));
@@ -1354,7 +1354,7 @@ mod tests {
         const MAX: i64 = 10;
         let widget = VirtualScroll::new(100)
             .with_valid_range(i64::MIN..MAX)
-            .with_auto_id();
+            .prepare();
 
         let mut harness =
             TestHarness::create_with_size(test_property_set(), widget, Size::new(100., 200.));

--- a/masonry/src/widgets/zstack.rs
+++ b/masonry/src/widgets/zstack.rs
@@ -337,7 +337,7 @@ mod tests {
         let widget = ZStack::new()
             .with(
                 NewWidget::new(
-                    SizedBox::new(Label::new("Background").with_auto_id())
+                    SizedBox::new(Label::new("Background").prepare())
                         .width(200.px())
                         .height(100.px()),
                 )
@@ -345,11 +345,11 @@ mod tests {
                 ChildAlignment::ParentAligned,
             )
             .with(
-                NewWidget::new(SizedBox::new(Label::new("Foreground").with_auto_id()))
+                NewWidget::new(SizedBox::new(Label::new("Foreground").prepare()))
                     .with_props(fg_props),
                 ChildAlignment::ParentAligned,
             )
-            .with_auto_id();
+            .prepare();
 
         let mut harness = TestHarness::create(test_property_set(), widget);
         assert_render_snapshot!(harness, "zstack_alignment_default");
@@ -380,20 +380,14 @@ mod tests {
         let widget = ZStack::new()
             .with_alignment(UnitPoint::CENTER)
             .with(
-                Label::new("ParentAligned").with_auto_id(),
+                Label::new("ParentAligned").prepare(),
                 ChildAlignment::ParentAligned,
             )
-            .with(Label::new("TopLeft").with_auto_id(), UnitPoint::TOP_LEFT)
-            .with(Label::new("TopRight").with_auto_id(), UnitPoint::TOP_RIGHT)
-            .with(
-                Label::new("BottomLeft").with_auto_id(),
-                UnitPoint::BOTTOM_LEFT,
-            )
-            .with(
-                Label::new("BottomRight").with_auto_id(),
-                UnitPoint::BOTTOM_RIGHT,
-            )
-            .with_auto_id();
+            .with(Label::new("TopLeft").prepare(), UnitPoint::TOP_LEFT)
+            .with(Label::new("TopRight").prepare(), UnitPoint::TOP_RIGHT)
+            .with(Label::new("BottomLeft").prepare(), UnitPoint::BOTTOM_LEFT)
+            .with(Label::new("BottomRight").prepare(), UnitPoint::BOTTOM_RIGHT)
+            .prepare();
 
         let mut harness = TestHarness::create(test_property_set(), widget);
         assert_render_snapshot!(harness, "zstack_alignments_self_aligned");

--- a/masonry/tests/examples.rs
+++ b/masonry/tests/examples.rs
@@ -50,7 +50,7 @@ mod tests {
     fn zero_size_custom_widget() {
         let mut harness = TestHarness::create_with(
             default_property_set(),
-            others::custom_widget::CustomWidget("Foobar".to_string()).with_auto_id(),
+            others::custom_widget::CustomWidget("Foobar".to_string()).prepare(),
             PARAMS_ZERO_SIZE,
         );
         let _ = harness.render();

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -328,6 +328,7 @@ impl RenderRoot {
         // LayerStack can't use Dimensions::AUTO because it'll resolve to the window size.
         // Instead we want to always measure LayerStack, so it can measure its base layer.
         let layer_stack = LayerStack::new(root_widget)
+            .prepare()
             .with_props(Dimensions::MAX)
             .to_pod();
 

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -15,8 +15,7 @@ use tracing::{Span, trace_span};
 use crate::core::{
     AccessCtx, AccessEvent, ActionCtx, ComposeCtx, CursorIcon, ErasedAction, EventCtx, Layer,
     LayoutCtx, MeasureCtx, NewWidget, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef,
-    PropertySet, QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, WidgetMut, WidgetRef,
-    pre_paint,
+    QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, WidgetMut, WidgetRef, pre_paint,
 };
 use crate::imaging::Painter;
 use crate::layout::LenReq;
@@ -572,19 +571,11 @@ pub trait Widget: AsDynWidget + Any {
     }
 
     /// Convenience method to wrap this in a [`NewWidget`].
-    fn with_auto_id(self) -> NewWidget<Self>
+    fn prepare(self) -> NewWidget<Self>
     where
         Self: Sized,
     {
         NewWidget::new(self)
-    }
-
-    /// Convenience method to wrap this in a [`NewWidget`] with the given [`PropertySet`].
-    fn with_props(self, props: impl Into<PropertySet>) -> NewWidget<Self>
-    where
-        Self: Sized,
-    {
-        NewWidget::new(self).with_props(props)
     }
 }
 

--- a/masonry_core/src/core/widget_pod.rs
+++ b/masonry_core/src/core/widget_pod.rs
@@ -86,7 +86,7 @@ enum WidgetPodInner<W: ?Sized> {
 impl<W: Widget> NewWidget<W> {
     /// Creates a new widget.
     ///
-    /// You can also get the same result with [`Widget::with_auto_id()`].
+    /// You can also get the same result with [`Widget::prepare()`].
     #[inline(always)]
     pub fn new(inner: W) -> Self {
         Self {

--- a/masonry_testing/src/modular_widget.rs
+++ b/masonry_testing/src/modular_widget.rs
@@ -7,8 +7,8 @@ use masonry_core::accesskit::{Node, Role};
 use masonry_core::core::{
     AccessCtx, AccessEvent, ActionCtx, ChildrenIds, ComposeCtx, CursorIcon, ErasedAction, EventCtx,
     Layer, LayoutCtx, MeasureCtx, NewWidget, NoAction, PaintCtx, PointerEvent, PropertiesMut,
-    PropertiesRef, PropertySet, QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget,
-    WidgetId, WidgetPod, WidgetRef, find_widget_under_pointer, pre_paint,
+    PropertiesRef, QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId,
+    WidgetPod, WidgetRef, find_widget_under_pointer, pre_paint,
 };
 use masonry_core::imaging::Painter;
 use masonry_core::kurbo::{Axis, Point, Size};
@@ -580,17 +580,10 @@ impl<S: 'static> Widget for ModularWidget<S> {
         "ModularWidget"
     }
 
-    fn with_auto_id(self) -> NewWidget<Self>
+    fn prepare(self) -> NewWidget<Self>
     where
         Self: Sized,
     {
         NewWidget::new(self)
-    }
-
-    fn with_props(self, props: impl Into<PropertySet>) -> NewWidget<Self>
-    where
-        Self: Sized,
-    {
-        NewWidget::new(self).with_props(props)
     }
 }

--- a/masonry_testing/src/recorder_widget.rs
+++ b/masonry_testing/src/recorder_widget.rs
@@ -17,7 +17,7 @@ use masonry_core::accesskit::{Node, Role};
 use masonry_core::core::{
     AccessCtx, AccessEvent, ActionCtx, ChildrenIds, ComposeCtx, CursorIcon, ErasedAction, EventCtx,
     Layer, LayoutCtx, MeasureCtx, NewWidget, PaintCtx, PointerEvent, PropertiesMut, PropertiesRef,
-    PropertySet, QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetRef,
+    QueryCtx, RegisterCtx, TextEvent, Update, UpdateCtx, Widget, WidgetId, WidgetRef,
 };
 use masonry_core::imaging::Painter;
 use masonry_core::kurbo::{Axis, Point, Size};
@@ -343,17 +343,10 @@ impl<W: Widget> Widget for Recorder<W> {
         "Recorder"
     }
 
-    fn with_auto_id(self) -> NewWidget<Self>
+    fn prepare(self) -> NewWidget<Self>
     where
         Self: Sized,
     {
         NewWidget::new(self)
-    }
-
-    fn with_props(self, props: impl Into<PropertySet>) -> NewWidget<Self>
-    where
-        Self: Sized,
-    {
-        NewWidget::new(self).with_props(props)
     }
 }


### PR DESCRIPTION
`Widget::with_auto_id()` was an unclear name. This changes the name to `prepare()`, which hints at the "builder pattern" nature of `NewWidget`.

Remove `Widget::with_props()`, and replace it with `my_widget.prepare().with_props()` to have only one set of builder methods.