### PR TITLE
Fix `Portal::set_viewport_pos` dirty flag choice.

### DIFF
--- a/masonry/src/widgets/portal.rs
+++ b/masonry/src/widgets/portal.rs
@@ -372,7 +372,7 @@ impl<W: Widget + FromDynWidget + ?Sized> Portal<W> {
             let progress_y = this.widget.viewport_pos.y / (content_size - portal_size).height;
             Self::vertical_scrollbar_mut(this).widget.cursor_progress = progress_y;
             Self::vertical_scrollbar_mut(this).ctx.request_render();
-            this.ctx.request_layout();
+            this.ctx.request_compose();
         }
         pos_changed
     }


### PR DESCRIPTION
`Portal::set_viewport_pos` was requesting layout, but that isn't actually needed. Just compose is enough for scroll translation. Other methods of `Portal` already correctly request compose.