### PR TITLE
Remove `ComposeCtx::needs_compose`.

### DIFF
--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -1119,12 +1119,6 @@ impl LayoutCtx<'_> {
 }
 
 impl ComposeCtx<'_> {
-    // TODO - Remove?
-    /// Returns whether [`Widget::compose`] will be called on this widget.
-    pub fn needs_compose(&self) -> bool {
-        self.widget_state.needs_compose
-    }
-
     /// Sets the scroll translation for the child widget.
     ///
     /// The translation is applied on top of the position from [`LayoutCtx::place_child`].


### PR DESCRIPTION
This is some sort of accident of history that has no use, as also hinted at by the speculative comment about removal.

You can only use `ComposeCtx` within `Widget::compose`. Checking inside `Widget::compose` whether `Widget::compose` will be called is crazy. Thus, let's just remove it.