### PR TITLE
Add external placeholders to `VisualLayerPlan`

### DIFF
--- a/masonry/src/tests/paint.rs
+++ b/masonry/src/tests/paint.rs
@@ -181,6 +181,39 @@ fn make_layer_split_tree(isolate_trailing_box: bool) -> NewWidget<impl Widget> {
         .prepare()
 }
 
+fn make_external_placeholder_tree() -> NewWidget<impl Widget> {
+    let leading = NewWidget::new(
+        ModularWidget::new(())
+            .measure_fn(|_, _, _, _, _, _| 20.)
+            .paint_fn(|_, ctx, _, scene| {
+                scene.fill(ctx.content_box(), RED).draw();
+            }),
+    );
+    let placeholder = NewWidget::new(
+        ModularWidget::new(())
+            .measure_fn(|_, _, _, _, _, _| 20.)
+            .layout_fn(|_, ctx, _, size| {
+                ctx.set_clip_path(size.to_rect());
+            })
+            .paint_fn(|_, ctx, _, _scene| {
+                ctx.set_paint_layer_mode(PaintLayerMode::External);
+            }),
+    );
+    let trailing = NewWidget::new(
+        ModularWidget::new(())
+            .measure_fn(|_, _, _, _, _, _| 20.)
+            .paint_fn(|_, ctx, _, scene| {
+                scene.fill(ctx.content_box(), BLUE).draw();
+            }),
+    );
+
+    Flex::row()
+        .with_fixed(leading)
+        .with_fixed(placeholder)
+        .with_fixed(trailing)
+        .prepare()
+}
+
 fn create_render_root(root_widget: NewWidget<impl Widget>) -> RenderRoot {
     let test_font = Blob::new(Arc::new(ROBOTO));
     RenderRoot::new(
@@ -219,6 +252,26 @@ fn isolated_scene_layers_update_the_plan_without_changing_rendering() {
     );
 
     assert_eq!(inline_harness.render(), isolated_harness.render());
+}
+
+#[test]
+fn external_placeholders_appear_in_painter_order() {
+    let mut root = create_render_root(make_external_placeholder_tree());
+    let (visual_layers, _) = root.redraw();
+    assert_eq!(visual_layers.layers.len(), 3);
+
+    assert!(matches!(
+        visual_layers.layers[0].kind,
+        crate::app::VisualLayerKind::Scene(_)
+    ));
+    assert!(matches!(
+        visual_layers.layers[1].kind,
+        crate::app::VisualLayerKind::External { .. }
+    ));
+    assert!(matches!(
+        visual_layers.layers[2].kind,
+        crate::app::VisualLayerKind::Scene(_)
+    ));
 }
 
 // Layered slightly misaligned grid layer painting:

--- a/masonry_core/src/app/mod.rs
+++ b/masonry_core/src/app/mod.rs
@@ -13,6 +13,6 @@ pub use tracing_backend::{
     TracingSubscriberHasBeenSetError, default_tracing_subscriber, try_init_test_tracing,
     try_init_tracing,
 };
-pub use visual_layers::{VisualLayer, VisualLayerPlan};
+pub use visual_layers::{VisualLayer, VisualLayerKind, VisualLayerPlan};
 
 pub(crate) use render_root::{MutateCallback, RenderRootState};

--- a/masonry_core/src/app/visual_layers.rs
+++ b/masonry_core/src/app/visual_layers.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use kurbo::Affine;
+use kurbo::{Affine, Rect};
 
 use crate::core::WidgetId;
 use crate::imaging::PaintSink;
@@ -27,24 +27,36 @@ impl VisualLayerPlan {
         S: PaintSink + ?Sized,
     {
         for layer in &self.layers {
-            replay_transformed(&layer.scene, sink, layer.transform);
+            if let VisualLayerKind::Scene(scene) = &layer.kind {
+                replay_transformed(scene, sink, layer.transform);
+            }
         }
     }
 
-    /// The root visual layer, if one exists.
+    /// The first scene layer, if one exists.
     ///
     /// In the current compatibility model, this is the first scene layer that
     /// flattened consumers treat as the base scene.
     pub fn root_layer(&self) -> Option<&VisualLayer> {
-        self.layers.first()
+        self.layers
+            .iter()
+            .find(|layer| matches!(layer.kind, VisualLayerKind::Scene(_)))
     }
 
-    /// All layers after the root layer.
+    /// All scene layers after the first one, in painter order.
     ///
     /// In the current compatibility model, these are replayed after the root layer
-    /// in painter order.
-    pub fn overlay_layers(&self) -> &[VisualLayer] {
-        self.layers.get(1..).unwrap_or(&[])
+    /// in painter order. External placeholders are skipped.
+    pub fn overlay_layers(&self) -> impl Iterator<Item = &VisualLayer> {
+        let mut saw_root_scene = false;
+        self.layers.iter().filter(move |layer| match layer.kind {
+            VisualLayerKind::Scene(_) if !saw_root_scene => {
+                saw_root_scene = true;
+                false
+            }
+            VisualLayerKind::Scene(_) => true,
+            VisualLayerKind::External { .. } => false,
+        })
     }
 }
 
@@ -54,17 +66,32 @@ impl VisualLayerPlan {
 /// to composite it into window space. The root layer uses the identity transform.
 #[derive(Debug)]
 pub struct VisualLayer {
-    /// The retained `imaging` scene for this layer in layer-local coordinates.
-    pub scene: Scene,
+    /// The visual content represented by this layer.
+    pub kind: VisualLayerKind,
     /// Transform from layer-local space to window space.
     pub transform: Affine,
-    /// The root widget that owns this layer.
-    pub root_id: WidgetId,
+    /// The widget that requested this layer boundary.
+    pub widget_id: WidgetId,
+}
+
+/// The content represented by a visual layer.
+#[derive(Debug)]
+pub enum VisualLayerKind {
+    /// Retained Masonry scene content in layer-local coordinates.
+    Scene(Scene),
+    /// A placeholder for externally realized content.
+    ///
+    /// The `bounds` are expressed in layer-local coordinates and should be transformed
+    /// by the layer's [`VisualLayer::transform`] into window space.
+    External {
+        /// Placeholder bounds in layer-local coordinates.
+        bounds: Rect,
+    },
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{VisualLayer, VisualLayerPlan};
+    use super::{VisualLayer, VisualLayerKind, VisualLayerPlan};
     use crate::core::WidgetId;
     use crate::imaging::Painter;
     use crate::imaging::record::{Scene, replay_transformed};
@@ -86,14 +113,21 @@ mod tests {
         let plan = VisualLayerPlan {
             layers: vec![
                 VisualLayer {
-                    scene: root_scene.clone(),
+                    kind: VisualLayerKind::Scene(root_scene.clone()),
                     transform: Affine::IDENTITY,
-                    root_id: WidgetId::next(),
+                    widget_id: WidgetId::next(),
                 },
                 VisualLayer {
-                    scene: overlay_scene.clone(),
+                    kind: VisualLayerKind::External {
+                        bounds: Rect::new(10.0, 0.0, 20.0, 10.0),
+                    },
+                    transform: Affine::IDENTITY,
+                    widget_id: WidgetId::next(),
+                },
+                VisualLayer {
+                    kind: VisualLayerKind::Scene(overlay_scene.clone()),
                     transform: Affine::translate((20.0, 5.0)),
-                    root_id: WidgetId::next(),
+                    widget_id: WidgetId::next(),
                 },
             ],
         };
@@ -110,5 +144,42 @@ mod tests {
         );
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn scene_layer_helpers_skip_external_placeholders() {
+        let root_scene = filled_scene(Rect::new(0.0, 0.0, 10.0, 10.0), Color::from_rgb8(255, 0, 0));
+        let overlay_scene =
+            filled_scene(Rect::new(0.0, 0.0, 4.0, 4.0), Color::from_rgb8(0, 0, 255));
+
+        let plan = VisualLayerPlan {
+            layers: vec![
+                VisualLayer {
+                    kind: VisualLayerKind::Scene(root_scene),
+                    transform: Affine::IDENTITY,
+                    widget_id: WidgetId::next(),
+                },
+                VisualLayer {
+                    kind: VisualLayerKind::External {
+                        bounds: Rect::new(10.0, 0.0, 20.0, 10.0),
+                    },
+                    transform: Affine::IDENTITY,
+                    widget_id: WidgetId::next(),
+                },
+                VisualLayer {
+                    kind: VisualLayerKind::Scene(overlay_scene),
+                    transform: Affine::translate((20.0, 5.0)),
+                    widget_id: WidgetId::next(),
+                },
+            ],
+        };
+
+        assert!(matches!(
+            plan.root_layer().map(|layer| &layer.kind),
+            Some(VisualLayerKind::Scene(_))
+        ));
+        let overlays: Vec<_> = plan.overlay_layers().collect();
+        assert_eq!(overlays.len(), 1);
+        assert!(matches!(overlays[0].kind, VisualLayerKind::Scene(_)));
     }
 }

--- a/masonry_core/src/core/paint_layer.rs
+++ b/masonry_core/src/core/paint_layer.rs
@@ -18,4 +18,10 @@ pub enum PaintLayerMode {
     /// layers occur, Masonry will split the surrounding scene as needed to preserve
     /// that order in the flattened visual-layer plan.
     IsolatedScene,
+    /// Record this widget subtree as an external placeholder layer.
+    ///
+    /// Current hosts do not realize these placeholders yet; compatibility consumers
+    /// simply skip them while flattening scene content. This mode exists so the core
+    /// paint model can represent external boundaries before host integration lands.
+    External,
 }

--- a/masonry_core/src/passes/paint.rs
+++ b/masonry_core/src/passes/paint.rs
@@ -8,7 +8,7 @@ use peniko::{Color, Fill};
 use tracing::{info_span, trace};
 use tree_arena::ArenaMut;
 
-use crate::app::{RenderRoot, RenderRootState, VisualLayer, VisualLayerPlan};
+use crate::app::{RenderRoot, RenderRootState, VisualLayer, VisualLayerKind, VisualLayerPlan};
 use crate::core::{
     DefaultProperties, PaintCtx, PaintLayerMode, PropertiesRef, PropertyArena, WidgetArenaNode,
     WidgetId,
@@ -21,7 +21,7 @@ use crate::util::get_debug_color;
 struct LayerCollector {
     current_scene: Scene,
     layers: Vec<VisualLayer>,
-    root_id: WidgetId,
+    current_owner_id: WidgetId,
     transform: Affine,
 }
 
@@ -30,7 +30,7 @@ impl LayerCollector {
         Self {
             current_scene: Scene::new(),
             layers: Vec::new(),
-            root_id,
+            current_owner_id: root_id,
             transform,
         }
     }
@@ -47,9 +47,17 @@ impl LayerCollector {
 
         let scene = std::mem::replace(&mut self.current_scene, empty_scene);
         self.layers.push(VisualLayer {
-            scene,
+            kind: VisualLayerKind::Scene(scene),
             transform: self.transform,
-            root_id: self.root_id,
+            widget_id: self.current_owner_id,
+        });
+    }
+
+    fn push_external_layer(&mut self, widget_id: WidgetId, bounds: kurbo::Rect) {
+        self.layers.push(VisualLayer {
+            kind: VisualLayerKind::External { bounds },
+            transform: self.transform,
+            widget_id,
         });
     }
 
@@ -134,16 +142,32 @@ fn paint_widget(
     state.request_post_paint = false;
     state.needs_paint = false;
 
-    let isolated_scene = !is_stashed && state.paint_layer_mode == PaintLayerMode::IsolatedScene;
-    if isolated_scene {
+    let paint_layer_mode = if is_stashed {
+        PaintLayerMode::Inline
+    } else {
+        state.paint_layer_mode
+    };
+
+    if matches!(
+        paint_layer_mode,
+        PaintLayerMode::IsolatedScene | PaintLayerMode::External
+    ) {
         layer_collector.finish_current_layer(false);
     }
+
+    let previous_owner_id = layer_collector.current_owner_id;
+    layer_collector.current_owner_id = match paint_layer_mode {
+        PaintLayerMode::Inline => previous_owner_id,
+        PaintLayerMode::IsolatedScene | PaintLayerMode::External => id,
+    };
 
     let border_box_to_layer_transform = *window_to_layer_transform * state.window_transform;
     let content_box_to_layer_transform =
         border_box_to_layer_transform.pre_translate(state.border_box_translation());
     let has_clip = state.clip_path.is_some();
-    if !is_stashed {
+    let paint_as_external = paint_layer_mode == PaintLayerMode::External;
+
+    if !is_stashed && !paint_as_external {
         let Some((pre_scene, scene, _)) = &mut scene_cache.get(&id) else {
             debug_panic!(
                 "Error in paint pass: scene should have been cached earlier in this function."
@@ -188,7 +212,7 @@ fn paint_widget(
         parent_state.merge_up(&mut node.item.state);
     });
 
-    if !is_stashed {
+    if !is_stashed && !paint_as_external {
         if global_state.debug_paint {
             // Draw the global axis aligned bounding rect of the widget
             const BORDER_WIDTH: f64 = 1.0;
@@ -240,9 +264,18 @@ fn paint_widget(
         }
     }
 
-    if isolated_scene {
+    if paint_as_external {
+        layer_collector.push_external_layer(id, state.border_box_size().to_rect());
+    }
+
+    if matches!(
+        paint_layer_mode,
+        PaintLayerMode::IsolatedScene | PaintLayerMode::External
+    ) {
         layer_collector.finish_current_layer(false);
     }
+
+    layer_collector.current_owner_id = previous_owner_id;
 }
 
 // --- MARK: ROOT

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -21,7 +21,8 @@ use tracing::debug;
 use masonry_core::accesskit::{Action, ActionRequest, Node, Role, Tree, TreeId, TreeUpdate};
 use masonry_core::anymore::AnyDebug;
 use masonry_core::app::{
-    RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy, try_init_test_tracing,
+    RenderRoot, RenderRootOptions, RenderRootSignal, VisualLayerKind, WindowSizePolicy,
+    try_init_test_tracing,
 };
 use masonry_core::core::keyboard::{Code, Key, KeyState, NamedKey};
 use masonry_core::core::{
@@ -505,11 +506,9 @@ impl<W: Widget> TestHarness<W> {
                 Affine::translate((f64::from(self.root_padding), f64::from(self.root_padding)));
 
             for layer in &visual_layers.layers {
-                replay_transformed(
-                    &layer.scene,
-                    &mut full_scene,
-                    padding_transform * layer.transform,
-                );
+                if let VisualLayerKind::Scene(scene) = &layer.kind {
+                    replay_transformed(scene, &mut full_scene, padding_transform * layer.transform);
+                }
             }
         }
 

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -9,7 +9,9 @@ use std::sync::{Arc, mpsc};
 use accesskit_winit::Adapter;
 use copypasta::nop_clipboard::NopClipboardContext;
 use copypasta::{ClipboardContext, ClipboardProvider};
-use masonry_core::app::{RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy};
+use masonry_core::app::{
+    RenderRoot, RenderRootOptions, RenderRootSignal, VisualLayerKind, WindowSizePolicy,
+};
 use masonry_core::core::keyboard::{Key, KeyState};
 use masonry_core::core::{
     DefaultProperties, ErasedAction, NewWidget, TextEvent, Widget, WindowEvent,
@@ -669,22 +671,29 @@ impl MasonryState<'_> {
         let (visual_layers, tree_update) = window.render_root.redraw();
         let overlays: Vec<_> = visual_layers
             .overlay_layers()
-            .iter()
-            .map(|layer| ImagingLayer {
-                scene: &layer.scene,
-                transform: layer.transform,
+            .map(|layer| {
+                let VisualLayerKind::Scene(scene) = &layer.kind else {
+                    unreachable!("overlay_layers only returns scene layers");
+                };
+                ImagingLayer {
+                    scene,
+                    transform: layer.transform,
+                }
             })
             .collect();
         let size = window.render_root.size();
         let root_layer = visual_layers
             .root_layer()
             .expect("paint should always produce a root layer");
+        let VisualLayerKind::Scene(root_scene) = &root_layer.kind else {
+            unreachable!("root_layer always returns a scene layer");
+        };
         let frame = PreparedFrame::new(
             size.width,
             size.height,
             window.handle.scale_factor(),
             window.base_color,
-            &root_layer.scene,
+            root_scene,
             &overlays,
         );
         Self::render(surface, window, frame, &self.render_cx, &mut self.renderer);


### PR DESCRIPTION
Extend the core paint model so `VisualLayerPlan` can represent external boundaries in painter order.

`PaintLayerMode::External` now emits an external placeholder layer between surrounding scene layers, while current compatibility consumers in `masonry_testing` and `masonry_winit` continue to flatten only the scene layers. This keeps runtime rendering unchanged while making the core plan able to describe `scene -> external -> scene` structure.

The new tests cover both sides of this step:
- external placeholders appear in the plan in painter order
- existing scene-only rendering compatibility still works