### PR TITLE
Remove ArenaRefList::into_item

### DIFF
--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -452,7 +452,7 @@ impl RenderRoot {
             .widget_arena
             .nodes
             .roots()
-            .into_item(self.root_id())
+            .item(self.root_id())
             .expect("root widget not in widget tree")
             .item
             .state

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -376,10 +376,7 @@ impl MutateCtx<'_> {
 impl<'w> QueryCtx<'w> {
     /// Returns a [`WidgetRef`] to a child widget.
     pub fn get(self, child: WidgetId) -> WidgetRef<'w, dyn Widget> {
-        let child_node = self
-            .children
-            .into_item(child)
-            .expect("get_mut: child not found");
+        let child_node = self.children.item(child).expect("get_mut: child not found");
         let child_type_id = (*child_node.item.widget).type_id();
         let child_stack = self
             .property_arena

--- a/masonry_core/src/core/widget_ref.rs
+++ b/masonry_core/src/core/widget_ref.rs
@@ -117,7 +117,7 @@ impl<'w, W: Widget + ?Sized> WidgetRef<'w, W> {
             .children_ids()
             .iter()
             .map(|&id| {
-                let Some(node_ref) = self.ctx.children.into_item(id) else {
+                let Some(node_ref) = self.ctx.children.item(id) else {
                     panic!(
                         "Error in '{}' #{parent_id}: child #{id} has not been added to tree",
                         self.widget.short_type_name()

--- a/tree_arena/src/tree_arena_safe.rs
+++ b/tree_arena/src/tree_arena_safe.rs
@@ -338,18 +338,7 @@ impl<'arena, T> ArenaRefList<'arena, T> {
     }
 
     /// Returns a handle to the element of the list with the given id.
-    pub fn item(&self, id: impl Into<NodeId>) -> Option<ArenaRef<'_, T>> {
-        let id = id.into();
-        self.children
-            .get(&id)
-            .map(|child| child.arena_ref(self.parent_id, self.parents_map.parents_map))
-    }
-
-    /// Returns a handle to the element of the list with the given id.
-    ///
-    /// This is the same as [`item`](Self::item), except it consumes
-    /// self. This is sometimes necessary to accommodate the borrow checker.
-    pub fn into_item(self, id: impl Into<NodeId>) -> Option<ArenaRef<'arena, T>> {
+    pub fn item(self, id: impl Into<NodeId>) -> Option<ArenaRef<'arena, T>> {
         let id = id.into();
         self.children
             .get(&id)

--- a/tree_arena/src/tree_arena_unsafe.rs
+++ b/tree_arena/src/tree_arena_unsafe.rs
@@ -423,20 +423,7 @@ impl<'arena, T> ArenaRefList<'arena, T> {
     /// Returns a shared handle to the element of the list with the given id.
     ///
     /// Returns a new [`ArenaRef`].
-    pub fn item(&self, id: impl Into<NodeId>) -> Option<ArenaRef<'_, T>> {
-        let id = id.into();
-        if self.has(id) {
-            self.parent_arena.find_inner(id)
-        } else {
-            None
-        }
-    }
-
-    /// Returns a shared handle to the element of the list with the given id.
-    ///
-    /// This is the same as [`item`](Self::item), except it consumes the
-    /// handle. This is sometimes necessary to accommodate the borrow checker.
-    pub fn into_item(self, id: impl Into<NodeId>) -> Option<ArenaRef<'arena, T>> {
+    pub fn item(self, id: impl Into<NodeId>) -> Option<ArenaRef<'arena, T>> {
         let id = id.into();
         if self.has(id) {
             self.parent_arena.find_inner(id)


### PR DESCRIPTION
This method was unnecessary: because ArenaRefList implements Copy, it's always safe to pass by value.