### PR TITLE
masonry_imaging: update for new imaging renderer traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,7 +2061,7 @@ checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 [[package]]
 name = "imaging"
 version = "0.0.1"
-source = "git+https://github.com/forest-rs/imaging.git?rev=0eea0499d2666195103b9837ac4c3ee474176a5b#0eea0499d2666195103b9837ac4c3ee474176a5b"
+source = "git+https://github.com/forest-rs/imaging.git?rev=79f02aedf5b65b4cd151ef45d8b40013d7289ee2#79f02aedf5b65b4cd151ef45d8b40013d7289ee2"
 dependencies = [
  "kurbo",
  "peniko",
@@ -2070,11 +2070,12 @@ dependencies = [
 [[package]]
 name = "imaging_skia"
 version = "0.0.1"
-source = "git+https://github.com/forest-rs/imaging.git?rev=0eea0499d2666195103b9837ac4c3ee474176a5b#0eea0499d2666195103b9837ac4c3ee474176a5b"
+source = "git+https://github.com/forest-rs/imaging.git?rev=79f02aedf5b65b4cd151ef45d8b40013d7289ee2#79f02aedf5b65b4cd151ef45d8b40013d7289ee2"
 dependencies = [
  "ash",
  "foreign-types-shared",
  "imaging",
+ "imaging_wgpu",
  "kurbo",
  "oaty",
  "peniko",
@@ -2086,9 +2087,10 @@ dependencies = [
 [[package]]
 name = "imaging_vello"
 version = "0.0.1"
-source = "git+https://github.com/forest-rs/imaging.git?rev=0eea0499d2666195103b9837ac4c3ee474176a5b#0eea0499d2666195103b9837ac4c3ee474176a5b"
+source = "git+https://github.com/forest-rs/imaging.git?rev=79f02aedf5b65b4cd151ef45d8b40013d7289ee2#79f02aedf5b65b4cd151ef45d8b40013d7289ee2"
 dependencies = [
  "imaging",
+ "imaging_wgpu",
  "kurbo",
  "peniko",
  "vello",
@@ -2097,7 +2099,7 @@ dependencies = [
 [[package]]
 name = "imaging_vello_cpu"
 version = "0.0.1"
-source = "git+https://github.com/forest-rs/imaging.git?rev=0eea0499d2666195103b9837ac4c3ee474176a5b#0eea0499d2666195103b9837ac4c3ee474176a5b"
+source = "git+https://github.com/forest-rs/imaging.git?rev=79f02aedf5b65b4cd151ef45d8b40013d7289ee2#79f02aedf5b65b4cd151ef45d8b40013d7289ee2"
 dependencies = [
  "imaging",
  "kurbo",
@@ -2109,13 +2111,23 @@ dependencies = [
 [[package]]
 name = "imaging_vello_hybrid"
 version = "0.0.1"
-source = "git+https://github.com/forest-rs/imaging.git?rev=0eea0499d2666195103b9837ac4c3ee474176a5b#0eea0499d2666195103b9837ac4c3ee474176a5b"
+source = "git+https://github.com/forest-rs/imaging.git?rev=79f02aedf5b65b4cd151ef45d8b40013d7289ee2#79f02aedf5b65b4cd151ef45d8b40013d7289ee2"
 dependencies = [
  "imaging",
+ "imaging_wgpu",
  "kurbo",
  "peniko",
  "vello_common",
  "vello_hybrid",
+ "wgpu",
+]
+
+[[package]]
+name = "imaging_wgpu"
+version = "0.0.1"
+source = "git+https://github.com/forest-rs/imaging.git?rev=79f02aedf5b65b4cd151ef45d8b40013d7289ee2#79f02aedf5b65b4cd151ef45d8b40013d7289ee2"
+dependencies = [
+ "imaging",
  "wgpu",
 ]
 
@@ -2467,6 +2479,7 @@ dependencies = [
  "imaging_vello",
  "imaging_vello_cpu",
  "imaging_vello_hybrid",
+ "imaging_wgpu",
  "kurbo",
  "peniko",
  "wgpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,14 @@ tree_arena = { version = "0.2.0", path = "tree_arena" }
 include_doc_path = { version = "0.1.0", path = "include_doc_path", package = "linebender_include_doc_path" }
 
 anymore = "1.0.0"
-imaging = { git = "https://github.com/forest-rs/imaging.git", rev = "0eea0499d2666195103b9837ac4c3ee474176a5b" }
-imaging_vello = { git = "https://github.com/forest-rs/imaging.git", rev = "0eea0499d2666195103b9837ac4c3ee474176a5b" }
-imaging_vello_hybrid = { git = "https://github.com/forest-rs/imaging.git", rev = "0eea0499d2666195103b9837ac4c3ee474176a5b" }
-imaging_vello_cpu = { git = "https://github.com/forest-rs/imaging.git", rev = "0eea0499d2666195103b9837ac4c3ee474176a5b" }
-imaging_skia = { git = "https://github.com/forest-rs/imaging.git", rev = "0eea0499d2666195103b9837ac4c3ee474176a5b", features = [
+imaging = { git = "https://github.com/forest-rs/imaging.git", rev = "79f02aedf5b65b4cd151ef45d8b40013d7289ee2" }
+imaging_wgpu = { git = "https://github.com/forest-rs/imaging.git", rev = "79f02aedf5b65b4cd151ef45d8b40013d7289ee2", features = [
+    "wgpu-28",
+] }
+imaging_vello = { git = "https://github.com/forest-rs/imaging.git", rev = "79f02aedf5b65b4cd151ef45d8b40013d7289ee2" }
+imaging_vello_hybrid = { git = "https://github.com/forest-rs/imaging.git", rev = "79f02aedf5b65b4cd151ef45d8b40013d7289ee2" }
+imaging_vello_cpu = { git = "https://github.com/forest-rs/imaging.git", rev = "79f02aedf5b65b4cd151ef45d8b40013d7289ee2" }
+imaging_skia = { git = "https://github.com/forest-rs/imaging.git", rev = "79f02aedf5b65b4cd151ef45d8b40013d7289ee2", features = [
     "gpu",
 ] }
 vello = { version = "0.8.0", default-features = false, features = ["wgpu"] }

--- a/masonry_imaging/Cargo.toml
+++ b/masonry_imaging/Cargo.toml
@@ -25,15 +25,16 @@ imaging_skia = ["dep:imaging_skia"]
 
 [dependencies]
 imaging.workspace = true
-imaging_vello = { workspace = true, optional = true }
-imaging_vello_hybrid = { workspace = true, optional = true }
 imaging_vello_cpu = { workspace = true, optional = true }
 kurbo.workspace = true
 peniko.workspace = true
-wgpu.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+imaging_wgpu.workspace = true
+imaging_vello = { workspace = true, optional = true }
+imaging_vello_hybrid = { workspace = true, optional = true }
 imaging_skia = { workspace = true, optional = true }
+wgpu.workspace = true
 
 [lints]
 workspace = true

--- a/masonry_imaging/src/lib.rs
+++ b/masonry_imaging/src/lib.rs
@@ -39,35 +39,41 @@ use imaging::{PaintSink, Painter};
 use kurbo::{Affine, Rect};
 use peniko::Color;
 
-#[cfg(any(feature = "imaging_vello", feature = "imaging_vello_hybrid"))]
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(feature = "imaging_vello", feature = "imaging_vello_hybrid")
+))]
 mod headless_wgpu;
 
 /// Masonry helpers for rendering retained scenes with `imaging_skia`.
 #[cfg(all(feature = "imaging_skia", not(target_arch = "wasm32")))]
 pub mod skia;
 /// Host-neutral texture rendering helpers for texture-capable backends.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod texture_render;
 /// Masonry helpers for rendering retained scenes with `imaging_vello`.
-#[cfg(feature = "imaging_vello")]
+#[cfg(all(not(target_arch = "wasm32"), feature = "imaging_vello"))]
 pub mod vello;
 /// Masonry helpers for rendering retained scenes with `imaging_vello_cpu`.
 #[cfg(feature = "imaging_vello_cpu")]
 pub mod vello_cpu;
 /// Masonry helpers for rendering retained scenes with `imaging_vello_hybrid`.
-#[cfg(feature = "imaging_vello_hybrid")]
+#[cfg(all(not(target_arch = "wasm32"), feature = "imaging_vello_hybrid"))]
 pub mod vello_hybrid;
 
-pub use imaging::render::{ImageRenderer, TextureRenderer};
+pub use imaging::render::ImageRenderer;
+#[cfg(not(target_arch = "wasm32"))]
+pub use imaging_wgpu::TextureRenderer;
 
 /// Backend-selected helpers for headless image rendering.
 pub mod image_render {
     #[cfg(all(
+        not(target_arch = "wasm32"),
         not(feature = "imaging_vello"),
-        feature = "imaging_skia",
-        not(target_arch = "wasm32")
+        feature = "imaging_skia"
     ))]
     pub use crate::skia::{BACKEND_NAME, Renderer, new_headless_renderer};
-    #[cfg(feature = "imaging_vello")]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "imaging_vello"))]
     pub use crate::vello::{BACKEND_NAME, Renderer, new_headless_renderer};
     #[cfg(all(
         not(feature = "imaging_vello"),
@@ -77,6 +83,7 @@ pub mod image_render {
     ))]
     pub use crate::vello_cpu::{BACKEND_NAME, Renderer, new_headless_renderer};
     #[cfg(all(
+        not(target_arch = "wasm32"),
         not(feature = "imaging_vello"),
         not(feature = "imaging_skia"),
         feature = "imaging_vello_hybrid"
@@ -98,7 +105,9 @@ pub mod image_render {
         all(feature = "imaging_skia", not(target_arch = "wasm32"))
     )))]
     mod no_backend {
-        use imaging::{RgbaImage, render::RenderSource};
+        use imaging::render::{
+            ImageBufferFormat, ImageBufferTarget, ImageRendererError, RenderSource,
+        };
 
         /// Error returned when no image-render backend feature is enabled.
         #[derive(Debug)]
@@ -125,16 +134,16 @@ pub mod image_render {
         }
 
         impl imaging::render::ImageRenderer for Renderer {
-            type Error = Error;
+            fn supported_image_formats(&self) -> Vec<ImageBufferFormat> {
+                Vec::new()
+            }
 
-            fn render_source_into<S: RenderSource + ?Sized>(
+            fn render_source_into(
                 &mut self,
-                _: &mut S,
-                _: u32,
-                _: u32,
-                _: &mut RgbaImage,
-            ) -> Result<(), Self::Error> {
-                Err(Error)
+                _: &mut dyn RenderSource,
+                _: ImageBufferTarget<'_>,
+            ) -> Result<(), ImageRendererError> {
+                Err(ImageRendererError::backend(Error))
             }
         }
     }
@@ -197,48 +206,25 @@ impl<'a> PreparedFrame<'a> {
             overlays,
         }
     }
-
-    /// Create a render source for window output in physical pixels.
-    pub fn window_source(self) -> WindowSource<'a> {
-        WindowSource { frame: self }
-    }
 }
 
