### PR TITLE
Remove `Ctx::window_origin`.

### DIFF
--- a/masonry/src/tests/compose.rs
+++ b/masonry/src/tests/compose.rs
@@ -71,7 +71,9 @@ fn request_compose() {
     });
 
     // Origin should be "parent_origin + pos + scroll_offset"
-    let origin = harness.get_widget(child_tag).ctx().window_origin();
+    let child = harness.get_widget(child_tag);
+    let ctx = child.ctx();
+    let origin = ctx.to_window(ctx.border_box().origin());
     assert_eq!(
         origin.to_vec2(),
         Vec2::new(7., 7.) + Point::new(30., 30.).to_vec2() + Vec2::new(8., 8.)
@@ -94,6 +96,8 @@ fn scroll_pixel_snap() {
     let harness = TestHarness::create(test_property_set(), parent);
 
     // Origin should be rounded to (0., 1.) by pixel-snapping.
-    let origin = harness.get_widget(child_tag).ctx().window_origin();
+    let child = harness.get_widget(child_tag);
+    let ctx = child.ctx();
+    let origin = ctx.to_window(ctx.border_box().origin());
     assert_eq!(origin, Point::new(0., 1.));
 }

--- a/masonry/src/tests/layout.rs
+++ b/masonry/src/tests/layout.rs
@@ -210,13 +210,18 @@ fn pixel_snapping() {
 
     let harness = TestHarness::create(test_property_set(), parent);
 
-    let child_pos = harness.get_widget(child_tag).ctx().window_origin();
-    let child_size = harness.get_widget(child_tag).ctx().border_box_size();
+    let child = harness.get_widget(child_tag);
+    let ctx = child.ctx();
+    let border_box = ctx.border_box();
+    let content_box = ctx.content_box();
+    let child_pos = ctx.to_window(border_box.origin());
     let first_baseline = harness.get_widget(parent_tag).ctx().first_baseline();
     let last_baseline = harness.get_widget(parent_tag).ctx().last_baseline();
 
     assert_eq!(child_pos, Point::new(5.0, 5.0));
-    assert_eq!(child_size, Size::new(10., 11.));
+    assert_eq!(content_box.origin(), Point::ORIGIN);
+    assert_eq!(content_box.size(), Size::new(10., 11.));
+    assert_eq!(border_box.size(), Size::new(10., 11.));
     assert_eq!(first_baseline, 2.4);
     assert_eq!(last_baseline, 2.6);
 }

--- a/masonry/src/widgets/selector.rs
+++ b/masonry/src/widgets/selector.rs
@@ -140,10 +140,11 @@ impl Selector {
         let layer_widget = NewWidget::new(menu);
 
         // TODO: We should ideally create a layer with the same transform as this widget.
+        let border_box = ctx.border_box();
         ctx.create_layer(
             layer_type,
             layer_widget,
-            ctx.window_origin() + Vec2::new(0., ctx.border_box_size().height),
+            ctx.to_window(border_box.origin()) + Vec2::new(0., border_box.size().height),
         );
     }
 }

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -1303,11 +1303,6 @@ impl_context_method!(
             self.widget_state.border_box_translation()
         }
 
-        /// Returns the widget's effective border-box origin in the window's coordinate space.
-        pub fn window_origin(&self) -> Point {
-            self.widget_state.border_box_window_origin()
-        }
-
         /// Returns the global transform mapping this widget's content-box coordinate space
         /// to the window's coordinate space.
         ///

--- a/masonry_core/src/core/widget_state.rs
+++ b/masonry_core/src/core/widget_state.rs
@@ -419,12 +419,6 @@ impl WidgetState {
         Vec2::new(self.border_box_insets.x0, self.border_box_insets.y0)
     }
 
-    /// Returns the widget's effective border-box origin in the window's coordinate space.
-    pub(crate) fn border_box_window_origin(&self) -> Point {
-        // We can just use the translation for (0,0)
-        self.window_transform.translation().to_point()
-    }
-
     /// Returns the first baseline relative to the top of the widget's layout border-box.
     pub(crate) fn layout_first_baseline(&self) -> f64 {
         if self.first_baseline.is_nan() {


### PR DESCRIPTION
`Ctx::window_origin` is a major footgun that is very easy to use incorrectly. You can't just take the transformed origin and add non-transformed values to it, as seen for example in the `Selector` widget code this PR also touches.

`Ctx::window_origin` essentially hides away the transform and thus leads people towards not thinking about it. If they achieved the same result via `Ctx::window_transform` or `Ctx::to_window` then there is a higher chance that they'll realize they also need to use those same conversions for other points, not just the origin.