### PR TITLE
Improve transform tracking.

### DIFF
--- a/masonry/src/tests/compose.rs
+++ b/masonry/src/tests/compose.rs
@@ -3,10 +3,11 @@
 
 use assert_matches::assert_matches;
 
-use crate::core::{ChildrenIds, NewWidget, Widget, WidgetPod, WidgetTag};
-use crate::kurbo::{Affine, Point, Vec2};
-use crate::layout::{Length, SizeDef};
+use crate::core::{ChildrenIds, NewWidget, Update, Widget, WidgetPod, WidgetTag};
+use crate::kurbo::{Affine, Point, Rect, Size, Vec2};
+use crate::layout::{AsUnit, Length, SizeDef};
 use crate::testing::{ModularWidget, Record, TestHarness, TestWidgetExt};
+use crate::tests::assert_rect_approx_eq;
 use crate::theme::test_property_set;
 use crate::widgets::SizedBox;
 
@@ -77,6 +78,105 @@ fn request_compose() {
     assert_eq!(
         origin.to_vec2(),
         Vec2::new(7., 7.) + Point::new(30., 30.).to_vec2() + Vec2::new(8., 8.)
+    );
+}
+
+#[test]
+fn scroll_translation_updates_composed_geometry_without_layout() {
+    struct ChildAndOffset {
+        child: WidgetPod<dyn Widget>,
+        offset: Vec2,
+    }
+
+    let child_tag = WidgetTag::unique();
+    let parent_tag = WidgetTag::unique();
+    let child = NewWidget::new(
+        ModularWidget::new(())
+            .measure_fn(|_, _, _, _, _, _| 10.3.px())
+            .record(),
+    )
+    .with_tag(child_tag);
+
+    let parent = ModularWidget::new(ChildAndOffset {
+        child: child.erased().to_pod(),
+        offset: Vec2::ZERO,
+    })
+    .layout_fn(|state, ctx, _, size| {
+        let child_size = ctx.compute_size(&mut state.child, SizeDef::fit(size), size.into());
+        ctx.run_layout(&mut state.child, child_size);
+        ctx.place_child(&mut state.child, Point::new(5.1, 5.3));
+    })
+    .compose_fn(|state, ctx| {
+        ctx.set_child_scroll_translation(&mut state.child, state.offset);
+    })
+    .register_children_fn(|state, ctx| {
+        ctx.register_child(&mut state.child);
+    })
+    .children_fn(|state| ChildrenIds::from_slice(&[state.child.id()]))
+    .prepare()
+    .with_tag(parent_tag);
+
+    let mut harness = TestHarness::create(test_property_set(), parent);
+    harness.flush_records_of(child_tag);
+
+    let hit_after_scroll = Point::new(16., 16.);
+    harness.mouse_move(hit_after_scroll);
+    let records = harness.take_records_of(child_tag);
+    assert!(
+        !records.iter().any(|record| matches!(
+            record,
+            Record::PointerEvent(_) | Record::Update(Update::HoveredChanged(true))
+        )),
+        "pointer should not reach the child before scroll translation"
+    );
+    assert!(!harness.get_widget(child_tag).ctx().is_hovered());
+
+    harness.edit_widget(parent_tag, |mut parent| {
+        parent.widget.state.offset = Vec2::new(2.2, 0.8);
+        parent.ctx.request_compose();
+    });
+
+    let records = harness.take_records_of(child_tag);
+    assert!(
+        !records
+            .iter()
+            .any(|record| matches!(record, Record::Layout(_))),
+        "scroll translation should not rerun child layout"
+    );
+    assert!(
+        records.iter().any(|record| matches!(
+            record,
+            Record::PointerEvent(_) | Record::Update(Update::HoveredChanged(true))
+        )),
+        "stationary pointer should reach the child after scroll translation"
+    );
+    assert!(harness.get_widget(child_tag).ctx().is_hovered());
+
+    let child = harness.get_widget(child_tag);
+    let child_id = child.id();
+    let ctx = child.ctx();
+    assert_eq!(ctx.border_box().size(), Size::new(10., 11.));
+    assert_rect_approx_eq(
+        "window border box",
+        ctx.window_transform().transform_rect_bbox(ctx.border_box()),
+        Rect::new(7., 6., 17., 17.),
+    );
+
+    let _ = harness.redraw();
+    let access_bounds = harness
+        .access_node(child_id)
+        .unwrap()
+        .bounding_box()
+        .unwrap();
+    assert_rect_approx_eq(
+        "access bounds",
+        Rect::new(
+            access_bounds.x0,
+            access_bounds.y0,
+            access_bounds.x1,
+            access_bounds.y1,
+        ),
+        Rect::new(7., 6., 17., 17.),
     );
 }
 

