### PR TITLE
feat: `app.with_on_start()` function

### DIFF
--- a/xilem/src/app.rs
+++ b/xilem/src/app.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use masonry::core::DefaultProperties;
 use masonry::peniko::{Blob, Color};
 use masonry::theme::{BACKGROUND_COLOR, default_property_set};
-use masonry_winit::app::{EventLoopBuilder, MasonryUserEvent, NewWindow, WindowId};
+use masonry_winit::app::{EventLoopBuilder, MasonryState, MasonryUserEvent, NewWindow, WindowId};
 use tokio::runtime::Runtime as TokioRuntime;
 use winit::error::EventLoopError;
 
@@ -27,6 +27,8 @@ pub struct Xilem<State, Logic> {
     default_base_color: Color,
     // Font data to include in loading.
     fonts: Vec<Blob<u8>>,
+    // Callback invoked once on startup, after windows creation.
+    on_start: Option<Box<dyn FnOnce(&mut MasonryState<'_>)>>,
 }
 
 /// State type used by [`Xilem::new_simple`].
@@ -147,6 +149,7 @@ where
             default_properties: None,
             default_base_color: BACKGROUND_COLOR,
             fonts: Vec::new(),
+            on_start: None,
         }
     }
 
@@ -169,6 +172,12 @@ where
     /// Sets default base color of windows.
     pub fn with_default_base_color(mut self, default_base_color: Color) -> Self {
         self.default_base_color = default_base_color;
+        self
+    }
+
+    /// Registers a callback to be called once the application has started
+    pub fn with_on_start(mut self, callback: impl FnOnce(&mut MasonryState<'_>) + 'static) -> Self {
+        self.on_start = Some(Box::new(callback));
         self
     }
 
@@ -200,6 +209,7 @@ where
             self.runtime,
             self.default_base_color,
             self.fonts,
+            self.on_start,
         )
     }
 }

--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -31,6 +31,8 @@ pub struct MasonryDriver<State: 'static, Logic> {
     default_base_color: Color,
     // Fonts which will be registered on startup.
     fonts: Vec<Blob<u8>>,
+    // Optional callback invoked once on startup, after windows creation.
+    start_callback: Option<Box<dyn FnOnce(&mut MasonryState<'_>)>>,
 }
 
 struct Window<State: 'static> {
@@ -54,6 +56,7 @@ where
         runtime: Arc<tokio::runtime::Runtime>,
         default_base_color: Color,
         fonts: Vec<Blob<u8>>,
+        start_callback: Option<Box<dyn FnOnce(&mut MasonryState<'_>)>>,
     ) -> (Self, Vec<NewWindow>) {
         let mut driver = Self {
             state,
@@ -63,6 +66,7 @@ where
             runtime,
             default_base_color,
             fonts,
+            start_callback,
         };
         let windows: Vec<_> = (driver.logic)(&mut driver.state)
             .map(|view| driver.build_window(view))
@@ -366,6 +370,11 @@ where
                 // because we don't have an easy way to return this to the application.
                 drop(root.register_fonts(font.clone()));
             }
+        }
+
+        // Calls callback functions after windows creation.
+        if let Some(cb) = self.start_callback.take() {
+            cb(state);
         }
     }
 


### PR DESCRIPTION
A new function `.with_on_start()` is introduced on `Xilem::new` to run a `FnOnce` after the app has started. 


```rust
let app = Xilem::new_simple(state, app_logic, opts)
  .with_on_start(move |_| {
      #[cfg(target_os = "macos")]
      menu.init_for_nsapp();
  })
app.run_in(EventLoop::with_user_event())?;
```

This has a few use cases, and amongst them:

1. Check for update on startup (with some API/GitHub releases/etc.)
2. More specific for macOS, but this allows compatibility with the [`muda`](https://docs.rs/muda/latest/muda/) crate. Without this, it's almost impossible to add items in the macOS menu bar (used by all applications), because `NSApplication` needs to be set **before** using `muda` functions, which is only possible after the initialization of `Xilem`

   If you're not familiar with macOS, the menu bar looks like this

   <img width="508" height="396" alt="Capture d’écran 2026-05-01 à 13 59 51" src="https://github.com/user-attachments/assets/8c5bf3d2-682a-4860-9552-b6ab06e979e9" />