### PR TITLE
Improve `assert_layout_done`.

### DIFF
--- a/masonry/src/tests/layout.rs
+++ b/masonry/src/tests/layout.rs
@@ -1,6 +1,9 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::cell::Cell;
+use std::rc::Rc;
+
 use assert_matches::assert_matches;
 
 use crate::core::{NewWidget, Widget, WidgetTag};
@@ -93,6 +96,36 @@ fn call_place_child_before_layout() {
     assert_debug_panics!(
         TestHarness::create(test_property_set(), widget),
         "trying to call 'place_child'"
+    );
+}
+
+#[test]
+fn call_child_size_before_layout() {
+    let parent_tag = WidgetTag::unique();
+    let layout_count = Rc::new(Cell::new(0));
+    let layout_count_for_fn = layout_count.clone();
+
+    let child = NewWidget::new(SizedBox::empty().width(20.px()).height(20.px()));
+    let parent = ModularWidget::new_parent(child).layout_fn(move |child, ctx, _, size| {
+        if layout_count_for_fn.get() > 0 {
+            let _ = ctx.child_size(child);
+        }
+
+        layout_count_for_fn.set(layout_count_for_fn.get() + 1);
+
+        let child_size = ctx.compute_size(child, SizeDef::fit(size), size.into());
+        ctx.run_layout(child, child_size);
+        ctx.place_child(child, Point::ORIGIN);
+    });
+    let widget = NewWidget::new(parent).with_tag(parent_tag);
+
+    let mut harness = TestHarness::create(test_property_set(), widget);
+
+    assert_debug_panics!(
+        harness.edit_widget(parent_tag, |mut parent| {
+            parent.ctx.request_layout();
+        }),
+        "trying to call 'child_size'"
     );
 }
 

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -773,7 +773,7 @@ impl LayoutCtx<'_> {
     #[track_caller]
     fn assert_layout_done(&self, child: &WidgetPod<impl Widget + ?Sized>, method_name: &str) {
         let child_state = self.get_child_state(child);
-        // request_layout is used as a visit marker, but only when debug_assertions are enabled.
+        // If debug_assertions are enabled, then request_layout is always true until visited.
         let child_not_visited = cfg!(debug_assertions) && child_state.request_layout;
         if child_state.needs_layout() || child_not_visited {
             debug_panic!(

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -772,7 +772,10 @@ impl MeasureCtx<'_> {
 impl LayoutCtx<'_> {
     #[track_caller]
     fn assert_layout_done(&self, child: &WidgetPod<impl Widget + ?Sized>, method_name: &str) {
-        if self.get_child_state(child).needs_layout() {
+        let child_state = self.get_child_state(child);
+        // request_layout is used as a visit marker, but only when debug_assertions are enabled.
+        let child_not_visited = cfg!(debug_assertions) && child_state.request_layout;
+        if child_state.needs_layout() || child_not_visited {
             debug_panic!(
                 "Error in {}: trying to call '{}' with child '{}' {} before computing its layout",
                 self.widget_id(),


### PR DESCRIPTION
Previously `assert_layout_done` only verified that layout was available (i.e. not "needed"). This meant that it would succeed with a cached layout even if `run_layout` had not been called.

This PR makes use of the debug vist marker we have to ensure that `assert_layout_done` fails if `run_layout` has not been called on the widget, even if it ends up having a cached layout available anyway.

The key motivation here is that layout caching logic is an internal implementation detail. Widgets should always call `run_layout` before accessing those results. Caching rules may change without announcement, and so depending on specific caching behavior can lead to subtle bugs.