--- a/masonry_core/src/core/contexts.rs
+++ b/masonry_core/src/core/contexts.rs
@@ -224,8 +224,7 @@ impl_context_method!(
         /// This transform is used during the mapping of this widget's border-box coordinate space
         /// to the parent's border-box coordinate space.
         ///
-        /// When calculating the effective border-box of this widget, first this transform
-        /// will be applied and then `scroll_translation` and `origin` applied on top.
+        /// This transform is applied before `scroll_translation` and `origin`.
         pub fn transform(&self) -> Affine {
             self.widget_state.transform
         }
@@ -349,17 +348,6 @@ impl MutateCtx<'_> {
             ancestors: None,
             property_arena: self.property_arena,
         }
-    }
-
-    /// Returns `true` if the [local transform] of this widget has been modified since
-    /// the last time this widget's transformation was resolved.
-    ///
-    /// This is exposed for Xilem, and is more likely to change or be removed
-    /// in major releases of Masonry.
-    ///
-    /// [local transform]: Self::transform
-    pub fn transform_has_changed(&self) -> bool {
-        self.widget_state.transform_changed
     }
 
     /// Sets which property stack this widget uses for property resolution.
@@ -1153,6 +1141,7 @@ impl ComposeCtx<'_> {
         if translation != child.scroll_translation {
             child.scroll_translation = translation;
             child.transform_changed = true;
+            child.needs_compose = true;
         }
     }
 
@@ -1185,6 +1174,7 @@ impl ComposeCtx<'_> {
         if translation != child.scroll_translation {
             child.scroll_translation = translation;
             child.transform_changed = true;
+            child.needs_compose = true;
         }
     }
 }
