### PR TITLE
Fix `clippy::collapsible_match` lints

### DIFF
--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -133,12 +133,12 @@ impl Widget for Button {
         event: &TextEvent,
     ) {
         match event {
-            TextEvent::Keyboard(event) if event.state.is_up() => {
-                if matches!(&event.key, Key::Character(c) if c == " ")
-                    || event.key == Key::Named(NamedKey::Enter)
-                {
-                    ctx.submit_action::<Self::Action>(ButtonPress { button: None });
-                }
+            TextEvent::Keyboard(event)
+                if event.state.is_up()
+                    && (matches!(&event.key, Key::Character(c) if c == " ")
+                        || event.key == Key::Named(NamedKey::Enter)) =>
+            {
+                ctx.submit_action::<Self::Action>(ButtonPress { button: None });
             }
             _ => (),
         }

--- a/masonry/src/widgets/checkbox.rs
+++ b/masonry/src/widgets/checkbox.rs
@@ -109,11 +109,9 @@ impl Widget for Checkbox {
                 ctx.capture_pointer();
                 trace!("Checkbox {:?} pressed", ctx.widget_id());
             }
-            PointerEvent::Up { .. } => {
-                if ctx.is_active() && ctx.is_hovered() {
-                    ctx.submit_action::<Self::Action>(CheckboxToggled(!self.checked));
-                    trace!("Checkbox {:?} released", ctx.widget_id());
-                }
+            PointerEvent::Up { .. } if ctx.is_active() && ctx.is_hovered() => {
+                ctx.submit_action::<Self::Action>(CheckboxToggled(!self.checked));
+                trace!("Checkbox {:?} released", ctx.widget_id());
             }
             _ => (),
         }

--- a/masonry/src/widgets/disclosure_button.rs
+++ b/masonry/src/widgets/disclosure_button.rs
@@ -71,20 +71,18 @@ impl Widget for DisclosureButton {
         event: &PointerEvent,
     ) {
         match event {
-            PointerEvent::Down { .. } => {
-                if !ctx.is_disabled() {
-                    ctx.capture_pointer();
-                    // Checked state impacts appearance and accessibility node
-                    ctx.request_render();
-                }
+            PointerEvent::Down { .. } if !ctx.is_disabled() => {
+                ctx.capture_pointer();
+                // Checked state impacts appearance and accessibility node
+                ctx.request_render();
             }
-            PointerEvent::Up { .. } => {
-                if ctx.is_pointer_capture_target() && ctx.is_hovered() && !ctx.is_disabled() {
-                    self.switch_disclosed_state();
-                    ctx.request_layout();
+            PointerEvent::Up { .. }
+                if ctx.is_pointer_capture_target() && ctx.is_hovered() && !ctx.is_disabled() =>
+            {
+                self.switch_disclosed_state();
+                ctx.request_layout();
 
-                    // TODO: Submit actions?
-                }
+                // TODO: Submit actions?
             }
             _ => (),
         }
@@ -97,15 +95,15 @@ impl Widget for DisclosureButton {
         event: &TextEvent,
     ) {
         match event {
-            TextEvent::Keyboard(event) if event.state.is_up() => {
-                if matches!(&event.key, Key::Character(c) if c == " ")
-                    || event.key == Key::Named(NamedKey::Enter)
-                {
-                    self.switch_disclosed_state();
-                    ctx.request_layout();
+            TextEvent::Keyboard(event)
+                if event.state.is_up()
+                    && (matches!(&event.key, Key::Character(c) if c == " ")
+                        || event.key == Key::Named(NamedKey::Enter)) =>
+            {
+                self.switch_disclosed_state();
+                ctx.request_layout();
 
-                    // TODO: Submit actions?
-                }
+                // TODO: Submit actions?
             }
             _ => (),
         }

--- a/masonry/src/widgets/radio_button.rs
+++ b/masonry/src/widgets/radio_button.rs
@@ -156,11 +156,9 @@ impl Widget for RadioButton {
                 ctx.capture_pointer();
                 trace!("RadioButton {:?} pressed", ctx.widget_id());
             }
-            PointerEvent::Up { .. } => {
-                if ctx.is_active() && ctx.is_hovered() {
-                    trace!("RadioButton {:?} released", ctx.widget_id());
-                    self.select(ctx);
-                }
+            PointerEvent::Up { .. } if ctx.is_active() && ctx.is_hovered() => {
+                trace!("RadioButton {:?} released", ctx.widget_id());
+                self.select(ctx);
             }
             _ => (),
         }

--- a/masonry/src/widgets/selector.rs
+++ b/masonry/src/widgets/selector.rs
@@ -159,15 +159,11 @@ impl Widget for Selector {
         event: &PointerEvent,
     ) {
         match event {
-            PointerEvent::Down(..) => {
-                if self.menu_layer_id.is_none() {
-                    ctx.capture_pointer();
-                }
+            PointerEvent::Down(..) if self.menu_layer_id.is_none() => {
+                ctx.capture_pointer();
             }
-            PointerEvent::Up(PointerButtonEvent { .. }) => {
-                if ctx.is_active() && ctx.is_hovered() {
-                    self.toggle_selector_layer(ctx);
-                }
+            PointerEvent::Up(PointerButtonEvent { .. }) if ctx.is_active() && ctx.is_hovered() => {
+                self.toggle_selector_layer(ctx);
             }
             _ => (),
         }
@@ -180,12 +176,12 @@ impl Widget for Selector {
         event: &TextEvent,
     ) {
         match event {
-            TextEvent::Keyboard(event) if event.state.is_up() => {
-                if matches!(&event.key, Key::Character(c) if c == " ")
-                    || event.key == Key::Named(NamedKey::Enter)
-                {
-                    self.toggle_selector_layer(ctx);
-                }
+            TextEvent::Keyboard(event)
+                if event.state.is_up()
+                    && (matches!(&event.key, Key::Character(c) if c == " ")
+                        || event.key == Key::Named(NamedKey::Enter)) =>
+            {
+                self.toggle_selector_layer(ctx);
                 // TODO - On arrow key, change selected_item
             }
             // TODO - Handle text selection

--- a/masonry/src/widgets/slider.rs
+++ b/masonry/src/widgets/slider.rs
@@ -177,22 +177,20 @@ impl Widget for Slider {
                     ctx.submit_action::<f64>(self.value);
                 }
             }
-            PointerEvent::Move(PointerUpdate { current, .. }) => {
-                if ctx.is_active() {
-                    let local_pos = ctx.local_position(current.position);
-                    let width = ctx.content_box_size().width;
-                    let is_focused = ctx.is_focus_target();
-                    let cache = ctx.property_cache();
-                    if self.update_value_from_position(
-                        local_pos.x,
-                        width,
-                        *props.get(cache),
-                        is_focused,
-                    ) {
-                        ctx.submit_action::<f64>(self.value);
-                    }
-                    ctx.request_render();
+            PointerEvent::Move(PointerUpdate { current, .. }) if ctx.is_active() => {
+                let local_pos = ctx.local_position(current.position);
+                let width = ctx.content_box_size().width;
+                let is_focused = ctx.is_focus_target();
+                let cache = ctx.property_cache();
+                if self.update_value_from_position(
+                    local_pos.x,
+                    width,
+                    *props.get(cache),
+                    is_focused,
+                ) {
+                    ctx.submit_action::<f64>(self.value);
                 }
+                ctx.request_render();
             }
             _ => {}
         }

--- a/masonry/src/widgets/split.rs
+++ b/masonry/src/widgets/split.rs
@@ -494,17 +494,15 @@ where
                         self.click_offset = pos - self.bar_center(length, scale);
                     }
                 }
-                PointerEvent::Move(PointerUpdate { current, .. }) => {
-                    if ctx.is_active() {
-                        let pos = ctx
-                            .local_position(current.position)
-                            .get_coord(self.split_axis);
-                        let length = ctx.content_box_size().get_coord(self.split_axis);
-                        // If widget has pointer capture, assume always it's hovered
-                        let effective_center = pos - self.click_offset;
-                        self.update_split_point_from_bar_center(length, effective_center, scale);
-                        ctx.request_layout();
-                    }
+                PointerEvent::Move(PointerUpdate { current, .. }) if ctx.is_active() => {
+                    let pos = ctx
+                        .local_position(current.position)
+                        .get_coord(self.split_axis);
+                    let length = ctx.content_box_size().get_coord(self.split_axis);
+                    // If widget has pointer capture, assume always it's hovered
+                    let effective_center = pos - self.click_offset;
+                    self.update_split_point_from_bar_center(length, effective_center, scale);
+                    ctx.request_layout();
                 }
                 PointerEvent::Up(..) | PointerEvent::Cancel(..) => {
                     self.click_offset = 0.0;

--- a/masonry/src/widgets/step_input.rs
+++ b/masonry/src/widgets/step_input.rs
@@ -1055,22 +1055,18 @@ impl<T: Steppable> Widget for StepInput<T> {
                         }
                     }
                     _ => match ke.code {
-                        Code::NumpadSubtract => {
-                            if ke.state.is_down() {
-                                value_changed = if snap {
-                                    self.prev_snap()
-                                } else {
-                                    self.prev_step()
-                                }
+                        Code::NumpadSubtract if ke.state.is_down() => {
+                            value_changed = if snap {
+                                self.prev_snap()
+                            } else {
+                                self.prev_step()
                             }
                         }
-                        Code::NumpadAdd => {
-                            if ke.state.is_down() {
-                                value_changed = if snap {
-                                    self.next_snap()
-                                } else {
-                                    self.next_step()
-                                }
+                        Code::NumpadAdd if ke.state.is_down() => {
+                            value_changed = if snap {
+                                self.next_snap()
+                            } else {
+                                self.next_step()
                             }
                         }
                         _ => (),

--- a/masonry/src/widgets/switch.rs
+++ b/masonry/src/widgets/switch.rs
@@ -119,11 +119,9 @@ impl Widget for Switch {
                 ctx.capture_pointer();
                 trace!("Switch {:?} pressed", ctx.widget_id());
             }
-            PointerEvent::Up { .. } => {
-                if ctx.is_active() && ctx.is_hovered() {
-                    ctx.submit_action::<Self::Action>(SwitchToggled(!self.on));
-                    trace!("Switch {:?} released", ctx.widget_id());
-                }
+            PointerEvent::Up { .. } if ctx.is_active() && ctx.is_hovered() => {
+                ctx.submit_action::<Self::Action>(SwitchToggled(!self.on));
+                trace!("Switch {:?} released", ctx.widget_id());
             }
             _ => (),
         }
@@ -167,10 +165,8 @@ impl Widget for Switch {
 
     fn update(&mut self, ctx: &mut UpdateCtx<'_>, _props: &mut PropertiesMut<'_>, event: &Update) {
         match event {
-            Update::WidgetAdded => {
-                if self.on {
-                    ctx.add_class("#toggled");
-                }
+            Update::WidgetAdded if self.on => {
+                ctx.add_class("#toggled");
             }
             Update::HoveredChanged(_)
             | Update::ActiveChanged(_)

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -515,19 +515,17 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
                 ctx.request_focus();
                 ctx.capture_pointer();
             }
-            PointerEvent::Move(PointerUpdate { current, .. }) => {
-                if ctx.is_active() {
-                    let cursor_pos = ctx.local_position(current.position);
-                    let (fctx, lctx) = ctx.text_contexts();
-                    self.editor
-                        .driver(fctx, lctx)
-                        .extend_selection_to_point(cursor_pos.x as f32, cursor_pos.y as f32);
-                    let new_generation = self.editor.generation();
-                    if new_generation != self.rendered_generation {
-                        ctx.request_render();
-                        ctx.set_ime_area(self.ime_area());
-                        self.rendered_generation = new_generation;
-                    }
+            PointerEvent::Move(PointerUpdate { current, .. }) if ctx.is_active() => {
+                let cursor_pos = ctx.local_position(current.position);
+                let (fctx, lctx) = ctx.text_contexts();
+                self.editor
+                    .driver(fctx, lctx)
+                    .extend_selection_to_point(cursor_pos.x as f32, cursor_pos.y as f32);
+                let new_generation = self.editor.generation();
+                if new_generation != self.rendered_generation {
+                    ctx.request_render();
+                    ctx.set_ime_area(self.ime_area());
+                    self.rendered_generation = new_generation;
                 }
             }
             _ => {}

--- a/masonry_core/src/passes/event.rs
+++ b/masonry_core/src/passes/event.rs
@@ -383,17 +383,15 @@ pub(crate) fn run_on_access_event_pass(
 
     // Handle focus events
     match event.action {
-        accesskit::Action::Focus if !handled.is_handled() => {
-            if root.is_still_interactive(target) {
-                root.global_state.next_focused_widget = Some(target);
-                handled = Handled::Yes;
-            }
+        accesskit::Action::Focus if !handled.is_handled() && root.is_still_interactive(target) => {
+            root.global_state.next_focused_widget = Some(target);
+            handled = Handled::Yes;
         }
-        accesskit::Action::Blur if !handled.is_handled() => {
-            if root.global_state.next_focused_widget == Some(target) {
-                root.global_state.next_focused_widget = None;
-                handled = Handled::Yes;
-            }
+        accesskit::Action::Blur
+            if !handled.is_handled() && root.global_state.next_focused_widget == Some(target) =>
+        {
+            root.global_state.next_focused_widget = None;
+            handled = Handled::Yes;
         }
         accesskit::Action::ScrollIntoView if !handled.is_handled() => {
             let widget_state = root.widget_arena.get_state(target);


### PR DESCRIPTION
These show up now when running Rust 1.95.