### PR TITLE
fix: Fix link to Trunk

### DIFF
--- a/xilem_web/README.md
+++ b/xilem_web/README.md
@@ -59,7 +59,7 @@ pub fn main() {
 }
 ```
 
-[Trunk]: https://trunkrs.dev/
+[Trunk]: https://trunk-rs.github.io/trunk
 [Xilem Core]: xilem_core
 
 <!-- cargo-rdme end -->

--- a/xilem_web/src/lib.rs
+++ b/xilem_web/src/lib.rs
@@ -36,7 +36,7 @@
 //! }
 //! ```
 //!
-//! [Trunk]: https://trunkrs.dev/
+//! [Trunk]: https://trunk-rs.github.io/trunk
 //! [Xilem Core]: xilem_core
 
 // LINEBENDER LINT SET - lib.rs - v3


### PR DESCRIPTION
The previous link was to a totally unrelated website. That website was most likely fraudulent.

The new link is also listed in https://github.com/trunk-rs/trunk which is the official README.md of Trunk.

This fixes #1797.