### PR TITLE
Improve tree_arena's safety documentation

### DIFF
--- a/tree_arena/src/tree_arena_safe.rs
+++ b/tree_arena/src/tree_arena_safe.rs
@@ -425,7 +425,6 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     ///
     /// This is the same as [`item`](Self::item), except it consumes
     /// self. This is sometimes necessary to accommodate the borrow checker.
-    /// // TODO - Remove?
     pub fn into_item(self, id: impl Into<NodeId>) -> Option<ArenaRef<'arena, T>> {
         let id = id.into();
         self.children

--- a/tree_arena/src/tree_arena_safe.rs
+++ b/tree_arena/src/tree_arena_safe.rs
@@ -414,6 +414,7 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     ///
     /// This is the same as [`item`](Self::item), except it consumes
     /// self. This is sometimes necessary to accommodate the borrow checker.
+    /// // TODO - Remove?
     pub fn into_item(self, id: impl Into<NodeId>) -> Option<ArenaRef<'arena, T>> {
         let id = id.into();
         self.children

--- a/tree_arena/src/tree_arena_safe.rs
+++ b/tree_arena/src/tree_arena_safe.rs
@@ -414,7 +414,6 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     ///
     /// This is the same as [`item`](Self::item), except it consumes
     /// self. This is sometimes necessary to accommodate the borrow checker.
-    /// // TODO - Remove?
     pub fn into_item(self, id: impl Into<NodeId>) -> Option<ArenaRef<'arena, T>> {
         let id = id.into();
         self.children

--- a/tree_arena/src/tree_arena_safe.rs
+++ b/tree_arena/src/tree_arena_safe.rs
@@ -23,7 +23,7 @@ struct TreeNode<T> {
 /// will keep track of parent-child relationships, lets you efficiently find
 /// an item anywhere in the tree hierarchy, and give you mutable access to this item
 /// and its children.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct TreeArena<T> {
     roots: HashMap<NodeId, TreeNode<T>>,
     parents_map: HashMap<NodeId, Option<NodeId>>,
@@ -41,6 +41,16 @@ pub struct ArenaRef<'arena, T> {
     pub item: &'arena T,
     /// Reference to the children of the node
     pub children: ArenaRefList<'arena, T>,
+}
+
+/// A handle giving shared access to a set of arena items.
+///
+/// See [`ArenaRef`] for more information.
+#[derive(Debug)]
+pub struct ArenaRefList<'arena, T> {
+    parent_id: Option<NodeId>,
+    children: &'arena HashMap<NodeId, TreeNode<T>>,
+    parents_map: ArenaMapRef<'arena>,
 }
 
 /// A reference type giving mutable access to an arena item and its children.
@@ -65,16 +75,6 @@ pub struct ArenaMut<'arena, T> {
     pub children: ArenaMutList<'arena, T>,
 }
 
-/// A handle giving shared access to a set of arena items.
-///
-/// See [`ArenaRef`] for more information.
-#[derive(Debug)]
-pub struct ArenaRefList<'arena, T> {
-    parent_id: Option<NodeId>,
-    children: &'arena HashMap<NodeId, TreeNode<T>>,
-    parents_map: ArenaMapRef<'arena>,
-}
-
 /// A handle giving mutable access to a set of arena items.
 ///
 /// See [`ArenaMut`] for more information.
@@ -87,13 +87,13 @@ pub struct ArenaMutList<'arena, T> {
 
 /// A shared reference to the parent father map
 #[derive(Clone, Copy, Debug)]
-pub struct ArenaMapRef<'arena> {
+struct ArenaMapRef<'arena> {
     parents_map: &'arena HashMap<NodeId, Option<NodeId>>,
 }
 
 /// A mutable reference to the parent father map
 #[derive(Debug)]
-pub struct ArenaMapMut<'arena> {
+struct ArenaMapMut<'arena> {
     parents_map: &'arena mut HashMap<NodeId, Option<NodeId>>,
 }
 
@@ -114,6 +114,12 @@ impl<T> Clone for ArenaRefList<'_, T> {
 }
 
 impl<T> Copy for ArenaRefList<'_, T> {}
+
+impl<T> Default for TreeArena<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl<T> TreeArena<T> {
     /// Creates an empty tree.
@@ -145,11 +151,6 @@ impl<T> TreeArena<T> {
         }
     }
 
