### PR TITLE
Add widget timers to Masonry and use them for delayed UI   behavior.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,6 +2467,7 @@ dependencies = [
  "tracing_android_trace",
  "tree_arena",
  "ui-events",
+ "understory_timing",
  "web-time",
 ]
 
@@ -5058,6 +5059,12 @@ dependencies = [
  "web-time",
  "winit",
 ]
+
+[[package]]
+name = "understory_timing"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd51bfaa2fed0422a43d7a29fcd928356376740422ac07191604039cfa3be4cd"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ imaging_vello_cpu = { git = "https://github.com/forest-rs/imaging.git", rev = "7
 imaging_skia = { git = "https://github.com/forest-rs/imaging.git", rev = "79f02aedf5b65b4cd151ef45d8b40013d7289ee2", features = [
     "gpu",
 ] }
+understory_timing = "0.1.2"
 vello = { version = "0.8.0", default-features = false, features = ["wgpu"] }
 wgpu = "28.0.0"
 kurbo = "0.13.0"

--- a/masonry/examples/layers.rs
+++ b/masonry/examples/layers.rs
@@ -77,10 +77,10 @@ impl Widget for OverlayBox {
     ) {
         if let PointerEvent::Move(PointerUpdate { current, .. }) = event {
             self.last_cursor_pos = current.logical_point();
-            if let Some(timer) = self.hover_timer.take() {
-                ctx.cancel_timer(timer);
+            if self.layer_root_id.take().is_some() && ctx.is_hovered() && self.hover_timer.is_none()
+            {
+                self.hover_timer = Some(ctx.request_timer(Duration::from_millis(300)));
             }
-            self.hover_timer = Some(ctx.request_timer(Duration::from_millis(300)));
         }
     }
 
@@ -90,13 +90,24 @@ impl Widget for OverlayBox {
 
     fn update(&mut self, ctx: &mut UpdateCtx<'_>, _props: &mut PropertiesMut<'_>, event: &Update) {
         match event {
+            Update::HoveredChanged(true)
+                if self.layer_root_id.is_none() && self.hover_timer.is_none() =>
+            {
+                self.hover_timer = Some(ctx.request_timer(Duration::from_millis(300)));
+            }
             Update::HoveredChanged(false) => {
                 if let Some(timer) = self.hover_timer.take() {
                     ctx.cancel_timer(timer);
                 }
+                if let Some(layer) = self.layer_root_id.take() {
+                    ctx.remove_layer(layer);
+                }
             }
-            Update::Timer(token) if Some(*token) == self.hover_timer => {
+            Update::TimerExpired(token) if Some(*token) == self.hover_timer => {
                 self.hover_timer = None;
+                if !ctx.is_hovered() {
+                    return;
+                }
                 let (overlay, layer_type) = (self.overlayer)();
                 self.layer_root_id = Some(overlay.id());
                 let layer_pos = self.last_cursor_pos + Vec2::new(5., -25.);

--- a/masonry/examples/layers.rs
+++ b/masonry/examples/layers.rs
@@ -10,7 +10,7 @@ use masonry::accesskit::{Node, Role};
 use masonry::core::{
     AccessCtx, ChildrenIds, ErasedAction, EventCtx, LayerType, LayoutCtx, MeasureCtx, NewWidget,
     NoAction, PaintCtx, PointerEvent, PointerUpdate, PropertiesMut, PropertiesRef, PropertySet,
-    RegisterCtx, StyleProperty, Update, UpdateCtx, Widget, WidgetId, WidgetPod,
+    RegisterCtx, StyleProperty, TimerToken, Update, UpdateCtx, Widget, WidgetId, WidgetPod,
 };
 use masonry::imaging::Painter;
 use masonry::kurbo::{Axis, Point, Size, Vec2};
@@ -20,7 +20,7 @@ use masonry::parley::FontWeight;
 use masonry::peniko::Color;
 use masonry::properties::{Background, BorderColor, BorderWidth, ContentColor};
 use masonry::theme::default_property_set;
-use masonry::util::{Duration, Instant};
+use masonry::util::Duration;
 use masonry::widgets::{Flex, Label, Selector};
 use masonry_winit::app::{AppDriver, DriverCtx, NewWindow, WindowId};
 use masonry_winit::winit::window::Window;
@@ -44,7 +44,7 @@ struct OverlayBox {
     child: WidgetPod<dyn Widget>,
     overlayer: Box<dyn Fn() -> (NewWidget<dyn Widget>, LayerType)>,
     layer_root_id: Option<WidgetId>,
-    last_mouse_move: Option<Instant>,
+    hover_timer: Option<TimerToken>,
     last_cursor_pos: Point,
 }
 
@@ -59,7 +59,7 @@ impl OverlayBox {
             child: child.erased().to_pod(),
             overlayer,
             layer_root_id: None,
-            last_mouse_move: None,
+            hover_timer: None,
             last_cursor_pos: Point::ZERO,
         }
     }
@@ -77,27 +77,10 @@ impl Widget for OverlayBox {
     ) {
         if let PointerEvent::Move(PointerUpdate { current, .. }) = event {
             self.last_cursor_pos = current.logical_point();
-            self.last_mouse_move = Some(Instant::now());
-            ctx.request_anim_frame();
-        }
-    }
-
-    fn on_anim_frame(
-        &mut self,
-        ctx: &mut UpdateCtx<'_>,
-        _props: &mut PropertiesMut<'_>,
-        _interval: u64,
-    ) {
-        if let Some(last_mouse_move) = self.last_mouse_move {
-            let now = Instant::now();
-            if now.duration_since(last_mouse_move) > Duration::from_millis(300) {
-                let (overlay, layer_type) = (self.overlayer)();
-                self.layer_root_id = Some(overlay.id());
-                let layer_pos = self.last_cursor_pos + Vec2::new(5., -25.);
-                ctx.create_layer(layer_type, overlay, layer_pos);
-            } else {
-                ctx.request_anim_frame();
+            if let Some(timer) = self.hover_timer.take() {
+                ctx.cancel_timer(timer);
             }
+            self.hover_timer = Some(ctx.request_timer(Duration::from_millis(300)));
         }
     }
 
@@ -105,9 +88,21 @@ impl Widget for OverlayBox {
         ctx.register_child(&mut self.child);
     }
 
-    fn update(&mut self, _ctx: &mut UpdateCtx<'_>, _props: &mut PropertiesMut<'_>, event: &Update) {
-        if let Update::HoveredChanged(false) = event {
-            self.last_mouse_move = None;
+    fn update(&mut self, ctx: &mut UpdateCtx<'_>, _props: &mut PropertiesMut<'_>, event: &Update) {
+        match event {
+            Update::HoveredChanged(false) => {
+                if let Some(timer) = self.hover_timer.take() {
+                    ctx.cancel_timer(timer);
+                }
+            }
+            Update::Timer(token) if Some(*token) == self.hover_timer => {
+                self.hover_timer = None;
+                let (overlay, layer_type) = (self.overlayer)();
+                self.layer_root_id = Some(overlay.id());
+                let layer_pos = self.last_cursor_pos + Vec2::new(5., -25.);
+                ctx.create_layer(layer_type, overlay, layer_pos);
+            }
+            _ => {}
         }
     }
 

--- a/masonry/src/doc/implementing_widget.md
+++ b/masonry/src/doc/implementing_widget.md
@@ -48,6 +48,7 @@ In the course of a frame, Masonry will run a series of passes over the widget tr
 - `on_pointer_event`, `on_text_event` and `on_access_event` are called once after a user-initiated event (like a mouse click or keyboard input).
 - `on_anim_frame` is called once per frame for animated widgets.
 - `update` is called many times during a frame, with various events reflecting changes in the widget's state (for instance, it gets or loses text focus).
+- `update` is also where timers requested by the widget are delivered as `Update::Timer`.
 - `measure` and `layout` are called during Masonry's layout pass.
   `measure` computes the preferred size of the widget on a single axis.
   `layout` receives a chosen size and lays out its children accordingly.
@@ -161,6 +162,12 @@ impl Widget for ColorRectangle {
     // ...
 }
 ```
+
+Use `on_anim_frame` for visual state that should advance with frame cadence, such as continuous motion or interpolation.
+For delayed one-shot behavior, use a timer instead.
+For example, a widget can store an `Option<TimerToken>`, set it with `ctx.request_timer(delay)`, then compare it against `Update::Timer(token)` in `update`.
+If the delayed behavior should continue, request a new one-shot timer from that `Update::Timer` branch.
+Cancel the stored token with `ctx.cancel_timer(token)` when the state that made the timer relevant no longer applies.
 
 ### Layout
 
@@ -348,6 +355,11 @@ Most context types include these methods for requesting future passes:
 - `request_accessibility_update()`
 - `request_layout()`
 - `request_anim_frame()`
+- `request_timer()`
+- `cancel_timer()`
+
+Use `request_anim_frame()` for frame-cadenced animation.
+Use `request_timer()` for delayed one-shot UI behavior such as cursor blinking, tooltip delays, debounce, or long press recognition.
 
 
 ### Using context in `ColorRectangle`

--- a/masonry/src/doc/implementing_widget.md
+++ b/masonry/src/doc/implementing_widget.md
@@ -48,7 +48,7 @@ In the course of a frame, Masonry will run a series of passes over the widget tr
 - `on_pointer_event`, `on_text_event` and `on_access_event` are called once after a user-initiated event (like a mouse click or keyboard input).
 - `on_anim_frame` is called once per frame for animated widgets.
 - `update` is called many times during a frame, with various events reflecting changes in the widget's state (for instance, it gets or loses text focus).
-- `update` is also where timers requested by the widget are delivered as `Update::Timer`.
+- `update` is also where timers requested by the widget are delivered as `Update::TimerExpired`.
 - `measure` and `layout` are called during Masonry's layout pass.
   `measure` computes the preferred size of the widget on a single axis.
   `layout` receives a chosen size and lays out its children accordingly.
@@ -165,8 +165,8 @@ impl Widget for ColorRectangle {
 
 Use `on_anim_frame` for visual state that should advance with frame cadence, such as continuous motion or interpolation.
 For delayed one-shot behavior, use a timer instead.
-For example, a widget can store an `Option<TimerToken>`, set it with `ctx.request_timer(delay)`, then compare it against `Update::Timer(token)` in `update`.
-If the delayed behavior should continue, request a new one-shot timer from that `Update::Timer` branch.
+For example, a widget can store an `Option<TimerToken>`, set it with `ctx.request_timer(delay)`, then compare it against `Update::TimerExpired(token)` in `update`.
+If the delayed behavior should continue, request a new one-shot timer from that `Update::TimerExpired` branch.
 Cancel the stored token with `ctx.cancel_timer(token)` when the state that made the timer relevant no longer applies.
 
 ### Layout

--- a/masonry/src/tests/update.rs
+++ b/masonry/src/tests/update.rs
@@ -16,6 +16,7 @@ use crate::testing::{
     assert_debug_panics,
 };
 use crate::theme::test_property_set;
+use crate::util::Duration;
 use crate::widgets::{Button, Flex, Label, SizedBox, TextArea};
 
 // TREE
@@ -62,6 +63,65 @@ fn new_widget() {
             Record::RegisterChildren,
             Record::Update(Update::WidgetAdded)
         ]
+    );
+}
+
+#[test]
+fn timer_update_targets_widget() {
+    let target_tag = WidgetTag::named("target");
+    let parent_tag = WidgetTag::named("parent");
+    let child = NewWidget::new(SizedBox::empty().record()).with_tag(target_tag);
+    let parent = NewWidget::new(ModularWidget::new_parent(child).record()).with_tag(parent_tag);
+
+    let mut harness = TestHarness::create(test_property_set(), parent);
+    let token = harness.edit_widget(target_tag, |mut widget| {
+        widget.ctx.request_timer(Duration::from_millis(10))
+    });
+
+    harness.flush_records_of(target_tag);
+    harness.flush_records_of(parent_tag);
+
+    harness.set_timer_time(Duration::from_millis(10));
+    assert_eq!(harness.handle_timers(), 1);
+
+    let records = harness.take_records_of(target_tag);
+    assert_any(
+        records,
+        |record| matches!(record, Record::Update(Update::Timer(seen)) if seen == token),
+    );
+
+    let records = harness.take_records_of(parent_tag);
+    assert!(
+        !records
+            .iter()
+            .any(|record| matches!(record, Record::Update(Update::Timer(_)))),
+        "timer update should not bubble to the parent"
+    );
+}
+
+#[test]
+fn cancelled_timer_does_not_fire() {
+    let target_tag = WidgetTag::named("target");
+    let widget = NewWidget::new(SizedBox::empty().record()).with_tag(target_tag);
+
+    let mut harness = TestHarness::create(test_property_set(), widget);
+    let token = harness.edit_widget(target_tag, |mut widget| {
+        widget.ctx.request_timer(Duration::from_millis(10))
+    });
+    harness.edit_widget(target_tag, |mut widget| {
+        widget.ctx.cancel_timer(token);
+    });
+    harness.flush_records_of(target_tag);
+
+    harness.set_timer_time(Duration::from_millis(10));
+    assert_eq!(harness.handle_timers(), 0);
+
+    let records = harness.take_records_of(target_tag);
+    assert!(
+        !records
+            .iter()
+            .any(|record| matches!(record, Record::Update(Update::Timer(_)))),
+        "cancelled timer should not be delivered"
     );
 }
 

--- a/masonry/src/tests/update.rs
+++ b/masonry/src/tests/update.rs
@@ -12,8 +12,8 @@ use crate::core::{
 };
 use crate::layout::{AsUnit, Length};
 use crate::testing::{
-    DebugName, ModularWidget, PRIMARY_MOUSE, Record, TestHarness, TestWidgetExt, assert_any,
-    assert_debug_panics,
+    DebugName, ModularWidget, PRIMARY_MOUSE, Record, TestHarness, TestWidgetExt, assert_all,
+    assert_any, assert_debug_panics,
 };
 use crate::theme::test_property_set;
 use crate::util::Duration;
@@ -81,22 +81,18 @@ fn timer_update_targets_widget() {
     harness.flush_records_of(target_tag);
     harness.flush_records_of(parent_tag);
 
-    harness.set_timer_time(Duration::from_millis(10));
-    assert_eq!(harness.handle_timers(), 1);
+    harness.handle_timers(Duration::from_millis(10));
 
     let records = harness.take_records_of(target_tag);
     assert_any(
         records,
-        |record| matches!(record, Record::Update(Update::Timer(seen)) if seen == token),
+        |record| matches!(record, Record::Update(Update::TimerExpired(seen)) if seen == token),
     );
 
     let records = harness.take_records_of(parent_tag);
-    assert!(
-        !records
-            .iter()
-            .any(|record| matches!(record, Record::Update(Update::Timer(_)))),
-        "timer update should not bubble to the parent"
-    );
+    assert_all(records, |record| {
+        !matches!(record, Record::Update(Update::TimerExpired(_)))
+    });
 }
 
 #[test]
@@ -113,16 +109,12 @@ fn cancelled_timer_does_not_fire() {
     });
     harness.flush_records_of(target_tag);
 
-    harness.set_timer_time(Duration::from_millis(10));
-    assert_eq!(harness.handle_timers(), 0);
+    harness.handle_timers(Duration::from_millis(10));
 
     let records = harness.take_records_of(target_tag);
-    assert!(
-        !records
-            .iter()
-            .any(|record| matches!(record, Record::Update(Update::Timer(_)))),
-        "cancelled timer should not be delivered"
-    );
+    assert_all(records, |record| {
+        !matches!(record, Record::Update(Update::TimerExpired(_)))
+    });
 }
 
 #[test]

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -30,6 +30,8 @@ const CURSOR_BLINK_INTERVAL: u64 = 500;
 const CURSOR_BLINK_TIME: u64 = CURSOR_BLINK_INTERVAL * 2;
 /// The timeout after which the cursor will stop blinking and stay solid.
 const CURSOR_BLINK_TIMEOUT: u64 = 10_000;
+// TODO: These should be read from system settings, but we currently
+// aren't aware of a robust way to read that cross-platform.
 
 /// `TextArea` implements the core of interactive text.
 ///
@@ -284,8 +286,7 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
             self.anim_prev_interval = self.anim_prev_interval.rem_euclid(CURSOR_BLINK_TIME);
         }
 
-        let should_show = self.anim_elapsed >= CURSOR_BLINK_TIMEOUT
-            || self.anim_prev_interval < CURSOR_BLINK_INTERVAL;
+        let should_show = self.anim_elapsed >= CURSOR_BLINK_TIMEOUT || self.anim_prev_interval == 0;
         if self.anim_cursor_visible == should_show {
             false
         } else {
@@ -885,7 +886,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
                 // We might need to use the disabled brush, and stop displaying the selection.
                 ctx.request_render();
             }
-            Update::Timer(token) if Some(*token) == self.cursor_blink_timer => {
+            Update::TimerExpired(token) if Some(*token) == self.cursor_blink_timer => {
                 self.cursor_blink_timer = None;
                 if ctx.is_window_focused() && ctx.is_focus_target() {
                     if self.advance_cursor_blink() {

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -11,8 +11,8 @@ use crate::core::keyboard::{Key, KeyState, NamedKey};
 use crate::core::{
     AccessCtx, AccessEvent, BrushIndex, ChildrenIds, CursorIcon, EventCtx, Ime, LayoutCtx,
     MeasureCtx, PaintCtx, PointerButton, PointerButtonEvent, PointerEvent, PointerUpdate,
-    PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, StyleProperty, TextEvent, Update,
-    UpdateCtx, Widget, WidgetId, WidgetMut, render_text, set_accesskit_brush_properties,
+    PropertiesMut, PropertiesRef, QueryCtx, RegisterCtx, StyleProperty, TextEvent, TimerToken,
+    Update, UpdateCtx, Widget, WidgetId, WidgetMut, render_text, set_accesskit_brush_properties,
 };
 use crate::imaging::Painter;
 use crate::kurbo::{Affine, Axis, Point, Rect, Size};
@@ -21,9 +21,15 @@ use crate::parley::PlainEditor;
 use crate::parley::editing::{Generation, SplitString};
 use crate::properties::{CaretColor, ContentColor, SelectionColor};
 use crate::theme::default_text_styles;
-use crate::util::bounding_box_to_rect;
-use crate::util::debug_panic;
+use crate::util::{Duration, bounding_box_to_rect, debug_panic};
 use crate::{TextAlign, theme};
+
+/// The time for half of a cursor blink cycle.
+const CURSOR_BLINK_INTERVAL: u64 = 500;
+/// The time for a complete cursor blink cycle.
+const CURSOR_BLINK_TIME: u64 = CURSOR_BLINK_INTERVAL * 2;
+/// The timeout after which the cursor will stop blinking and stay solid.
+const CURSOR_BLINK_TIMEOUT: u64 = 10_000;
 
 /// `TextArea` implements the core of interactive text.
 ///
@@ -82,6 +88,9 @@ pub struct TextArea<const USER_EDITABLE: bool> {
 
     /// Time elapsed (ms) to calculate the timeout of the cursor's blink animation.
     anim_elapsed: u64,
+
+    /// Pending cursor blink timer.
+    cursor_blink_timer: Option<TimerToken>,
 }
 
 // --- MARK: BUILDERS
@@ -126,6 +135,7 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
             anim_cursor_visible: true,
             anim_prev_interval: 0,
             anim_elapsed: 0,
+            cursor_blink_timer: None,
         }
     }
 
@@ -256,6 +266,36 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
             "TextArea::ime_area should only be called when the editor layout is available"
         );
         bounding_box_to_rect(self.editor.ime_cursor_area())
+    }
+
+    fn reset_cursor_blink(&mut self) -> bool {
+        self.anim_prev_interval = 0;
+        self.anim_elapsed = 0;
+        let was_hidden = !self.anim_cursor_visible;
+        self.anim_cursor_visible = true;
+        was_hidden
+    }
+
+    fn advance_cursor_blink(&mut self) -> bool {
+        self.anim_prev_interval += CURSOR_BLINK_INTERVAL;
+        self.anim_elapsed += CURSOR_BLINK_INTERVAL;
+
+        if self.anim_prev_interval >= CURSOR_BLINK_TIME {
+            self.anim_prev_interval = self.anim_prev_interval.rem_euclid(CURSOR_BLINK_TIME);
+        }
+
+        let should_show = self.anim_elapsed >= CURSOR_BLINK_TIMEOUT
+            || self.anim_prev_interval < CURSOR_BLINK_INTERVAL;
+        if self.anim_cursor_visible == should_show {
+            false
+        } else {
+            self.anim_cursor_visible = should_show;
+            true
+        }
+    }
+
+    fn cursor_should_blink(&self) -> bool {
+        self.anim_elapsed < CURSOR_BLINK_TIMEOUT
     }
 }
 
@@ -425,55 +465,6 @@ pub enum TextAction {
 impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
     type Action = TextAction;
 
-    fn on_anim_frame(
-        &mut self,
-        ctx: &mut UpdateCtx<'_>,
-        _props: &mut PropertiesMut<'_>,
-        interval: u64,
-    ) {
-        /// The time for a complete blink cycle, in milliseconds.
-        /// For the first half (i.e. currently 0.5s) the cursor is shown, and for the second half,
-        /// it is hidden.
-        const CURSOR_BLINK_TIME: u64 = 1000;
-
-        /// The timeout, in milliseconds, after which the cursor will stop blinking (i.e. stay
-        /// solid).
-        const CURSOR_BLINK_TIMEOUT: u64 = 10_000; // 10 seconds
-
-        // TODO: These should be reading from the system settings, but we currently
-        // aren't aware of a robust way to read that cross-platform.
-
-        if ctx.is_window_focused() && ctx.is_focus_target() {
-            if self.anim_elapsed < CURSOR_BLINK_TIMEOUT {
-                let interval_ms = interval / 1_000_000; // ns to ms
-                self.anim_prev_interval += interval_ms;
-                self.anim_elapsed += interval_ms;
-
-                if self.anim_prev_interval >= CURSOR_BLINK_TIME {
-                    self.anim_prev_interval = self.anim_prev_interval.rem_euclid(CURSOR_BLINK_TIME);
-                }
-
-                // TODO: request timer here
-                ctx.request_anim_frame();
-
-                // Request paint only if changed.
-                if self.anim_prev_interval < CURSOR_BLINK_TIME / 2 && !self.anim_cursor_visible {
-                    self.anim_cursor_visible = true;
-                    ctx.request_paint_only();
-                } else if self.anim_prev_interval >= CURSOR_BLINK_TIME / 2
-                    && self.anim_cursor_visible
-                {
-                    self.anim_cursor_visible = false;
-                    ctx.request_paint_only();
-                }
-            } else if !self.anim_cursor_visible {
-                // Request paint only if changed.
-                self.anim_cursor_visible = true;
-                ctx.request_paint_only();
-            }
-        }
-    }
-
     fn on_pointer_event(
         &mut self,
         ctx: &mut EventCtx<'_>,
@@ -538,10 +529,19 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
         _props: &mut PropertiesMut<'_>,
         event: &TextEvent,
     ) {
-        // Reset the blink animation.
-        self.anim_prev_interval = 0;
-        self.anim_elapsed = 0;
-        ctx.request_anim_frame();
+        if let Some(timer) = self.cursor_blink_timer.take() {
+            ctx.cancel_timer(timer);
+        }
+        if ctx.is_window_focused()
+            && ctx.is_focus_target()
+            && !matches!(event, TextEvent::WindowFocusChange(false))
+        {
+            if self.reset_cursor_blink() {
+                ctx.request_paint_only();
+            }
+            self.cursor_blink_timer =
+                Some(ctx.request_timer(Duration::from_millis(CURSOR_BLINK_INTERVAL)));
+        }
 
         match event {
             TextEvent::Keyboard(key_event) => {
@@ -859,12 +859,43 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
                 let _ = self.editor.edit_styles();
                 ctx.request_layout();
             }
-            Update::FocusChanged(_) => {
+            Update::FocusChanged(true) => {
+                if let Some(timer) = self.cursor_blink_timer.take() {
+                    ctx.cancel_timer(timer);
+                }
+                if self.reset_cursor_blink() {
+                    ctx.request_paint_only();
+                }
+                if ctx.is_window_focused() && self.cursor_should_blink() {
+                    self.cursor_blink_timer =
+                        Some(ctx.request_timer(Duration::from_millis(CURSOR_BLINK_INTERVAL)));
+                }
+                ctx.request_render();
+            }
+            Update::FocusChanged(false) => {
+                if let Some(timer) = self.cursor_blink_timer.take() {
+                    ctx.cancel_timer(timer);
+                }
                 ctx.request_render();
             }
             Update::DisabledChanged(_) => {
+                if let Some(timer) = self.cursor_blink_timer.take() {
+                    ctx.cancel_timer(timer);
+                }
                 // We might need to use the disabled brush, and stop displaying the selection.
                 ctx.request_render();
+            }
+            Update::Timer(token) if Some(*token) == self.cursor_blink_timer => {
+                self.cursor_blink_timer = None;
+                if ctx.is_window_focused() && ctx.is_focus_target() {
+                    if self.advance_cursor_blink() {
+                        ctx.request_paint_only();
+                    }
+                    if self.cursor_should_blink() {
+                        self.cursor_blink_timer =
+                            Some(ctx.request_timer(Duration::from_millis(CURSOR_BLINK_INTERVAL)));
+                    }
+                }
             }
             _ => {}
         }

--- a/masonry/src/widgets/text_input.rs
+++ b/masonry/src/widgets/text_input.rs
@@ -414,8 +414,7 @@ mod tests {
         assert_render_snapshot!(harness, "text_input_selection_unfocused");
 
         harness.process_text_event(TextEvent::WindowFocusChange(true));
-        harness.set_timer_time(Duration::from_millis(500));
-        harness.handle_timers();
+        harness.handle_timers(Duration::from_millis(500));
 
         assert_render_snapshot!(harness, "text_input_cursor_blink");
     }

--- a/masonry/src/widgets/text_input.rs
+++ b/masonry/src/widgets/text_input.rs
@@ -377,6 +377,7 @@ mod tests {
     use crate::dpi::PhysicalSize;
     use crate::testing::{TestHarness, assert_render_snapshot};
     use crate::theme::test_property_set;
+    use crate::util::Duration;
     use crate::widgets::TextArea;
 
     const HARNESS_PARAMS: TestHarnessParams = {
@@ -413,7 +414,8 @@ mod tests {
         assert_render_snapshot!(harness, "text_input_selection_unfocused");
 
         harness.process_text_event(TextEvent::WindowFocusChange(true));
-        harness.animate_ms(500 + 1);
+        harness.set_timer_time(Duration::from_millis(500));
+        harness.handle_timers();
 
         assert_render_snapshot!(harness, "text_input_cursor_blink");
     }

--- a/masonry_core/Cargo.toml
+++ b/masonry_core/Cargo.toml
@@ -38,6 +38,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter", "time"] }
 tracing-tracy = { version = "0.11.4", optional = true }
 tree_arena.workspace = true
 ui-events.workspace = true
+understory_timing.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 time = { workspace = true, features = ["macros", "formatting"] }

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -48,10 +48,6 @@ use crate::util::Duration;
 /// IME area as the `last_sent_ime_area`.
 const INVALID_IME_AREA: Rect = Rect::new(f64::NAN, f64::NAN, f64::NAN, f64::NAN);
 
-fn duration_to_timer_ticks(duration: Duration) -> TimerInstant {
-    u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
-}
-
 // --- MARK: STRUCTS
 
 /// The composition root of Masonry.
@@ -980,6 +976,10 @@ impl RenderRoot {
     /// The time is measured from an origin chosen by the host. All calls to
     /// this method and [`next_timer_deadline`](Self::next_timer_deadline) must
     /// use the same origin.
+    ///
+    /// This is separate from [`handle_timers`](Self::handle_timers) because timer
+    /// requests made while handling normal events also need to be scheduled
+    /// relative to the current host time.
     pub fn set_timer_time(&mut self, time: Duration) {
         self.global_state.timer_now = duration_to_timer_ticks(time);
     }
@@ -994,9 +994,8 @@ impl RenderRoot {
 
     /// Delivers all timers due at or before the current timer time.
     ///
-    /// Returns the number of timers delivered. Timers targeting removed widgets
-    /// are discarded.
-    pub fn handle_timers(&mut self) -> usize {
+    /// Timers targeting removed widgets are discarded.
+    pub fn handle_timers(&mut self) {
         let now = self.global_state.timer_now;
         let mut fired = Vec::new();
         // Pop the due set before dispatch. Widget updates may request or cancel
@@ -1007,18 +1006,16 @@ impl RenderRoot {
             fired.push((timer.into_target(), token));
         }
 
-        let mut delivered = 0;
+        let had_due_timer = !fired.is_empty();
         for (target, token) in fired {
             if !self.widget_arena.has(target) {
                 continue;
             }
             run_update_timer_pass(self, target, token);
-            delivered += 1;
         }
-        if delivered != 0 {
+        if had_due_timer {
             self.run_rewrite_passes();
         }
-        delivered
     }
 
     /// Returns true if the accessibility tree needs to be rebuilt.
@@ -1089,6 +1086,10 @@ impl RenderRootState {
             || !self.mutate_callbacks.is_empty()
             || !self.actions.is_empty()
     }
+}
+
+fn duration_to_timer_ticks(duration: Duration) -> TimerInstant {
+    u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
 }
 
 impl RenderRootSignal {

--- a/masonry_core/src/app/render_root.rs
+++ b/masonry_core/src/app/render_root.rs
@@ -14,14 +14,15 @@ use parley::fontique::{
 use parley::{FontContext, LayoutContext};
 use tracing::{debug, info_span, warn};
 use tree_arena::{ArenaMut, TreeArena};
+use understory_timing::{TimerInstant, TimerQueue};
 
 use crate::app::VisualLayerPlan;
 use crate::app::layer_stack::LayerStack;
 use crate::core::{
     AccessCtx, AccessEvent, BrushIndex, CursorIcon, DefaultProperties, ErasedAction, FromDynWidget,
     Handled, Ime, LayerType, NewWidget, PointerEvent, PropertiesRef, PropertyArena, QueryCtx,
-    ResizeDirection, TextEvent, Widget, WidgetArena, WidgetArenaNode, WidgetId, WidgetMut,
-    WidgetPod, WidgetRef, WidgetState, WidgetTag, WidgetTagInner, WindowEvent,
+    ResizeDirection, TextEvent, TimerToken, Widget, WidgetArena, WidgetArenaNode, WidgetId,
+    WidgetMut, WidgetPod, WidgetRef, WidgetState, WidgetTag, WidgetTagInner, WindowEvent,
 };
 use crate::imaging::record::Scene;
 use crate::passes::accessibility::run_accessibility_pass;
@@ -37,14 +38,19 @@ use crate::passes::paint::run_paint_pass;
 use crate::passes::update::{
     run_update_disabled_pass, run_update_focus_pass, run_update_focusable_pass,
     run_update_fonts_pass, run_update_pointer_pass, run_update_props_pass, run_update_scroll_pass,
-    run_update_stashed_pass, run_update_widget_tree_pass,
+    run_update_stashed_pass, run_update_timer_pass, run_update_widget_tree_pass,
 };
 use crate::passes::{PassTracing, recurse_on_children};
 use crate::properties::Dimensions;
+use crate::util::Duration;
 
 /// We ensure that any valid initial IME area is sent to the platform by storing an invalid initial
 /// IME area as the `last_sent_ime_area`.
 const INVALID_IME_AREA: Rect = Rect::new(f64::NAN, f64::NAN, f64::NAN, f64::NAN);
+
+fn duration_to_timer_ticks(duration: Duration) -> TimerInstant {
+    u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
+}
 
 // --- MARK: STRUCTS
 
@@ -165,6 +171,12 @@ pub(crate) struct RenderRootState {
 
     /// Whether the next accessibility pass tree should be updated during `render()`.
     pub(crate) access_tree_active: bool,
+
+    /// Queue of pending widget timers.
+    pub(crate) timers: TimerQueue<WidgetId>,
+
+    /// Current host-provided timer time.
+    pub(crate) timer_now: TimerInstant,
 
     /// DPI scale factor.
     ///
@@ -375,6 +387,8 @@ impl RenderRoot {
                     hovered_widget: None,
                 },
                 access_tree_active: false,
+                timers: TimerQueue::new(),
+                timer_now: 0,
                 scale_factor,
                 debug_paint,
             },
@@ -961,6 +975,52 @@ impl RenderRoot {
         self.root_state().needs_anim
     }
 
+    /// Sets the current host-provided timer time.
+    ///
+    /// The time is measured from an origin chosen by the host. All calls to
+    /// this method and [`next_timer_deadline`](Self::next_timer_deadline) must
+    /// use the same origin.
+    pub fn set_timer_time(&mut self, time: Duration) {
+        self.global_state.timer_now = duration_to_timer_ticks(time);
+    }
+
+    /// Returns the next timer deadline, measured from the host's timer origin.
+    pub fn next_timer_deadline(&self) -> Option<Duration> {
+        self.global_state
+            .timers
+            .next_deadline()
+            .map(Duration::from_nanos)
+    }
+
+    /// Delivers all timers due at or before the current timer time.
+    ///
+    /// Returns the number of timers delivered. Timers targeting removed widgets
+    /// are discarded.
+    pub fn handle_timers(&mut self) -> usize {
+        let now = self.global_state.timer_now;
+        let mut fired = Vec::new();
+        // Pop the due set before dispatch. Widget updates may request or cancel
+        // timers; those mutations should not change which timers fire in this
+        // drain cycle.
+        while let Some(timer) = self.global_state.timers.pop_expired(now) {
+            let token = TimerToken(timer.id());
+            fired.push((timer.into_target(), token));
+        }
+
+        let mut delivered = 0;
+        for (target, token) in fired {
+            if !self.widget_arena.has(target) {
+                continue;
+            }
+            run_update_timer_pass(self, target, token);
+            delivered += 1;
+        }
+        if delivered != 0 {
+            self.run_rewrite_passes();
+        }
+        delivered
+    }
+
     /// Returns true if the accessibility tree needs to be rebuilt.
     ///
     /// This will be inhibited if `access_tree_active` is false.
@@ -1005,6 +1065,17 @@ impl RenderRootState {
     /// Sends a signal to the runner of this app, which allows global actions to be triggered by a widget.
     pub(crate) fn emit_signal(&mut self, signal: RenderRootSignal) {
         (self.signal_sink)(signal);
+    }
+
+    pub(crate) fn request_timer(&mut self, target: WidgetId, delay: Duration) -> TimerToken {
+        let id = self
+            .timers
+            .schedule_once(target, self.timer_now, duration_to_timer_ticks(delay));
+        TimerToken(id)
+    }
+
+    pub(crate) fn cancel_timer(&mut self, token: TimerToken) -> bool {
+        self.timers.cancel(token.0)
     }
 
     /// Does something in this state indicate that the rewrite passes need to be reran.

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -22,14 +22,14 @@ use crate::app::{MutateCallback, RenderRootSignal, RenderRootState};
 use crate::core::{
     AllowRawMut, BrushIndex, ClassSet, ErasedAction, FromDynWidget, LayerType, NewWidget,
     PaintLayerMode, PropertiesMut, PropertiesRef, PropertyArena, PropertyCache, PropertyStackId,
-    ResizeDirection, Widget, WidgetArenaNode, WidgetId, WidgetMut, WidgetPod, WidgetRef,
-    WidgetState,
+    ResizeDirection, TimerToken, Widget, WidgetArenaNode, WidgetId, WidgetMut, WidgetPod,
+    WidgetRef, WidgetState,
 };
 use crate::kurbo::{Affine, Axis, Insets, Point, Rect, Size, Vec2};
 use crate::layout::{LayoutSize, LenDef, Length, SizeDef};
 use crate::passes::layout::{place_widget, resolve_length, resolve_size, run_layout_on};
 use crate::peniko::Color;
-use crate::util::{ParentLinkedList, get_debug_color};
+use crate::util::{Duration, ParentLinkedList, get_debug_color};
 
 // Note - Most methods defined in this file revolve around `WidgetState` fields.
 // Consider reading `WidgetState` documentation (especially the documented naming scheme)
@@ -428,6 +428,34 @@ impl_context_method!(
                 &mut self.global_state.font_context,
                 &mut self.global_state.text_layout_context,
             )
+        }
+    }
+);
+
+impl_context_method!(
+    MutateCtx<'_>,
+    ActionCtx<'_>,
+    EventCtx<'_>,
+    UpdateCtx<'_>,
+    RawCtx<'_>,
+    {
+        /// Requests a timer for the current widget.
+        ///
+        /// When the timer expires, this widget receives [`Update::Timer`] with
+        /// the returned token. Timer delivery is best-effort: timers targeting
+        /// removed widgets are ignored by the host.
+        ///
+        /// [`Update::Timer`]: crate::core::Update::Timer
+        pub fn request_timer(&mut self, delay: Duration) -> TimerToken {
+            self.global_state.request_timer(self.widget_id(), delay)
+        }
+
+        /// Cancels a timer previously requested by a widget.
+        ///
+        /// Cancelling an already-fired or unknown timer is allowed and has no
+        /// effect.
+        pub fn cancel_timer(&mut self, token: TimerToken) {
+            self.global_state.cancel_timer(token);
         }
     }
 );

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -441,11 +441,11 @@ impl_context_method!(
     {
         /// Requests a timer for the current widget.
         ///
-        /// When the timer expires, this widget receives [`Update::Timer`] with
+        /// When the timer expires, this widget receives [`Update::TimerExpired`] with
         /// the returned token. Timer delivery is best-effort: timers targeting
         /// removed widgets are ignored by the host.
         ///
-        /// [`Update::Timer`]: crate::core::Update::Timer
+        /// [`Update::TimerExpired`]: crate::core::Update::TimerExpired
         pub fn request_timer(&mut self, delay: Duration) -> TimerToken {
             self.global_state.request_timer(self.widget_id(), delay)
         }

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -1644,6 +1644,11 @@ impl_context_method!(
         }
 
         /// Requests an animation frame.
+        ///
+        /// Use this for visual state that should advance with frame cadence,
+        /// such as continuous motion or interpolation. For delayed one-shot UI
+        /// behavior like cursor blinking, tooltip delays, debounce, or long
+        /// press recognition, prefer [`request_timer`](Self::request_timer).
         pub fn request_anim_frame(&mut self) {
             trace!("request_anim_frame");
             self.widget_state.request_anim = true;

--- a/masonry_core/src/core/events.rs
+++ b/masonry_core/src/core/events.rs
@@ -14,7 +14,7 @@ use crate::util::Duration;
 ///
 /// Timer tokens are assigned by a [`RenderRoot`](crate::app::RenderRoot)'s
 /// timer queue. A widget can keep the token to recognize a later
-/// [`Update::Timer`] or cancel the timer before it fires.
+/// [`Update::TimerExpired`] or cancel the timer before it fires.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TimerToken(pub(crate) TimerId);
 
@@ -137,7 +137,7 @@ pub enum Update {
     ChildHoveredChanged(bool),
 
     /// Called when a timer requested by this widget expires.
-    Timer(TimerToken),
+    TimerExpired(TimerToken),
 
     /// Called when the [active] status of the current widget changes.
     ///
@@ -303,7 +303,7 @@ impl Update {
             Self::FocusChanged(true) => "FocusChanged(true)",
             Self::ChildFocusChanged(true) => "ChildFocusChanged(true)",
             Self::RequestPanToChild(_) => "RequestPanToChild(_)",
-            Self::Timer(_) => "Timer(_)",
+            Self::TimerExpired(_) => "TimerExpired(_)",
             Self::FontsChanged => "FontsChanged",
         }
     }

--- a/masonry_core/src/core/events.rs
+++ b/masonry_core/src/core/events.rs
@@ -5,9 +5,25 @@
 
 use kurbo::Rect;
 use ui_events::keyboard::{Code, Key, KeyState, KeyboardEvent};
+use understory_timing::TimerId;
 
 use crate::dpi::PhysicalSize;
 use crate::util::Duration;
+
+/// Identifier for a timer requested by a widget.
+///
+/// Timer tokens are assigned by a [`RenderRoot`](crate::app::RenderRoot)'s
+/// timer queue. A widget can keep the token to recognize a later
+/// [`Update::Timer`] or cancel the timer before it fires.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TimerToken(pub(crate) TimerId);
+
+impl TimerToken {
+    /// Returns the integer value of the timer token.
+    pub fn to_raw(self) -> u64 {
+        self.0.get()
+    }
+}
 
 // --- MARK: TYPES
 
@@ -119,6 +135,9 @@ pub enum Update {
     ///
     /// [hovered]: crate::doc::masonry_concepts#widget-status
     ChildHoveredChanged(bool),
+
+    /// Called when a timer requested by this widget expires.
+    Timer(TimerToken),
 
     /// Called when the [active] status of the current widget changes.
     ///
@@ -284,6 +303,7 @@ impl Update {
             Self::FocusChanged(true) => "FocusChanged(true)",
             Self::ChildFocusChanged(true) => "ChildFocusChanged(true)",
             Self::RequestPanToChild(_) => "RequestPanToChild(_)",
+            Self::Timer(_) => "Timer(_)",
             Self::FontsChanged => "FontsChanged",
         }
     }

--- a/masonry_core/src/core/widget.rs
+++ b/masonry_core/src/core/widget.rs
@@ -195,6 +195,10 @@ pub trait Widget: AsDynWidget + Any {
     /// [`request_anim`](UpdateCtx::request_anim_frame) unless the animation
     /// has finished.
     ///
+    /// Use timers instead of animation frames for delayed one-shot UI behavior
+    /// such as cursor blinking, tooltip delays, debounce, or long press
+    /// recognition.
+    ///
     /// On the first frame when transitioning from idle to animating, `interval`
     /// will be 0. (This logic is presently per-window but might change to
     /// per-widget to make it more consistent). Otherwise it is in nanoseconds.

--- a/masonry_core/src/doc/pass_system.md
+++ b/masonry_core/src/doc/pass_system.md
@@ -51,7 +51,7 @@ The animation pass may be considered as a special event pass: it's not triggered
 ### Timer delivery
 
 Widget timers are delayed callbacks requested with context methods such as [`UpdateCtx::request_timer`].
-When a timer expires, Masonry delivers [`Update::Timer`] to the widget that requested it.
+When a timer expires, Masonry delivers [`Update::TimerExpired`] to the widget that requested it.
 
 Timer delivery does not bubble to ancestors.
 Like the animation pass, it is triggered externally by the host event loop and sets off the rewrite passes after delivery.
@@ -265,7 +265,7 @@ They can access the layout of children if they have already been laid out.
 [`RegisterCtx`]: crate::core::RegisterCtx
 [`QueryCtx`]: crate::core::QueryCtx
 [`WidgetAdded`]: crate::core::Update::WidgetAdded
-[`Update::Timer`]: crate::core::Update::Timer
+[`Update::TimerExpired`]: crate::core::Update::TimerExpired
 [`UpdateCtx::request_timer`]: crate::core::UpdateCtx::request_timer
 [`Ime::Disabled`]: crate::core::Ime::Disabled
 [`FocusChanged`]: crate::core::Update::FocusChanged

--- a/masonry_core/src/doc/pass_system.md
+++ b/masonry_core/src/doc/pass_system.md
@@ -48,6 +48,16 @@ It runs in depth-first preorder on all animated widgets in the tree.
 
 The animation pass may be considered as a special event pass: it's not triggered by user interaction, and it doesn't bubble, but it's also triggered externally and sets off the rewrite passes.
 
+### Timer delivery
+
+Widget timers are delayed callbacks requested with context methods such as [`UpdateCtx::request_timer`].
+When a timer expires, Masonry delivers [`Update::Timer`] to the widget that requested it.
+
+Timer delivery does not bubble to ancestors.
+Like the animation pass, it is triggered externally by the host event loop and sets off the rewrite passes after delivery.
+Timers are best for delayed one-shot UI behavior such as cursor blinking, tooltip delays, debounce, and long press recognition.
+Use animation frames instead for visual state that should advance with frame cadence.
+
 
 ## Rewrite passes
 
@@ -255,6 +265,8 @@ They can access the layout of children if they have already been laid out.
 [`RegisterCtx`]: crate::core::RegisterCtx
 [`QueryCtx`]: crate::core::QueryCtx
 [`WidgetAdded`]: crate::core::Update::WidgetAdded
+[`Update::Timer`]: crate::core::Update::Timer
+[`UpdateCtx::request_timer`]: crate::core::UpdateCtx::request_timer
 [`Ime::Disabled`]: crate::core::Ime::Disabled
 [`FocusChanged`]: crate::core::Update::FocusChanged
 [`ChildFocusChanged`]: crate::core::Update::ChildFocusChanged

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -1248,11 +1248,14 @@ pub(crate) fn run_update_fonts_pass(root: &mut RenderRoot) {
     );
 }
 
+// ----------------
+
+// --- MARK: TIMERS
 pub(crate) fn run_update_timer_pass(root: &mut RenderRoot, target: WidgetId, token: TimerToken) {
     let _span = info_span!("update_timer").entered();
 
     run_single_update_pass(root, Some(target), |widget, ctx, props| {
-        widget.update(ctx, props, &Update::Timer(token));
+        widget.update(ctx, props, &Update::TimerExpired(token));
     });
 }
 

--- a/masonry_core/src/passes/update.rs
+++ b/masonry_core/src/passes/update.rs
@@ -10,8 +10,8 @@ use ui_events::pointer::PointerType;
 use crate::app::{RenderRoot, RenderRootSignal, RenderRootState};
 use crate::core::{
     ClassSetDiff, CursorIcon, DefaultProperties, Ime, PointerEvent, PointerInfo, PropertiesMut,
-    PropertiesRef, PropertyArena, PropertyCache, QueryCtx, RegisterCtx, TextEvent, Update,
-    UpdateCtx, Widget, WidgetArenaNode, WidgetId, WidgetState,
+    PropertiesRef, PropertyArena, PropertyCache, QueryCtx, RegisterCtx, TextEvent, TimerToken,
+    Update, UpdateCtx, Widget, WidgetArenaNode, WidgetId, WidgetState,
 };
 use crate::passes::event::{run_on_pointer_event_pass, run_on_text_event_pass};
 use crate::passes::{enter_span, enter_span_if, merge_state_up, recurse_on_children};
@@ -1246,6 +1246,14 @@ pub(crate) fn run_update_fonts_pass(root: &mut RenderRoot) {
         &root.property_arena,
         root_node,
     );
+}
+
+pub(crate) fn run_update_timer_pass(root: &mut RenderRoot, target: WidgetId, token: TimerToken) {
+    let _span = info_span!("update_timer").entered();
+
+    run_single_update_pass(root, Some(target), |widget, ctx, props| {
+        widget.update(ctx, props, &Update::Timer(token));
+    });
 }
 
 // ----------------

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -857,16 +857,11 @@ impl<W: Widget> TestHarness<W> {
         self.process_signals();
     }
 
-    /// Sets the simulated timer time.
-    pub fn set_timer_time(&mut self, time: Duration) {
+    /// Advances the simulated timer time and delivers all due timers.
+    pub fn handle_timers(&mut self, time: Duration) {
         self.render_root.set_timer_time(time);
-    }
-
-    /// Delivers all due simulated timers.
-    pub fn handle_timers(&mut self) -> usize {
-        let delivered = self.render_root.handle_timers();
+        self.render_root.handle_timers();
         self.process_signals();
-        delivered
     }
 
     /// Helper method to directly enable/disable a widget.

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -857,6 +857,18 @@ impl<W: Widget> TestHarness<W> {
         self.process_signals();
     }
 
+    /// Sets the simulated timer time.
+    pub fn set_timer_time(&mut self, time: Duration) {
+        self.render_root.set_timer_time(time);
+    }
+
+    /// Delivers all due simulated timers.
+    pub fn handle_timers(&mut self) -> usize {
+        let delivered = self.render_root.handle_timers();
+        self.process_signals();
+        delivered
+    }
+
     /// Helper method to directly enable/disable a widget.
     pub fn set_disabled(&mut self, widget: WidgetTag<impl Widget>, disabled: bool) {
         self.edit_widget(widget, |mut target| {

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -627,17 +627,14 @@ impl MasonryState<'_> {
     }
 
     fn drain_due_timers(&mut self, event_loop: &ActiveEventLoop, app_driver: &mut dyn AppDriver) {
-        let mut delivered = 0;
         for window in self.windows.values_mut() {
             window
                 .render_root
                 .set_timer_time(window.timer_origin.elapsed());
-            delivered += window.render_root.handle_timers();
+            window.render_root.handle_timers();
         }
 
-        if delivered != 0 {
-            self.handle_signals(event_loop, app_driver);
-        }
+        self.handle_signals(event_loop, app_driver);
     }
 
     // --- MARK: REDRAW

--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -27,8 +27,9 @@ use ui_events_winit::{WindowEventReducer, WindowEventTranslation};
 use winit::application::ApplicationHandler;
 use winit::dpi::PhysicalSize;
 use winit::error::EventLoopError;
+use winit::event::StartCause;
 use winit::event::{DeviceEvent as WinitDeviceEvent, DeviceId, WindowEvent as WinitWindowEvent};
-use winit::event_loop::ActiveEventLoop;
+use winit::event_loop::{ActiveEventLoop, ControlFlow};
 use winit::window::{Window as WindowHandle, WindowAttributes, WindowId as HandleId};
 
 use crate::app::{
@@ -132,6 +133,7 @@ pub struct Window {
     pub(crate) accesskit_adapter: Adapter,
     event_reducer: WindowEventReducer,
     pub(crate) render_root: RenderRoot,
+    timer_origin: Instant,
     pub(crate) base_color: Color,
 }
 
@@ -147,6 +149,7 @@ impl Window {
         size: PhysicalSize<u32>,
         scale_factor: f64,
     ) -> Self {
+        let timer_origin = Instant::now();
         Self {
             id: window_id,
             handle,
@@ -166,6 +169,7 @@ impl Window {
                     test_font: None,
                 },
             ),
+            timer_origin,
             base_color,
         }
     }
@@ -348,8 +352,9 @@ impl ApplicationHandler<MasonryUserEvent> for MainState<'_> {
         self.masonry_state.handle_about_to_wait(event_loop);
     }
 
-    fn new_events(&mut self, event_loop: &ActiveEventLoop, cause: winit::event::StartCause) {
-        self.masonry_state.handle_new_events(event_loop, cause);
+    fn new_events(&mut self, event_loop: &ActiveEventLoop, cause: StartCause) {
+        self.masonry_state
+            .handle_new_events(event_loop, cause, self.app_driver.as_mut());
     }
 
     fn exiting(&mut self, event_loop: &ActiveEventLoop) {
@@ -600,6 +605,41 @@ impl MasonryState<'_> {
         window.handle.set_ime_allowed(false);
     }
 
+    fn next_timer_wakeup(&self) -> Option<Instant> {
+        self.windows
+            .values()
+            .filter_map(|window| {
+                let delay = window
+                    .render_root
+                    .next_timer_deadline()?
+                    .saturating_sub(window.timer_origin.elapsed());
+                Instant::now().checked_add(delay)
+            })
+            .min()
+    }
+
+    fn arm_next_timer(&self, event_loop: &ActiveEventLoop) {
+        if let Some(deadline) = self.next_timer_wakeup() {
+            event_loop.set_control_flow(ControlFlow::WaitUntil(deadline));
+        } else {
+            event_loop.set_control_flow(ControlFlow::Wait);
+        }
+    }
+
+    fn drain_due_timers(&mut self, event_loop: &ActiveEventLoop, app_driver: &mut dyn AppDriver) {
+        let mut delivered = 0;
+        for window in self.windows.values_mut() {
+            window
+                .render_root
+                .set_timer_time(window.timer_origin.elapsed());
+            delivered += window.render_root.handle_timers();
+        }
+
+        if delivered != 0 {
+            self.handle_signals(event_loop, app_driver);
+        }
+    }
+
     // --- MARK: REDRAW
     fn redraw(&mut self, handle_id: HandleId, app_driver: &mut dyn AppDriver) {
         let _span = info_span!("redraw");
@@ -835,6 +875,9 @@ impl MasonryState<'_> {
             self.frame = Some(tracing_tracy::client::non_continuous_frame!("Masonry"));
         }
         window
+            .render_root
+            .set_timer_time(window.timer_origin.elapsed());
+        window
             .accesskit_adapter
             .process_event(&window.handle, &event);
 
@@ -970,6 +1013,9 @@ impl MasonryState<'_> {
                 self.windows.get_mut(window_id).unwrap()
             }
         };
+        window
+            .render_root
+            .set_timer_time(window.timer_origin.elapsed());
         match event {
             MasonryUserEvent::AccessKit(_, event) => {
                 match event {
@@ -1004,10 +1050,19 @@ impl MasonryState<'_> {
 
     // --- MARK: EMPTY WINIT HANDLERS
     /// Delegate method for [`ApplicationHandler::about_to_wait()`].
-    pub fn handle_about_to_wait(&mut self, _: &ActiveEventLoop) {}
+    pub fn handle_about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        self.arm_next_timer(event_loop);
+    }
 
     /// Delegate method for [`ApplicationHandler::new_events()`].
-    pub fn handle_new_events(&mut self, _: &ActiveEventLoop, _: winit::event::StartCause) {}
+    pub fn handle_new_events(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        _: StartCause,
+        app_driver: &mut dyn AppDriver,
+    ) {
+        self.drain_due_timers(event_loop, app_driver);
+    }
 
     /// Delegate method for [`ApplicationHandler::exiting()`].
     pub fn handle_exiting(&mut self, _: &ActiveEventLoop) {}
@@ -1141,6 +1196,8 @@ impl MasonryState<'_> {
             let window = self.windows.get(&handle_id).unwrap();
             window.handle.request_redraw();
         }
+
+        self.arm_next_timer(event_loop);
     }
 
     fn handle_id(&self, window_id: WindowId) -> HandleId {

--- a/xilem/examples/external_event_loop.rs
+++ b/xilem/examples/external_event_loop.rs
@@ -111,7 +111,8 @@ impl ApplicationHandler<MasonryUserEvent> for ExternalApp {
         event_loop: &winit::event_loop::ActiveEventLoop,
         cause: winit::event::StartCause,
     ) {
-        self.masonry_state.handle_new_events(event_loop, cause);
+        self.masonry_state
+            .handle_new_events(event_loop, cause, self.app_driver.as_mut());
     }
 
     fn exiting(&mut self, event_loop: &winit::event_loop::ActiveEventLoop) {


### PR DESCRIPTION
* Add `understory_timing` as a `masonry_core` dependency.
* Store pending widget timers in `RenderRoot`.
* Add `TimerToken` and deliver expired timers through `Update::Timer`.
* Add context APIs:
  * `request_timer(delay) -> TimerToken`
  * `cancel_timer(token)`
* Add backend hooks for timer driving:
  * `RenderRoot::set_timer_time`
  * `RenderRoot::next_timer_deadline`
  * `RenderRoot::handle_timers`
* Update `masonry_winit` to drive timer time and platform wakeups.
* Convert `TextArea` cursor blinking to one-shot timers.
* Convert the layers tooltip-delay example to one-shot timers.
* Document when to use timers versus animation frames.

 ## Rationale

Masonry has several UI behaviors that are delayed but not frame-cadenced. Examples include cursor blinking, tooltip
  delays, debounce, and long press recognition. These fit a timer model better than animation frames.

This PR adds a widget-local timer lifecycle: widgets request a timer, keep the returned `TimerToken`, and receive
  `Update::Timer` when it expires. Widgets can cancel pending timers when the relevant state changes.

Animation frames remain the right tool for continuous visual updates, such as interpolation or motion that should advance with frame cadence.