@@ -1674,7 +1664,7 @@ impl_context_method!(
         pub fn set_transform(&mut self, transform: Affine) {
             self.widget_state.transform = transform;
             self.widget_state.transform_changed = true;
-            self.request_compose();
+            self.widget_state.needs_compose = true;
         }
 
         /// Adds a string to this widget's [class set].

--- a/masonry_core/src/core/widget_pod.rs
+++ b/masonry_core/src/core/widget_pod.rs
@@ -83,8 +83,7 @@ pub struct WidgetOptions {
     /// Local transform used during the mapping of this widget's border-box coordinate space
     /// to the parent's border-box coordinate space.
     ///
-    /// When calculating the effective border-box of this widget, first this transform
-    /// will be applied and then `scroll_translation` and `origin` applied on top.
+    /// This transform is applied before `scroll_translation` and `origin`.
     pub transform: Affine,
     /// The disabled state the widget will be created with.
     pub disabled: bool,

--- a/masonry_core/src/core/widget_state.rs
+++ b/masonry_core/src/core/widget_state.rs
@@ -138,8 +138,7 @@ pub(crate) struct WidgetState {
     /// Local transform used during the mapping of this widget's border-box coordinate space
     /// to the parent's border-box coordinate space.
     ///
-    /// When calculating the effective border-box of this widget, first this transform
-    /// will be applied and then `scroll_translation` and `origin` applied on top.
+    /// This transform is applied before `scroll_translation` and `origin`.
     pub(crate) transform: Affine,
     /// Global transform mapping this widget's border-box coordinate space
     /// to the window's coordinate space.
@@ -152,7 +151,8 @@ pub(crate) struct WidgetState {
     pub(crate) window_transform: Affine,
     /// Translation applied by scrolling, applied after applying `transform` to this widget.
     pub(crate) scroll_translation: Vec2,
-    /// The `transform` or `scroll_translation` has changed.
+    /// The effective compose transform has changed because `transform`, `scroll_translation`, or
+    /// `origin` has changed.
     pub(crate) transform_changed: bool,
 
     // --- INTERACTIONS ---
@@ -192,7 +192,7 @@ pub(crate) struct WidgetState {
 
     /// The `compose` method must be called on this widget
     pub(crate) request_compose: bool,
-    /// The `compose` method must be called on this widget or a descendant
+    /// The `compose` pass must run on this widget.
     pub(crate) needs_compose: bool,
 
     /// The `pre_paint` method must be called on this widget
@@ -427,6 +427,18 @@ impl WidgetState {
     /// and subtract this [`Vec2`] to translate from border-box to content-box.
     pub(crate) fn border_box_translation(&self) -> Vec2 {
         Vec2::new(self.border_box_insets.x0, self.border_box_insets.y0)
+    }
+
+    /// Returns this widget's total local transform needed for composing.
+    ///
+    /// This maps from this widget's border-box coordinate space into its
+    /// parent's border-box coordinate space. It includes the widget's local
+    /// transform, scroll translation, and origin.
+    pub(crate) fn compose_local_transform(&self) -> Affine {
+        // The translation needs to be applied after the local transform so scrolling
+        // and layout origin are in the transformed coordinate space, similar to CSS.
+        let local_translation = self.scroll_translation + self.origin.to_vec2();
+        self.transform.then_translate(local_translation)
     }
 
     /// Returns the first baseline relative to the top of the widget's layout border-box.

--- a/masonry_core/src/passes/accessibility.rs
+++ b/masonry_core/src/passes/accessibility.rs
@@ -91,8 +91,7 @@ fn build_access_node(
     let mut node = Node::new(widget.accessibility_role());
     node.set_bounds(to_accesskit_rect(ctx.widget_state.border_box()));
 
-    let local_translation = ctx.widget_state.scroll_translation + ctx.widget_state.origin.to_vec2();
-    let mut local_transform = ctx.widget_state.transform.then_translate(local_translation);
+    let mut local_transform = ctx.widget_state.compose_local_transform();
 
     // TODO - Remove once Masonry uses physical coordinates.
     // See https://github.com/linebender/xilem/issues/1264

--- a/masonry_core/src/passes/compose.rs
+++ b/masonry_core/src/passes/compose.rs
@@ -29,13 +29,8 @@ fn compose_widget(
         return;
     }
 
-    // The translation needs to be applied *after* applying the transform,
-    // as translation by scrolling should be within the transformed coordinate space.
-    // Same is true for the aligned border-box origin, to behave similar as in CSS.
-    let local_translation = state.scroll_translation + state.origin.to_vec2();
-
-    state.window_transform =
-        parent_window_transform * state.transform.then_translate(local_translation);
+    let local_transform = state.compose_local_transform();
+    state.window_transform = parent_window_transform * local_transform;
 
     let paint_box = state.paint_box();
     state.bounding_box = state.window_transform.transform_rect_bbox(paint_box);

--- a/masonry_core/src/passes/layout.rs
+++ b/masonry_core/src/passes/layout.rs
@@ -518,6 +518,7 @@ pub(crate) fn place_widget(child_state: &mut WidgetState, origin: Point) {
     // TODO - We may want to invalidate in other cases as well
     if origin != child_state.origin {
         child_state.transform_changed = true;
+        child_state.needs_compose = true;
     }
     child_state.origin = origin;
     child_state.end_point = end_point;


### PR DESCRIPTION
The old `transform_changed` was busted. It was internally documented as tracking `transform` and `scroll_translation`, but in practice it was also tracking `origin`, but then exposed in `MutateCtx::transform_has_changed` with the claim that it only tracks `transform` -- and then Xilem was using it with that assumption.

This PR cleans that up by removing `MutateCtx::transform_has_changed` and properly documenting `transform_changed` as tracking everything which affects the full transform that the compose pass calculates. Currently that is `transform`, `scroll_translation`, and `origin`.

What's more, the `transform_changed` flag isn't even merged up the tree, yet the compose pass checks it to decide whether to traverse into a branch. Thus, the compose pass was implicitly depending on unrelated code paths to set the `needs_compose` flag.

This PR sets the `needs_compose` flag explicitly, to ensure things remain working even when that flag isn't being set elsewhere.

The composing logic was duplicated in both the compose and accessibility passes. Yet it is critical for correct accessibility behavior for that to stay in sync with the compose results.

This PR introduces `WidgetState::compose_local_transform` as a helper method, which will calculate the correct local transform. This will help this logic stay in sync. This is especially relevant as the logic gets more fragile, i.e. with the pixel snapping of #1803.

Finally, this PR adds a new test which makes sure that scroll translation doesn't trigger a layout, is respected by hit testing, and that the regular and accessibility bounds are the same.