### PR TITLE
Rename `WidgetState::paint_insets` to `paint_box_insets`.

### DIFF
--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -924,7 +924,7 @@ impl LayoutCtx<'_> {
             insets.x1 - self.widget_state.border_box_insets.x1,
             insets.y1 - self.widget_state.border_box_insets.y1,
         );
-        self.widget_state.paint_insets = insets.nonnegative();
+        self.widget_state.paint_box_insets = insets.nonnegative();
     }
 
     /// Sets explicit baselines for this widget.

--- a/masonry_core/src/core/widget_state.rs
+++ b/masonry_core/src/core/widget_state.rs
@@ -105,7 +105,7 @@ pub(crate) struct WidgetState {
     ///
     /// In general, these will be zero; the exception is for things like
     /// drop shadows or overflowing text.
-    pub(crate) paint_insets: Insets,
+    pub(crate) paint_box_insets: Insets,
     /// An axis aligned bounding rect (AABB in 2D),
     /// containing itself and all its descendents in the window's coordinate space.
     ///
@@ -297,7 +297,7 @@ impl WidgetState {
             end_point: Point::ORIGIN,
             layout_border_box_size: Size::ZERO,
             border_box_insets: Insets::ZERO,
-            paint_insets: Insets::ZERO,
+            paint_box_insets: Insets::ZERO,
             bounding_box: Rect::ZERO,
             first_baseline: f64::NAN,
             last_baseline: f64::NAN,
@@ -407,7 +407,7 @@ impl WidgetState {
 
     /// Returns the widget's aligned paint-box rect in the widget's border-box coordinate space.
     pub(crate) fn paint_box(&self) -> Rect {
-        self.border_box_size().to_rect() + self.paint_insets
+        self.border_box_size().to_rect() + self.paint_box_insets
     }
 
     /// Returns the [`Vec2`] for translating between this widget's

--- a/masonry_core/src/passes/layout.rs
+++ b/masonry_core/src/passes/layout.rs
@@ -403,7 +403,7 @@ pub(crate) fn run_layout_on(
         }
     });
 
-    state.paint_insets = Insets::ZERO;
+    state.paint_box_insets = Insets::ZERO;
 
     // Compute the insets for deriving the content-box from the border-box
     let border_box_insets = border_width.insets_up(Insets::ZERO);
@@ -428,18 +428,18 @@ pub(crate) fn run_layout_on(
     let shadow = props.get::<BoxShadow>(&mut state.property_cache);
     if shadow.is_visible() {
         let shadow_insets = shadow.get_insets();
-        state.paint_insets = Insets {
-            x0: state.paint_insets.x0.max(shadow_insets.x0),
-            y0: state.paint_insets.y0.max(shadow_insets.y0),
-            x1: state.paint_insets.x1.max(shadow_insets.x1),
-            y1: state.paint_insets.y1.max(shadow_insets.y1),
+        state.paint_box_insets = Insets {
+            x0: state.paint_box_insets.x0.max(shadow_insets.x0),
+            y0: state.paint_box_insets.y0.max(shadow_insets.y0),
+            x1: state.paint_box_insets.x1.max(shadow_insets.x1),
+            y1: state.paint_box_insets.y1.max(shadow_insets.y1),
         };
     }
 
     if trace {
         trace!(
             "Computed layout: border-box={}, first_baseline={}, last_baseline={} insets={:?}",
-            border_box_size, state.first_baseline, state.last_baseline, state.paint_insets,
+            border_box_size, state.first_baseline, state.last_baseline, state.paint_box_insets,
         );
     }
 


### PR DESCRIPTION
This is an internal Masonry Core variable name that refers to the paint-box insets. This rename brings it in line with the related fields like `border_box_insets`, `bounding_box` etc.