### PR TITLE
xilem: WindowView::with_default_properties for runtime theme swap

### DIFF
--- a/xilem/src/window_view.rs
+++ b/xilem/src/window_view.rs
@@ -1,7 +1,9 @@
 // Copyright 2025 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::{theme::BACKGROUND_COLOR, util::debug_panic};
+use std::sync::Arc;
+
+use masonry::{core::DefaultProperties, theme::BACKGROUND_COLOR, util::debug_panic};
 use masonry_winit::app::{NewWindow, Window, WindowId};
 
 use crate::core::{MessageCtx, Mut, View, ViewElement, ViewMarker};
@@ -16,6 +18,8 @@ pub struct WindowView<State: 'static> {
     pub(crate) masonry_root: MasonryRoot<State>,
     /// The base color of the window.
     pub(crate) base_color: Option<Color>,
+    /// Tree-wide default properties, applied on `Arc` identity change.
+    pub(crate) default_properties: Option<Arc<DefaultProperties>>,
 }
 
 pub(crate) type WindowViewState = <Box<AnyWidgetView<(), ()>> as View<(), (), ViewCtx>>::ViewState;
@@ -37,6 +41,7 @@ pub fn window<V: WidgetView<State>, State: 'static>(
         options: WindowOptions::new(title),
         masonry_root: MasonryRoot::new(root_view),
         base_color: None,
+        default_properties: None,
     }
 }
 
@@ -55,6 +60,15 @@ impl<State> WindowView<State> {
     /// This is [`masonry::theme::BACKGROUND_COLOR`] by default.
     pub fn with_base_color(mut self, color: Color) -> Self {
         self.base_color = Some(color);
+        self
+    }
+
+    /// Set tree-wide default properties for runtime theme swaps.
+    ///
+    /// Applied on `Arc` identity change; cache the value so a new identity
+    /// only appears when the theme actually changes.
+    pub fn with_default_properties(mut self, default_properties: Arc<DefaultProperties>) -> Self {
+        self.default_properties = Some(default_properties);
         self
     }
 }
@@ -108,6 +122,15 @@ impl<State> View<State, (), ViewCtx> for WindowView<State> {
             && let Some(base_color) = self.base_color
         {
             *window.base_color() = base_color;
+        }
+
+        if let Some(props) = &self.default_properties
+            && prev
+                .default_properties
+                .as_ref()
+                .is_none_or(|p| !Arc::ptr_eq(p, props))
+        {
+            window.render_root().set_default_properties(props.clone());
         }
 
         self.masonry_root.rebuild(


### PR DESCRIPTION
Scope
One file: `xilem/src/window_view.rs`.

Background
[`RenderRoot::set_default_properties`] (added in #1821) lets a host swap the tree-wide default property set at runtime, but it's only reachable from code that holds a `RenderRoot`. Xilem apps go through `WindowView`, so they can't reach the new method at the moment.

Fix
Adds `WindowView::with_default_properties(Arc<DefaultProperties>)`. The new set gets pushed to the render root in `rebuild` only when the `Arc` identity changes (`Arc::ptr_eq`), so steady-state frames don't re-apply. `None` (the default) leaves the startup set untouched.

Testing
No tests in this PR. Xilem doesn't have masonry's `TestHarness`, and the propagation invariant is already covered by the test that landed with #1821. Anecdotally, when applied to my fork in my app, a theme toggle correctly recolors ContentColor-defaulted widgets without restart. I have screenshots or screen recordings available if desired.

Disclosure: AI-assisted; still my responsibility.

Closes #1819.

Relevant issues:
- #1765: related, still leaves `background_color()`, system light/dark detection, and the per-widget override API to that issue.
- #1786: related, leaves per-widget-type styling for later.