### PR TITLE
Make scale factor more widely accessible.

### DIFF
--- a/masonry/src/widgets/divider.rs
+++ b/masonry/src/widgets/divider.rs
@@ -737,7 +737,7 @@ impl Widget for Divider {
         painter: &mut Painter<'_>,
     ) {
         // TODO: Replace with snap-aware paint helper once that exists.
-        let one_dp = 1. / ctx.get_scale_factor();
+        let one_dp = 1. / ctx.scale_factor();
 
         let cache = ctx.property_cache();
         let color = props.get::<ContentColor>(cache);

--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -425,7 +425,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Widget for Portal<W> {
 
         match *event {
             PointerEvent::Scroll(PointerScrollEvent { delta, .. }) => {
-                let scale_factor = ctx.get_scale_factor();
+                let scale_factor = ctx.scale_factor();
                 let line_px = PhysicalPosition {
                     x: 120.0 * scale_factor,
                     y: 120.0 * scale_factor,

--- a/masonry/src/widgets/virtual_scroll.rs
+++ b/masonry/src/widgets/virtual_scroll.rs
@@ -537,7 +537,7 @@ impl Widget for VirtualScroll {
         match event {
             PointerEvent::Scroll(PointerScrollEvent { delta, .. }) => {
                 let size = ctx.content_box_size();
-                let scale_factor = ctx.get_scale_factor();
+                let scale_factor = ctx.scale_factor();
                 let line_px = PhysicalPosition {
                     x: 120.0 * scale_factor,
                     y: 120.0 * scale_factor,

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -1339,25 +1339,15 @@ impl_context_method!(
             let translation = self.widget_state.border_box_translation();
             self.widget_state.window_transform * (point + translation)
         }
+
+        /// Returns the DPI scaling factor.
+        ///
+        /// This can be useful for loading image resources meant for a specific scale.
+        pub fn scale_factor(&self) -> f64 {
+            self.global_state.scale_factor
+        }
     }
 );
-
-impl_context_method!(AccessCtx<'_>, EventCtx<'_>, PaintCtx<'_>, {
-    /// Returns DPI scaling factor.
-    ///
-    /// This is not required for most widgets, and should be used only for precise
-    /// rendering, such as rendering single pixel lines or selecting image variants.
-    /// This is currently only provided in the render stages, as these are the only passes which
-    /// are re-run when the scale factor changes, except [`EventCtx`] where it is necessary to
-    /// translate pointer events which are currently in physical coordinates.
-    ///
-    /// Note that accessibility nodes and paint results will automatically be scaled by Masonry.
-    /// This also doesn't account for the widget's current transform, which cannot currently be
-    /// accessed by widgets directly.
-    pub fn get_scale_factor(&self) -> f64 {
-        self.global_state.scale_factor
-    }
-});
 
 // --- MARK: GET STATUS
 


### PR DESCRIPTION
Renamed `get_scale_factor` to `scale_factor`, so that it follows the [Rust naming convention](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter).

Made it available to more contexts by moving it into the layout related macro block.

Simplified the comment by focusing on the primary benefit of using the method. The *single pixel lines* use case that was mentioned before will get dedicated helper methods in a future PR, so `scale_factor` will no longer be the recommended approach for that.