-/// Masonry render source for a window-sized frame.
-#[derive(Clone, Copy, Debug)]
-pub struct WindowSource<'a> {
-    frame: PreparedFrame<'a>,
-}
-
-impl<'a> WindowSource<'a> {
-    /// Create a render source for window output in physical pixels.
-    pub fn new(frame: PreparedFrame<'a>) -> Self {
-        Self { frame }
-    }
-}
-
-impl RenderSource for WindowSource<'_> {
+impl RenderSource for PreparedFrame<'_> {
     fn validate(&self) -> Result<(), ValidateError> {
-        validate_layers(self.frame.base, self.frame.overlays)
+        validate_layers(self.base, self.overlays)
     }
 
     fn paint_into(&mut self, sink: &mut dyn PaintSink) {
         {
             let mut painter = Painter::new(sink);
             painter.fill_rect(
-                Rect::new(
-                    0.0,
-                    0.0,
-                    f64::from(self.frame.width),
-                    f64::from(self.frame.height),
-                ),
-                self.frame.background_color,
+                Rect::new(0.0, 0.0, f64::from(self.width), f64::from(self.height)),
+                self.background_color,
             );
         }
 
-        let scale = Affine::scale(self.frame.scale_factor);
-        replay_transformed(self.frame.base, sink, scale);
-        for layer in self.frame.overlays {
+        let scale = Affine::scale(self.scale_factor);
+        replay_transformed(self.base, sink, scale);
+        for layer in self.overlays {
             replay_transformed(layer.scene, sink, scale * layer.transform);
         }
     }

--- a/masonry_imaging/src/skia.rs
+++ b/masonry_imaging/src/skia.rs
@@ -24,17 +24,17 @@ impl std::error::Error for Error {}
 pub const BACKEND_NAME: &str = "imaging_skia";
 
 /// Masonry alias for the selected Skia image renderer type.
-pub type Renderer = imaging_skia::SkiaRenderer;
+pub type Renderer = imaging_skia::SkiaCpuRenderer;
 
 /// Masonry alias for the selected Skia texture renderer type.
-pub type TargetRenderer = imaging_skia::SkiaGpuTargetRenderer;
+pub type TargetRenderer = imaging_skia::SkiaRenderer;
 
 /// Masonry alias for the selected Skia texture target wrapper.
-pub type TextureTarget<'a> = imaging_skia::TextureTarget<'a>;
+pub type TextureTarget = wgpu::Texture;
 
 /// Create a reusable headless Skia renderer.
 pub fn new_headless_renderer() -> Result<Renderer, Error> {
-    Ok(imaging_skia::SkiaRenderer::new())
+    Ok(imaging_skia::SkiaCpuRenderer::new())
 }
 
 /// Create a reusable GPU Skia target renderer bound to an existing WGPU adapter, device, and queue.
@@ -43,5 +43,5 @@ pub fn new_target_renderer(
     device: wgpu::Device,
     queue: wgpu::Queue,
 ) -> Result<TargetRenderer, Error> {
-    imaging_skia::SkiaGpuTargetRenderer::new(adapter, device, queue).map_err(Error::Backend)
+    imaging_skia::SkiaRenderer::new(adapter, device, queue).map_err(Error::Backend)
 }

--- a/masonry_imaging/src/texture_render.rs
+++ b/masonry_imaging/src/texture_render.rs
@@ -72,7 +72,7 @@ impl Default for Renderer {
     feature = "imaging_vello_hybrid"
 ))]
 mod shared_texture_renderer {
-    use imaging::render::TextureRenderer;
+    use imaging_wgpu::{TextureRenderer, TextureRendererError};
 
     use crate::PreparedFrame;
 
@@ -122,13 +122,13 @@ mod shared_texture_renderer {
     pub(super) fn render_window_source_to_texture<R>(
         renderer: &mut R,
         frame: PreparedFrame<'_>,
-        target: R::TextureTarget<'_>,
-    ) -> Result<(), R::Error>
+        target: R::TextureTarget,
+    ) -> Result<(), TextureRendererError>
     where
         R: TextureRenderer,
     {
-        let mut source = frame.window_source();
-        renderer.render_source_to_texture(&mut source, target)
+        let mut frame = frame;
+        renderer.render_source_into_texture(&mut frame, target)
     }
 }
 
