### PR TITLE
Remove Vello image override support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,7 +2460,6 @@ dependencies = [
  "imaging_vello_hybrid",
  "kurbo",
  "peniko",
- "vello",
  "wgpu",
 ]
 

--- a/masonry_imaging/Cargo.toml
+++ b/masonry_imaging/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 
 [features]
 default = ["imaging_vello"]
-imaging_vello = ["dep:imaging_vello", "dep:vello"]
+imaging_vello = ["dep:imaging_vello"]
 imaging_vello_hybrid = ["dep:imaging_vello_hybrid"]
 imaging_vello_cpu = ["dep:imaging_vello_cpu"]
 imaging_skia = ["dep:imaging_skia"]
@@ -31,7 +31,6 @@ imaging_vello_cpu = { workspace = true, optional = true }
 kurbo.workspace = true
 peniko.workspace = true
 wgpu.workspace = true
-vello = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 imaging_skia = { workspace = true, optional = true }

--- a/masonry_imaging/src/texture_render.rs
+++ b/masonry_imaging/src/texture_render.rs
@@ -25,13 +25,6 @@ pub struct RenderTarget<'a> {
     pub view: &'a wgpu::TextureView,
 }
 
-/// Masonry paint output prepared for texture rendering.
-#[derive(Clone, Copy, Debug)]
-pub struct RenderInput<'a> {
-    /// Flattened Masonry frame content prepared for rendering.
-    pub frame: PreparedFrame<'a>,
-}
-
 /// Errors that can occur while rendering Masonry content into a target texture.
 #[derive(Debug)]
 pub struct Error(imp::Error);
@@ -61,9 +54,9 @@ impl Renderer {
     pub fn render_to_texture(
         &mut self,
         target: RenderTarget<'_>,
-        input: RenderInput<'_>,
+        frame: PreparedFrame<'_>,
     ) -> Result<(), Error> {
-        self.0.render_to_texture(target, input).map_err(Error)
+        self.0.render_to_texture(target, frame).map_err(Error)
     }
 }
 
@@ -73,25 +66,23 @@ impl Default for Renderer {
     }
 }
 
-#[cfg(all(
-    not(feature = "imaging_vello"),
-    any(
-        all(feature = "imaging_skia", not(target_arch = "wasm32")),
-        feature = "imaging_vello_hybrid"
-    )
+#[cfg(any(
+    all(feature = "imaging_skia", not(target_arch = "wasm32")),
+    feature = "imaging_vello",
+    feature = "imaging_vello_hybrid"
 ))]
