### PR TITLE
Fix test harness mouse move.

### DIFF
--- a/masonry/src/widgets/button.rs
+++ b/masonry/src/widgets/button.rs
@@ -513,10 +513,6 @@ mod tests {
     // or a with a keyboard shortcut indicator.
 
     #[test]
-    #[should_panic = "is not visible"]
-    // FIXME: Somehow the harness can't find the button under the coordinates it gets
-    // for the button center.
-    // See https://github.com/linebender/xilem/issues/1756
     fn textless_button() {
         let tag = WidgetTag::unique();
         let button = Button::with_text("").prepare().with_tag(tag);

--- a/masonry_testing/src/harness.rs
+++ b/masonry_testing/src/harness.rs
@@ -693,7 +693,8 @@ impl<W: Widget> TestHarness<W> {
     #[track_caller]
     pub fn mouse_move_to(&mut self, id: WidgetId) {
         let widget = self.get_widget_with_id(id);
-        let local_widget_center = (widget.ctx().border_box_size() / 2.0).to_vec2().to_point();
+        let local_widget_center = widget.ctx().border_box().center();
+
         let widget_center = widget.ctx().window_transform() * local_widget_center;
 
         // TODO - Add reachable_by_pointer() method.
@@ -731,7 +732,7 @@ impl<W: Widget> TestHarness<W> {
     #[track_caller]
     pub fn mouse_move_to_unchecked(&mut self, id: WidgetId) {
         let widget = self.get_widget_with_id(id);
-        let local_widget_center = (widget.ctx().border_box_size() / 2.0).to_vec2().to_point();
+        let local_widget_center = widget.ctx().border_box().center();
         let widget_center = widget.ctx().window_transform() * local_widget_center;
 
         if widget.ctx().is_stashed() {


### PR DESCRIPTION
The test harness uses `widget.ctx().window_transform()` which transforms from window space to content-box space. Doing border-box size division won't lead to correct results. It's better to take the center of the correct rect.

Fixes #1756