@@ -178,10 +178,11 @@ mod imp {
 ))]
 mod imp {
     use super::shared_texture_renderer::{RendererCache, render_window_source_to_texture};
-    use crate::skia::{TargetRenderer, TextureTarget, new_target_renderer};
+    use crate::skia::{TargetRenderer, new_target_renderer};
 
     use super::RenderTarget;
     use crate::PreparedFrame;
+    use imaging_wgpu::TextureRendererError;
 
     /// Errors that can occur while rendering Masonry content with Skia.
     #[derive(Debug)]
@@ -189,7 +190,7 @@ mod imp {
         /// Creating the Skia renderer failed.
         CreateRenderer(crate::skia::Error),
         /// Rendering the Masonry source failed.
-        Render(imaging_skia::Error),
+        Render(TextureRendererError),
     }
 
     impl core::fmt::Display for Error {
@@ -242,7 +243,7 @@ mod imp {
                 },
             )?;
 
-            render_window_source_to_texture(renderer, frame, TextureTarget::new(target.texture))
+            render_window_source_to_texture(renderer, frame, target.texture.clone())
                 .map_err(Error::Render)
         }
     }
@@ -257,6 +258,7 @@ mod imp {
 
     use super::RenderTarget;
     use crate::PreparedFrame;
+    use imaging_wgpu::TextureRendererError;
 
     /// Errors that can occur while rendering Masonry content with Vello.
     #[derive(Debug)]
@@ -264,7 +266,7 @@ mod imp {
         /// Creating the Vello renderer failed.
         CreateRenderer(crate::vello::Error),
         /// Rendering the scene to the texture failed.
-        Render(imaging_vello::Error),
+        Render(TextureRendererError),
     }
 
     impl core::fmt::Display for Error {
@@ -329,12 +331,13 @@ mod imp {
 
     use super::RenderTarget;
     use crate::PreparedFrame;
+    use imaging_wgpu::TextureRendererError;
 
     /// Errors that can occur while rendering Masonry content with Vello Hybrid.
     #[derive(Debug)]
     pub(super) enum Error {
         /// Rendering the Masonry source failed.
-        Render(imaging_vello_hybrid::Error),
+        Render(TextureRendererError),
     }
 
     impl core::fmt::Display for Error {

--- a/masonry_imaging/src/vello.rs
+++ b/masonry_imaging/src/vello.rs
@@ -32,10 +32,10 @@ pub const BACKEND_NAME: &str = "imaging_vello";
 pub type Renderer = imaging_vello::VelloRenderer;
 
 /// Masonry alias for the selected Vello texture renderer type.
-pub type TargetRenderer = imaging_vello::VelloTargetRenderer;
+pub type TargetRenderer = imaging_vello::VelloRenderer;
 
 /// Masonry alias for the selected Vello texture target wrapper.
-pub type TextureTarget<'a> = imaging_vello::TextureTarget<'a>;
+pub type TextureTarget = imaging_wgpu::TextureViewTarget;
 
 /// Create a reusable headless Vello renderer.
 pub fn new_headless_renderer() -> Result<Renderer, Error> {
@@ -48,5 +48,5 @@ pub fn new_target_renderer(
     device: wgpu::Device,
     queue: wgpu::Queue,
 ) -> Result<TargetRenderer, Error> {
-    imaging_vello::VelloTargetRenderer::new(device, queue).map_err(Error::Backend)
+    imaging_vello::VelloRenderer::new(device, queue).map_err(Error::Backend)
 }

--- a/masonry_imaging/src/vello_hybrid.rs
+++ b/masonry_imaging/src/vello_hybrid.rs
@@ -32,10 +32,10 @@ pub const BACKEND_NAME: &str = "imaging_vello_hybrid";
 pub type Renderer = imaging_vello_hybrid::VelloHybridRenderer;
 
 /// Masonry alias for the selected Vello Hybrid texture renderer type.
-pub type TargetRenderer = imaging_vello_hybrid::VelloHybridTargetRenderer;
+pub type TargetRenderer = imaging_vello_hybrid::VelloHybridRenderer;
 
 /// Masonry alias for the selected Vello Hybrid texture target wrapper.
-pub type TextureTarget<'a> = imaging_vello_hybrid::TextureTarget<'a>;
+pub type TextureTarget = imaging_wgpu::TextureViewTarget;
 
 /// Create a reusable headless Vello Hybrid renderer.
 pub fn new_headless_renderer() -> Result<Renderer, Error> {
@@ -47,5 +47,5 @@ pub fn new_headless_renderer() -> Result<Renderer, Error> {
 
 /// Create a reusable Vello Hybrid target renderer bound to an existing WGPU device and queue.
 pub fn new_target_renderer(device: wgpu::Device, queue: wgpu::Queue) -> TargetRenderer {
-    imaging_vello_hybrid::VelloHybridTargetRenderer::new(device, queue)
+    imaging_vello_hybrid::VelloHybridRenderer::new(device, queue)
 }


### PR DESCRIPTION
Update Masonry's imaging integration to match the new upstream renderer trait split and backend types.

This updates the workspace imaging dependency revision, adds the new `imaging_wgpu` dependency, and switches Masonry to the revised renderer APIs exposed by upstream:

- re-export `TextureRenderer` from `imaging_wgpu` instead of `imaging`
- update the no-backend stub to the new `ImageRenderer` contract
- use the new Vello, Vello Hybrid, and Skia texture renderer types and target wrappers
- route texture rendering through the new shared `TextureRendererError` surface

It also folds in the small Masonry-local simplification enabled by the new traits: `PreparedFrame` now implements `RenderSource` directly, so `texture_render` can render frames without a separate `WindowSource` wrapper.

This keeps the external behavior the same while reducing adapter surface inside `masonry_imaging`.