-    /// An iterator visiting all root ids in arbitrary order.
-    pub fn root_ids(&self) -> impl Iterator<Item = NodeId> {
-        self.roots.keys().copied()
-    }
-
     /// Returns a handle giving access to the roots of the tree.
     ///
     /// Using [`insert`](ArenaMutList::insert) on this handle
@@ -164,13 +165,19 @@ impl<T> TreeArena<T> {
         }
     }
 
+    /// An iterator visiting all root ids in arbitrary order.
+    pub fn root_ids(&self) -> impl Iterator<Item = NodeId> {
+        self.roots.keys().copied()
+    }
+
     /// Finds an item in the tree.
     ///
     /// Returns a shared reference to the item if present.
     ///
     /// # Complexity
     ///
-    /// O(Depth). In future implementations, this will be O(1).
+    /// - O(Depth) in the safe implementation.
+    /// - O(1) in the unsafe implementation.
     pub fn find(&self, id: impl Into<NodeId>) -> Option<ArenaRef<'_, T>> {
         self.roots().find_inner(id.into())
     }
@@ -181,7 +188,8 @@ impl<T> TreeArena<T> {
     ///
     /// # Complexity
     ///
-    /// O(Depth). In future implementations, this will be O(1).
+    /// - O(Depth) in the safe implementation.
+    /// - O(1) in the unsafe implementation.
     pub fn find_mut(&mut self, id: impl Into<NodeId>) -> Option<ArenaMut<'_, T>> {
         self.roots_mut().find_mut_inner(id.into())
     }
@@ -301,35 +309,6 @@ impl<T> ArenaRef<'_, T> {
     }
 }
 
-impl<T> ArenaMut<'_, T> {
-    /// Id of the item this handle is associated with.
-    pub fn id(&self) -> NodeId {
-        self.children
-            .parent_id
-            .expect("ArenaRefList always has a parent_id when it's a member of ArenaRef")
-    }
-
-    /// Returns a shared reference equivalent to this one.
-    pub fn reborrow(&mut self) -> ArenaRef<'_, T> {
-        ArenaRef {
-            parent_id: self.parent_id,
-            item: self.item,
-            children: self.children.reborrow(),
-        }
-    }
-
-    /// Returns a mutable reference equivalent to this one.
-    ///
-    /// This is sometimes useful to work with the borrow checker.
-    pub fn reborrow_mut(&mut self) -> ArenaMut<'_, T> {
-        ArenaMut {
-            parent_id: self.parent_id,
-            item: self.item,
-            children: self.children.reborrow_mut(),
-        }
-    }
-}
-
 impl<'arena, T> ArenaRefList<'arena, T> {
     /// Returns `true` if the list has an element with the given id.
     pub fn has(self, id: impl Into<NodeId>) -> bool {
@@ -362,7 +341,9 @@ impl<'arena, T> ArenaRefList<'arena, T> {
     ///
     /// # Complexity
     ///
-    /// O(Depth). In future implementations, this will be O(1).
+    /// - O(Depth) in the safe implementation.
+    /// - O(Depth) in the unsafe implementation, when not called from the root.
+    /// - O(1) in the unsafe implementation, when called from the root.
     pub fn find(self, id: impl Into<NodeId>) -> Option<ArenaRef<'arena, T>> {
         self.find_inner(id.into())
     }
@@ -385,6 +366,35 @@ impl<'arena, T> ArenaRefList<'arena, T> {
 
         let node = node_children.get(&id)?;
         Some(node.arena_ref(*parent_id, self.parents_map.parents_map))
+    }
+}
+
+impl<T> ArenaMut<'_, T> {
+    /// Id of the item this handle is associated with.
+    pub fn id(&self) -> NodeId {
+        self.children
+            .parent_id
+            .expect("ArenaMut always has a parent_id when it's a member of ArenaMut")
+    }
+
+    /// Returns a shared reference equivalent to this one.
+    pub fn reborrow(&mut self) -> ArenaRef<'_, T> {
+        ArenaRef {
+            parent_id: self.parent_id,
+            item: self.item,
+            children: self.children.reborrow(),
+        }
+    }
+
+    /// Returns a mutable reference equivalent to this one.
+    ///
+    /// This is sometimes useful to work with the borrow checker.
+    pub fn reborrow_mut(&mut self) -> ArenaMut<'_, T> {
+        ArenaMut {
+            parent_id: self.parent_id,
+            item: self.item,
+            children: self.children.reborrow_mut(),
+        }
     }
 }
 
