### PR TITLE
MacOS: Present next frame in single CATransaction when resized from bottom left

### DIFF
--- a/masonry_winit/src/event_loop_runner.rs
+++ b/masonry_winit/src/event_loop_runner.rs
@@ -880,7 +880,9 @@ impl MasonryState<'_> {
         // visible jitter.
         #[cfg(target_os = "macos")]
         match event {
-            WinitWindowEvent::Resized(_) | WinitWindowEvent::RedrawRequested => {}
+            WinitWindowEvent::Resized(_)
+            | WinitWindowEvent::RedrawRequested
+            | WinitWindowEvent::Moved(_) => {}
             _ => {
                 if let Some(surface) = self
                     .resized_window


### PR DESCRIPTION
Resized and moved conceptually are both requesting a redraw and should participate in the same resize transaction, as bottom-left resize moves the window origin, generating moved events along resized. Resizing the window from the bottom left, therefore, caused the same effect we saw in [#1521](https://github.com/linebender/xilem/issues/1521). (you might as well close this issue now). Adding `WindowEvent::Moved` to be treated as transaction-end.