-mod non_vello {
+mod shared_texture_renderer {
     use imaging::render::TextureRenderer;
 
     use crate::PreparedFrame;
 
     #[derive(Debug)]
-    pub(super) struct CachedRenderer<R, K> {
+    pub(super) struct RendererCache<R, K> {
         key: Option<K>,
         inner: Option<R>,
     }
 
-    impl<R, K> CachedRenderer<R, K>
+    impl<R, K> RendererCache<R, K>
     where
         K: Copy + Eq,
     {
@@ -119,6 +110,15 @@ mod non_vello {
         }
     }
 
+    #[cfg(any(feature = "imaging_vello", feature = "imaging_vello_hybrid"))]
+    #[inline]
+    pub(super) fn device_queue_key(target: super::RenderTarget<'_>) -> (usize, usize) {
+        (
+            target.device as *const _ as usize,
+            target.queue as *const _ as usize,
+        )
+    }
+
     pub(super) fn render_window_source_to_texture<R>(
         renderer: &mut R,
         frame: PreparedFrame<'_>,
@@ -138,6 +138,8 @@ mod non_vello {
     all(feature = "imaging_skia", not(target_arch = "wasm32"))
 )))]
 mod imp {
+    use crate::PreparedFrame;
+
     #[derive(Debug)]
     pub(super) enum Error {}
 
@@ -162,7 +164,7 @@ mod imp {
         pub(super) fn render_to_texture(
             &mut self,
             _: super::RenderTarget<'_>,
-            _: super::RenderInput<'_>,
+            _: PreparedFrame<'_>,
         ) -> Result<(), Error> {
             unreachable!("a renderer backend feature is required")
         }
@@ -175,10 +177,11 @@ mod imp {
     not(target_arch = "wasm32")
 ))]
 mod imp {
-    use super::non_vello::{CachedRenderer, render_window_source_to_texture};
+    use super::shared_texture_renderer::{RendererCache, render_window_source_to_texture};
     use crate::skia::{TargetRenderer, TextureTarget, new_target_renderer};
 
-    use super::{RenderInput, RenderTarget};
+    use super::RenderTarget;
+    use crate::PreparedFrame;
 
     /// Errors that can occur while rendering Masonry content with Skia.
     #[derive(Debug)]
@@ -203,7 +206,7 @@ mod imp {
     /// Runtime renderer state for the Skia backend.
     #[derive(Debug)]
     pub(super) struct Renderer {
-        inner: CachedRenderer<TargetRenderer, (usize, usize, usize)>,
+        inner: RendererCache<TargetRenderer, (usize, usize, usize)>,
     }
 
     impl Renderer {
@@ -213,7 +216,7 @@ mod imp {
         /// Create an empty renderer state.
         pub(super) fn new() -> Self {
             Self {
-                inner: CachedRenderer::new(),
+                inner: RendererCache::new(),
             }
         }
 
@@ -221,7 +224,7 @@ mod imp {
         pub(super) fn render_to_texture(
             &mut self,
             target: RenderTarget<'_>,
-            input: RenderInput<'_>,
+            frame: PreparedFrame<'_>,
         ) -> Result<(), Error> {
             let renderer = self.inner.get_or_try_init(
                 (
@@ -239,83 +242,46 @@ mod imp {
                 },
             )?;
 
-            render_window_source_to_texture(
-                renderer,
-                input.frame,
-                TextureTarget::new(target.texture),
-            )
-            .map_err(Error::Render)
+            render_window_source_to_texture(renderer, frame, TextureTarget::new(target.texture))
+                .map_err(Error::Render)
         }
     }
 }
 
 #[cfg(feature = "imaging_vello")]
-impl Renderer {
-    /// Set a persistent image override for the Vello backend.
-    pub fn set_image_override(&mut self, image: peniko::ImageData, texture: wgpu::Texture) {
-        self.0.set_image_override(image, texture);
-    }
-
-    /// Clear a previously-set Vello image override.
-    pub fn clear_image_override(&mut self, image: &peniko::ImageData) {
-        self.0.clear_image_override(image);
-    }
-}
-
-#[cfg(feature = "imaging_vello")]
 mod imp {
-    use std::collections::HashMap;
+    use super::shared_texture_renderer::{
+        RendererCache, device_queue_key, render_window_source_to_texture,
+    };
+    use crate::vello::{TargetRenderer, TextureTarget, new_target_renderer};
 
-    use vello::{AaConfig, AaSupport, RenderParams, Renderer as VelloRenderer, RendererOptions};
-
-    use crate::vello::build_scene_from_source;
-
-    use super::{RenderInput, RenderTarget};
+    use super::RenderTarget;
+    use crate::PreparedFrame;
 
     /// Errors that can occur while rendering Masonry content with Vello.
     #[derive(Debug)]
     pub(super) enum Error {
-        /// Building the native Vello scene failed.
-        BuildScene(crate::vello::Error),
         /// Creating the Vello renderer failed.
-        CreateRenderer(vello::Error),
+        CreateRenderer(crate::vello::Error),
         /// Rendering the scene to the texture failed.
-        Render(vello::Error),
+        Render(imaging_vello::Error),
     }
 
     impl core::fmt::Display for Error {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             match self {
-                Self::BuildScene(err) => write!(f, "building Vello scene failed: {err}"),
                 Self::CreateRenderer(err) => write!(f, "creating Vello renderer failed: {err}"),
-                Self::Render(err) => write!(f, "rendering with Vello failed: {err}"),
+                Self::Render(err) => write!(f, "rendering with Vello failed: {err:?}"),
             }
         }
     }
 
     impl std::error::Error for Error {}
 
-    #[derive(Debug)]
-    struct ImageOverrideState {
-        image: peniko::ImageData,
-        texture: wgpu::Texture,
-        applied: bool,
-        prev: Option<wgpu::TexelCopyTextureInfoBase<wgpu::Texture>>,
-    }
-
     /// Runtime renderer state for the Vello backend.
+    #[derive(Debug)]
     pub(super) struct Renderer {
-        inner: Option<VelloRenderer>,
-        image_overrides: HashMap<u64, ImageOverrideState>,
-    }
-
-    impl core::fmt::Debug for Renderer {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            f.debug_struct("Renderer")
-                .field("inner", &self.inner.as_ref().map(|_| "(VelloRenderer)"))
-                .field("image_overrides", &self.image_overrides)
-                .finish()
-        }
+        inner: RendererCache<TargetRenderer, (usize, usize)>,
     }
 
     impl Renderer {
@@ -325,8 +291,7 @@ mod imp {
         /// Create an empty renderer state.
         pub(super) fn new() -> Self {
             Self {
-                inner: None,
-                image_overrides: HashMap::new(),
+                inner: RendererCache::new(),
             }
         }
 
@@ -334,121 +299,19 @@ mod imp {
         pub(super) fn render_to_texture(
             &mut self,
             target: RenderTarget<'_>,
-            input: RenderInput<'_>,
+            frame: PreparedFrame<'_>,
         ) -> Result<(), Error> {
-            let mut source = input.frame.window_source();
-            let scene = build_scene_from_source(&mut source, input.frame.width, input.frame.height)
-                .map_err(Error::BuildScene)?;
+            let renderer = self.inner.get_or_try_init(device_queue_key(target), || {
+                new_target_renderer(target.device.clone(), target.queue.clone())
+                    .map_err(Error::CreateRenderer)
+            })?;
 
-            if self.inner.is_none() {
-                let renderer_options = RendererOptions {
-                    antialiasing_support: AaSupport::area_only(),
-                    ..Default::default()
-                };
-                self.inner = Some(
-                    VelloRenderer::new(target.device, renderer_options)
-                        .map_err(Error::CreateRenderer)?,
-                );
-            }
-            let renderer = self.inner.as_mut().unwrap();
-
-            for state in self.image_overrides.values_mut() {
-                if state.applied {
-                    continue;
-                }
-                state.prev = renderer.override_image(
-                    &state.image,
-                    Some(wgpu::TexelCopyTextureInfoBase {
-                        texture: state.texture.clone(),
-                        mip_level: 0,
-                        origin: wgpu::Origin3d::ZERO,
-                        aspect: wgpu::TextureAspect::All,
-                    }),
-                );
-                state.applied = true;
-            }
-
-            let render_params = RenderParams {
-                // WindowSource already paints the background into the scene, so keep
-                // Vello's target clear transparent here instead of applying the base color twice.
-                base_color: peniko::Color::from_rgba8(0, 0, 0, 0),
-                width: input.frame.width,
-                height: input.frame.height,
-                antialiasing_method: AaConfig::Area,
-            };
-            renderer
-                .render_to_texture(
-                    target.device,
-                    target.queue,
-                    &scene,
-                    target.view,
-                    &render_params,
-                )
-                .map_err(Error::Render)
-        }
-
-        /// Set a persistent image override for the Vello backend.
-        pub(super) fn set_image_override(
-            &mut self,
-            image: peniko::ImageData,
-            texture: wgpu::Texture,
-        ) {
-            let image_id = image.data.id();
-
-            if let Some(existing) = self.image_overrides.get_mut(&image_id) {
-                existing.texture = texture;
-                if existing.applied {
-                    if let Some(renderer) = &mut self.inner {
-                        renderer.override_image(
-                            &existing.image,
-                            Some(wgpu::TexelCopyTextureInfoBase {
-                                texture: existing.texture.clone(),
-                                mip_level: 0,
-                                origin: wgpu::Origin3d::ZERO,
-                                aspect: wgpu::TextureAspect::All,
-                            }),
-                        );
-                    } else {
-                        existing.applied = false;
-                    }
-                }
-                return;
-            }
-
-            let mut state = ImageOverrideState {
-                image,
-                texture,
-                applied: false,
-                prev: None,
-            };
-
-            if let Some(renderer) = &mut self.inner {
-                state.prev = renderer.override_image(
-                    &state.image,
-                    Some(wgpu::TexelCopyTextureInfoBase {
-                        texture: state.texture.clone(),
-                        mip_level: 0,
-                        origin: wgpu::Origin3d::ZERO,
-                        aspect: wgpu::TextureAspect::All,
-                    }),
-                );
-                state.applied = true;
-            }
-
-            self.image_overrides.insert(image_id, state);
-        }
-
-        /// Clear a previously-set Vello image override.
-        pub(super) fn clear_image_override(&mut self, image: &peniko::ImageData) {
-            let image_id = image.data.id();
-            let Some(state) = self.image_overrides.remove(&image_id) else {
-                return;
-            };
-            if state.applied
-                && let Some(renderer) = &mut self.inner
-            {
-                renderer.override_image(&state.image, state.prev);
-            }
+            render_window_source_to_texture(
+                renderer,
+                frame,
+                TextureTarget::new(target.view, frame.width, frame.height),
+            )
+            .map_err(Error::Render)
         }
     }
 }
@@ -459,10 +322,13 @@ mod imp {
     feature = "imaging_vello_hybrid"
 ))]
 mod imp {
-    use super::non_vello::{CachedRenderer, render_window_source_to_texture};
+    use super::shared_texture_renderer::{
+        RendererCache, device_queue_key, render_window_source_to_texture,
+    };
     use crate::vello_hybrid::{TargetRenderer, TextureTarget, new_target_renderer};
 
-    use super::{RenderInput, RenderTarget};
+    use super::RenderTarget;
+    use crate::PreparedFrame;
 
     /// Errors that can occur while rendering Masonry content with Vello Hybrid.
     #[derive(Debug)]
@@ -484,7 +350,7 @@ mod imp {
     /// Runtime renderer state for the Vello Hybrid backend.
     #[derive(Debug)]
     pub(super) struct Renderer {
-        inner: CachedRenderer<TargetRenderer, (usize, usize)>,
+        inner: RendererCache<TargetRenderer, (usize, usize)>,
     }
 
     impl Renderer {
@@ -494,7 +360,7 @@ mod imp {
         /// Create an empty renderer state.
         pub(super) fn new() -> Self {
             Self {
-                inner: CachedRenderer::new(),
+                inner: RendererCache::new(),
             }
         }
 
@@ -502,25 +368,19 @@ mod imp {
         pub(super) fn render_to_texture(
             &mut self,
             target: RenderTarget<'_>,
-            input: RenderInput<'_>,
+            frame: PreparedFrame<'_>,
         ) -> Result<(), Error> {
-            let renderer = self.inner.get_or_try_init(
-                (
-                    target.device as *const _ as usize,
-                    target.queue as *const _ as usize,
-                ),
-                || {
-                    Ok(new_target_renderer(
-                        target.device.clone(),
-                        target.queue.clone(),
-                    ))
-                },
-            )?;
+            let renderer = self.inner.get_or_try_init(device_queue_key(target), || {
+                Ok(new_target_renderer(
+                    target.device.clone(),
+                    target.queue.clone(),
+                ))
+            })?;
 
             render_window_source_to_texture(
                 renderer,
-                input.frame,
-                TextureTarget::new(target.view, input.frame.width, input.frame.height),
+                frame,
+                TextureTarget::new(target.view, frame.width, frame.height),
             )
             .map_err(Error::Render)
         }

--- a/masonry_imaging/src/vello.rs
+++ b/masonry_imaging/src/vello.rs
@@ -3,9 +3,6 @@
 
 use core::fmt;
 
-use imaging::render::RenderSource;
-use kurbo::Rect;
-
 use crate::headless_wgpu;
 
 /// Errors that can occur while creating or using a Vello renderer.
@@ -34,27 +31,22 @@ pub const BACKEND_NAME: &str = "imaging_vello";
 /// Masonry alias for the selected Vello renderer type.
 pub type Renderer = imaging_vello::VelloRenderer;
 
+/// Masonry alias for the selected Vello texture renderer type.
+pub type TargetRenderer = imaging_vello::VelloTargetRenderer;
+
+/// Masonry alias for the selected Vello texture target wrapper.
+pub type TextureTarget<'a> = imaging_vello::TextureTarget<'a>;
+
 /// Create a reusable headless Vello renderer.
 pub fn new_headless_renderer() -> Result<Renderer, Error> {
     let (device, queue) = headless_wgpu::try_init_device_and_queue().map_err(|_| Error::Init)?;
     imaging_vello::VelloRenderer::new(device, queue).map_err(Error::Backend)
 }
 
-/// Build a native Vello scene from any render source.
-pub fn build_scene_from_source<S: RenderSource + ?Sized>(
-    source: &mut S,
-    width: u32,
-    height: u32,
-) -> Result<vello::Scene, Error> {
-    source
-        .validate()
-        .map_err(imaging_vello::Error::InvalidScene)
-        .map_err(Error::Backend)?;
-
-    let mut native = vello::Scene::new();
-    let bounds = Rect::new(0.0, 0.0, f64::from(width), f64::from(height));
-    let mut sink = imaging_vello::VelloSceneSink::new(&mut native, bounds);
-    source.paint_into(&mut sink);
-    sink.finish().map_err(Error::Backend)?;
-    Ok(native)
+/// Create a reusable Vello target renderer bound to an existing WGPU device and queue.
+pub fn new_target_renderer(
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+) -> Result<TargetRenderer, Error> {
+    imaging_vello::VelloTargetRenderer::new(device, queue).map_err(Error::Backend)
 }

--- a/masonry_winit/src/app_driver.rs
+++ b/masonry_winit/src/app_driver.rs
@@ -8,8 +8,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use masonry_core::app::RenderRoot;
 use masonry_core::core::{ErasedAction, WidgetId};
-#[cfg(feature = "imaging_vello")]
-use masonry_core::peniko::ImageData;
 use tracing::field::DisplayValue;
 use winit::event_loop::ActiveEventLoop;
 
@@ -168,43 +166,6 @@ impl DriverCtx<'_, '_> {
     /// Panics if the window cannot be found.
     pub fn close_window(&mut self, window_id: WindowId) {
         self.state.close_window(window_id);
-    }
-
-    /// Set a persistent Vello image override.
-    ///
-    /// This associates the given [`ImageData`] with the provided GPU texture.
-    ///
-    /// Correct behaviour is not guaranteed if the texture does not have the same
-    /// dimensions as the image.
-    ///
-    /// Overrides persist until cleared with [`DriverCtx::clear_image_override`].
-    ///
-    /// Note: Masonry currently uses a shared Vello renderer, so overrides are global to that
-    /// renderer/device.
-    ///
-    /// ## When does this take effect?
-    ///
-    /// The underlying Vello [`Renderer`](vello::Renderer) is created lazily during
-    /// rendering. If you call this method before the renderer exists, Masonry will store the
-    /// override and apply it automatically once a renderer has been created.
-    ///
-    /// # Texture requirements
-    ///
-    /// When set, Vello will copy from `texture` into its internal image atlas whenever the
-    /// `image` is drawn in the UI scene.
-    ///
-    /// The texture must be `Rgba8Unorm` and include `COPY_SRC` usage.
-    #[cfg(feature = "imaging_vello")]
-    pub fn set_image_override(&mut self, image: ImageData, texture: wgpu::Texture) {
-        self.state.set_image_override(image, texture);
-    }
-
-    /// Clear a previously-set image override for the given `ImageData`.
-    ///
-    /// Note: overrides are global to the current renderer/device; see [`set_image_override`](Self::set_image_override).
-    #[cfg(feature = "imaging_vello")]
-    pub fn clear_image_override(&mut self, image: &ImageData) {
-        self.state.clear_image_override(image);
     }
 
     /// Exits the application (stops the event loop).

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -17,8 +17,7 @@ use masonry_core::core::{
 use masonry_core::peniko::Color;
 use masonry_core::util::Instant;
 use masonry_imaging::texture_render::{
-    RenderInput as ImagingRenderInput, RenderTarget as ImagingRenderTarget,
-    Renderer as ImagingRenderer,
+    RenderTarget as ImagingRenderTarget, Renderer as ImagingRenderer,
 };
 use masonry_imaging::{Layer as ImagingLayer, PreparedFrame};
 use tracing::{info, info_span, trace};
@@ -599,20 +598,6 @@ impl MasonryState<'_> {
         window.handle.set_ime_allowed(false);
     }
 
-    #[cfg(feature = "imaging_vello")]
-    pub(crate) fn set_image_override(
-        &mut self,
-        image: masonry_core::peniko::ImageData,
-        texture: wgpu::Texture,
-    ) {
-        self.renderer.set_image_override(image, texture);
-    }
-
-    #[cfg(feature = "imaging_vello")]
-    pub(crate) fn clear_image_override(&mut self, image: &masonry_core::peniko::ImageData) {
-        self.renderer.clear_image_override(image);
-    }
-
     // --- MARK: REDRAW
     fn redraw(&mut self, handle_id: HandleId, app_driver: &mut dyn AppDriver) {
         let _span = info_span!("redraw");
@@ -736,7 +721,7 @@ impl MasonryState<'_> {
                 texture: &surface.target_texture,
                 view: &surface.target_view,
             },
-            ImagingRenderInput { frame },
+            frame,
         ) {
             tracing::error!(
                 backend = ImagingRenderer::BACKEND_NAME,


### PR DESCRIPTION
Image overrides were a Vello-only workaround that Masonry does not use and does not want to encourage downstream use of.

Keeping them around had two costs:

* they exposed a public driver API for a backend-specific escape hatch
* they forced `masonry_imaging` to keep a separate Vello texture-render path that Skia, Vello Hybrid, and Vello CPU could not share

Remove that support end-to-end:

* drop the `DriverCtx` image-override API
* remove the event-loop forwarding
* remove the Vello renderer override state

With that workaround gone, the Vello texture path can use the same shared `TextureRenderer`-based flow as the other backends. `masonry_imaging` no longer needs a direct `vello` dependency or a special native-scene helper for this case.

This simplifies the runtime rendering code and keeps the architecture pointed at the real replacement: proper layer/external-texture handling rather than a backend-specific image substitution hook.