@@ -528,7 +538,9 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     ///
     /// # Complexity
     ///
-    /// O(Depth).
+    /// - O(Depth) in the safe implementation.
+    /// - O(Depth) in the unsafe implementation, when not called from the root.
+    /// - O(1) in the unsafe implementation, when called from the root.
     pub fn find(&self, id: impl Into<NodeId>) -> Option<ArenaRef<'_, T>> {
         self.reborrow().find(id)
     }
@@ -539,7 +551,9 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     ///
     /// # Complexity
     ///
-    /// O(Depth).
+    /// - O(Depth) in the safe implementation.
+    /// - O(Depth) in the unsafe implementation, when not called from the root.
+    /// - O(1) in the unsafe implementation, when called from the root.
     pub fn find_mut(self, id: impl Into<NodeId>) -> Option<ArenaMut<'arena, T>> {
         self.find_mut_inner(id.into())
     }
@@ -583,7 +597,7 @@ impl ArenaMapRef<'_> {
     /// If `start_id` is Some, the path ends just before that id instead; `start_id` is not included.
     ///
     /// If there is no path from `start_id` to id, returns an empty vector.
-    pub fn get_id_path(self, id: NodeId, start_id: Option<NodeId>) -> Vec<NodeId> {
+    fn get_id_path(self, id: NodeId, start_id: Option<NodeId>) -> Vec<NodeId> {
         let mut path = Vec::new();
 
         if !self.parents_map.contains_key(&id) {
@@ -612,7 +626,7 @@ impl ArenaMapRef<'_> {
 
 impl ArenaMapMut<'_> {
     /// Returns a shared handle equivalent to this one.
-    pub fn reborrow(&self) -> ArenaMapRef<'_> {
+    fn reborrow(&self) -> ArenaMapRef<'_> {
         ArenaMapRef {
             parents_map: self.parents_map,
         }
@@ -621,7 +635,7 @@ impl ArenaMapMut<'_> {
     /// Returns a mutable handle equivalent to this one.
     ///
     /// This is sometimes useful to work with the borrow checker.
-    pub fn reborrow_mut(&mut self) -> ArenaMapMut<'_> {
+    fn reborrow_mut(&mut self) -> ArenaMapMut<'_> {
         ArenaMapMut {
             parents_map: self.parents_map,
         }
@@ -635,7 +649,7 @@ impl ArenaMapMut<'_> {
     /// If `start_id` is Some, the path ends just before that id instead; `start_id` is not included.
     ///
     /// If there is no path from `start_id` to id, returns an empty vector.
-    pub fn get_id_path(&self, id: NodeId, start_id: Option<NodeId>) -> Vec<NodeId> {
+    fn get_id_path(&self, id: NodeId, start_id: Option<NodeId>) -> Vec<NodeId> {
         self.reborrow().get_id_path(id, start_id)
     }
 }

--- a/tree_arena/src/tree_arena_safe.rs
+++ b/tree_arena/src/tree_arena_safe.rs
@@ -425,6 +425,7 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     ///
     /// This is the same as [`item`](Self::item), except it consumes
     /// self. This is sometimes necessary to accommodate the borrow checker.
+    /// // TODO - Remove?
     pub fn into_item(self, id: impl Into<NodeId>) -> Option<ArenaRef<'arena, T>> {
         let id = id.into();
         self.children

--- a/tree_arena/src/tree_arena_unsafe.rs
+++ b/tree_arena/src/tree_arena_unsafe.rs
@@ -425,21 +425,18 @@ impl<'arena, T> ArenaRefList<'arena, T> {
     /// O(depth) and the limiting factor for find methods
     /// not from the root
     fn is_descendant(&self, id: NodeId) -> bool {
-        if self.parent_arena.items.contains_key(&id) {
-            // the id of the parent
-            let parent_id = self.parent_id;
-
-            // The arena is derived from the root, and the id is in the tree
-            if parent_id.is_none() {
-                return true;
-            }
-
-            // iff the path is empty, there is no path from id to self
-            !self.parent_arena.get_id_path(id, parent_id).is_empty()
-        } else {
-            // if the id is not in the tree, it is not a descendant
-            false
+        // Check if id is in the tree at all.
+        if !self.parent_arena.items.contains_key(&id) {
+            return false;
         }
+
+        // If parent_id is None, this is the root list, all nodes are descendants.
+        if self.parent_id.is_none() {
+            return true;
+        }
+
+        // Iff the path is empty, there is no path from id to self
+        !self.parent_arena.get_id_path(id, self.parent_id).is_empty()
     }
 
     /// Returns `true` if the list has an element with the given id.
@@ -542,9 +539,6 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     }
 
     /// Returns a shared handle to the element of the list with the given id.
-    ///
-    /// Returns a tuple of a mutable reference to the child and a handle to access
-    /// its children.
     pub fn item(&self, id: impl Into<NodeId>) -> Option<ArenaRef<'_, T>> {
         let id = id.into();
         if self.has(id) {
@@ -555,9 +549,6 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     }
 
     /// Returns a mutable handle to the element of the list with the given id.
-    ///
-    /// Returns a tuple of a mutable reference to the child and a handle to access
-    /// its children.
     pub fn item_mut(&mut self, id: impl Into<NodeId>) -> Option<ArenaMut<'_, T>> {
         let id = id.into();
         if self.has(id) {

--- a/tree_arena/src/tree_arena_unsafe.rs
+++ b/tree_arena/src/tree_arena_unsafe.rs
@@ -655,10 +655,6 @@ impl<'arena, T> ArenaMutList<'arena, T> {
         let parent_id = *arena.parents.get(&id)?;
         let node_cell = arena.items.get(&id)?;
 
-        // FIXME
-        // The following may actually be unsound.
-        // See https://github.com/Storyyeller/stable_deref_trait/issues/15
-
         // SAFETY
         //
         // `node_cell.get().as_mut()` uses pointer trickery to get us two references to
@@ -672,11 +668,12 @@ impl<'arena, T> ArenaMutList<'arena, T> {
         // `ArenaMutList` are only allowed to use it to read/mutate children of the node
         // at `id` (as required by the safety precondition of this method).
         //
-        // `node`
-        //
         // Note that "to read/mutate children of the node" includes inserting or removing
         // children. Doing so can reallocate the arena; this is sound, because the arena
         // stores its nodes in boxes. Reallocating the arena does not invalidate `node`.
+        //
+        // FIXME - That last paragraph may actually be wrong.
+        // See https://github.com/Storyyeller/stable_deref_trait/issues/15
         let node = unsafe { node_cell.get().as_mut()? };
         let TreeNode { item, children } = node;
 

--- a/tree_arena/src/tree_arena_unsafe.rs
+++ b/tree_arena/src/tree_arena_unsafe.rs
@@ -43,8 +43,8 @@ pub struct TreeArena<T> {
 
 /// A reference type giving shared access to an arena item and its children.
 ///
-/// When you borrow an item from a [`TreeArena`], it returns an [`ArenaRef`].
-/// You can access its children to get access to child [`ArenaRef`] handles.
+/// When you borrow an item from a [`TreeArena`], it returns an `ArenaRef`.
+/// You can access its children to get access to child `ArenaRef` handles.
 #[derive(Debug)]
 pub struct ArenaRef<'arena, T> {
     /// Parent of the Node
@@ -100,6 +100,8 @@ pub struct ArenaMutList<'arena, T> {
     /// Array of items
     child_arr: &'arena mut Vec<NodeId>,
 }
+
+// -- MARK: IMPLS
 
 impl<Item> Clone for ArenaRef<'_, Item> {
     fn clone(&self) -> Self {
@@ -226,6 +228,12 @@ impl<T> DataMap<T> {
     }
 }
 
+impl<T> Default for TreeArena<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> TreeArena<T> {
     /// Creates a new empty tree
     pub fn new() -> Self {
@@ -253,11 +261,6 @@ impl<T> TreeArena<T> {
         }
     }
 
-    /// An iterator visiting all root ids in arbitrary order.
-    pub fn root_ids(&self) -> impl Iterator<Item = NodeId> {
-        self.roots.iter().copied()
-    }
-
     /// Returns a handle whose children are the roots, if any, of the tree.
     ///
     /// Using [`insert`](ArenaMutList::insert) on this handle
@@ -272,13 +275,19 @@ impl<T> TreeArena<T> {
         }
     }
 
+    /// An iterator visiting all root ids in arbitrary order.
+    pub fn root_ids(&self) -> impl Iterator<Item = NodeId> {
+        self.roots.iter().copied()
+    }
+
     /// Finds an item in the tree.
     ///
     /// Returns a shared reference to the item if present.
     ///
     /// # Complexity
     ///
-    /// O(1).
+    /// - O(Depth) in the safe implementation.
+    /// - O(1) in the unsafe implementation.
     pub fn find(&self, id: impl Into<NodeId>) -> Option<ArenaRef<'_, T>> {
         self.data_map.find_inner(id.into())
     }
@@ -286,6 +295,36 @@ impl<T> TreeArena<T> {
     /// Finds an item in the tree.
     ///
     /// Returns a mutable reference to the item if present.
+    ///
+
+impl<T> ArenaMut<'_, T> {
+    /// Id of the item this handle is associated with.
+    pub fn id(&self) -> NodeId {
+        self.children
+            .parent_id
+            .expect("ArenaMut always has a parent_id when it's a member of ArenaMut")
+    }
+
+    /// Returns a shared reference equivalent to this one.
+    pub fn reborrow(&mut self) -> ArenaRef<'_, T> {
+        ArenaRef {
+            parent_id: self.parent_id,
+            item: self.item,
+            children: self.children.reborrow(),
+        }
+    }
+
+    /// Returns a mutable reference equivalent to this one.
+    ///
+    /// This is sometimes useful to work with the borrow checker.
+    pub fn reborrow_mut(&mut self) -> ArenaMut<'_, T> {
+        ArenaMut {
+            parent_id: self.parent_id,
+            item: self.item,
+            children: self.children.reborrow_mut(),
+        }
+    }
+}
     pub fn find_mut(&mut self, id: impl Into<NodeId>) -> Option<ArenaMut<'_, T>> {
         // safe as derived from the arena itself and has assoc lifetime with the arena
         self.data_map.find_mut_inner(id.into())
@@ -359,12 +398,6 @@ impl<T> TreeArena<T> {
     }
 }
 
-impl<T> Default for TreeArena<T> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl<T> ArenaRef<'_, T> {
     /// Id of the item this handle is associated with.
     pub fn id(&self) -> NodeId {
@@ -410,7 +443,7 @@ impl<'arena, T> ArenaRefList<'arena, T> {
     }
 
     /// Returns `true` if the list has an element with the given id.
-    pub fn has(&self, id: impl Into<NodeId>) -> bool {
+    pub fn has(self, id: impl Into<NodeId>) -> bool {
         let child_id = id.into();
         let parent_id = self.parent_id;
         self.parent_arena
@@ -451,7 +484,9 @@ impl<'arena, T> ArenaRefList<'arena, T> {
     ///
     /// # Complexity
     ///
-    /// O(Depth). except access from root which is O(1).
+    /// - O(Depth) in the safe implementation.
+    /// - O(Depth) in the unsafe implementation, when not called from the root.
+    /// - O(1) in the unsafe implementation, when called from the root.
     pub fn find(self, id: impl Into<NodeId>) -> Option<ArenaRef<'arena, T>> {
         // the id to search for
         let id: NodeId = id.into();
@@ -652,18 +687,22 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     ///
     /// # Complexity
     ///
-    /// O(Depth). except access from root which is O(1).
+    /// - O(Depth) in the safe implementation.
+    /// - O(Depth) in the unsafe implementation, when not called from the root.
+    /// - O(1) in the unsafe implementation, when called from the root.
     pub fn find(&self, id: impl Into<NodeId>) -> Option<ArenaRef<'_, T>> {
         self.reborrow().find(id)
     }
 
     /// Finds an arena item among the list's items and their descendants.
     ///
-    /// Returns a shared reference to the item if present.
+    /// Returns a mutable reference to the item if present.
     ///
     /// # Complexity
     ///
-    /// O(Depth). except access from root which is O(1).
+    /// - O(Depth) in the safe implementation.
+    /// - O(Depth) in the unsafe implementation, when not called from the root.
+    /// - O(1) in the unsafe implementation, when called from the root.
     pub fn find_mut(self, id: impl Into<NodeId>) -> Option<ArenaMut<'arena, T>> {
         let id = id.into();
         if self.is_descendant(id) {

--- a/tree_arena/src/tree_arena_unsafe.rs
+++ b/tree_arena/src/tree_arena_unsafe.rs
@@ -127,73 +127,6 @@ impl<T> DataMap<T> {
         }
     }
 
-    fn find_node(&self, id: NodeId) -> Option<&TreeNode<T>> {
-        let node_cell = self.items.get(&id)?;
-
-        // SAFETY
-        // We need there to be no mutable access to the node
-        // Mutable access to the node would imply there is some &mut self
-        // As we are taking &self, there can be no mutable access to the node
-        // Thus this is safe
-
-        Some(unsafe { node_cell.get().as_ref()? })
-    }
-
-    /// Finds an item in the tree.
-    ///
-    /// Returns a shared reference to the item if present.
-    ///
-    /// Time Complexity O(1)
-    fn find_inner(&self, id: NodeId) -> Option<ArenaRef<'_, T>> {
-        let parent_id = *self.parents.get(&id)?;
-
-        let TreeNode { item, .. } = self.find_node(id)?;
-
-        let children = ArenaRefList {
-            parent_arena: self,
-            parent_id: Some(id),
-        };
-
-        Some(ArenaRef {
-            parent_id,
-            item,
-            children,
-        })
-    }
-
-    /// Finds an item in the tree.
-    ///
-    /// Returns a mutable reference to the item if present.
-    ///
-    /// Time Complexity O(1)
-    fn find_mut_inner(&mut self, id: NodeId) -> Option<ArenaMut<'_, T>> {
-        let parent_id = *self.parents.get(&id)?;
-        let node_cell = self.items.get(&id)?;
-
-        // SAFETY
-        //
-        // When using this on [`ArenaMutList`] associated with some node,
-        // must ensure that `id` is a descendant of that node, otherwise can
-        // obtain two mutable references to the same node
-        //
-        // Similarly we cannot take any other actions that would affect this node,
-        // such as removing it or removing a parent (and thus this node) or violate
-        // exclusivity by creating a shared reference to the node
-        let TreeNode { item, children } = unsafe { node_cell.get().as_mut()? };
-
-        let children = ArenaMutList {
-            parent_arena: self,
-            parent_id: Some(id),
-            child_arr: children,
-        };
-
-        Some(ArenaMut {
-            parent_id,
-            item,
-            children,
-        })
-    }
-
     /// Returns the path of items from the given item to the root of the tree.
     ///
     /// The path is in order from the bottom to the top, starting at the given item and ending at
@@ -289,7 +222,7 @@ impl<T> TreeArena<T> {
     /// - O(Depth) in the safe implementation.
     /// - O(1) in the unsafe implementation.
     pub fn find(&self, id: impl Into<NodeId>) -> Option<ArenaRef<'_, T>> {
-        self.data_map.find_inner(id.into())
+        self.roots().find_inner(id.into())
     }
 
     /// Finds an item in the tree.
@@ -301,8 +234,8 @@ impl<T> TreeArena<T> {
     /// - O(Depth) in the safe implementation.
     /// - O(1) in the unsafe implementation.
     pub fn find_mut(&mut self, id: impl Into<NodeId>) -> Option<ArenaMut<'_, T>> {
-        // safe as derived from the arena itself and has assoc lifetime with the arena
-        self.data_map.find_mut_inner(id.into())
+        // SAFETY: id will always point to a descendant of the root list.
+        unsafe { self.roots_mut().find_mut_inner(id.into()) }
     }
 
     /// Returns the path of items from the given item to the root of the tree.
@@ -387,7 +320,6 @@ impl<T> ArenaRef<'_, T> {
     // (since the roots are stored in the TreeArena to which the ArenaRefList doesn't have access).
     pub fn child_ids(&self) -> impl IntoIterator<Item = NodeId> {
         self.children
-            .parent_arena
             .find_node(self.id())
             .into_iter()
             .flat_map(|c: &TreeNode<T>| &c.children)
@@ -431,7 +363,7 @@ impl<'arena, T> ArenaRefList<'arena, T> {
     pub fn item(self, id: impl Into<NodeId>) -> Option<ArenaRef<'arena, T>> {
         let id = id.into();
         if self.has(id) {
-            self.parent_arena.find_inner(id)
+            self.find_inner(id)
         } else {
             None
         }
@@ -451,10 +383,49 @@ impl<'arena, T> ArenaRefList<'arena, T> {
         let id: NodeId = id.into();
 
         if self.is_descendant(id) {
-            self.parent_arena.find_inner(id)
+            self.find_inner(id)
         } else {
             None
         }
+    }
+
+    /// Finds an item in the tree.
+    fn find_inner(self, id: NodeId) -> Option<ArenaRef<'arena, T>> {
+        let parent_id = *self.parent_arena.parents.get(&id)?;
+
+        let TreeNode { item, .. } = self.find_node(id)?;
+
+        let children = ArenaRefList {
+            parent_arena: self.parent_arena,
+            parent_id: Some(id),
+        };
+
+        Some(ArenaRef {
+            parent_id,
+            item,
+            children,
+        })
+    }
+
+    fn find_node(self, id: NodeId) -> Option<&'arena TreeNode<T>> {
+        let node_cell = self.parent_arena.items.get(&id)?;
+
+        // SAFETY
+        //
+        // `node_cell.get().as_ref()` creates a shared borrow of the node
+        // with a lifetime of 'arena.
+        //
+        // This is sound because `self.arena` is a `&DataMap<T>`, and the only other code
+        // path that can access `node_cell` is `ArenaMutList::find_mut_inner`.
+        // `ArenaMutList::parent_arena` is a `&mut DataMap<T>`, which means that an
+        // `ArenaRefList` can't be constructed as long as an `ArenaMutList` is live.
+        //
+        // In other words, this method can only be called when no mutable view of
+        // node_cell is live.
+
+        // TODO - Rewrite above description after disjoint borrows are added.
+
+        Some(unsafe { node_cell.get().as_ref()? })
     }
 }
 
@@ -504,7 +475,7 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     pub fn item(&self, id: impl Into<NodeId>) -> Option<ArenaRef<'_, T>> {
         let id = id.into();
         if self.has(id) {
-            self.parent_arena.find_inner(id)
+            self.reborrow().find_inner(id)
         } else {
             None
         }
@@ -514,8 +485,8 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     pub fn item_mut(&mut self, id: impl Into<NodeId>) -> Option<ArenaMut<'_, T>> {
         let id = id.into();
         if self.has(id) {
-            // safe as we check the node is a direct child node
-            self.parent_arena.find_mut_inner(id)
+            // SAFETY: We just checked that `id` is a direct child of self.
+            unsafe { self.reborrow_mut().find_mut_inner(id) }
         } else {
             None
         }
@@ -528,7 +499,11 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     pub fn into_item(self, id: impl Into<NodeId>) -> Option<ArenaRef<'arena, T>> {
         let id = id.into();
         if self.has(id) {
-            self.parent_arena.find_inner(id)
+            let reborrow = ArenaRefList {
+                parent_arena: self.parent_arena,
+                parent_id: self.parent_id,
+            };
+            reborrow.find_inner(id)
         } else {
             None
         }
@@ -541,8 +516,8 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     pub fn into_item_mut(self, id: impl Into<NodeId>) -> Option<ArenaMut<'arena, T>> {
         let id = id.into();
         if self.has(id) {
-            // safe as we check the node is a direct child node
-            self.parent_arena.find_mut_inner(id)
+            // SAFETY: We just checked that `id` is a direct child of self.
+            unsafe { self.find_mut_inner(id) }
         } else {
             None
         }
@@ -582,7 +557,9 @@ impl<'arena, T> ArenaMutList<'arena, T> {
             .items
             .insert(child_id, Box::new(UnsafeCell::new(node)));
 
-        self.parent_arena.find_mut_inner(child_id).unwrap()
+        // SAFETY: We just inserted `child_id` into the arena,
+        // so we know it's a descendant of self.
+        unsafe { self.reborrow_mut().find_mut_inner(child_id).unwrap() }
     }
 
     // TODO - How to handle when a subtree is removed?
@@ -659,11 +636,61 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     pub fn find_mut(self, id: impl Into<NodeId>) -> Option<ArenaMut<'arena, T>> {
         let id = id.into();
         if self.is_descendant(id) {
-            // safe as we check the node is a descendant
-            self.parent_arena.find_mut_inner(id)
+            // SAFETY: We just checked that `id` is a descendant of self.
+            unsafe { self.find_mut_inner(id) }
         } else {
             None
         }
+    }
+
+    /// Finds an item in the tree.
+    ///
+    /// Returns `None` if `id` is not in the tree.
+    ///
+    /// # Safety
+    ///
+    /// If `id` is in the tree, it must be a descendant of this list.
+    unsafe fn find_mut_inner(self, id: NodeId) -> Option<ArenaMut<'arena, T>> {
+        let arena = self.parent_arena;
+        let parent_id = *arena.parents.get(&id)?;
+        let node_cell = arena.items.get(&id)?;
+
+        // FIXME
+        // The following may actually be unsound.
+        // See https://github.com/Storyyeller/stable_deref_trait/issues/15
+
+        // SAFETY
+        //
+        // `node_cell.get().as_mut()` uses pointer trickery to get us two references to
+        // overlapping data:
+        // - `arena` points to the entire arena
+        // - `node` points to the specific node
+        //
+        // (Both references have a lifetime of 'arena)
+        //
+        // This is sound because `arena` is wrapped in `ArenaMutList`, and users of
+        // `ArenaMutList` are only allowed to use it to read/mutate children of the node
+        // at `id` (as required by the safety precondition of this method).
+        //
+        // `node`
+        //
+        // Note that "to read/mutate children of the node" includes inserting or removing
+        // children. Doing so can reallocate the arena; this is sound, because the arena
+        // stores its nodes in boxes. Reallocating the arena does not invalidate `node`.
+        let node = unsafe { node_cell.get().as_mut()? };
+        let TreeNode { item, children } = node;
+
+        let children = ArenaMutList {
+            parent_arena: arena,
+            parent_id: Some(id),
+            child_arr: children,
+        };
+
+        Some(ArenaMut {
+            parent_id,
+            item,
+            children,
+        })
     }
 
     /// Used in tests to simulate a call to `Self::insert` or `Self::remove` that

--- a/tree_arena/src/tree_arena_unsafe.rs
+++ b/tree_arena/src/tree_arena_unsafe.rs
@@ -296,35 +296,6 @@ impl<T> TreeArena<T> {
     ///
     /// Returns a mutable reference to the item if present.
     ///
-
-impl<T> ArenaMut<'_, T> {
-    /// Id of the item this handle is associated with.
-    pub fn id(&self) -> NodeId {
-        self.children
-            .parent_id
-            .expect("ArenaMut always has a parent_id when it's a member of ArenaMut")
-    }
-
-    /// Returns a shared reference equivalent to this one.
-    pub fn reborrow(&mut self) -> ArenaRef<'_, T> {
-        ArenaRef {
-            parent_id: self.parent_id,
-            item: self.item,
-            children: self.children.reborrow(),
-        }
-    }
-
-    /// Returns a mutable reference equivalent to this one.
-    ///
-    /// This is sometimes useful to work with the borrow checker.
-    pub fn reborrow_mut(&mut self) -> ArenaMut<'_, T> {
-        ArenaMut {
-            parent_id: self.parent_id,
-            item: self.item,
-            children: self.children.reborrow_mut(),
-        }
-    }
-}
     pub fn find_mut(&mut self, id: impl Into<NodeId>) -> Option<ArenaMut<'_, T>> {
         // safe as derived from the arena itself and has assoc lifetime with the arena
         self.data_map.find_mut_inner(id.into())


### PR DESCRIPTION
See [#masonry > Refactoring tree arena for disjoint borrows](https://xi.zulipchat.com/#narrow/channel/317477-masonry/topic/Refactoring.20tree.20arena.20for.20disjoint.20borrows/with/586266467) for rationale.

Note that this PR neither changes the behavior of tree_arena_unsafe nor the conditions under which it's sound.

The PR makes `find_mut_inner` unsafe, but I'd argue it was already unsafe in the sense that calling it with the wrong arguments would lead to UB. This was acceptable because the method was private and the rest of the code never called it with wrong arguments, but I would argue that marking the method as unsafe is more accurate and helpful.

Similarly, the PR points out the [box invalidation problem](https://github.com/Storyyeller/stable_deref_trait/issues/15), but that problem already exists in our current implementation.