### PR TITLE
Track Xilem transform changes in Xilem.

### DIFF
--- a/xilem_masonry/src/masonry_root.rs
+++ b/xilem_masonry/src/masonry_root.rs
@@ -54,6 +54,7 @@ impl<State> View<State, (), ViewCtx> for MasonryRoot<State> {
         render_root.edit_base_layer(|mut root| {
             let mut root = root.downcast();
             ctx.reset_changed_props();
+            ctx.reset_changed_transforms();
             self.root_widget_view.rebuild(
                 &prev.root_widget_view,
                 root_widget_view_state,

--- a/xilem_masonry/src/view/transform.rs
+++ b/xilem_masonry/src/view/transform.rs
@@ -124,7 +124,8 @@ where
             element.reborrow_mut(),
             app_state,
         );
-        let transform_changed = element.ctx.transform_has_changed();
+        let id = element.id();
+        let transform_changed = ctx.transform_has_changed(id);
         // If the child view changed the transform, we know we're out of date.
         if transform_changed {
             // If it has changed the transform, then we know that it will only be due to effects
@@ -139,6 +140,7 @@ where
             element
                 .ctx
                 .set_transform(self.transform * view_state.previous_transform);
+            ctx.mark_transform_changed(id);
         }
     }
 

--- a/xilem_masonry/src/view_ctx.rs
+++ b/xilem_masonry/src/view_ctx.rs
@@ -20,6 +20,7 @@ pub struct ViewCtx {
     proxy: Arc<dyn RawProxy>,
     runtime: Arc<tokio::runtime::Runtime>,
     props_changed: HashSet<(WidgetId, TypeId)>,
+    transforms_changed: HashSet<WidgetId>,
     environment: Environment,
 }
 
@@ -93,6 +94,15 @@ impl ViewCtx {
         self.props_changed.insert((id, TypeId::of::<P>()));
     }
 
+    /// Marks the transform of the widget with the given id as changed.
+    ///
+    /// This is used to avoid bugs when multiple `Transformed` views are stacked on the same widget.
+    ///
+    /// This should be reset at the end of each rebuild.
+    pub fn mark_transform_changed(&mut self, id: WidgetId) {
+        self.transforms_changed.insert(id);
+    }
+
     /// Checks if the property `P` of the widget with the given id has changed during this rebuild.
     ///
     /// This is used to avoid bugs when multiple `Prop` views are stacked on the same widget.
@@ -100,11 +110,25 @@ impl ViewCtx {
         self.props_changed.contains(&(id, TypeId::of::<P>()))
     }
 
+    /// Checks if the transform of the widget with the given id has changed during this rebuild.
+    ///
+    /// This is used to avoid bugs when multiple `Transformed` views are stacked on the same widget.
+    pub fn transform_has_changed(&self, id: WidgetId) -> bool {
+        self.transforms_changed.contains(&id)
+    }
+
     /// Resets the changed properties for all widgets.
     ///
     /// This should be called at the start of each rebuild.
     pub fn reset_changed_props(&mut self) {
         self.props_changed.clear();
+    }
+
+    /// Resets the changed transforms for all widgets.
+    ///
+    /// This should be called at the start of each rebuild.
+    pub fn reset_changed_transforms(&mut self) {
+        self.transforms_changed.clear();
     }
 
     /// Returns an event queue to which [`SendMessage`](crate::core::SendMessage)s can be submitted.
@@ -122,6 +146,7 @@ impl ViewCtx {
             proxy,
             runtime,
             props_changed: HashSet::default(),
+            transforms_changed: HashSet::default(),
             environment: Environment::new(),
         }
     }


### PR DESCRIPTION
Xilem wants to know whether a child view has changed the widget's transform.

Currently this dirty flag is managed by Masonry and exposed via `MutateCtx::transform_has_changed`. However, Masonry itself doesn't care about the flag but does care about a similar flag. This means that Xilem's requirements are creating increased complexity inside Masonry. See also #1811.

This PR here adds the necessary dirty flag tracking to Xilem itself. It's quite straightforward and mimics the existing prop change tracking which has the same root motivation.

This will enable the eventual removal of `MutateCtx::transform_has_changed` from Masonry.