### PR TITLE
Tweak `NewWidget::with_props` to add props instead of overwriting them

### DIFF
--- a/masonry/src/tests/mod.rs
+++ b/masonry/src/tests/mod.rs
@@ -13,5 +13,6 @@ mod event;
 mod layout;
 mod mutate;
 mod paint;
+mod properties;
 mod update;
 mod widget_tag;

--- a/masonry/src/tests/properties.rs
+++ b/masonry/src/tests/properties.rs
@@ -1,32 +1,32 @@
 // Copyright 2026 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::core::palette::css::ORANGE;
-use crate::core::{NewWidget, PropertySet, layout::AsUnit as _};
+use crate::core::Widget as _;
+use crate::layout::AsUnit as _;
+use crate::palette::css::BLUE;
 use crate::properties::{ContentColor, Dimensions, Gap};
+use crate::widgets::Button;
 
 #[test]
 fn widget_new_properties() {
-    let harness = TestHarness::new();
-
-    let widget = Button::new("").prepare();
+    let widget = Button::with_text("").prepare();
 
     // Set Dimensions, Gap, ContentColor to some values.
     let widget = widget
         .with_props(Dimensions::STRETCH)
         .with_props(Gap::new(10.px()))
-        .with_props(ContentColor::new(ORANGE));
+        .with_props(ContentColor::new(BLUE));
 
-    let props = &new_widget.properties;
-    assert_eq!(props.get::<Dimensions>(), Dimensions::STRETCH);
-    assert_eq!(props.get::<Gap>(), Gap::new(10.px()));
-    assert_eq!(props.get::<ContentColor>(), ContentColor::new(ORANGE));
+    let props = &widget.properties;
+    assert_eq!(props.get::<Dimensions>(), Some(&Dimensions::STRETCH));
+    assert_eq!(props.get::<Gap>(), Some(&Gap::new(10.px())));
+    assert_eq!(props.get::<ContentColor>(), Some(&ContentColor::new(BLUE)));
 
     // Override Dimensions and Gap but not ContentColor.
     let widget = widget.with_props((Dimensions::MIN, Gap::ZERO));
 
-    let props = &new_widget.properties;
-    assert_eq!(props.get::<Dimensions>(), Dimensions::MIN);
-    assert_eq!(props.get::<Gap>(), Gap::ZERO);
-    assert_eq!(props.get::<ContentColor>(), ContentColor::new(ORANGE));
+    let props = &widget.properties;
+    assert_eq!(props.get::<Dimensions>(), Some(&Dimensions::MIN));
+    assert_eq!(props.get::<Gap>(), Some(&Gap::ZERO));
+    assert_eq!(props.get::<ContentColor>(), Some(&ContentColor::new(BLUE)));
 }

--- a/masonry/src/tests/properties.rs
+++ b/masonry/src/tests/properties.rs
@@ -1,0 +1,32 @@
+// Copyright 2026 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::core::palette::css::ORANGE;
+use crate::core::{NewWidget, PropertySet, layout::AsUnit as _};
+use crate::properties::{ContentColor, Dimensions, Gap};
+
+#[test]
+fn widget_new_properties() {
+    let harness = TestHarness::new();
+
+    let widget = Button::new("").prepare();
+
+    // Set Dimensions, Gap, ContentColor to some values.
+    let widget = widget
+        .with_props(Dimensions::STRETCH)
+        .with_props(Gap::new(10.px()))
+        .with_props(ContentColor::new(ORANGE));
+
+    let props = &new_widget.properties;
+    assert_eq!(props.get::<Dimensions>(), Dimensions::STRETCH);
+    assert_eq!(props.get::<Gap>(), Gap::new(10.px()));
+    assert_eq!(props.get::<ContentColor>(), ContentColor::new(ORANGE));
+
+    // Override Dimensions and Gap but not ContentColor.
+    let widget = widget.with_props((Dimensions::MIN, Gap::ZERO));
+
+    let props = &new_widget.properties;
+    assert_eq!(props.get::<Dimensions>(), Dimensions::MIN);
+    assert_eq!(props.get::<Gap>(), Gap::ZERO);
+    assert_eq!(props.get::<ContentColor>(), ContentColor::new(ORANGE));
+}

--- a/masonry_core/src/core/widget_pod.rs
+++ b/masonry_core/src/core/widget_pod.rs
@@ -154,6 +154,9 @@ impl<W: Widget + ?Sized> NewWidget<W> {
 
     /// Applies the given [properties] to this widget.
     ///
+    /// Calling this method multiple times will merge the properties together,
+    /// with later properties taking precedence over earlier ones with the same type.
+    ///
     /// [properties]: crate::doc::masonry_concepts#properties
     pub fn with_props(mut self, props: impl Into<PropertySet>) -> Self {
         if self.properties.map.is_empty() {

--- a/masonry_core/src/core/widget_pod.rs
+++ b/masonry_core/src/core/widget_pod.rs
@@ -152,9 +152,18 @@ impl<W: Widget + ?Sized> NewWidget<W> {
         self
     }
 
-    /// Sets the [`PropertySet`] for this widget.
+    /// Applies the given [properties] to this widget.
+    ///
+    /// [properties]: crate::doc::masonry_concepts#properties
     pub fn with_props(mut self, props: impl Into<PropertySet>) -> Self {
-        self.properties = props.into();
+        if self.properties.map.is_empty() {
+            self.properties = props.into();
+        } else {
+            let props = props.into();
+            self.properties
+                .map
+                .extend(props.map.into_raw().into_values());
+        }
         self
     }
 


### PR DESCRIPTION
This removes a potential footgun where calling `new_widget.with_props(A).with_props(B)` would get the propset `(B)` instead of `(A, B)`.