### PR TITLE
Add `AppCtx` for shared app-wide services.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,7 +1120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2447,6 +2447,7 @@ dependencies = [
  "anymore",
  "assert_matches",
  "console_error_panic_hook",
+ "copypasta",
  "cursor-icon",
  "dpi",
  "float-cmp 0.10.0",
@@ -2491,6 +2492,7 @@ version = "0.4.0"
 dependencies = [
  "accesskit_consumer",
  "assert_matches",
+ "copypasta",
  "image",
  "imaging_vello_cpu",
  "masonry_core",
@@ -2732,7 +2734,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3880,7 +3882,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4344,7 +4346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4489,7 +4491,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5034,7 +5036,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5809,7 +5811,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ ui-events = { version = "0.3.0", default-features = false, features = ["kurbo"] 
 ui-events-winit = { version = "0.3.0", default-features = false }
 smallvec = "1.15.1"
 hashbrown = { version = "0.17.0", default-features = false, features = ["default-hasher"] }
+copypasta = "0.10.2"
 dpi = "0.1.2"
 image = { version = "0.25.10", default-features = false }
 resvg = "0.47.0"

--- a/masonry/README.md
+++ b/masonry/README.md
@@ -100,13 +100,13 @@ impl AppDriver for Driver {
         debug_assert_eq!(window_id, self.window_id, "unknown window");
 
         if action.is::<ButtonPress>() {
-            let render_root = ctx.render_root(window_id);
+            let (app_ctx, render_root) = ctx.render_root(window_id);
 
-            render_root.edit_widget_with_tag(TEXT_INPUT_TAG, |mut text_input| {
+            render_root.edit_widget_with_tag(app_ctx, TEXT_INPUT_TAG, |mut text_input| {
                 let mut text_area = TextInput::text_mut(&mut text_input);
                 TextArea::reset_text(&mut text_area, "");
             });
-            render_root.edit_widget_with_tag(LIST_TAG, |mut list| {
+            render_root.edit_widget_with_tag(app_ctx, LIST_TAG, |mut list| {
                 let child = Label::new(self.next_task.clone()).prepare();
                 Flex::add_fixed(&mut list, child);
             });

--- a/masonry/examples/calc_masonry.rs
+++ b/masonry/examples/calc_masonry.rs
@@ -155,7 +155,9 @@ impl AppDriver for CalcState {
     ) {
         debug_assert_eq!(window_id, self.window_id, "unknown window");
 
-        let Some(source) = ctx.render_root(window_id).get_widget(widget_id) else {
+        let (app_ctx, render_root) = ctx.render_root(window_id);
+
+        let Some(source) = render_root.get_widget(widget_id) else {
             return;
         };
         let Some(button) = source.downcast::<Button>() else {
@@ -171,7 +173,7 @@ impl AppDriver for CalcState {
             CalcAction::None => (),
         }
 
-        ctx.render_root(window_id).edit_base_layer(|mut root| {
+        render_root.edit_base_layer(app_ctx, |mut root| {
             let mut grid = root.downcast();
             let mut flex = Grid::get_mut(&mut grid, 0);
             let mut flex = flex.downcast();

--- a/masonry/examples/gallery/badge.rs
+++ b/masonry/examples/gallery/badge.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::app::RenderRoot;
+use masonry::app::{AppCtx, RenderRoot};
 use masonry::core::{
     ErasedAction, Handled, NewWidget, PropertySet, StyleProperty, Widget, WidgetId, WidgetTag,
 };
@@ -56,12 +56,12 @@ impl BadgeDemo {
         )
     }
 
-    fn apply_count(&self, render_root: &mut RenderRoot) {
-        render_root.edit_widget_with_tag(self.count_label, |mut label| {
+    fn apply_count(&self, app_ctx: &mut AppCtx, render_root: &mut RenderRoot) {
+        render_root.edit_widget_with_tag(app_ctx, self.count_label, |mut label| {
             Label::set_text(&mut label, format!("count: {}", self.count));
         });
 
-        render_root.edit_widget_with_tag(self.inbox_badged, |mut badged| {
+        render_root.edit_widget_with_tag(app_ctx, self.inbox_badged, |mut badged| {
             if let Some(badge) = Self::make_count_badge(self.count) {
                 Badged::set_badge(&mut badged, badge);
             } else {
@@ -240,12 +240,13 @@ impl DemoPage for BadgeDemo {
         wrap_in_shell(self.shell, NewWidget::new(body).erased())
     }
 
-    fn on_selected(&mut self, render_root: &mut RenderRoot) {
-        self.apply_count(render_root);
+    fn on_selected(&mut self, app_ctx: &mut AppCtx, render_root: &mut RenderRoot) {
+        self.apply_count(app_ctx, render_root);
     }
 
     fn on_action(
         &mut self,
+        app_ctx: &mut AppCtx,
         render_root: &mut RenderRoot,
         action: &ErasedAction,
         widget_id: WidgetId,
@@ -265,13 +266,13 @@ impl DemoPage for BadgeDemo {
 
         if widget_id == dec_id {
             self.count = self.count.saturating_sub(1);
-            self.apply_count(render_root);
+            self.apply_count(app_ctx, render_root);
             return Handled::Yes;
         }
 
         if widget_id == inc_id {
             self.count = self.count.saturating_add(1);
-            self.apply_count(render_root);
+            self.apply_count(app_ctx, render_root);
             return Handled::Yes;
         }
 

--- a/masonry/examples/gallery/checkbox.rs
+++ b/masonry/examples/gallery/checkbox.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::app::RenderRoot;
+use masonry::app::{AppCtx, RenderRoot};
 use masonry::core::{ErasedAction, Handled, NewWidget, StyleProperty, Widget, WidgetId, WidgetTag};
 use masonry::properties::types::CrossAxisAlignment;
 use masonry::widgets::{Checkbox, CheckboxToggled, Flex, Label};
@@ -52,6 +52,7 @@ impl DemoPage for CheckboxDemo {
 
     fn on_action(
         &mut self,
+        app_ctx: &mut AppCtx,
         render_root: &mut RenderRoot,
         action: &ErasedAction,
         widget_id: WidgetId,
@@ -66,10 +67,10 @@ impl DemoPage for CheckboxDemo {
             return Handled::No;
         }
 
-        render_root.edit_widget_with_tag(self.state_label, |mut label| {
+        render_root.edit_widget_with_tag(app_ctx, self.state_label, |mut label| {
             Label::set_text(&mut label, format!("Checked: {checked}"));
         });
-        render_root.edit_widget_with_tag(self.checkbox, |mut checkbox| {
+        render_root.edit_widget_with_tag(app_ctx, self.checkbox, |mut checkbox| {
             Checkbox::set_checked(&mut checkbox, checked);
         });
         Handled::Yes

--- a/masonry/examples/gallery/demo.rs
+++ b/masonry/examples/gallery/demo.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::app::RenderRoot;
+use masonry::app::{AppCtx, RenderRoot};
 use masonry::core::{ErasedAction, Handled, NewWidget, Widget, WidgetId, WidgetTag};
 use masonry::layout::Length;
 use masonry::properties::types::CrossAxisAlignment;
@@ -21,10 +21,11 @@ pub(crate) trait DemoPage {
     fn shell_tags(&self) -> ShellTags;
     fn build(&self) -> NewWidget<dyn Widget>;
 
-    fn on_selected(&mut self, _render_root: &mut RenderRoot) {}
+    fn on_selected(&mut self, _app_ctx: &mut AppCtx, _render_root: &mut RenderRoot) {}
 
     fn on_action(
         &mut self,
+        app_ctx: &mut AppCtx,
         render_root: &mut RenderRoot,
         action: &ErasedAction,
         widget_id: WidgetId,

--- a/masonry/examples/gallery/main.rs
+++ b/masonry/examples/gallery/main.rs
@@ -73,11 +73,11 @@ impl Driver {
     ) {
         let shell = self.demos[demo_idx].shell_tags();
 
-        let render_root = ctx.render_root(window_id);
-        render_root.edit_widget_with_tag(shell.disabled_toggle, |mut checkbox| {
+        let (app_ctx, render_root) = ctx.render_root(window_id);
+        render_root.edit_widget_with_tag(app_ctx, shell.disabled_toggle, |mut checkbox| {
             Checkbox::set_checked(&mut checkbox, disabled);
         });
-        render_root.edit_widget_with_tag(shell.content_wrapper, |mut content| {
+        render_root.edit_widget_with_tag(app_ctx, shell.content_wrapper, |mut content| {
             content.ctx.set_disabled(disabled);
         });
     }
@@ -91,11 +91,11 @@ impl Driver {
 
         {
             let name = self.demos[idx].name();
-            let render_root = ctx.render_root(window_id);
-            render_root.edit_widget_with_tag(self.title_tag, |mut label| {
+            let (app_ctx, render_root) = ctx.render_root(window_id);
+            render_root.edit_widget_with_tag(app_ctx, self.title_tag, |mut label| {
                 Label::set_text(&mut label, name);
             });
-            render_root.edit_widget_with_tag(self.stack_tag, |mut stack| {
+            render_root.edit_widget_with_tag(app_ctx, self.stack_tag, |mut stack| {
                 IndexedStack::set_active_child(&mut stack, idx);
             });
         }
@@ -104,8 +104,8 @@ impl Driver {
         self.apply_demo_disabled(ctx, window_id, idx, disabled);
 
         {
-            let render_root = ctx.render_root(window_id);
-            self.demos[idx].on_selected(render_root);
+            let (app_ctx, render_root) = ctx.render_root(window_id);
+            self.demos[idx].on_selected(app_ctx, render_root);
         }
     }
 }
@@ -120,11 +120,12 @@ impl AppDriver for Driver {
     ) {
         debug_assert_eq!(window_id, self.window_id, "unknown window");
 
+        let (app_ctx, render_root) = ctx.render_root(window_id);
+
         // Sidebar button pressed: select demo.
         if action.is::<ButtonPress>() {
             // Sidebar: match by tagged ids.
             let selected_idx = {
-                let render_root = ctx.render_root(window_id);
                 self.sidebar_buttons
                     .iter()
                     .enumerate()
@@ -144,7 +145,6 @@ impl AppDriver for Driver {
         if let Some(toggled) = action.downcast_ref::<CheckboxToggled>() {
             let toggled = toggled.0;
             let disabled_demo = {
-                let render_root = ctx.render_root(window_id);
                 self.demos.iter().enumerate().find_map(|(idx, demo)| {
                     let shell = demo.shell_tags();
                     let id = render_root
@@ -163,9 +163,11 @@ impl AppDriver for Driver {
         }
 
         // Forward everything else to demos.
-        let render_root = ctx.render_root(window_id);
         for demo in &mut self.demos {
-            if demo.on_action(render_root, &action, widget_id).is_handled() {
+            if demo
+                .on_action(app_ctx, render_root, &action, widget_id)
+                .is_handled()
+            {
                 return;
             }
         }

--- a/masonry/examples/gallery/pagination.rs
+++ b/masonry/examples/gallery/pagination.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::app::RenderRoot;
+use masonry::app::{AppCtx, RenderRoot};
 use masonry::core::{Handled, NewWidget, Widget, WidgetId, WidgetTag};
 use masonry::widgets::{Flex, Label, PageChanged, Pagination, Step, StepInput};
 
@@ -53,6 +53,7 @@ impl DemoPage for PaginationDemo {
 
     fn on_action(
         &mut self,
+        app_ctx: &mut AppCtx,
         render_root: &mut RenderRoot,
         action: &masonry::core::ErasedAction,
         widget_id: WidgetId,
@@ -86,34 +87,34 @@ impl DemoPage for PaginationDemo {
                 .id();
 
             if widget_id == id_page_count {
-                render_root.edit_widget_with_tag(self.tag_pagination, |mut widget| {
+                render_root.edit_widget_with_tag(app_ctx, self.tag_pagination, |mut widget| {
                     Pagination::set_page_count(&mut widget, value as usize);
                 });
                 return Handled::Yes;
             }
             if widget_id == id_page_active {
-                render_root.edit_widget_with_tag(self.tag_content, |mut content| {
+                render_root.edit_widget_with_tag(app_ctx, self.tag_content, |mut content| {
                     Label::set_text(&mut content, format!("Now on page {}", value));
                 });
-                render_root.edit_widget_with_tag(self.tag_pagination, |mut widget| {
+                render_root.edit_widget_with_tag(app_ctx, self.tag_pagination, |mut widget| {
                     Pagination::set_active_page(&mut widget, (value - 1) as usize);
                 });
                 return Handled::Yes;
             }
             if widget_id == id_buttons_start {
-                render_root.edit_widget_with_tag(self.tag_pagination, |mut widget| {
+                render_root.edit_widget_with_tag(app_ctx, self.tag_pagination, |mut widget| {
                     Pagination::set_buttons_start(&mut widget, value as u8);
                 });
                 return Handled::Yes;
             }
             if widget_id == id_buttons_end {
-                render_root.edit_widget_with_tag(self.tag_pagination, |mut widget| {
+                render_root.edit_widget_with_tag(app_ctx, self.tag_pagination, |mut widget| {
                     Pagination::set_buttons_end(&mut widget, value as u8);
                 });
                 return Handled::Yes;
             }
             if widget_id == id_buttons_total {
-                render_root.edit_widget_with_tag(self.tag_pagination, |mut widget| {
+                render_root.edit_widget_with_tag(app_ctx, self.tag_pagination, |mut widget| {
                     Pagination::set_buttons_total(&mut widget, value as u8);
                 });
                 return Handled::Yes;
@@ -131,10 +132,10 @@ impl DemoPage for PaginationDemo {
                 return Handled::No;
             }
 
-            render_root.edit_widget_with_tag(self.tag_content, |mut content| {
+            render_root.edit_widget_with_tag(app_ctx, self.tag_content, |mut content| {
                 Label::set_text(&mut content, format!("Now on page {}", page_idx + 1));
             });
-            render_root.edit_widget_with_tag(self.tag_page_active, |mut widget| {
+            render_root.edit_widget_with_tag(app_ctx, self.tag_page_active, |mut widget| {
                 StepInput::set_base(&mut widget, (page_idx + 1).cast_signed());
             });
             return Handled::Yes;

--- a/masonry/examples/gallery/progress.rs
+++ b/masonry/examples/gallery/progress.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::app::RenderRoot;
+use masonry::app::{AppCtx, RenderRoot};
 use masonry::core::{ErasedAction, Handled, NewWidget, StyleProperty, Widget, WidgetId, WidgetTag};
 use masonry::properties::types::CrossAxisAlignment;
 use masonry::widgets::{Checkbox, CheckboxToggled, Flex, Label, ProgressBar, Slider};
@@ -31,18 +31,18 @@ impl ProgressDemo {
         }
     }
 
-    fn apply(&mut self, render_root: &mut RenderRoot) {
+    fn apply(&mut self, app_ctx: &mut AppCtx, render_root: &mut RenderRoot) {
         let progress = if self.is_indeterminate {
             None
         } else {
             Some(self.value)
         };
 
-        render_root.edit_widget_with_tag(self.bar, |mut bar| {
+        render_root.edit_widget_with_tag(app_ctx, self.bar, |mut bar| {
             ProgressBar::set_progress(&mut bar, progress);
         });
 
-        render_root.edit_widget_with_tag(self.value_label, |mut label| {
+        render_root.edit_widget_with_tag(app_ctx, self.value_label, |mut label| {
             Label::set_text(
                 &mut label,
                 if let Some(value) = progress {
@@ -53,7 +53,7 @@ impl ProgressDemo {
             );
         });
 
-        render_root.edit_widget_with_tag(self.indeterminate, |mut checkbox| {
+        render_root.edit_widget_with_tag(app_ctx, self.indeterminate, |mut checkbox| {
             Checkbox::set_checked(&mut checkbox, self.is_indeterminate);
         });
     }
@@ -89,12 +89,13 @@ impl DemoPage for ProgressDemo {
         wrap_in_shell(self.shell, NewWidget::new(body).erased())
     }
 
-    fn on_selected(&mut self, render_root: &mut RenderRoot) {
-        self.apply(render_root);
+    fn on_selected(&mut self, app_ctx: &mut AppCtx, render_root: &mut RenderRoot) {
+        self.apply(app_ctx, render_root);
     }
 
     fn on_action(
         &mut self,
+        app_ctx: &mut AppCtx,
         render_root: &mut RenderRoot,
         action: &ErasedAction,
         widget_id: WidgetId,
@@ -108,7 +109,7 @@ impl DemoPage for ProgressDemo {
                 return Handled::No;
             }
             self.is_indeterminate = toggled.0;
-            self.apply(render_root);
+            self.apply(app_ctx, render_root);
             return Handled::Yes;
         }
 
@@ -118,7 +119,7 @@ impl DemoPage for ProgressDemo {
                 return Handled::No;
             }
             self.value = value.clamp(0.0, 1.0);
-            self.apply(render_root);
+            self.apply(app_ctx, render_root);
             return Handled::Yes;
         }
 

--- a/masonry/examples/gallery/radio_buttons.rs
+++ b/masonry/examples/gallery/radio_buttons.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::app::RenderRoot;
+use masonry::app::{AppCtx, RenderRoot};
 use masonry::core::{ErasedAction, Handled, NewWidget, StyleProperty, Widget, WidgetId, WidgetTag};
 use masonry::properties::types::CrossAxisAlignment;
 use masonry::widgets::{Flex, Label, RadioButton, RadioButtonSelected, RadioGroup};
@@ -59,6 +59,7 @@ impl DemoPage for RadioButtonsDemo {
 
     fn on_action(
         &mut self,
+        app_ctx: &mut AppCtx,
         render_root: &mut RenderRoot,
         action: &ErasedAction,
         widget_id: WidgetId,
@@ -67,13 +68,13 @@ impl DemoPage for RadioButtonsDemo {
             return Handled::No;
         }
 
-        let selected_text = render_root.edit_widget(widget_id, |mut button| {
+        let selected_text = render_root.edit_widget(app_ctx, widget_id, |mut button| {
             let mut button = button.downcast::<RadioButton>();
             let label = RadioButton::label_mut(&mut button);
             label.widget.text().clone()
         });
 
-        render_root.edit_widget_with_tag(self.state_label, move |mut label| {
+        render_root.edit_widget_with_tag(app_ctx, self.state_label, move |mut label| {
             Label::set_text(&mut label, format!("Selected: {selected_text}"));
         });
         Handled::Yes

--- a/masonry/examples/gallery/slider.rs
+++ b/masonry/examples/gallery/slider.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::app::RenderRoot;
+use masonry::app::{AppCtx, RenderRoot};
 use masonry::core::{ErasedAction, Handled, NewWidget, StyleProperty, Widget, WidgetId, WidgetTag};
 use masonry::properties::types::CrossAxisAlignment;
 use masonry::widgets::{Flex, Label, Slider, SliderMoved};
@@ -53,6 +53,7 @@ impl DemoPage for SliderDemo {
 
     fn on_action(
         &mut self,
+        app_ctx: &mut AppCtx,
         render_root: &mut RenderRoot,
         action: &ErasedAction,
         widget_id: WidgetId,
@@ -66,7 +67,7 @@ impl DemoPage for SliderDemo {
         if widget_id != id {
             return Handled::No;
         }
-        render_root.edit_widget_with_tag(self.value_label, |mut label| {
+        render_root.edit_widget_with_tag(app_ctx, self.value_label, |mut label| {
             Label::set_text(&mut label, format!("Value: {value:.3}"));
         });
         Handled::Yes

--- a/masonry/examples/gallery/step_input.rs
+++ b/masonry/examples/gallery/step_input.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::app::RenderRoot;
+use masonry::app::{AppCtx, RenderRoot};
 use masonry::core::{
     ErasedAction, Handled, NewWidget, PropertyStack, Selector, StyleProperty, Widget, WidgetId,
     WidgetTag,
@@ -63,7 +63,7 @@ impl DemoPage for StepInputDemo {
         self.shell
     }
 
-    fn on_selected(&mut self, render_root: &mut RenderRoot) {
+    fn on_selected(&mut self, app_ctx: &mut AppCtx, render_root: &mut RenderRoot) {
         if self.initialized {
             return;
         }
@@ -103,7 +103,7 @@ impl DemoPage for StepInputDemo {
         );
 
         let id = render_root.property_arena().insert(stack);
-        render_root.edit_widget_with_tag(self.tag_custom, |mut widget| {
+        render_root.edit_widget_with_tag(app_ctx, self.tag_custom, |mut widget| {
             widget.ctx.set_property_stack(id);
         });
 
@@ -112,6 +112,7 @@ impl DemoPage for StepInputDemo {
 
     fn on_action(
         &mut self,
+        app_ctx: &mut AppCtx,
         render_root: &mut RenderRoot,
         action: &ErasedAction,
         widget_id: WidgetId,
@@ -122,10 +123,10 @@ impl DemoPage for StepInputDemo {
                 .unwrap()
                 .id();
             if widget_id == id_balance {
-                render_root.edit_widget_with_tag(self.tag_left, |mut widget| {
+                render_root.edit_widget_with_tag(app_ctx, self.tag_left, |mut widget| {
                     StepInput::set_base(&mut widget, BALANCE_TOTAL / 2);
                 });
-                render_root.edit_widget_with_tag(self.tag_right, |mut widget| {
+                render_root.edit_widget_with_tag(app_ctx, self.tag_right, |mut widget| {
                     StepInput::set_base(&mut widget, BALANCE_TOTAL / 2);
                 });
                 return Handled::Yes;
@@ -142,12 +143,12 @@ impl DemoPage for StepInputDemo {
                 .id();
 
             if widget_id == id_left {
-                render_root.edit_widget_with_tag(self.tag_right, |mut widget| {
+                render_root.edit_widget_with_tag(app_ctx, self.tag_right, |mut widget| {
                     StepInput::set_base(&mut widget, BALANCE_TOTAL - value);
                 });
                 return Handled::Yes;
             } else if widget_id == id_right {
-                render_root.edit_widget_with_tag(self.tag_left, |mut widget| {
+                render_root.edit_widget_with_tag(app_ctx, self.tag_left, |mut widget| {
                     StepInput::set_base(&mut widget, BALANCE_TOTAL - value);
                 });
                 return Handled::Yes;

--- a/masonry/examples/gallery/switch.rs
+++ b/masonry/examples/gallery/switch.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::app::RenderRoot;
+use masonry::app::{AppCtx, RenderRoot};
 use masonry::core::{ErasedAction, Handled, NewWidget, StyleProperty, Widget, WidgetId, WidgetTag};
 use masonry::properties::types::CrossAxisAlignment;
 use masonry::widgets::{Flex, Label, Switch, SwitchToggled};
@@ -50,6 +50,7 @@ impl DemoPage for SwitchDemo {
 
     fn on_action(
         &mut self,
+        app_ctx: &mut AppCtx,
         render_root: &mut RenderRoot,
         action: &ErasedAction,
         widget_id: WidgetId,
@@ -64,10 +65,10 @@ impl DemoPage for SwitchDemo {
             return Handled::No;
         }
 
-        render_root.edit_widget_with_tag(self.state_label, |mut label| {
+        render_root.edit_widget_with_tag(app_ctx, self.state_label, |mut label| {
             Label::set_text(&mut label, format!("On: {toggled}"));
         });
-        render_root.edit_widget_with_tag(self.switch, |mut switch| {
+        render_root.edit_widget_with_tag(app_ctx, self.switch, |mut switch| {
             Switch::set_on(&mut switch, toggled);
         });
         Handled::Yes

--- a/masonry/examples/gallery/tooltip.rs
+++ b/masonry/examples/gallery/tooltip.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::app::RenderRoot;
+use masonry::app::{AppCtx, RenderRoot};
 use masonry::core::{ErasedAction, Handled, NewWidget, StyleProperty, Widget, WidgetId, WidgetTag};
 use masonry::kurbo::Point;
 use masonry::layers::Tooltip;
@@ -51,6 +51,7 @@ impl DemoPage for TooltipDemo {
 
     fn on_action(
         &mut self,
+        app_ctx: &mut AppCtx,
         render_root: &mut RenderRoot,
         action: &ErasedAction,
         widget_id: WidgetId,
@@ -69,7 +70,7 @@ impl DemoPage for TooltipDemo {
                 .with_style(StyleProperty::FontSize(14.0))
                 .prepare(),
         ));
-        render_root.add_layer(tooltip.erased(), Point::new(320.0, 120.0));
+        render_root.add_layer(app_ctx, tooltip.erased(), Point::new(320.0, 120.0));
         Handled::Yes
     }
 }

--- a/masonry/examples/gallery/transforms.rs
+++ b/masonry/examples/gallery/transforms.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::app::RenderRoot;
+use masonry::app::{AppCtx, RenderRoot};
 use masonry::core::{
     ErasedAction, Handled, NewWidget, PropertySet, StyleProperty, Widget, WidgetId, WidgetTag,
 };
@@ -43,17 +43,17 @@ impl TransformsDemo {
         }
     }
 
-    fn apply(&self, render_root: &mut RenderRoot) {
+    fn apply(&self, app_ctx: &mut AppCtx, render_root: &mut RenderRoot) {
         let pivot = Vec2::new(80.0, 80.0);
         let transform = Affine::translate(pivot)
             .then_rotate(self.angle_rad)
             .then_scale(self.scale)
             .then_translate(-pivot);
 
-        render_root.edit_widget_with_tag(self.target, |mut target| {
+        render_root.edit_widget_with_tag(app_ctx, self.target, |mut target| {
             target.set_transform(transform);
         });
-        render_root.edit_widget_with_tag(self.state_label, |mut label| {
+        render_root.edit_widget_with_tag(app_ctx, self.state_label, |mut label| {
             Label::set_text(
                 &mut label,
                 format!(
@@ -128,12 +128,13 @@ impl DemoPage for TransformsDemo {
         wrap_in_shell(self.shell, NewWidget::new(body).erased())
     }
 
-    fn on_selected(&mut self, render_root: &mut RenderRoot) {
-        self.apply(render_root);
+    fn on_selected(&mut self, app_ctx: &mut AppCtx, render_root: &mut RenderRoot) {
+        self.apply(app_ctx, render_root);
     }
 
     fn on_action(
         &mut self,
+        app_ctx: &mut AppCtx,
         render_root: &mut RenderRoot,
         action: &ErasedAction,
         widget_id: WidgetId,
@@ -144,28 +145,28 @@ impl DemoPage for TransformsDemo {
 
         if self.matches_button(render_root, self.btn_rotate_left, widget_id) {
             self.angle_rad -= 15_f64.to_radians();
-            self.apply(render_root);
+            self.apply(app_ctx, render_root);
             return Handled::Yes;
         }
         if self.matches_button(render_root, self.btn_rotate_right, widget_id) {
             self.angle_rad += 15_f64.to_radians();
-            self.apply(render_root);
+            self.apply(app_ctx, render_root);
             return Handled::Yes;
         }
         if self.matches_button(render_root, self.btn_scale_down, widget_id) {
             self.scale = (self.scale / 1.1).clamp(0.3, 3.0);
-            self.apply(render_root);
+            self.apply(app_ctx, render_root);
             return Handled::Yes;
         }
         if self.matches_button(render_root, self.btn_scale_up, widget_id) {
             self.scale = (self.scale * 1.1).clamp(0.3, 3.0);
-            self.apply(render_root);
+            self.apply(app_ctx, render_root);
             return Handled::Yes;
         }
         if self.matches_button(render_root, self.btn_reset, widget_id) {
             self.angle_rad = 0.0;
             self.scale = 1.0;
-            self.apply(render_root);
+            self.apply(app_ctx, render_root);
             return Handled::Yes;
         }
         Handled::No

--- a/masonry/examples/grid_masonry.rs
+++ b/masonry/examples/grid_masonry.rs
@@ -42,7 +42,9 @@ impl AppDriver for Driver {
                 _ => 0.5,
             };
 
-            ctx.render_root(window_id).edit_base_layer(|mut root| {
+            let (app_ctx, render_root) = ctx.render_root(window_id);
+
+            render_root.edit_base_layer(app_ctx, |mut root| {
                 let mut grid = root.downcast::<Grid>();
                 grid.insert_prop(Gap::new(Length::px(self.grid_gap)));
             });

--- a/masonry/examples/split_playground.rs
+++ b/masonry/examples/split_playground.rs
@@ -41,8 +41,9 @@ impl Driver {
     fn set_mode(&mut self, ctx: &mut DriverCtx<'_, '_>, mode: SplitPointMode) {
         self.mode = mode;
 
-        let render_root = ctx.render_root(self.window_id);
-        render_root.edit_widget_with_tag(SPLIT_TAG, |mut split| {
+        let (app_ctx, render_root) = ctx.render_root(self.window_id);
+
+        render_root.edit_widget_with_tag(app_ctx, SPLIT_TAG, |mut split| {
             let split_point = match mode {
                 SplitPointMode::Fraction => SplitPoint::Fraction(0.5),
                 SplitPointMode::FromStart => SplitPoint::FromStart(220.px()),
@@ -51,7 +52,7 @@ impl Driver {
             Split::set_split_point(&mut split, split_point);
         });
 
-        render_root.edit_widget_with_tag(STATUS_TAG, |mut label| {
+        render_root.edit_widget_with_tag(app_ctx, STATUS_TAG, |mut label| {
             let text = match mode {
                 SplitPointMode::Fraction => "Mode: fraction (0.5)",
                 SplitPointMode::FromStart => "Mode: from start (220px)",
@@ -75,7 +76,7 @@ impl AppDriver for Driver {
             return;
         }
 
-        let render_root = ctx.render_root(window_id);
+        let (_, render_root) = ctx.render_root(window_id);
         let fraction_id = render_root.get_widget_with_tag(FRACTION_BTN).unwrap().id();
         let start_id = render_root.get_widget_with_tag(START_BTN).unwrap().id();
         let end_id = render_root.get_widget_with_tag(END_BTN).unwrap().id();

--- a/masonry/examples/to_do_list.rs
+++ b/masonry/examples/to_do_list.rs
@@ -38,13 +38,13 @@ impl AppDriver for Driver {
         debug_assert_eq!(window_id, self.window_id, "unknown window");
 
         if action.is::<ButtonPress>() {
-            let render_root = ctx.render_root(window_id);
+            let (app_ctx, render_root) = ctx.render_root(window_id);
 
-            render_root.edit_widget_with_tag(TEXT_INPUT_TAG, |mut text_input| {
+            render_root.edit_widget_with_tag(app_ctx, TEXT_INPUT_TAG, |mut text_input| {
                 let mut text_area = TextInput::text_mut(&mut text_input);
                 TextArea::reset_text(&mut text_area, "");
             });
-            render_root.edit_widget_with_tag(LIST_TAG, |mut list| {
+            render_root.edit_widget_with_tag(app_ctx, LIST_TAG, |mut list| {
                 let child = Label::new(self.next_task.clone()).prepare();
                 Flex::add_fixed(&mut list, child);
             });

--- a/masonry/examples/virtual_fizzbuzz.rs
+++ b/masonry/examples/virtual_fizzbuzz.rs
@@ -40,8 +40,9 @@ impl AppDriver for Driver {
     ) {
         debug_assert_eq!(window_id, self.window_id, "unknown window");
 
-        let scroll_id = ctx
-            .render_root(window_id)
+        let (app_ctx, render_root) = ctx.render_root(window_id);
+
+        let scroll_id = render_root
             .get_widget_with_tag(self.scroll_tag)
             .map(|w| w.id());
 
@@ -51,7 +52,8 @@ impl AppDriver for Driver {
             let action = action
                 .downcast::<VirtualScrollAction>()
                 .expect("Only expected Virtual Scroll actions");
-            ctx.render_root(window_id).edit_base_layer(|mut root| {
+
+            render_root.edit_base_layer(app_ctx, |mut root| {
                 let mut scroll = root.downcast::<VirtualScroll>();
                 // We need to tell the `VirtualScroll` which request this is associated with
                 // This is so that the controller knows which actions have been handled.

--- a/masonry/src/lib.rs
+++ b/masonry/src/lib.rs
@@ -70,13 +70,13 @@
 //!         debug_assert_eq!(window_id, self.window_id, "unknown window");
 //!
 //!         if action.is::<ButtonPress>() {
-//!             let render_root = ctx.render_root(window_id);
+//!             let (app_ctx, render_root) = ctx.render_root(window_id);
 //!
-//!             render_root.edit_widget_with_tag(TEXT_INPUT_TAG, |mut text_input| {
+//!             render_root.edit_widget_with_tag(app_ctx, TEXT_INPUT_TAG, |mut text_input| {
 //!                 let mut text_area = TextInput::text_mut(&mut text_input);
 //!                 TextArea::reset_text(&mut text_area, "");
 //!             });
-//!             render_root.edit_widget_with_tag(LIST_TAG, |mut list| {
+//!             render_root.edit_widget_with_tag(app_ctx, LIST_TAG, |mut list| {
 //!                 let child = Label::new(self.next_task.clone()).prepare();
 //!                 Flex::add_fixed(&mut list, child);
 //!             });

--- a/masonry/src/tests/paint.rs
+++ b/masonry/src/tests/paint.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use assert_matches::assert_matches;
 
-use crate::app::{RenderRoot, RenderRootOptions, WindowSizePolicy};
+use crate::app::{AppCtx, RenderRoot, RenderRootOptions, WindowSizePolicy};
 use crate::core::{NewWidget, PaintLayerMode, PropertySet, Widget, WidgetTag};
 use crate::dpi::PhysicalSize;
 use crate::kurbo::{Circle, Dashes, Point, Stroke, Vec2};
@@ -17,6 +17,7 @@ use crate::properties::types::MainAxisAlignment;
 use crate::properties::{Background, Dimensions, Gap, Padding};
 use crate::testing::{
     ModularWidget, ROBOTO, Record, TestHarness, TestWidgetExt, assert_render_snapshot,
+    create_app_ctx,
 };
 use crate::theme::test_property_set;
 use crate::widgets::{Align, ChildAlignment, Flex, Grid, GridParams, Label, SizedBox, ZStack};
@@ -214,9 +215,10 @@ fn make_external_placeholder_tree() -> NewWidget<impl Widget> {
         .prepare()
 }
 
-fn create_render_root(root_widget: NewWidget<impl Widget>) -> RenderRoot {
+fn create_render_root(app_ctx: &mut AppCtx, root_widget: NewWidget<impl Widget>) -> RenderRoot {
     let test_font = Blob::new(Arc::new(ROBOTO));
     RenderRoot::new(
+        app_ctx,
         root_widget,
         |_| {},
         RenderRootOptions {
@@ -232,12 +234,13 @@ fn create_render_root(root_widget: NewWidget<impl Widget>) -> RenderRoot {
 
 #[test]
 fn isolated_scene_layers_update_the_plan_without_changing_rendering() {
-    let mut inline_root = create_render_root(make_layer_split_tree(false));
-    let (inline_layers, _) = inline_root.redraw();
+    let mut app_ctx = create_app_ctx();
+    let mut inline_root = create_render_root(&mut app_ctx, make_layer_split_tree(false));
+    let (inline_layers, _) = inline_root.redraw(&mut app_ctx);
     assert_eq!(inline_layers.layers.len(), 1);
 
-    let mut isolated_root = create_render_root(make_layer_split_tree(true));
-    let (isolated_layers, _) = isolated_root.redraw();
+    let mut isolated_root = create_render_root(&mut app_ctx, make_layer_split_tree(true));
+    let (isolated_layers, _) = isolated_root.redraw(&mut app_ctx);
     assert_eq!(isolated_layers.layers.len(), 2);
 
     let mut inline_harness =
@@ -250,8 +253,9 @@ fn isolated_scene_layers_update_the_plan_without_changing_rendering() {
 
 #[test]
 fn external_placeholders_appear_in_painter_order() {
-    let mut root = create_render_root(make_external_placeholder_tree());
-    let (visual_layers, _) = root.redraw();
+    let mut app_ctx = create_app_ctx();
+    let mut root = create_render_root(&mut app_ctx, make_external_placeholder_tree());
+    let (visual_layers, _) = root.redraw(&mut app_ctx);
     assert_eq!(visual_layers.layers.len(), 3);
 
     assert!(matches!(

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -583,6 +583,17 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
                             ctx.set_clipboard(text.to_string());
                         }
                     }
+                    // Paste
+                    Key::Character(x)
+                        if EDITABLE && action_mod && x.as_str().eq_ignore_ascii_case("v") =>
+                    {
+                        let text = ctx.get_clipboard();
+                        let (fctx, lctx) = ctx.text_contexts();
+                        self.editor
+                            .driver(fctx, lctx)
+                            .insert_or_replace_selection(text.as_str());
+                        edited = true;
+                    }
                     Key::Character(a) if action_mod && a.as_str().eq_ignore_ascii_case("a") => {
                         let mut drv = self.editor.driver(fctx, lctx);
 
@@ -784,25 +795,6 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
                 if new_generation != self.rendered_generation {
                     ctx.request_layout();
                     self.rendered_generation = new_generation;
-                }
-            }
-
-            TextEvent::ClipboardPaste(text) => {
-                if EDITABLE {
-                    let (fctx, lctx) = ctx.text_contexts();
-                    self.editor
-                        .driver(fctx, lctx)
-                        .insert_or_replace_selection(text);
-
-                    // TODO - Factor out with other branches
-                    let new_generation = self.editor.generation();
-                    if new_generation != self.rendered_generation {
-                        ctx.submit_action::<Self::Action>(TextAction::Changed(
-                            self.text().into_iter().collect(),
-                        ));
-                        ctx.request_layout();
-                        self.rendered_generation = new_generation;
-                    }
                 }
             }
         }

--- a/masonry_core/Cargo.toml
+++ b/masonry_core/Cargo.toml
@@ -26,6 +26,7 @@ accesskit.workspace = true
 anymap3 = "1.0.1"
 anymore.workspace = true
 cursor-icon = "1.2.0"
+copypasta.workspace = true
 dpi.workspace = true
 imaging.workspace = true
 kurbo.workspace = true

--- a/masonry_core/src/app/context.rs
+++ b/masonry_core/src/app/context.rs
@@ -1,0 +1,38 @@
+// Copyright 2026 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! The main shared context for a Masonry app.
+
+use copypasta::ClipboardProvider;
+
+/// Shared context for a Masonry application.
+///
+/// Provides app-wide services across different render roots.
+pub struct AppCtx {
+    clipboard: Box<dyn ClipboardProvider>,
+}
+
+impl core::fmt::Debug for AppCtx {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("AppCtx")
+    }
+}
+
+impl AppCtx {
+    /// Creates a new shared context for Masonry.
+    ///
+    /// Only one should be created per application.
+    pub fn new(clipboard: Box<dyn ClipboardProvider>) -> Self {
+        Self { clipboard }
+    }
+
+    /// Sets the clipboard contents to the provided `text`.
+    pub fn set_clipboard(&mut self, text: String) {
+        self.clipboard.set_contents(text).unwrap();
+    }
+
+    /// Returns the current clipboard text content.
+    pub fn get_clipboard(&mut self) -> String {
+        self.clipboard.get_contents().unwrap()
+    }
+}

--- a/masonry_core/src/app/mod.rs
+++ b/masonry_core/src/app/mod.rs
@@ -3,11 +3,13 @@
 
 //! Types needed for running a Masonry app.
 
+mod context;
 mod layer_stack;
 mod render_root;
 mod tracing_backend;
 mod visual_layers;
 
+pub use context::AppCtx;
 pub use render_root::{RenderRoot, RenderRootOptions, RenderRootSignal, WindowSizePolicy};
 pub use tracing_backend::{
     TracingSubscriberHasBeenSetError, default_tracing_subscriber, try_init_test_tracing,

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -15,8 +15,8 @@ use parley::{FontContext, LayoutContext};
 use tracing::{debug, info_span, warn};
 use tree_arena::{ArenaMut, TreeArena};
 
-use crate::app::VisualLayerPlan;
 use crate::app::layer_stack::LayerStack;
+use crate::app::{AppCtx, VisualLayerPlan};
 use crate::core::{
     AccessCtx, AccessEvent, BrushIndex, CursorIcon, DefaultProperties, ErasedAction, FromDynWidget,
     Handled, Ime, LayerType, NewWidget, PointerEvent, PropertiesRef, PropertyArena, QueryCtx,
@@ -236,8 +236,6 @@ pub enum RenderRootSignal {
     EndIme,
     /// The IME area has been moved.
     ImeMoved(LogicalPosition<f64>, LogicalSize<f64>),
-    /// A user interaction has sent something to the clipboard.
-    ClipboardStore(String),
     /// The window needs to be redrawn.
     RequestRedraw,
     /// The window should be redrawn for an animation frame. Currently this isn't really different from `RequestRedraw`.
@@ -313,6 +311,7 @@ impl RenderRoot {
     /// The `masonry` crate doesn't provide a way to do that:
     /// look for `masonry_winit::app::run` instead.
     pub fn new(
+        app_ctx: &mut AppCtx,
         root_widget: NewWidget<impl Widget + ?Sized>,
         signal_sink: impl FnMut(RenderRootSignal) + 'static,
         options: RenderRootOptions,
@@ -403,7 +402,7 @@ impl RenderRoot {
         }
 
         // We run a set of passes to initialize the widget tree
-        root.run_rewrite_passes();
+        root.run_rewrite_passes(app_ctx);
 
         root
     }
@@ -471,7 +470,7 @@ impl RenderRoot {
 
     // --- MARK: WINDOW_EVENT
     /// Handles a window event.
-    pub fn handle_window_event(&mut self, event: WindowEvent) -> Handled {
+    pub fn handle_window_event(&mut self, app_ctx: &mut AppCtx, event: WindowEvent) -> Handled {
         match event {
             WindowEvent::Rescale(scale_factor) => {
                 self.global_state.scale_factor = scale_factor;
@@ -482,12 +481,12 @@ impl RenderRoot {
                 self.global_state.size = size;
                 self.root_state_mut().request_layout = true;
                 self.root_state_mut().set_needs_layout(true);
-                self.run_rewrite_passes();
+                self.run_rewrite_passes(app_ctx);
                 Handled::Yes
             }
             WindowEvent::AnimFrame(duration) => {
-                run_update_anim_pass(self, duration.as_nanos() as u64);
-                self.run_rewrite_passes();
+                run_update_anim_pass(app_ctx, self, duration.as_nanos() as u64);
+                self.run_rewrite_passes(app_ctx);
 
                 Handled::Yes
             }
@@ -509,33 +508,33 @@ impl RenderRoot {
 
     // --- MARK: PUB FUNCTIONS
     /// Handles a pointer event.
-    pub fn handle_pointer_event(&mut self, event: PointerEvent) -> Handled {
+    pub fn handle_pointer_event(&mut self, app_ctx: &mut AppCtx, event: PointerEvent) -> Handled {
         let _span = info_span!("pointer_event");
-        let handled = run_on_pointer_event_pass(self, &event);
-        run_update_pointer_pass(self);
-        self.run_rewrite_passes();
+        let handled = run_on_pointer_event_pass(app_ctx, self, &event);
+        run_update_pointer_pass(app_ctx, self);
+        self.run_rewrite_passes(app_ctx);
 
         handled
     }
 
     /// Handles a text event.
-    pub fn handle_text_event(&mut self, event: TextEvent) -> Handled {
+    pub fn handle_text_event(&mut self, app_ctx: &mut AppCtx, event: TextEvent) -> Handled {
         let _span = info_span!("text_event");
-        let handled = run_on_text_event_pass(self, &event);
-        run_update_focus_pass(self);
+        let handled = run_on_text_event_pass(app_ctx, self, &event);
+        run_update_focus_pass(app_ctx, self);
 
         if matches!(event, TextEvent::Ime(Ime::Enabled)) {
             // Reset the last sent IME area, as the platform reset the IME state and may have
             // forgotten it.
             self.global_state.last_sent_ime_area = INVALID_IME_AREA;
         }
-        self.run_rewrite_passes();
+        self.run_rewrite_passes(app_ctx);
 
         handled
     }
 
     /// Handles an accesskit event.
-    pub fn handle_access_event(&mut self, event: ActionRequest) {
+    pub fn handle_access_event(&mut self, app_ctx: &mut AppCtx, event: ActionRequest) {
         let _span = info_span!("access_event");
         if event.target_tree != TreeId::ROOT {
             warn!(
@@ -553,36 +552,40 @@ impl RenderRoot {
             data: event.data,
         };
 
-        run_on_access_event_pass(self, &event, WidgetId(id));
-        self.run_rewrite_passes();
+        run_on_access_event_pass(app_ctx, self, &event, WidgetId(id));
+        self.run_rewrite_passes(app_ctx);
     }
 
     /// Registers all fonts that exist in the given data.
     ///
     /// Returns a list of pairs each containing the family identifier and fonts
     /// added to that family.
-    pub fn register_fonts(&mut self, data: Blob<u8>) -> Vec<(FamilyId, Vec<FontInfo>)> {
+    pub fn register_fonts(
+        &mut self,
+        app_ctx: &mut AppCtx,
+        data: Blob<u8>,
+    ) -> Vec<(FamilyId, Vec<FontInfo>)> {
         let ret = self
             .global_state
             .font_context
             .collection
             .register_fonts(data, None);
-        run_update_fonts_pass(self);
+        run_update_fonts_pass(app_ctx, self);
         ret
     }
 
     /// Redraws the window.
     ///
     /// Returns the current visual-layer plan and, if accessibility is active, a tree update.
-    pub fn redraw(&mut self) -> (VisualLayerPlan, Option<TreeUpdate>) {
-        self.run_rewrite_passes();
+    pub fn redraw(&mut self, app_ctx: &mut AppCtx) -> (VisualLayerPlan, Option<TreeUpdate>) {
+        self.run_rewrite_passes(app_ctx);
 
         let access_tree_active = self.global_state.access_tree_active;
 
         // TODO - Handle invalidation regions
-        let visual_layers = run_paint_pass(self);
+        let visual_layers = run_paint_pass(app_ctx, self);
         let tree_update = access_tree_active
-            .then(|| run_accessibility_pass(self, self.global_state.scale_factor));
+            .then(|| run_accessibility_pass(app_ctx, self, self.global_state.scale_factor));
         (visual_layers, tree_update)
     }
 
@@ -648,11 +651,15 @@ impl RenderRoot {
     /// Returns a [`WidgetMut`] to the root widget of the [base layer](crate::doc::masonry_concepts#layers).
     ///
     /// Because of how `WidgetMut` works, it can only be passed to a user-provided callback.
-    pub fn edit_base_layer<R>(&mut self, f: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R) -> R {
+    pub fn edit_base_layer<R>(
+        &mut self,
+        app_ctx: &mut AppCtx,
+        f: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R,
+    ) -> R {
         let layer_id = self.layer_root_id(0);
-        let res = mutate_widget(self, layer_id, f);
+        let res = mutate_widget(app_ctx, self, layer_id, f);
 
-        self.run_rewrite_passes();
+        self.run_rewrite_passes(app_ctx);
 
         res
     }
@@ -666,13 +673,14 @@ impl RenderRoot {
     /// Panics if `idx` is out of bounds.
     pub fn edit_layer<R>(
         &mut self,
+        app_ctx: &mut AppCtx,
         layer_idx: usize,
         f: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R,
     ) -> R {
         let layer_id = self.layer_root_id(layer_idx);
-        let res = mutate_widget(self, layer_id, f);
+        let res = mutate_widget(app_ctx, self, layer_id, f);
 
-        self.run_rewrite_passes();
+        self.run_rewrite_passes(app_ctx);
 
         res
     }
@@ -687,6 +695,7 @@ impl RenderRoot {
     #[track_caller]
     pub fn edit_widget<R>(
         &mut self,
+        app_ctx: &mut AppCtx,
         id: WidgetId,
         f: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R,
     ) -> R {
@@ -694,9 +703,9 @@ impl RenderRoot {
             panic!("Could not find widget {id} in tree.");
         }
 
-        let res = mutate_widget(self, id, f);
+        let res = mutate_widget(app_ctx, self, id, f);
 
-        self.run_rewrite_passes();
+        self.run_rewrite_passes(app_ctx);
 
         res
     }
@@ -707,6 +716,7 @@ impl RenderRoot {
     #[track_caller]
     pub fn edit_widget_with_tag<R, W: Widget + FromDynWidget + ?Sized>(
         &mut self,
+        app_ctx: &mut AppCtx,
         tag: WidgetTag<W>,
         f: impl FnOnce(WidgetMut<'_, W>) -> R,
     ) -> R {
@@ -714,9 +724,9 @@ impl RenderRoot {
             panic!("Could not find widget with tag '{tag}' in widget tree.");
         };
 
-        let res = mutate_widget(self, id, |mut widget_mut| f(widget_mut.downcast()));
+        let res = mutate_widget(app_ctx, self, id, |mut widget_mut| f(widget_mut.downcast()));
 
-        self.run_rewrite_passes();
+        self.run_rewrite_passes(app_ctx);
 
         res
     }
@@ -724,14 +734,19 @@ impl RenderRoot {
     /// Adds a new layer at the end of the stack, with the given widget as its root, at the given position.
     ///
     /// The given `pos` must be in the window's coordinate space.
-    pub fn add_layer(&mut self, root: NewWidget<impl Widget + ?Sized>, pos: Point) {
+    pub fn add_layer(
+        &mut self,
+        app_ctx: &mut AppCtx,
+        root: NewWidget<impl Widget + ?Sized>,
+        pos: Point,
+    ) {
         debug!("added layer to stack");
-        mutate_widget(self, self.root_id(), |mut layer_stack| {
+        mutate_widget(app_ctx, self, self.root_id(), |mut layer_stack| {
             let mut layer_stack = layer_stack.downcast::<LayerStack>();
             LayerStack::add_layer(&mut layer_stack, root, pos);
         });
 
-        self.run_rewrite_passes();
+        self.run_rewrite_passes(app_ctx);
     }
 
     /// Removes the layer with the given widget as root.
@@ -742,13 +757,13 @@ impl RenderRoot {
     ///
     /// Panics in debug mode if the intended layer is the base layer or
     /// is not found.
-    pub fn remove_layer(&mut self, root_id: WidgetId) {
-        mutate_widget(self, self.root_id(), |mut layer_stack| {
+    pub fn remove_layer(&mut self, app_ctx: &mut AppCtx, root_id: WidgetId) {
+        mutate_widget(app_ctx, self, self.root_id(), |mut layer_stack| {
             let mut layer_stack = layer_stack.downcast::<LayerStack>();
             LayerStack::remove_layer(&mut layer_stack, root_id);
         });
 
-        self.run_rewrite_passes();
+        self.run_rewrite_passes(app_ctx);
     }
 
     /// Repositions the layer with the given widget as root.
@@ -761,13 +776,13 @@ impl RenderRoot {
     ///
     /// Panics in debug mode if the intended layer is the base layer or
     /// is not found.
-    pub fn reposition_layer(&mut self, root_id: WidgetId, new_origin: Point) {
-        mutate_widget(self, self.root_id(), |mut layer_stack| {
+    pub fn reposition_layer(&mut self, app_ctx: &mut AppCtx, root_id: WidgetId, new_origin: Point) {
+        mutate_widget(app_ctx, self, self.root_id(), |mut layer_stack| {
             let mut layer_stack = layer_stack.downcast::<LayerStack>();
             LayerStack::reposition_layer(&mut layer_stack, root_id, new_origin);
         });
 
-        self.run_rewrite_passes();
+        self.run_rewrite_passes(app_ctx);
     }
 
     /// Returns the current size of the window.
@@ -790,7 +805,7 @@ impl RenderRoot {
     /// update flags and internal values to a consistent state.
     ///
     /// See the [passes documentation](crate::doc::pass_system) for details.
-    pub(crate) fn run_rewrite_passes(&mut self) {
+    pub(crate) fn run_rewrite_passes(&mut self, app_ctx: &mut AppCtx) {
         const REWRITE_PASSES_MAX: usize = 4;
 
         for _ in 0..REWRITE_PASSES_MAX {
@@ -798,18 +813,18 @@ impl RenderRoot {
             // expected to have its own early exits.
             // Calling a run_xxx_pass should always be very fast if the pass doesn't need to do anything.
 
-            run_mutate_pass(self);
-            run_action_pass(self);
-            run_update_widget_tree_pass(self);
-            run_update_disabled_pass(self);
-            run_update_stashed_pass(self);
+            run_mutate_pass(app_ctx, self);
+            run_action_pass(app_ctx, self);
+            run_update_widget_tree_pass(app_ctx, self);
+            run_update_disabled_pass(app_ctx, self);
+            run_update_stashed_pass(app_ctx, self);
             run_update_focusable_pass(self);
-            run_update_focus_pass(self);
-            run_layout_pass(self);
-            run_update_scroll_pass(self);
-            run_compose_pass(self);
-            run_update_pointer_pass(self);
-            run_update_props_pass(self);
+            run_update_focus_pass(app_ctx, self);
+            run_layout_pass(app_ctx, self);
+            run_update_scroll_pass(app_ctx, self);
+            run_compose_pass(app_ctx, self);
+            run_update_pointer_pass(app_ctx, self);
+            run_update_props_pass(app_ctx, self);
 
             if !self.needs_rewrite_passes() {
                 break;
@@ -931,7 +946,7 @@ impl RenderRoot {
     /// and the [focus anchor](crate::doc::masonry_concepts#focus-anchor).
     ///
     /// Returns false if the widget is not found in the tree or can't be focused.
-    pub fn focus_on(&mut self, id: Option<WidgetId>) -> bool {
+    pub fn focus_on(&mut self, app_ctx: &mut AppCtx, id: Option<WidgetId>) -> bool {
         if let Some(id) = id
             && !self.is_still_interactive(id)
         {
@@ -939,7 +954,7 @@ impl RenderRoot {
         }
         self.global_state.next_focused_widget = id;
         self.global_state.focus_anchor = id;
-        self.run_rewrite_passes();
+        self.run_rewrite_passes(app_ctx);
         true
     }
 

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -18,7 +18,7 @@ use parley::{FontContext, LayoutContext};
 use tracing::{trace, warn};
 use tree_arena::{ArenaMut, ArenaMutList, ArenaRefList};
 
-use crate::app::{MutateCallback, RenderRootSignal, RenderRootState};
+use crate::app::{AppCtx, MutateCallback, RenderRootSignal, RenderRootState};
 use crate::core::{
     AllowRawMut, BrushIndex, ClassSet, ErasedAction, FromDynWidget, LayerType, NewWidget,
     PaintLayerMode, PropertiesMut, PropertiesRef, PropertyArena, PropertyCache, PropertyStackId,
@@ -56,6 +56,7 @@ macro_rules! impl_context_method {
 /// requires a later pass (for instance, if your widget has a `set_color` method),
 /// you will need to signal that change in the pass (eg [`request_render`](MutateCtx::request_render)).
 pub struct MutateCtx<'a> {
+    pub(crate) app_ctx: &'a mut AppCtx,
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) parent_widget_state: Option<&'a mut WidgetState>,
     pub(crate) widget_state: &'a mut WidgetState,
@@ -66,6 +67,7 @@ pub struct MutateCtx<'a> {
 
 /// A context provided to the [`Widget::on_action`] method.
 pub struct ActionCtx<'a> {
+    pub(crate) app_ctx: &'a mut AppCtx,
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) widget_state: &'a mut WidgetState,
     pub(crate) children: ArenaMutList<'a, WidgetArenaNode>,
@@ -87,6 +89,7 @@ pub struct QueryCtx<'a> {
 
 /// A context given when calling another context's `get_raw_mut()` method.
 pub struct RawCtx<'a> {
+    pub(crate) app_ctx: &'a mut AppCtx,
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) parent_widget_state: &'a mut WidgetState,
     pub(crate) widget_state: &'a mut WidgetState,
@@ -96,6 +99,7 @@ pub struct RawCtx<'a> {
 
 /// A context provided to event-handling [`Widget`] methods.
 pub struct EventCtx<'a> {
+    pub(crate) app_ctx: &'a mut AppCtx,
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) widget_state: &'a mut WidgetState,
     pub(crate) children: ArenaMutList<'a, WidgetArenaNode>,
@@ -107,6 +111,8 @@ pub struct EventCtx<'a> {
 
 /// A context provided to the [`Widget::register_children`] method.
 pub struct RegisterCtx<'a> {
+    #[expect(dead_code, reason = "AppCtx plumbing is done but not yet utilized")]
+    pub(crate) app_ctx: &'a mut AppCtx,
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) children: ArenaMutList<'a, WidgetArenaNode>,
     #[cfg(debug_assertions)]
@@ -115,6 +121,7 @@ pub struct RegisterCtx<'a> {
 
 /// A context provided to the [`Widget::update`] method.
 pub struct UpdateCtx<'a> {
+    pub(crate) app_ctx: &'a mut AppCtx,
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) widget_state: &'a mut WidgetState,
     pub(crate) children: ArenaMutList<'a, WidgetArenaNode>,
@@ -124,6 +131,7 @@ pub struct UpdateCtx<'a> {
 
 /// A context provided to [`Widget::measure`] methods.
 pub struct MeasureCtx<'a> {
+    pub(crate) app_ctx: &'a mut AppCtx,
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) widget_state: &'a mut WidgetState,
     pub(crate) children: ArenaMutList<'a, WidgetArenaNode>,
@@ -135,6 +143,7 @@ pub struct MeasureCtx<'a> {
 
 /// A context provided to [`Widget::layout`] methods.
 pub struct LayoutCtx<'a> {
+    pub(crate) app_ctx: &'a mut AppCtx,
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) widget_state: &'a mut WidgetState,
     pub(crate) children: ArenaMutList<'a, WidgetArenaNode>,
@@ -143,6 +152,7 @@ pub struct LayoutCtx<'a> {
 
 /// A context provided to the [`Widget::compose`] method.
 pub struct ComposeCtx<'a> {
+    pub(crate) app_ctx: &'a mut AppCtx,
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) widget_state: &'a mut WidgetState,
     pub(crate) children: ArenaMutList<'a, WidgetArenaNode>,
@@ -151,6 +161,8 @@ pub struct ComposeCtx<'a> {
 
 /// A context passed to [`Widget::paint`] method.
 pub struct PaintCtx<'a> {
+    #[expect(dead_code, reason = "AppCtx plumbing is done but not yet utilized")]
+    pub(crate) app_ctx: &'a mut AppCtx,
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) widget_state: &'a mut WidgetState,
     pub(crate) children: ArenaMutList<'a, WidgetArenaNode>,
@@ -158,6 +170,8 @@ pub struct PaintCtx<'a> {
 
 /// A context passed to [`Widget::accessibility`] method.
 pub struct AccessCtx<'a> {
+    #[expect(dead_code, reason = "AppCtx plumbing is done but not yet utilized")]
+    pub(crate) app_ctx: &'a mut AppCtx,
     pub(crate) global_state: &'a mut RenderRootState,
     pub(crate) widget_state: &'a mut WidgetState,
     pub(crate) children: ArenaMutList<'a, WidgetArenaNode>,
@@ -304,6 +318,7 @@ impl MutateCtx<'_> {
         let child_type_id = (*node_mut.item.widget).type_id();
         let child_stack = self.property_arena.get(child_stack_id, child_type_id);
         let child_ctx = MutateCtx {
+            app_ctx: self.app_ctx,
             global_state: self.global_state,
             parent_widget_state: Some(&mut self.widget_state),
             widget_state: &mut node_mut.item.state,
@@ -324,6 +339,7 @@ impl MutateCtx<'_> {
 
     pub(crate) fn reborrow_mut(&mut self) -> MutateCtx<'_> {
         MutateCtx {
+            app_ctx: self.app_ctx,
             global_state: self.global_state,
             // We don't don't reborrow `parent_widget_state`. This avoids running
             // `merge_up` in `WidgetMut::Drop` multiple times for the same state.
@@ -343,6 +359,7 @@ impl MutateCtx<'_> {
 
     pub(crate) fn update_mut(&mut self) -> UpdateCtx<'_> {
         UpdateCtx {
+            app_ctx: self.app_ctx,
             global_state: self.global_state,
             widget_state: self.widget_state,
             children: self.children.reborrow_mut(),
@@ -661,6 +678,7 @@ impl_context_method!(MeasureCtx<'_>, LayoutCtx<'_>, {
         let id = child.id();
         let node = self.children.item_mut(id).unwrap();
         resolve_length(
+            self.app_ctx,
             self.global_state,
             self.property_arena,
             node,
@@ -850,6 +868,7 @@ impl LayoutCtx<'_> {
         let id = child.id();
         let node = self.children.item_mut(id).unwrap();
         resolve_size(
+            self.app_ctx,
             self.global_state,
             self.property_arena,
             node,
@@ -882,7 +901,13 @@ impl LayoutCtx<'_> {
         let id = child.id();
         let node = self.children.item_mut(id).unwrap();
 
-        run_layout_on(self.global_state, self.property_arena, node, chosen_size);
+        run_layout_on(
+            self.app_ctx,
+            self.global_state,
+            self.property_arena,
+            node,
+            chosen_size,
+        );
 
         let state_mut = &mut self.children.item_mut(id).unwrap().item.state;
         self.widget_state.merge_up(state_mut);
@@ -1855,6 +1880,7 @@ impl_context_method!(
                 .item_mut(child.id())
                 .expect("get_mut: child not found");
             let child_ctx = RawCtx {
+                app_ctx: self.app_ctx,
                 global_state: self.global_state,
                 parent_widget_state: self.widget_state,
                 widget_state: &mut node_mut.item.state,
@@ -1889,6 +1915,7 @@ impl_context_method!(
                 .item_mut(child.id())
                 .expect("get_mut: child not found");
             let child_ctx = RawCtx {
+                app_ctx: self.app_ctx,
                 global_state: self.global_state,
                 parent_widget_state: self.widget_state,
                 widget_state: &mut node_mut.item.state,
@@ -1966,14 +1993,18 @@ impl_context_method!(
             self.widget_state.ime_area = None;
         }
 
-        /// Sets the contents of the platform clipboard.
+        /// Sets the text content of the platform clipboard.
         ///
         /// For example, text widgets should call this for "cut" and "copy" user interactions.
         /// Note that we currently don't support the "Primary" selection buffer on X11/Wayland.
-        pub fn set_clipboard(&mut self, contents: String) {
+        pub fn set_clipboard(&mut self, text: String) {
             trace!("set_clipboard");
-            self.global_state
-                .emit_signal(RenderRootSignal::ClipboardStore(contents));
+            self.app_ctx.set_clipboard(text);
+        }
+
+        /// Returns the text contents of the platform clipboard.
+        pub fn get_clipboard(&mut self) -> String {
+            self.app_ctx.get_clipboard()
         }
 
         /// Starts a window drag.

--- a/masonry_core/src/core/events.rs
+++ b/masonry_core/src/core/events.rs
@@ -35,9 +35,6 @@ pub enum TextEvent {
     Ime(Ime),
     /// The window took or lost focus.
     WindowFocusChange(bool),
-    // TODO - Handle rich text copy-pasting
-    /// The user pasted content in.
-    ClipboardPaste(String),
 }
 
 /// An accessibility event.
@@ -221,7 +218,6 @@ impl TextEvent {
             Self::Ime(Ime::Preedit(s, _)) if s.is_empty() => "Ime::Preedit(\"\")",
             Self::Ime(Ime::Preedit(_, _)) => "Ime::Preedit(\"...\")",
             Self::WindowFocusChange(_) => "WindowFocusChange",
-            Self::ClipboardPaste(_) => "ClipboardPaste",
         }
     }
 }

--- a/masonry_core/src/passes/accessibility.rs
+++ b/masonry_core/src/passes/accessibility.rs
@@ -6,7 +6,7 @@ use kurbo::Rect;
 use tracing::{info_span, trace};
 use tree_arena::ArenaMut;
 
-use crate::app::{RenderRoot, RenderRootState};
+use crate::app::{AppCtx, RenderRoot, RenderRootState};
 use crate::core::{
     AccessCtx, DefaultProperties, PropertiesRef, PropertyArena, Widget, WidgetArenaNode, WidgetId,
 };
@@ -14,6 +14,7 @@ use crate::passes::{enter_span_if, recurse_on_children};
 
 // --- MARK: BUILD TREE
 fn build_accessibility_tree(
+    app_ctx: &mut AppCtx,
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
     property_arena: &PropertyArena,
@@ -44,6 +45,7 @@ fn build_accessibility_tree(
 
         let stack = property_arena.get(state.property_stack_id, widget.type_id());
         let mut ctx = AccessCtx {
+            app_ctx,
             global_state,
             widget_state: state,
             children: children.reborrow_mut(),
@@ -71,6 +73,7 @@ fn build_accessibility_tree(
     let parent_state = state;
     recurse_on_children(id, widget, children, |mut node| {
         build_accessibility_tree(
+            app_ctx,
             global_state,
             default_properties,
             property_arena,
@@ -150,7 +153,11 @@ fn to_accesskit_rect(r: Rect) -> accesskit::Rect {
 
 // --- MARK: ROOT
 /// See the [passes documentation](crate::doc::pass_system#render-passes).
-pub(crate) fn run_accessibility_pass(root: &mut RenderRoot, scale_factor: f64) -> TreeUpdate {
+pub(crate) fn run_accessibility_pass(
+    app_ctx: &mut AppCtx,
+    root: &mut RenderRoot,
+    scale_factor: f64,
+) -> TreeUpdate {
     let _span = info_span!("accessibility").entered();
 
     let mut tree_update = TreeUpdate {
@@ -171,6 +178,7 @@ pub(crate) fn run_accessibility_pass(root: &mut RenderRoot, scale_factor: f64) -
     let root_node = root.widget_arena.get_node_mut(root.root_id());
 
     build_accessibility_tree(
+        app_ctx,
         &mut root.global_state,
         &root.property_arena.default_properties,
         &root.property_arena,

--- a/masonry_core/src/passes/action.rs
+++ b/masonry_core/src/passes/action.rs
@@ -3,12 +3,17 @@
 
 use tracing::debug;
 
-use crate::app::{RenderRoot, RenderRootSignal};
+use crate::app::{AppCtx, RenderRoot, RenderRootSignal};
 use crate::core::{ActionCtx, ErasedAction, Handled, PropertiesMut, WidgetId};
 use crate::passes::{enter_span, merge_state_up};
 
 /// Propagates the `action` from the `source` all the way up to the root widget.
-fn handle_action(root: &mut RenderRoot, action: &ErasedAction, source: WidgetId) -> Handled {
+fn handle_action(
+    app_ctx: &mut AppCtx,
+    root: &mut RenderRoot,
+    action: &ErasedAction,
+    source: WidgetId,
+) -> Handled {
     let mut next_widget_id = root.widget_arena.parent_of(source);
     let mut is_handled = false;
 
@@ -31,6 +36,7 @@ fn handle_action(root: &mut RenderRoot, action: &ErasedAction, source: WidgetId)
             let class_set = &node.item.class_set;
 
             let mut ctx = ActionCtx {
+                app_ctx,
                 global_state: &mut root.global_state,
                 widget_state: &mut node.item.state,
                 children: node.children.reborrow_mut(),
@@ -59,7 +65,7 @@ fn handle_action(root: &mut RenderRoot, action: &ErasedAction, source: WidgetId)
 /// Propagate actions from the source widgets up all the way to the app driver.
 ///
 /// See the [passes documentation](crate::doc::pass_system#the-action-pass).
-pub(crate) fn run_action_pass(root: &mut RenderRoot) {
+pub(crate) fn run_action_pass(app_ctx: &mut AppCtx, root: &mut RenderRoot) {
     let actions = std::mem::take(&mut root.global_state.actions);
     for (action, source) in actions {
         if !root.has_widget(source) {
@@ -79,7 +85,7 @@ pub(crate) fn run_action_pass(root: &mut RenderRoot) {
             );
             continue;
         }
-        if let Handled::No = handle_action(root, &action, source) {
+        if let Handled::No = handle_action(app_ctx, root, &action, source) {
             root.global_state
                 .emit_signal(RenderRootSignal::Action(action, source));
         }

--- a/masonry_core/src/passes/anim.rs
+++ b/masonry_core/src/passes/anim.rs
@@ -4,12 +4,13 @@
 use tracing::info_span;
 use tree_arena::ArenaMut;
 
-use crate::app::{RenderRoot, RenderRootState};
+use crate::app::{AppCtx, RenderRoot, RenderRootState};
 use crate::core::{DefaultProperties, PropertiesMut, PropertyArena, UpdateCtx, WidgetArenaNode};
 use crate::passes::{enter_span_if, recurse_on_children};
 
 // --- MARK: UPDATE ANIM
 fn update_anim_for_widget(
+    app_ctx: &mut AppCtx,
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
     property_arena: &PropertyArena,
@@ -36,6 +37,7 @@ fn update_anim_for_widget(
         state.request_anim = false;
         let stack = property_arena.get(state.property_stack_id, widget.type_id());
         let mut ctx = UpdateCtx {
+            app_ctx,
             global_state,
             widget_state: state,
             children: children.reborrow_mut(),
@@ -54,6 +56,7 @@ fn update_anim_for_widget(
     let parent_state = state;
     recurse_on_children(id, widget, children, |mut node| {
         update_anim_for_widget(
+            app_ctx,
             global_state,
             default_properties,
             property_arena,
@@ -71,11 +74,12 @@ fn update_anim_for_widget(
 /// Run the animation pass.
 ///
 /// See the [passes documentation](crate::doc::pass_system#animation-pass).
-pub(crate) fn run_update_anim_pass(root: &mut RenderRoot, elapsed_ns: u64) {
+pub(crate) fn run_update_anim_pass(app_ctx: &mut AppCtx, root: &mut RenderRoot, elapsed_ns: u64) {
     let _span = info_span!("update_anim").entered();
 
     let root_node = root.widget_arena.get_node_mut(root.root_id());
     update_anim_for_widget(
+        app_ctx,
         &mut root.global_state,
         &root.property_arena.default_properties,
         &root.property_arena,

--- a/masonry_core/src/passes/compose.rs
+++ b/masonry_core/src/passes/compose.rs
@@ -5,12 +5,13 @@ use kurbo::Affine;
 use tracing::info_span;
 use tree_arena::ArenaMut;
 
-use crate::app::{RenderRoot, RenderRootState};
+use crate::app::{AppCtx, RenderRoot, RenderRootState};
 use crate::core::{ComposeCtx, PropertyArena, WidgetArenaNode};
 use crate::passes::{enter_span_if, recurse_on_children};
 
 // --- MARK: RECURSE
 fn compose_widget(
+    app_ctx: &mut AppCtx,
     global_state: &mut RenderRootState,
     property_arena: &PropertyArena,
     node: ArenaMut<'_, WidgetArenaNode>,
@@ -41,6 +42,7 @@ fn compose_widget(
     state.bounding_box = state.window_transform.transform_rect_bbox(paint_box);
 
     let mut ctx = ComposeCtx {
+        app_ctx,
         global_state,
         widget_state: state,
         children: children.reborrow_mut(),
@@ -63,6 +65,7 @@ fn compose_widget(
     let parent_state = state;
     recurse_on_children(id, widget, children, |mut node| {
         compose_widget(
+            app_ctx,
             global_state,
             property_arena,
             node.reborrow_mut(),
@@ -81,7 +84,7 @@ fn compose_widget(
 
 // --- MARK: ROOT
 /// See the [passes documentation](crate::doc::pass_system#compose-pass).
-pub(crate) fn run_compose_pass(root: &mut RenderRoot) {
+pub(crate) fn run_compose_pass(app_ctx: &mut AppCtx, root: &mut RenderRoot) {
     let _span = info_span!("compose").entered();
 
     // If widgets have moved, pointer-related info may be stale.
@@ -92,6 +95,7 @@ pub(crate) fn run_compose_pass(root: &mut RenderRoot) {
 
     let root_node = root.widget_arena.get_node_mut(root.root_id());
     compose_widget(
+        app_ctx,
         &mut root.global_state,
         &root.property_arena,
         root_node,

--- a/masonry_core/src/passes/event.rs
+++ b/masonry_core/src/passes/event.rs
@@ -3,7 +3,7 @@
 
 use tracing::{info_span, trace};
 
-use crate::app::{RenderRoot, RenderRootSignal};
+use crate::app::{AppCtx, RenderRoot, RenderRootSignal};
 use crate::core::keyboard::{Key, KeyState, NamedKey};
 use crate::core::{
     AccessEvent, EventCtx, Handled, Ime, PointerButtonEvent, PointerEvent, PointerGestureEvent,
@@ -71,6 +71,7 @@ fn try_event_position(event: &PointerEvent) -> Option<PhysicalPosition<f64>> {
 }
 
 fn run_event_pass<E>(
+    app_ctx: &mut AppCtx,
     root: &mut RenderRoot,
     target: Option<WidgetId>,
     event: &E,
@@ -108,6 +109,7 @@ fn run_event_pass<E>(
                 .property_arena
                 .get(node.item.state.property_stack_id, widget_type_id);
             let mut ctx = EventCtx {
+                app_ctx,
                 global_state: &mut root.global_state,
                 widget_state: &mut node.item.state,
                 children: node.children.reborrow_mut(),
@@ -147,7 +149,11 @@ fn run_event_pass<E>(
 
 // --- MARK: POINTER_EVENT
 /// See the [passes documentation](crate::doc::pass_system#event-passes).
-pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEvent) -> Handled {
+pub(crate) fn run_on_pointer_event_pass(
+    app_ctx: &mut AppCtx,
+    root: &mut RenderRoot,
+    event: &PointerEvent,
+) -> Handled {
     let _span = info_span!("dispatch_pointer_event").entered();
 
     trace!(
@@ -196,6 +202,7 @@ pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEv
                 .property_arena
                 .get(layer_root.item.state.property_stack_id, layer_type_id);
             let mut ctx = EventCtx {
+                app_ctx,
                 global_state: &mut root.global_state,
                 widget_state: &mut layer_root.item.state,
                 children: layer_root.children.reborrow_mut(),
@@ -242,6 +249,7 @@ pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEv
 
     let skip_if_disabled = !matches!(event, PointerEvent::Cancel { .. });
     let handled = run_event_pass(
+        app_ctx,
         root,
         target_widget_id,
         event,
@@ -273,9 +281,14 @@ pub(crate) fn run_on_pointer_event_pass(root: &mut RenderRoot, event: &PointerEv
 
 // --- MARK: TEXT EVENT
 /// See the [passes documentation](crate::doc::pass_system#event-passes).
-pub(crate) fn run_on_text_event_pass(root: &mut RenderRoot, event: &TextEvent) -> Handled {
+pub(crate) fn run_on_text_event_pass(
+    app_ctx: &mut AppCtx,
+    root: &mut RenderRoot,
+    event: &TextEvent,
+) -> Handled {
     if matches!(event, TextEvent::WindowFocusChange(false)) {
         run_on_pointer_event_pass(
+            app_ctx,
             root,
             &PointerEvent::Cancel(PointerInfo {
                 pointer_id: None,
@@ -305,6 +318,7 @@ pub(crate) fn run_on_text_event_pass(root: &mut RenderRoot, event: &TextEvent) -
 
     let skip_if_disabled = !matches!(event, TextEvent::Ime(Ime::Disabled));
     let mut handled = run_event_pass(
+        app_ctx,
         root,
         target,
         event,
@@ -361,6 +375,7 @@ pub(crate) fn run_on_text_event_pass(root: &mut RenderRoot, event: &TextEvent) -
 // --- MARK: ACCESS EVENT
 /// See the [passes documentation](crate::doc::pass_system#event-passes).
 pub(crate) fn run_on_access_event_pass(
+    app_ctx: &mut AppCtx,
     root: &mut RenderRoot,
     event: &AccessEvent,
     target: WidgetId,
@@ -370,6 +385,7 @@ pub(crate) fn run_on_access_event_pass(
 
     let skip_if_disabled = true;
     let mut handled = run_event_pass(
+        app_ctx,
         root,
         Some(target),
         event,

--- a/masonry_core/src/passes/layout.rs
+++ b/masonry_core/src/passes/layout.rs
@@ -11,7 +11,7 @@ use dpi::LogicalSize;
 use tracing::{info_span, trace};
 use tree_arena::ArenaMut;
 
-use crate::app::{RenderRoot, RenderRootSignal, RenderRootState, WindowSizePolicy};
+use crate::app::{AppCtx, RenderRoot, RenderRootSignal, RenderRootState, WindowSizePolicy};
 use crate::core::{
     ChildrenIds, LayoutCtx, MeasureCtx, PropertiesRef, PropertyArena, Widget, WidgetArenaNode,
     WidgetState,
@@ -163,6 +163,7 @@ fn resolve_len_def(
 ///
 /// [`Dim::Auto`]: crate::layout::Dim::Auto
 pub(crate) fn resolve_length(
+    app_ctx: &mut AppCtx,
     global_state: &mut RenderRootState,
     property_arena: &PropertyArena,
     node: ArenaMut<'_, WidgetArenaNode>,
@@ -211,6 +212,7 @@ pub(crate) fn resolve_length(
     // Otherwise fall back to measurement
     let mut children = node.children;
     let mut ctx = MeasureCtx {
+        app_ctx,
         global_state,
         widget_state: &mut node.item.state,
         children: children.reborrow_mut(),
@@ -252,6 +254,7 @@ pub(crate) fn resolve_length(
 ///
 /// [`Dim::Auto`]: crate::layout::Dim::Auto
 pub(crate) fn resolve_size(
+    app_ctx: &mut AppCtx,
     global_state: &mut RenderRootState,
     property_arena: &PropertyArena,
     node: ArenaMut<'_, WidgetArenaNode>,
@@ -309,6 +312,7 @@ pub(crate) fn resolve_size(
     // Otherwise fall back to measurement
     let mut children = node.children;
     let mut ctx = MeasureCtx {
+        app_ctx,
         global_state,
         widget_state: &mut node.item.state,
         children: children.reborrow_mut(),
@@ -362,6 +366,7 @@ pub(crate) fn resolve_size(
 ///
 /// [`Widget::layout`]: crate::core::Widget::layout
 pub(crate) fn run_layout_on(
+    app_ctx: &mut AppCtx,
     global_state: &mut RenderRootState,
     property_arena: &PropertyArena,
     node: ArenaMut<'_, WidgetArenaNode>,
@@ -484,6 +489,7 @@ pub(crate) fn run_layout_on(
     let content_box_size = padding.size_down(content_box_size, scale);
 
     let mut ctx = LayoutCtx {
+        app_ctx,
         global_state,
         widget_state: state,
         children: children.reborrow_mut(),
@@ -596,7 +602,7 @@ pub(crate) fn place_widget(child_state: &mut WidgetState, origin: Point) {
 
 // --- MARK: ROOT
 /// See the [passes documentation](crate::doc::pass_system#layout-pass).
-pub(crate) fn run_layout_pass(root: &mut RenderRoot) {
+pub(crate) fn run_layout_pass(app_ctx: &mut AppCtx, root: &mut RenderRoot) {
     if !root.root_state().needs_layout() {
         return;
     }
@@ -608,6 +614,7 @@ pub(crate) fn run_layout_pass(root: &mut RenderRoot) {
     let mut root_node = root.widget_arena.get_node_mut(root.root_id());
     let root_node_size = match root.global_state.size_policy {
         WindowSizePolicy::User => resolve_size(
+            app_ctx,
             &mut root.global_state,
             &root.property_arena,
             root_node.reborrow_mut(),
@@ -615,6 +622,7 @@ pub(crate) fn run_layout_pass(root: &mut RenderRoot) {
             window_size.into(),
         ),
         WindowSizePolicy::Content => resolve_size(
+            app_ctx,
             &mut root.global_state,
             &root.property_arena,
             root_node.reborrow_mut(),
@@ -624,6 +632,7 @@ pub(crate) fn run_layout_pass(root: &mut RenderRoot) {
     };
 
     run_layout_on(
+        app_ctx,
         &mut root.global_state,
         &root.property_arena,
         root_node.reborrow_mut(),

--- a/masonry_core/src/passes/mutate.rs
+++ b/masonry_core/src/passes/mutate.rs
@@ -3,11 +3,12 @@
 
 use tracing::info_span;
 
-use crate::app::RenderRoot;
+use crate::app::{AppCtx, RenderRoot};
 use crate::core::{MutateCtx, PropertiesMut, Widget, WidgetId, WidgetMut};
 use crate::passes::merge_state_up;
 
 pub(crate) fn mutate_widget<R>(
+    app_ctx: &mut AppCtx,
     root: &mut RenderRoot,
     id: WidgetId,
     mutate_fn: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R,
@@ -32,6 +33,7 @@ pub(crate) fn mutate_widget<R>(
 
     let root_widget = WidgetMut {
         ctx: MutateCtx {
+            app_ctx,
             global_state: &mut root.global_state,
             parent_widget_state: None,
             widget_state: state,
@@ -66,13 +68,13 @@ pub(crate) fn mutate_widget<R>(
 /// Apply any deferred mutations (created using `...Ctx::mutate_later`)
 ///
 /// See the [passes documentation](crate::doc::pass_system#the-mutate-pass).
-pub(crate) fn run_mutate_pass(root: &mut RenderRoot) {
+pub(crate) fn run_mutate_pass(app_ctx: &mut AppCtx, root: &mut RenderRoot) {
     let callbacks = std::mem::take(&mut root.global_state.mutate_callbacks);
     for callback in callbacks {
         // Skip callbacks whose target was removed since they were emitted.
         if !root.widget_arena.has(callback.id) {
             continue;
         }
-        mutate_widget(root, callback.id, callback.callback);
+        mutate_widget(app_ctx, root, callback.id, callback.callback);
     }
 }

--- a/masonry_core/src/passes/paint.rs
+++ b/masonry_core/src/passes/paint.rs
@@ -8,7 +8,9 @@ use peniko::{Color, Fill};
 use tracing::{info_span, trace};
 use tree_arena::ArenaMut;
 
-use crate::app::{RenderRoot, RenderRootState, VisualLayer, VisualLayerKind, VisualLayerPlan};
+use crate::app::{
+    AppCtx, RenderRoot, RenderRootState, VisualLayer, VisualLayerKind, VisualLayerPlan,
+};
 use crate::core::{
     DefaultProperties, PaintCtx, PaintLayerMode, PropertiesRef, PropertyArena, WidgetArenaNode,
     WidgetId,
@@ -69,6 +71,7 @@ impl LayerCollector {
 
 // --- MARK: PAINT WIDGET
 fn paint_widget(
+    app_ctx: &mut AppCtx,
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
     property_arena: &PropertyArena,
@@ -103,6 +106,7 @@ fn paint_widget(
 
         let stack = property_arena.get(state.property_stack_id, widget.type_id());
         let mut ctx = PaintCtx {
+            app_ctx,
             global_state,
             widget_state: state,
             children: children.reborrow_mut(),
@@ -201,6 +205,7 @@ fn paint_widget(
         // - Once we implement compositor layers, we may want to paint outside of the clip path anyway in anticipation of user scrolling.
         // - We still want to reset needs_paint and request_paint flags.
         paint_widget(
+            app_ctx,
             global_state,
             default_properties,
             property_arena,
@@ -280,7 +285,7 @@ fn paint_widget(
 
 // --- MARK: ROOT
 /// See the [passes documentation](crate::doc::pass_system#render-passes).
-pub(crate) fn run_paint_pass(root: &mut RenderRoot) -> VisualLayerPlan {
+pub(crate) fn run_paint_pass(app_ctx: &mut AppCtx, root: &mut RenderRoot) -> VisualLayerPlan {
     let _span = info_span!("paint").entered();
 
     // TODO - This is a bit of a hack until we refactor widget tree mutation.
@@ -303,6 +308,7 @@ pub(crate) fn run_paint_pass(root: &mut RenderRoot) -> VisualLayerPlan {
 
         let mut collector = LayerCollector::new(layer_widget_id, transform);
         paint_layer(
+            app_ctx,
             root,
             &mut collector,
             &mut scene_cache,
@@ -322,6 +328,7 @@ pub(crate) fn run_paint_pass(root: &mut RenderRoot) -> VisualLayerPlan {
 /// This is a helper that handles the split borrows needed to access
 /// `global_state`, `default_properties`, and `widget_arena` simultaneously.
 fn paint_layer(
+    app_ctx: &mut AppCtx,
     root: &mut RenderRoot,
     layer_collector: &mut LayerCollector,
     scene_cache: &mut HashMap<WidgetId, (Scene, Scene, Scene)>,
@@ -351,6 +358,7 @@ fn paint_layer(
     let window_to_layer_transform = layer_node.item.state.window_transform.inverse();
 
     paint_widget(
+        app_ctx,
         &mut root.global_state,
         &root.property_arena.default_properties,
         &root.property_arena,

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -7,7 +7,7 @@ use tracing::{info_span, trace};
 use tree_arena::{ArenaMut, ArenaMutList};
 use ui_events::pointer::PointerType;
 
-use crate::app::{RenderRoot, RenderRootSignal, RenderRootState};
+use crate::app::{AppCtx, RenderRoot, RenderRootSignal, RenderRootState};
 use crate::core::{
     ClassSetDiff, CursorIcon, DefaultProperties, Ime, PointerEvent, PointerInfo, PropertiesMut,
     PropertiesRef, PropertyArena, PropertyCache, QueryCtx, RegisterCtx, TextEvent, Update,
@@ -56,6 +56,7 @@ fn dummy_pointer_cancel() -> PointerEvent {
 }
 
 fn run_targeted_update_pass(
+    app_ctx: &mut AppCtx,
     root: &mut RenderRoot,
     target: Option<WidgetId>,
     mut pass_fn: impl FnMut(&mut dyn Widget, &mut UpdateCtx<'_>, &mut PropertiesMut<'_>),
@@ -75,6 +76,7 @@ fn run_targeted_update_pass(
             .get(state.property_stack_id, widget.type_id());
 
         let mut ctx = UpdateCtx {
+            app_ctx,
             global_state: &mut root.global_state,
             widget_state: state,
             children,
@@ -98,6 +100,7 @@ fn run_targeted_update_pass(
 }
 
 fn run_single_update_pass(
+    app_ctx: &mut AppCtx,
     root: &mut RenderRoot,
     target: Option<WidgetId>,
     mut pass_fn: impl FnMut(&mut dyn Widget, &mut UpdateCtx<'_>, &mut PropertiesMut<'_>),
@@ -121,6 +124,7 @@ fn run_single_update_pass(
         .get(state.property_stack_id, widget.type_id());
 
     let mut ctx = UpdateCtx {
+        app_ctx,
         global_state: &mut root.global_state,
         widget_state: state,
         children,
@@ -147,6 +151,7 @@ fn run_single_update_pass(
 
 // --- MARK: TREE
 fn update_widget_tree(
+    app_ctx: &mut AppCtx,
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
     property_arena: &PropertyArena,
@@ -167,11 +172,18 @@ fn update_widget_tree(
         return;
     }
 
-    register_children(global_state, widget, state, children.reborrow_mut());
+    register_children(
+        app_ctx,
+        global_state,
+        widget,
+        state,
+        children.reborrow_mut(),
+    );
 
     if state.is_new {
         let stack = property_arena.get(state.property_stack_id, widget.type_id());
         let mut ctx = UpdateCtx {
+            app_ctx,
             global_state,
             widget_state: state,
             children: children.reborrow_mut(),
@@ -196,7 +208,13 @@ fn update_widget_tree(
         state.is_new = false;
 
         if state.children_changed {
-            register_children(global_state, widget, state, children.reborrow_mut());
+            register_children(
+                app_ctx,
+                global_state,
+                widget,
+                state,
+                children.reborrow_mut(),
+            );
         }
     }
 
@@ -210,6 +228,7 @@ fn update_widget_tree(
             parent: ancestors,
         };
         update_widget_tree(
+            app_ctx,
             global_state,
             default_properties,
             property_arena,
@@ -221,6 +240,7 @@ fn update_widget_tree(
 }
 
 fn register_children(
+    app_ctx: &mut AppCtx,
     global_state: &mut RenderRootState,
     widget: &mut (dyn Widget + 'static),
     state: &mut WidgetState,
@@ -229,6 +249,7 @@ fn register_children(
     state.children_changed = false;
 
     let mut ctx = RegisterCtx {
+        app_ctx,
         global_state,
         children: children.reborrow_mut(),
         #[cfg(debug_assertions)]
@@ -270,12 +291,13 @@ fn register_children(
 }
 
 /// See the [passes documentation](crate::doc::pass_system#update-tree-pass).
-pub(crate) fn run_update_widget_tree_pass(root: &mut RenderRoot) {
+pub(crate) fn run_update_widget_tree_pass(app_ctx: &mut AppCtx, root: &mut RenderRoot) {
     let _span = info_span!("update_new_widgets").entered();
 
     // INIT TREE
     if root.layer_stack.incomplete() {
         let mut ctx = RegisterCtx {
+            app_ctx,
             global_state: &mut root.global_state,
             children: root.widget_arena.nodes.roots_mut(),
             #[cfg(debug_assertions)]
@@ -286,6 +308,7 @@ pub(crate) fn run_update_widget_tree_pass(root: &mut RenderRoot) {
 
     let root_node = root.widget_arena.get_node_mut(root.root_id());
     update_widget_tree(
+        app_ctx,
         &mut root.global_state,
         &root.property_arena.default_properties,
         &root.property_arena,
@@ -300,6 +323,7 @@ pub(crate) fn run_update_widget_tree_pass(root: &mut RenderRoot) {
 /// See the [passes documentation](crate::doc::pass_system#update-passes).
 /// See the [disabled status documentation](../doc/06_masonry_concepts.md#disabled).
 fn update_disabled_for_widget(
+    app_ctx: &mut AppCtx,
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
     property_arena: &PropertyArena,
@@ -323,6 +347,7 @@ fn update_disabled_for_widget(
     if disabled != state.is_disabled {
         let stack = property_arena.get(state.property_stack_id, widget.type_id());
         let mut ctx = UpdateCtx {
+            app_ctx,
             global_state,
             widget_state: state,
             children: children.reborrow_mut(),
@@ -350,6 +375,7 @@ fn update_disabled_for_widget(
     let parent_state = state;
     recurse_on_children(id, widget, children, |mut node| {
         update_disabled_for_widget(
+            app_ctx,
             global_state,
             default_properties,
             property_arena,
@@ -360,7 +386,7 @@ fn update_disabled_for_widget(
     });
 }
 
-pub(crate) fn run_update_disabled_pass(root: &mut RenderRoot) {
+pub(crate) fn run_update_disabled_pass(app_ctx: &mut AppCtx, root: &mut RenderRoot) {
     let _span = info_span!("update_disabled").entered();
 
     // If a widget was enabled or disabled, the pointer icon may need to change.
@@ -370,6 +396,7 @@ pub(crate) fn run_update_disabled_pass(root: &mut RenderRoot) {
 
     let root_node = root.widget_arena.get_node_mut(root.root_id());
     update_disabled_for_widget(
+        app_ctx,
         &mut root.global_state,
         &root.property_arena.default_properties,
         &root.property_arena,
@@ -387,6 +414,7 @@ pub(crate) fn run_update_disabled_pass(root: &mut RenderRoot) {
 /// See the [passes documentation](crate::doc::pass_system#update-passes).
 /// See the [stashed status documentation](../doc/06_masonry_concepts.md#stashed).
 fn update_stashed_for_widget(
+    app_ctx: &mut AppCtx,
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
     property_arena: &PropertyArena,
@@ -410,6 +438,7 @@ fn update_stashed_for_widget(
     if stashed != state.is_stashed {
         let stack = property_arena.get(state.property_stack_id, widget.type_id());
         let mut ctx = UpdateCtx {
+            app_ctx,
             global_state,
             widget_state: state,
             children: children.reborrow_mut(),
@@ -443,6 +472,7 @@ fn update_stashed_for_widget(
     let parent_state = state;
     recurse_on_children(id, widget, children, |mut node| {
         update_stashed_for_widget(
+            app_ctx,
             global_state,
             default_properties,
             property_arena,
@@ -453,11 +483,12 @@ fn update_stashed_for_widget(
     });
 }
 
-pub(crate) fn run_update_stashed_pass(root: &mut RenderRoot) {
+pub(crate) fn run_update_stashed_pass(app_ctx: &mut AppCtx, root: &mut RenderRoot) {
     let _span = info_span!("update_stashed").entered();
 
     let root_node = root.widget_arena.get_node_mut(root.root_id());
     update_stashed_for_widget(
+        app_ctx,
         &mut root.global_state,
         &root.property_arena.default_properties,
         &root.property_arena,
@@ -616,7 +647,7 @@ fn find_first_focusable(
 // --- MARK: FOCUS
 /// See the [passes documentation](crate::doc::pass_system#update-passes).
 /// See the [focus status documentation](../doc/06_masonry_concepts.md#text-focus).
-pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
+pub(crate) fn run_update_focus_pass(app_ctx: &mut AppCtx, root: &mut RenderRoot) {
     let _span = info_span!("update_focus").entered();
     // If the next-focused widget is disabled, stashed or removed, we set
     // the focused id to None
@@ -654,7 +685,7 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
         if let Some(prev_focused) = prev_focused
             && root.has_widget(prev_focused)
         {
-            run_on_text_event_pass(root, &TextEvent::Ime(Ime::Disabled));
+            run_on_text_event_pass(app_ctx, root, &TextEvent::Ime(Ime::Disabled));
         }
 
         // Disable the IME, which was enabled specifically for this widget. Note that if the newly
@@ -709,11 +740,12 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
         // See comment in that function.
 
         fn update_focused_status_of(
+            app_ctx: &mut AppCtx,
             root: &mut RenderRoot,
             widget_id: WidgetId,
             focused_set: &HashSet<WidgetId>,
         ) {
-            run_targeted_update_pass(root, Some(widget_id), |widget, ctx, props| {
+            run_targeted_update_pass(app_ctx, root, Some(widget_id), |widget, ctx, props| {
                 let has_focused = focused_set.contains(&ctx.widget_id());
 
                 if ctx.widget_state.has_focus_target != has_focused {
@@ -732,7 +764,7 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
                 && root.widget_arena.get_state_mut(widget_id).has_focus_target
                     != focused_set.contains(&widget_id)
             {
-                update_focused_status_of(root, widget_id, &focused_set);
+                update_focused_status_of(app_ctx, root, widget_id, &focused_set);
             }
         }
         for widget_id in next_focused_path.iter().copied() {
@@ -740,7 +772,7 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
                 && root.widget_arena.get_state_mut(widget_id).has_focus_target
                     != focused_set.contains(&widget_id)
             {
-                update_focused_status_of(root, widget_id, &focused_set);
+                update_focused_status_of(app_ctx, root, widget_id, &focused_set);
             }
         }
     }
@@ -749,12 +781,12 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
     if prev_focused != next_focused {
         // We send FocusChange event to widget that lost and the widget that gained focus.
         // We also request accessibility, because build_access_node() depends on the focus state.
-        run_single_update_pass(root, prev_focused, |widget, ctx, props| {
+        run_single_update_pass(app_ctx, root, prev_focused, |widget, ctx, props| {
             widget.update(ctx, props, &Update::FocusChanged(false));
             ctx.widget_state.request_accessibility = true;
             ctx.widget_state.needs_accessibility = true;
         });
-        run_single_update_pass(root, next_focused, |widget, ctx, props| {
+        run_single_update_pass(app_ctx, root, next_focused, |widget, ctx, props| {
             widget.update(ctx, props, &Update::FocusChanged(true));
             ctx.widget_state.request_accessibility = true;
             ctx.widget_state.needs_accessibility = true;
@@ -789,7 +821,7 @@ pub(crate) fn run_update_focus_pass(root: &mut RenderRoot) {
 // child is visible. (If the target area is larger than the parent, the parent will try
 // to show the top left of that area.)
 /// See the [passes documentation](crate::doc::pass_system#update-passes).
-pub(crate) fn run_update_scroll_pass(root: &mut RenderRoot) {
+pub(crate) fn run_update_scroll_pass(app_ctx: &mut AppCtx, root: &mut RenderRoot) {
     let _span = info_span!("update_scroll").entered();
 
     let scroll_request_targets = std::mem::take(&mut root.global_state.scroll_request_targets);
@@ -798,7 +830,7 @@ pub(crate) fn run_update_scroll_pass(root: &mut RenderRoot) {
         let mut target_rect = rect;
 
         // We run the update pass on the target itself and then its ancestors.
-        run_targeted_update_pass(root, Some(target), |widget, ctx, props| {
+        run_targeted_update_pass(app_ctx, root, Some(target), |widget, ctx, props| {
             // Convert the target_rect from border-box space to content-box space.
             let local_rect = target_rect - ctx.widget_state.border_box_translation();
 
@@ -822,7 +854,7 @@ pub(crate) fn run_update_scroll_pass(root: &mut RenderRoot) {
 
 // --- MARK: POINTER
 /// See the [passes documentation](crate::doc::pass_system#update-passes).
-pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
+pub(crate) fn run_update_pointer_pass(app_ctx: &mut AppCtx, root: &mut RenderRoot) {
     if !root.global_state.needs_pointer_pass {
         return;
     }
@@ -852,7 +884,7 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
         && !root.is_still_interactive(id)
     {
         // The event pass will set pointer_capture_target to None.
-        run_on_pointer_event_pass(root, &dummy_pointer_cancel());
+        run_on_pointer_event_pass(app_ctx, root, &dummy_pointer_cancel());
     }
 
     // -- UPDATE ACTIVE --
@@ -886,11 +918,12 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
         // The above assumes that accessing the widget tree is O(1) for simplicity.
 
         fn update_active_status_of(
+            app_ctx: &mut AppCtx,
             root: &mut RenderRoot,
             widget_id: WidgetId,
             active_set: &HashSet<WidgetId>,
         ) {
-            run_targeted_update_pass(root, Some(widget_id), |widget, ctx, props| {
+            run_targeted_update_pass(app_ctx, root, Some(widget_id), |widget, ctx, props| {
                 let has_active = active_set.contains(&ctx.widget_id());
 
                 if ctx.widget_state.has_active != has_active {
@@ -906,7 +939,7 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
                 && root.widget_arena.get_state_mut(widget_id).has_active
                     != active_set.contains(&widget_id)
             {
-                update_active_status_of(root, widget_id, &active_set);
+                update_active_status_of(app_ctx, root, widget_id, &active_set);
             }
         }
         for widget_id in next_active_path.iter().copied() {
@@ -914,20 +947,20 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
                 && root.widget_arena.get_state_mut(widget_id).has_active
                     != active_set.contains(&widget_id)
             {
-                update_active_status_of(root, widget_id, &active_set);
+                update_active_status_of(app_ctx, root, widget_id, &active_set);
             }
         }
     }
 
     if prev_active_widget != next_active_widget {
-        run_single_update_pass(root, prev_active_widget, |widget, ctx, props| {
+        run_single_update_pass(app_ctx, root, prev_active_widget, |widget, ctx, props| {
             ctx.widget_state.is_active = false;
             ctx.widget_state.class_diff.is_active = Some(false);
             ctx.widget_state.request_update_props = true;
             ctx.widget_state.needs_update_props = true;
             widget.update(ctx, props, &Update::ActiveChanged(false));
         });
-        run_single_update_pass(root, next_active_widget, |widget, ctx, props| {
+        run_single_update_pass(app_ctx, root, next_active_widget, |widget, ctx, props| {
             ctx.widget_state.is_active = true;
             ctx.widget_state.class_diff.is_active = Some(true);
             ctx.widget_state.request_update_props = true;
@@ -987,11 +1020,12 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
         // The above assumes that accessing the widget tree is O(1) for simplicity.
 
         fn update_hovered_status_of(
+            app_ctx: &mut AppCtx,
             root: &mut RenderRoot,
             widget_id: WidgetId,
             hovered_set: &HashSet<WidgetId>,
         ) {
-            run_targeted_update_pass(root, Some(widget_id), |widget, ctx, props| {
+            run_targeted_update_pass(app_ctx, root, Some(widget_id), |widget, ctx, props| {
                 let has_hovered = hovered_set.contains(&ctx.widget_id());
 
                 if ctx.widget_state.has_hovered != has_hovered {
@@ -1007,7 +1041,7 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
                 && root.widget_arena.get_state_mut(widget_id).has_hovered
                     != hovered_set.contains(&widget_id)
             {
-                update_hovered_status_of(root, widget_id, &hovered_set);
+                update_hovered_status_of(app_ctx, root, widget_id, &hovered_set);
             }
         }
         for widget_id in next_hovered_path.iter().copied() {
@@ -1015,20 +1049,20 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
                 && root.widget_arena.get_state_mut(widget_id).has_hovered
                     != hovered_set.contains(&widget_id)
             {
-                update_hovered_status_of(root, widget_id, &hovered_set);
+                update_hovered_status_of(app_ctx, root, widget_id, &hovered_set);
             }
         }
     }
 
     if prev_hovered_widget != next_hovered_widget {
-        run_single_update_pass(root, prev_hovered_widget, |widget, ctx, props| {
+        run_single_update_pass(app_ctx, root, prev_hovered_widget, |widget, ctx, props| {
             ctx.widget_state.is_hovered = false;
             ctx.widget_state.class_diff.is_hovered = Some(false);
             ctx.widget_state.request_update_props = true;
             ctx.widget_state.needs_update_props = true;
             widget.update(ctx, props, &Update::HoveredChanged(false));
         });
-        run_single_update_pass(root, next_hovered_widget, |widget, ctx, props| {
+        run_single_update_pass(app_ctx, root, next_hovered_widget, |widget, ctx, props| {
             ctx.widget_state.is_hovered = true;
             ctx.widget_state.class_diff.is_hovered = Some(true);
             ctx.widget_state.request_update_props = true;
@@ -1096,6 +1130,7 @@ pub(crate) fn run_update_pointer_pass(root: &mut RenderRoot) {
 // --- MARK: PROPS
 /// See the [passes documentation](crate::doc::pass_system#update-passes).
 fn update_props_for_widget(
+    app_ctx: &mut AppCtx,
     global_state: &mut RenderRootState,
     property_arena: &PropertyArena,
     node: ArenaMut<'_, WidgetArenaNode>,
@@ -1131,6 +1166,7 @@ fn update_props_for_widget(
 
                 if new_index != *index || state.property_cache.invalidated {
                     let mut ctx = UpdateCtx {
+                        app_ctx,
                         global_state,
                         widget_state: state,
                         children: children.reborrow_mut(),
@@ -1154,7 +1190,7 @@ fn update_props_for_widget(
 
     let parent_state = state;
     recurse_on_children(id, widget, children, |mut node| {
-        update_props_for_widget(global_state, property_arena, node.reborrow_mut());
+        update_props_for_widget(app_ctx, global_state, property_arena, node.reborrow_mut());
         parent_state.merge_up(&mut node.item.state);
     });
 }
@@ -1178,7 +1214,7 @@ fn cached_props_changed(diff: &ClassSetDiff, cache: &PropertyCache) -> bool {
         || (diff.has_focus_target.is_some() && cache.relevant_has_focus_target)
 }
 
-pub(crate) fn run_update_props_pass(root: &mut RenderRoot) {
+pub(crate) fn run_update_props_pass(app_ctx: &mut AppCtx, root: &mut RenderRoot) {
     let _span = info_span!("update_props").entered();
 
     if !root.root_state().needs_update_props {
@@ -1186,7 +1222,12 @@ pub(crate) fn run_update_props_pass(root: &mut RenderRoot) {
     }
 
     let root_node = root.widget_arena.get_node_mut(root.root_id());
-    update_props_for_widget(&mut root.global_state, &root.property_arena, root_node);
+    update_props_for_widget(
+        app_ctx,
+        &mut root.global_state,
+        &root.property_arena,
+        root_node,
+    );
 }
 
 // ----------------
@@ -1194,6 +1235,7 @@ pub(crate) fn run_update_props_pass(root: &mut RenderRoot) {
 // --- MARK: FONTS
 /// See the [passes documentation](crate::doc::pass_system#update-passes).
 fn update_fonts_for_widget(
+    app_ctx: &mut AppCtx,
     global_state: &mut RenderRootState,
     default_properties: &DefaultProperties,
     property_arena: &PropertyArena,
@@ -1210,6 +1252,7 @@ fn update_fonts_for_widget(
 
     let stack = property_arena.get(state.property_stack_id, widget.type_id());
     let mut ctx = UpdateCtx {
+        app_ctx,
         global_state,
         widget_state: state,
         children: children.reborrow_mut(),
@@ -1227,6 +1270,7 @@ fn update_fonts_for_widget(
     let parent_state = state;
     recurse_on_children(id, widget, children, |mut node| {
         update_fonts_for_widget(
+            app_ctx,
             global_state,
             default_properties,
             property_arena,
@@ -1236,11 +1280,12 @@ fn update_fonts_for_widget(
     });
 }
 
-pub(crate) fn run_update_fonts_pass(root: &mut RenderRoot) {
+pub(crate) fn run_update_fonts_pass(app_ctx: &mut AppCtx, root: &mut RenderRoot) {
     let _span = info_span!("update_fonts").entered();
 
     let root_node = root.widget_arena.get_node_mut(root.root_id());
     update_fonts_for_widget(
+        app_ctx,
         &mut root.global_state,
         &root.property_arena.default_properties,
         &root.property_arena,

--- a/masonry_testing/Cargo.toml
+++ b/masonry_testing/Cargo.toml
@@ -19,6 +19,7 @@ targets = []
 
 [dependencies]
 accesskit_consumer.workspace = true
+copypasta.workspace = true
 image = { workspace = true, features = ["png"] }
 imaging_vello_cpu = { workspace = true }
 masonry_core.workspace = true

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -26,6 +26,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, mpsc};
 use std::time::UNIX_EPOCH;
 
+use copypasta::ClipboardProvider;
 use image::{DynamicImage, ImageFormat, ImageReader, Rgba, RgbaImage};
 use imaging_vello_cpu::VelloCpuRenderer;
 use masonry_core::imaging::record::{Scene, replay_transformed};
@@ -36,7 +37,7 @@ use tracing::debug;
 use masonry_core::accesskit::{Action, ActionRequest, Node, Role, Tree, TreeId, TreeUpdate};
 use masonry_core::anymore::AnyDebug;
 use masonry_core::app::{
-    RenderRoot, RenderRootOptions, RenderRootSignal, VisualLayerKind, VisualLayerPlan,
+    AppCtx, RenderRoot, RenderRootOptions, RenderRootSignal, VisualLayerKind, VisualLayerPlan,
     WindowSizePolicy, try_init_test_tracing,
 };
 use masonry_core::core::keyboard::{Code, Key, KeyState, NamedKey};
@@ -144,6 +145,7 @@ pub const PRIMARY_MOUSE: PointerInfo = PointerInfo {
 /// [`insta`]: https://docs.rs/insta/latest/insta/
 #[derive(Debug)]
 pub struct TestHarness<W: Widget> {
+    app_ctx: AppCtx,
     signal_receiver: mpsc::Receiver<RenderRootSignal>,
     render_root: RenderRoot,
     access_tree: accesskit_consumer::Tree,
@@ -158,7 +160,6 @@ pub struct TestHarness<W: Widget> {
     action_queue: VecDeque<(ErasedAction, WidgetId)>,
     has_ime_session: bool,
     ime_rect: (LogicalPosition<f64>, LogicalSize<f64>),
-    clipboard: String,
     title: String,
     _marker: PhantomData<W>,
 }
@@ -206,6 +207,10 @@ pub struct TestHarnessParams {
     pub max_screenshot_size: u32,
 }
 
+struct SimpleClipboard {
+    contents: String,
+}
+
 /// Assert a snapshot of a rendered frame of your app.
 ///
 /// This macro takes a test harness and a name, renders the current state of the app,
@@ -246,6 +251,31 @@ macro_rules! assert_failing_render_snapshot {
     ($test_harness:expr, $name:expr) => {
         $test_harness.check_render_snapshot(env!("CARGO_MANIFEST_DIR"), $name, true)
     };
+}
+
+impl SimpleClipboard {
+    /// Create an empty clipboard.
+    fn new() -> Self {
+        Self {
+            contents: String::new(),
+        }
+    }
+}
+
+impl ClipboardProvider for SimpleClipboard {
+    fn get_contents(
+        &mut self,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        Ok(self.contents.clone())
+    }
+
+    fn set_contents(
+        &mut self,
+        contents: String,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+        self.contents = contents;
+        Ok(())
+    }
 }
 
 impl TestHarnessParams {
@@ -341,6 +371,12 @@ pub const ROBOTO: &[u8] = include_bytes!(concat!(
     "/resources/fonts/roboto/Roboto-Regular.ttf"
 ));
 
+/// Creates a new [`AppCtx`] suitable for testing.
+pub fn create_app_ctx() -> AppCtx {
+    let clipboard = SimpleClipboard::new();
+    AppCtx::new(Box::new(clipboard))
+}
+
 impl<W: Widget> TestHarness<W> {
     // -- MARK: CREATE
     /// Builds harness with given root widget.
@@ -384,6 +420,8 @@ impl<W: Widget> TestHarness<W> {
 
         let (signal_sender, signal_receiver) = mpsc::channel::<RenderRootSignal>();
 
+        let mut app_ctx = create_app_ctx();
+
         let dummy_tree_update = TreeUpdate {
             tree_id: TreeId::ROOT,
             nodes: vec![(0.into(), Node::new(Role::Window))],
@@ -394,20 +432,25 @@ impl<W: Widget> TestHarness<W> {
             }),
             focus: 0.into(),
         };
+
+        let render_root = RenderRoot::new(
+            &mut app_ctx,
+            root_widget,
+            move |signal| signal_sender.send(signal).unwrap(),
+            RenderRootOptions {
+                default_properties: Arc::new(default_props),
+                use_system_fonts: false,
+                size_policy: WindowSizePolicy::User,
+                size: window_size,
+                scale_factor: params.scale_factor,
+                test_font: Some(data),
+            },
+        );
+
         let mut harness = Self {
+            app_ctx,
             signal_receiver,
-            render_root: RenderRoot::new(
-                root_widget,
-                move |signal| signal_sender.send(signal).unwrap(),
-                RenderRootOptions {
-                    default_properties: Arc::new(default_props),
-                    use_system_fonts: false,
-                    size_policy: WindowSizePolicy::User,
-                    size: window_size,
-                    scale_factor: params.scale_factor,
-                    test_font: Some(data),
-                },
-            ),
+            render_root,
             access_tree: accesskit_consumer::Tree::new(dummy_tree_update, false),
             renderer: None,
             mouse_state,
@@ -420,7 +463,6 @@ impl<W: Widget> TestHarness<W> {
             action_queue: VecDeque::new(),
             has_ime_session: false,
             ime_rect: Default::default(),
-            clipboard: String::new(),
             title: String::new(),
             _marker: PhantomData,
         };
@@ -429,7 +471,7 @@ impl<W: Widget> TestHarness<W> {
         harness.process_window_event(WindowEvent::EnableAccessTree);
         harness.animate_ms(0);
 
-        let (_, tree_update) = harness.render_root.redraw();
+        let (_, tree_update) = harness.render_root.redraw(&mut harness.app_ctx);
         let tree_update = tree_update.unwrap();
         harness
             .access_tree
@@ -446,7 +488,9 @@ impl<W: Widget> TestHarness<W> {
     ///
     /// This will run [rewrite passes](masonry_core::doc::pass_system#rewrite-passes) after the event is processed.
     pub fn process_window_event(&mut self, event: WindowEvent) -> Handled {
-        let handled = self.render_root.handle_window_event(event);
+        let handled = self
+            .render_root
+            .handle_window_event(&mut self.app_ctx, event);
         self.process_signals();
         handled
     }
@@ -455,7 +499,9 @@ impl<W: Widget> TestHarness<W> {
     ///
     /// This will run [rewrite passes](masonry_core::doc::pass_system#rewrite-passes) after the event is processed.
     pub fn process_pointer_event(&mut self, event: PointerEvent) -> Handled {
-        let handled = self.render_root.handle_pointer_event(event);
+        let handled = self
+            .render_root
+            .handle_pointer_event(&mut self.app_ctx, event);
         self.process_signals();
         handled
     }
@@ -464,7 +510,7 @@ impl<W: Widget> TestHarness<W> {
     ///
     /// This will run [rewrite passes](masonry_core::doc::pass_system#rewrite-passes) after the event is processed.
     pub fn process_text_event(&mut self, event: TextEvent) -> Handled {
-        let handled = self.render_root.handle_text_event(event);
+        let handled = self.render_root.handle_text_event(&mut self.app_ctx, event);
         self.process_signals();
         handled
     }
@@ -473,7 +519,8 @@ impl<W: Widget> TestHarness<W> {
     ///
     /// This will run [rewrite passes](masonry_core::doc::pass_system#rewrite-passes) after the event is processed.
     pub fn process_access_event(&mut self, event: ActionRequest) {
-        self.render_root.handle_access_event(event);
+        self.render_root
+            .handle_access_event(&mut self.app_ctx, event);
         self.process_signals();
     }
 
@@ -497,9 +544,6 @@ impl<W: Widget> TestHarness<W> {
                 RenderRootSignal::ImeMoved(position, size) => {
                     self.ime_rect = (position, size);
                 }
-                RenderRootSignal::ClipboardStore(text) => {
-                    self.clipboard = text;
-                }
                 RenderRootSignal::RequestRedraw => (),
                 RenderRootSignal::RequestAnimFrame => (),
                 RenderRootSignal::TakeFocus => (),
@@ -519,11 +563,14 @@ impl<W: Widget> TestHarness<W> {
                 RenderRootSignal::ShowWindowMenu(_) => (),
                 RenderRootSignal::WidgetSelectedInInspector(_) => (),
                 RenderRootSignal::NewLayer(_type, root, pos) => {
-                    self.render_root.add_layer(root, pos);
+                    self.render_root.add_layer(&mut self.app_ctx, root, pos);
                 }
-                RenderRootSignal::RemoveLayer(root_id) => self.render_root.remove_layer(root_id),
+                RenderRootSignal::RemoveLayer(root_id) => {
+                    self.render_root.remove_layer(&mut self.app_ctx, root_id);
+                }
                 RenderRootSignal::RepositionLayer(root_id, new_pos) => {
-                    self.render_root.reposition_layer(root_id, new_pos);
+                    self.render_root
+                        .reposition_layer(&mut self.app_ctx, root_id, new_pos);
                 }
             }
         }
@@ -583,7 +630,7 @@ impl<W: Widget> TestHarness<W> {
     ///
     /// If you want to get a bitmap image of the contents, use [`Self::render`] instead.
     pub fn redraw(&mut self) -> (VisualLayerPlan, TreeUpdate) {
-        let (visual_layers, tree_update) = self.render_root.redraw();
+        let (visual_layers, tree_update) = self.render_root.redraw(&mut self.app_ctx);
         let tree_update = tree_update.unwrap();
         self.access_tree
             .update_and_process_changes(tree_update.clone(), &mut NoOpTreeChangeHandler);
@@ -751,12 +798,15 @@ impl<W: Widget> TestHarness<W> {
     /// [`ScrollIntoView`]: masonry_core::accesskit::Action::ScrollIntoView
     #[track_caller]
     pub fn scroll_into_view(&mut self, id: WidgetId) {
-        self.render_root.handle_access_event(ActionRequest {
-            action: Action::ScrollIntoView,
-            target_tree: TreeId::ROOT,
-            target_node: id.to_raw().into(),
-            data: None,
-        });
+        self.render_root.handle_access_event(
+            &mut self.app_ctx,
+            ActionRequest {
+                action: Action::ScrollIntoView,
+                target_tree: TreeId::ROOT,
+                target_node: id.to_raw().into(),
+                data: None,
+            },
+        );
     }
 
     /// Clicks the given widget.
@@ -774,12 +824,15 @@ impl<W: Widget> TestHarness<W> {
     /// [`Click`]: masonry_core::accesskit::Action::Click
     #[track_caller]
     pub fn accessibility_click_on(&mut self, id: WidgetId) {
-        self.render_root.handle_access_event(ActionRequest {
-            action: Action::Click,
-            target_tree: TreeId::ROOT,
-            target_node: id.to_raw().into(),
-            data: None,
-        });
+        self.render_root.handle_access_event(
+            &mut self.app_ctx,
+            ActionRequest {
+                action: Action::Click,
+                target_tree: TreeId::ROOT,
+                target_node: id.to_raw().into(),
+                data: None,
+            },
+        );
     }
 
     // TODO - Handle complicated IME
@@ -789,7 +842,7 @@ impl<W: Widget> TestHarness<W> {
         // For each character
         for c in text.split("").filter(|s| !s.is_empty()) {
             let event = TextEvent::Ime(Ime::Commit(c.to_string()));
-            self.render_root.handle_text_event(event);
+            self.render_root.handle_text_event(&mut self.app_ctx, event);
         }
         self.process_signals();
     }
@@ -808,7 +861,7 @@ impl<W: Widget> TestHarness<W> {
             modifiers,
             ..KeyboardEvent::default()
         });
-        self.render_root.handle_text_event(event);
+        self.render_root.handle_text_event(&mut self.app_ctx, event);
         self.process_signals();
     }
 
@@ -831,7 +884,7 @@ impl<W: Widget> TestHarness<W> {
                 panic!("Cannot focus widget {id}: widget is disabled");
             }
         }
-        let succeeded = self.render_root.focus_on(id);
+        let succeeded = self.render_root.focus_on(&mut self.app_ctx, id);
         assert!(
             succeeded,
             "RenderRoot::focus_on refused a widget which TestHarness::focus_on accepted."
@@ -851,8 +904,10 @@ impl<W: Widget> TestHarness<W> {
 
     /// Runs an animation pass on the widget tree.
     pub fn animate_ms(&mut self, ms: u64) {
-        self.render_root
-            .handle_window_event(WindowEvent::AnimFrame(Duration::from_millis(ms)));
+        self.render_root.handle_window_event(
+            &mut self.app_ctx,
+            WindowEvent::AnimFrame(Duration::from_millis(ms)),
+        );
         self.process_signals();
     }
 
@@ -970,10 +1025,12 @@ impl<W: Widget> TestHarness<W> {
     ///
     /// Because of how `WidgetMut` works, it can only be passed to a user-provided callback.
     pub fn edit_root_widget<R>(&mut self, f: impl FnOnce(WidgetMut<'_, W>) -> R) -> R {
-        let ret = self.render_root.edit_base_layer(|mut root| {
-            let root = root.downcast::<W>();
-            f(root)
-        });
+        let ret = self
+            .render_root
+            .edit_base_layer(&mut self.app_ctx, |mut root| {
+                let root = root.downcast::<W>();
+                f(root)
+            });
         self.process_signals();
         ret
     }
@@ -986,7 +1043,7 @@ impl<W: Widget> TestHarness<W> {
         id: WidgetId,
         f: impl FnOnce(WidgetMut<'_, dyn Widget>) -> R,
     ) -> R {
-        let ret = self.render_root.edit_widget(id, f);
+        let ret = self.render_root.edit_widget(&mut self.app_ctx, id, f);
         self.process_signals();
         ret
     }
@@ -1000,7 +1057,9 @@ impl<W: Widget> TestHarness<W> {
         tag: WidgetTag<W2>,
         f: impl FnOnce(WidgetMut<'_, W2>) -> R,
     ) -> R {
-        let ret = self.render_root.edit_widget_with_tag(tag, f);
+        let ret = self
+            .render_root
+            .edit_widget_with_tag(&mut self.app_ctx, tag, f);
         self.process_signals();
         ret
     }
@@ -1053,8 +1112,8 @@ impl<W: Widget> TestHarness<W> {
     /// Returns the contents of the emulated clipboard.
     ///
     /// This is an empty string by default.
-    pub fn clipboard_contents(&self) -> String {
-        self.clipboard.clone()
+    pub fn clipboard_contents(&mut self) -> String {
+        self.app_ctx.get_clipboard()
     }
 
     /// Returns the size of the simulated window.
@@ -1107,7 +1166,7 @@ impl<W: Widget> TestHarness<W> {
     ) {
         if std::env::var("SKIP_RENDER_TESTS").is_ok_and(|it| !it.is_empty()) {
             // We still redraw to get some coverage in the paint code.
-            let _ = self.render_root.redraw();
+            let _ = self.render_root.redraw(&mut self.app_ctx);
 
             return;
         }

--- a/masonry_testing/src/lib.rs
+++ b/masonry_testing/src/lib.rs
@@ -73,7 +73,7 @@ mod wrapper_widget;
 pub use assert_any::{assert_all, assert_any, assert_none};
 pub use assert_debug_panics::assert_debug_panics_inner;
 pub use debug_name::DebugName;
-pub use harness::{PRIMARY_MOUSE, ROBOTO, TestHarness, TestHarnessParams};
+pub use harness::{PRIMARY_MOUSE, ROBOTO, TestHarness, TestHarnessParams, create_app_ctx};
 pub use modular_widget::ModularWidget;
 pub use recorder_widget::{Record, Recorder, Recording};
 pub use wrapper_widget::WrapperWidget;

--- a/masonry_winit/Cargo.toml
+++ b/masonry_winit/Cargo.toml
@@ -45,7 +45,7 @@ masonry_imaging = { workspace = true, default-features = false }
 vello = { workspace = true, optional = true }
 wgpu.workspace = true
 wgpu-profiler = { optional = true, version = "0.26.0", default-features = false }
-copypasta = "0.10.2"
+copypasta.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # We need Metal to interact with CoreAnimation during window resizing.

--- a/masonry_winit/src/app_driver.rs
+++ b/masonry_winit/src/app_driver.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use masonry_core::app::RenderRoot;
+use masonry_core::app::{AppCtx, RenderRoot};
 use masonry_core::core::{ErasedAction, WidgetId};
 use tracing::field::DisplayValue;
 use winit::event_loop::ActiveEventLoop;
@@ -109,7 +109,7 @@ pub trait AppDriver {
     ) {
     }
 
-    /// A hook which will be executed when the application starts, to allow initial configuration of the `MasonryState`.
+    /// A hook which will be executed when the application starts, to allow initial configuration.
     ///
     /// Use cases include loading fonts.
     ///
@@ -118,7 +118,7 @@ pub trait AppDriver {
     /// not assume it will only be called once (but should feel free to waste work if it is called multiple times,
     /// for example, as the mentioned circumstances are very rare).
     // TODO: Turn into something like on window created, or split into two.
-    fn on_start(&mut self, state: &mut MasonryState<'_>) {}
+    fn on_start(&mut self, ctx: &mut DriverCtx<'_, '_>) {}
 
     /// A hook called when a user has requested to close a window.
     fn on_close_requested(&mut self, window_id: WindowId, ctx: &mut DriverCtx<'_, '_>) {
@@ -132,22 +132,42 @@ pub trait AppDriver {
 impl DriverCtx<'_, '_> {
     // TODO - Add method to create timer
 
-    /// Access the [`RenderRoot`] of the given window.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the window cannot be found.
-    pub fn render_root(&mut self, window_id: WindowId) -> &mut RenderRoot {
-        &mut self.window(window_id).render_root
+    /// Returns the shared app context.
+    pub fn app_ctx(&mut self) -> &mut AppCtx {
+        &mut self.state.app_ctx
     }
 
-    /// Access the [`Window`] state of the given window.
+    /// Returns the shared app context and every [`RenderRoot`].
+    pub fn render_roots(&mut self) -> (&mut AppCtx, impl Iterator<Item = &mut RenderRoot>) {
+        (
+            &mut self.state.app_ctx,
+            self.state
+                .windows
+                .values_mut()
+                .map(|window| &mut window.render_root),
+        )
+    }
+
+    /// Returns the shared app context and the [`RenderRoot`] of the given window.
     ///
     /// # Panics
     ///
     /// Panics if the window cannot be found.
-    pub fn window(&mut self, window_id: WindowId) -> &mut Window {
-        self.state.window_mut(window_id)
+    pub fn render_root(&mut self, window_id: WindowId) -> (&mut AppCtx, &mut RenderRoot) {
+        let handle_id = self.state.handle_id(window_id);
+        let window = self.state.windows.get_mut(&handle_id).unwrap();
+        (&mut self.state.app_ctx, &mut window.render_root)
+    }
+
+    /// Returns the shared app context and the [`Window`] state of the given window.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the window cannot be found.
+    pub fn window(&mut self, window_id: WindowId) -> (&mut AppCtx, &mut Window) {
+        let handle_id = self.state.handle_id(window_id);
+        let window = self.state.windows.get_mut(&handle_id).unwrap();
+        (&mut self.state.app_ctx, window)
     }
 
     /// Creates a new window.

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -10,9 +10,8 @@ use accesskit_winit::Adapter;
 use copypasta::nop_clipboard::NopClipboardContext;
 use copypasta::{ClipboardContext, ClipboardProvider};
 use masonry_core::app::{
-    RenderRoot, RenderRootOptions, RenderRootSignal, VisualLayerKind, WindowSizePolicy,
+    AppCtx, RenderRoot, RenderRootOptions, RenderRootSignal, VisualLayerKind, WindowSizePolicy,
 };
-use masonry_core::core::keyboard::{Key, KeyState};
 use masonry_core::core::{
     DefaultProperties, ErasedAction, NewWidget, TextEvent, Widget, WindowEvent,
 };
@@ -137,6 +136,7 @@ pub struct Window {
 
 impl Window {
     pub(crate) fn new(
+        app_ctx: &mut AppCtx,
         window_id: WindowId,
         handle: Arc<WindowHandle>,
         accesskit_adapter: Adapter,
@@ -153,6 +153,7 @@ impl Window {
             accesskit_adapter,
             event_reducer: WindowEventReducer::default(),
             render_root: RenderRoot::new(
+                app_ctx,
                 root_widget,
                 move |signal| {
                     signal_sender.clone().send((window_id, signal)).unwrap();
@@ -204,6 +205,8 @@ impl Debug for Window {
 /// `MasonryState` via [`MasonryState::new`] and forward events to it via the appropriate method (e.g.,
 /// calling [`handle_window_event`](MasonryState::handle_window_event) in [`window_event`](ApplicationHandler::window_event)).
 pub struct MasonryState<'a> {
+    pub(crate) app_ctx: AppCtx,
+
     /// The event loop is suspended when the app is e.g. in the background on Android.
     /// We aren't allowed to have any `Surface`s, and we also don't expect to receive any events.
     /// See [`ApplicationHandler::suspended()`] for details.
@@ -219,12 +222,10 @@ pub struct MasonryState<'a> {
     window_id_to_handle_id: HashMap<WindowId, HandleId>,
 
     surfaces: HashMap<HandleId, RenderSurface<'a>>,
-    windows: HashMap<HandleId, Window>,
+    pub(crate) windows: HashMap<HandleId, Window>,
     /// On Metal, we need to track the state of resize requests to avoid jitter.
     #[cfg(target_os = "macos")]
     resized_window: Option<HandleId>,
-
-    clipboard_cx: Box<dyn ClipboardProvider>,
 
     // Is `Some` if the most recently displayed frame was an animation frame.
     last_anim: Option<Instant>,
@@ -411,7 +412,11 @@ impl MasonryState<'_> {
             clipboard_cx.unwrap()
         };
 
+        let app_ctx = AppCtx::new(clipboard_cx);
+
         MasonryState {
+            app_ctx,
+
             is_suspended: true,
             render_cx,
             renderer: ImagingRenderer::new(),
@@ -426,8 +431,6 @@ impl MasonryState<'_> {
             surfaces: HashMap::new(),
             #[cfg(target_os = "macos")]
             resized_window: None,
-
-            clipboard_cx,
 
             signal_sender,
             default_properties: Arc::new(default_properties),
@@ -497,7 +500,7 @@ impl MasonryState<'_> {
             }
             // TODO: This is wrong in the case where the driver tries to create a window whilst suspended
             // The on_start would be called twice.
-            app_driver.on_start(self);
+            app_driver.on_start(&mut DriverCtx::new(self, event_loop));
         }
 
         self.handle_signals(event_loop, app_driver);
@@ -569,6 +572,7 @@ impl MasonryState<'_> {
         let size = handle.inner_size();
 
         let window = Window::new(
+            &mut self.app_ctx,
             new_window.id,
             handle,
             adapter,
@@ -656,7 +660,7 @@ impl MasonryState<'_> {
 
         window
             .render_root
-            .handle_window_event(WindowEvent::AnimFrame(elapsed));
+            .handle_window_event(&mut self.app_ctx, WindowEvent::AnimFrame(elapsed));
 
         // If this animation will continue, store the time.
         // If a new animation starts, then it will have zero reported elapsed time.
@@ -668,7 +672,7 @@ impl MasonryState<'_> {
             self.render_cx.on_window_resize_state_change(surface, true);
         }
 
-        let (visual_layers, tree_update) = window.render_root.redraw();
+        let (visual_layers, tree_update) = window.render_root.redraw(&mut self.app_ctx);
         let overlays: Vec<_> = visual_layers
             .overlay_layers()
             .map(|layer| {
@@ -850,28 +854,14 @@ impl MasonryState<'_> {
         {
             match wet {
                 WindowEventTranslation::Keyboard(k) => {
-                    // TODO - Detect in Masonry code instead
-                    let action_mod = if cfg!(target_os = "macos") {
-                        k.modifiers.meta()
-                    } else {
-                        k.modifiers.ctrl()
-                    };
-                    if let Key::Character(c) = &k.key
-                        && c.as_str().eq_ignore_ascii_case("v")
-                        && action_mod
-                        && k.state == KeyState::Down
-                    {
-                        window
-                            .render_root
-                            .handle_text_event(TextEvent::ClipboardPaste(
-                                self.clipboard_cx.get_contents().unwrap(),
-                            ));
-                    } else {
-                        window.render_root.handle_text_event(TextEvent::Keyboard(k));
-                    }
+                    window
+                        .render_root
+                        .handle_text_event(&mut self.app_ctx, TextEvent::Keyboard(k));
                 }
                 WindowEventTranslation::Pointer(p) => {
-                    window.render_root.handle_pointer_event(p);
+                    window
+                        .render_root
+                        .handle_pointer_event(&mut self.app_ctx, p);
                 }
             }
         }
@@ -896,7 +886,7 @@ impl MasonryState<'_> {
             WinitWindowEvent::ScaleFactorChanged { scale_factor, .. } => {
                 window
                     .render_root
-                    .handle_window_event(WindowEvent::Rescale(scale_factor));
+                    .handle_window_event(&mut self.app_ctx, WindowEvent::Rescale(scale_factor));
             }
             WinitWindowEvent::RedrawRequested => {
                 self.redraw(handle_id, app_driver);
@@ -915,16 +905,18 @@ impl MasonryState<'_> {
 
                 window
                     .render_root
-                    .handle_window_event(WindowEvent::Resize(size));
+                    .handle_window_event(&mut self.app_ctx, WindowEvent::Resize(size));
             }
             WinitWindowEvent::Ime(ime) => {
                 let ime = winit_ime_to_masonry(ime);
-                window.render_root.handle_text_event(TextEvent::Ime(ime));
+                window
+                    .render_root
+                    .handle_text_event(&mut self.app_ctx, TextEvent::Ime(ime));
             }
             WinitWindowEvent::Focused(new_focus) => {
                 window
                     .render_root
-                    .handle_text_event(TextEvent::WindowFocusChange(new_focus));
+                    .handle_text_event(&mut self.app_ctx, TextEvent::WindowFocusChange(new_focus));
             }
             _ => (),
         }
@@ -978,15 +970,17 @@ impl MasonryState<'_> {
                     accesskit_winit::WindowEvent::InitialTreeRequested => {
                         window
                             .render_root
-                            .handle_window_event(WindowEvent::EnableAccessTree);
+                            .handle_window_event(&mut self.app_ctx, WindowEvent::EnableAccessTree);
                     }
                     accesskit_winit::WindowEvent::ActionRequested(action_request) => {
-                        window.render_root.handle_access_event(action_request);
+                        window
+                            .render_root
+                            .handle_access_event(&mut self.app_ctx, action_request);
                     }
                     accesskit_winit::WindowEvent::AccessibilityDeactivated => {
                         window
                             .render_root
-                            .handle_window_event(WindowEvent::DisableAccessTree);
+                            .handle_window_event(&mut self.app_ctx, WindowEvent::DisableAccessTree);
                     }
                 }
             }
@@ -1061,9 +1055,6 @@ impl MasonryState<'_> {
                 RenderRootSignal::ImeMoved(position, size) => {
                     handle.set_ime_cursor_area(position, size);
                 }
-                RenderRootSignal::ClipboardStore(text) => {
-                    self.clipboard_cx.set_contents(text).unwrap();
-                }
                 RenderRootSignal::RequestRedraw => {
                     need_redraw.insert(*handle_id);
                 }
@@ -1118,11 +1109,15 @@ impl MasonryState<'_> {
                     info!("Widget selected in inspector: {widget_id} - {display_name}");
                 }
                 RenderRootSignal::NewLayer(_type, root, pos) => {
-                    window.render_root.add_layer(root, pos);
+                    window.render_root.add_layer(&mut self.app_ctx, root, pos);
                 }
-                RenderRootSignal::RemoveLayer(root_id) => window.render_root.remove_layer(root_id),
+                RenderRootSignal::RemoveLayer(root_id) => {
+                    window.render_root.remove_layer(&mut self.app_ctx, root_id);
+                }
                 RenderRootSignal::RepositionLayer(root_id, new_pos) => {
-                    window.render_root.reposition_layer(root_id, new_pos);
+                    window
+                        .render_root
+                        .reposition_layer(&mut self.app_ctx, root_id, new_pos);
                 }
             }
         }
@@ -1143,16 +1138,11 @@ impl MasonryState<'_> {
         }
     }
 
-    fn handle_id(&self, window_id: WindowId) -> HandleId {
+    pub(crate) fn handle_id(&self, window_id: WindowId) -> HandleId {
         *self
             .window_id_to_handle_id
             .get(&window_id)
             .unwrap_or_else(|| panic!("could not find window for id {window_id:?}"))
-    }
-
-    pub(crate) fn window_mut(&mut self, window_id: WindowId) -> &mut Window {
-        let handle_id = self.handle_id(window_id);
-        self.windows.get_mut(&handle_id).unwrap()
     }
 
     /// Returns true if app is currently suspended.
@@ -1164,15 +1154,6 @@ impl MasonryState<'_> {
     /// Suspended apps have no surfaces and receive no events.
     pub fn is_suspended(&self) -> bool {
         self.is_suspended
-    }
-
-    // TODO: Remove this method.
-    // It's currently used to call register_fonts and set_focus_fallback.
-    #[doc(hidden)]
-    pub fn roots(&mut self) -> impl Iterator<Item = &mut RenderRoot> {
-        self.windows
-            .values_mut()
-            .map(|window| &mut window.render_root)
     }
 
     /// Sets how frames are presented to the user.

--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -7,9 +7,7 @@ use std::sync::Arc;
 
 use masonry::core::{ErasedAction, WidgetId};
 use masonry::peniko::Blob;
-use masonry_winit::app::{
-    AppDriver, DriverCtx, MasonryState, MasonryUserEvent, NewWindow, WindowId,
-};
+use masonry_winit::app::{AppDriver, DriverCtx, MasonryUserEvent, NewWindow, WindowId};
 
 use crate::core::{
     DynMessage, MessageCtx, MessageResult, ProxyError, RawProxy, SendMessage, View, ViewId,
@@ -347,11 +345,13 @@ where
         self.handle_message_result(window_id, masonry_ctx, message_result);
     }
 
-    fn on_start(&mut self, state: &mut MasonryState<'_>) {
+    fn on_start(&mut self, ctx: &mut DriverCtx<'_, '_>) {
         // self.fonts is never used again, so we may as well deallocate it.
         let fonts = std::mem::take(&mut self.fonts);
 
-        for root in state.roots() {
+        let (app_ctx, roots) = ctx.render_roots();
+
+        for root in roots {
             if let Some(root_widget) = root
                 .get_layer_root(0)
                 .downcast::<masonry::widgets::Passthrough>()
@@ -364,7 +364,7 @@ where
             for font in &fonts {
                 // We currently don't do anything with the resulting family information,
                 // because we don't have an easy way to return this to the application.
-                drop(root.register_fonts(font.clone()));
+                drop(root.register_fonts(app_ctx, font.clone()));
             }
         }
     }

--- a/xilem/src/window_view.rs
+++ b/xilem/src/window_view.rs
@@ -1,7 +1,9 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::{theme::BACKGROUND_COLOR, util::debug_panic};
+use masonry::app::AppCtx;
+use masonry::theme::BACKGROUND_COLOR;
+use masonry::util::debug_panic;
 use masonry_winit::app::{NewWindow, Window, WindowId};
 
 use crate::core::{MessageCtx, Mut, View, ViewElement, ViewMarker};
@@ -63,7 +65,7 @@ impl<State> WindowView<State> {
 pub struct PodWindow(pub NewWindow);
 
 impl ViewElement for PodWindow {
-    type Mut<'a> = &'a mut Window;
+    type Mut<'a> = (&'a mut AppCtx, &'a mut Window);
 }
 
 impl<State> ViewMarker for WindowView<State> where State: 'static {}
@@ -100,7 +102,7 @@ impl<State> View<State, (), ViewCtx> for WindowView<State> {
         prev: &Self,
         root_widget_view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        window: Mut<'_, Self::Element>,
+        (app_ctx, window): Mut<'_, Self::Element>,
         app_state: &mut State,
     ) {
         self.options.rebuild(&prev.options, window.handle());
@@ -114,7 +116,7 @@ impl<State> View<State, (), ViewCtx> for WindowView<State> {
             &prev.masonry_root,
             root_widget_view_state,
             ctx,
-            window.render_root(),
+            (app_ctx, window.render_root()),
             app_state,
         );
     }
@@ -123,21 +125,25 @@ impl<State> View<State, (), ViewCtx> for WindowView<State> {
         &self,
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        window: Mut<'_, Self::Element>,
+        (app_ctx, window): Mut<'_, Self::Element>,
     ) {
         self.masonry_root
-            .teardown(view_state, ctx, window.render_root());
+            .teardown(view_state, ctx, (app_ctx, window.render_root()));
     }
 
     fn message(
         &self,
         view_state: &mut Self::ViewState,
         message: &mut MessageCtx,
-        window: Mut<'_, Self::Element>,
+        (app_ctx, window): Mut<'_, Self::Element>,
         app_state: &mut State,
     ) -> xilem_core::MessageResult<()> {
-        self.masonry_root
-            .message(view_state, message, window.render_root(), app_state)
+        self.masonry_root.message(
+            view_state,
+            message,
+            (app_ctx, window.render_root()),
+            app_state,
+        )
     }
 }
 

--- a/xilem_masonry/src/masonry_root.rs
+++ b/xilem_masonry/src/masonry_root.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::app::RenderRoot;
+use masonry::app::{AppCtx, RenderRoot};
 use masonry::widgets::Passthrough;
 
 use crate::core::{MessageCtx, Mut, View, ViewElement, ViewMarker};
@@ -19,7 +19,7 @@ pub(crate) type MasonryRootState = <Box<AnyWidgetView<(), ()>> as View<(), (), V
 pub struct InitialRootWidget(pub Pod<Passthrough>);
 
 impl ViewElement for InitialRootWidget {
-    type Mut<'a> = &'a mut RenderRoot;
+    type Mut<'a> = (&'a mut AppCtx, &'a mut RenderRoot);
 }
 
 impl<State: 'static> MasonryRoot<State> {
@@ -47,11 +47,11 @@ impl<State> View<State, (), ViewCtx> for MasonryRoot<State> {
         prev: &Self,
         root_widget_view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        render_root: Mut<'_, Self::Element>,
+        (app_ctx, render_root): Mut<'_, Self::Element>,
         app_state: &mut State,
     ) {
         let mut root_id = None;
-        render_root.edit_base_layer(|mut root| {
+        render_root.edit_base_layer(app_ctx, |mut root| {
             let mut root = root.downcast();
             ctx.reset_changed_props();
             self.root_widget_view.rebuild(
@@ -73,9 +73,9 @@ impl<State> View<State, (), ViewCtx> for MasonryRoot<State> {
         &self,
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        render_root: Mut<'_, Self::Element>,
+        (app_ctx, render_root): Mut<'_, Self::Element>,
     ) {
-        render_root.edit_base_layer(|mut root| {
+        render_root.edit_base_layer(app_ctx, |mut root| {
             self.root_widget_view
                 .teardown(view_state, ctx, root.downcast());
         });
@@ -85,10 +85,10 @@ impl<State> View<State, (), ViewCtx> for MasonryRoot<State> {
         &self,
         view_state: &mut Self::ViewState,
         message: &mut MessageCtx,
-        render_root: Mut<'_, Self::Element>,
+        (app_ctx, render_root): Mut<'_, Self::Element>,
         app_state: &mut State,
     ) -> xilem_core::MessageResult<()> {
-        render_root.edit_base_layer(|mut root| {
+        render_root.edit_base_layer(app_ctx, |mut root| {
             self.root_widget_view
                 .message(view_state, message, root.downcast(), app_state)
         })


### PR DESCRIPTION
For some state it makes sense to have only one copy per app. Until now we haven't had a mechanism to store and provide access to such shared app state. Instead we've hacked around it in various ways. Let's look at two examples.

1. Clipboard access. Deciding what to get from the clipboard, if anything, is a widget level concern. Different widgets might want different formats like plain text, rich text, or images. Some widget might want to implement its own custom in-app copy/paste mechanism for some app data and ignore the platform clipboard. However, the current hack we have is that `masonry_winit` detects Ctrl+V and replaces the key event with a plain text paste event. This does not allow for the aforementioned variety of paste logic. Widgets need to be able to decide what to do with the key event or they might want to access the clipboard even from a pointer event.

2. Font database/cache access. This is currently implemented at the `RenderRoot` level, meaning that font resolution, loading, and caching is duplicated for each root. It works but is needlessly inefficient.

This PR introduces a new `AppCtx` type that encapsulates these kind of app-wide services. It does require a fair amount of plumbing at the framework level. I think the benefit of synchronous mutable access at the widget level makes it worth it.

Because the plumbing changes are already quite noisy I migrated only the clipboard access in this PR. Font context migration would be follow-up work.
