### PR TITLE
Make `TextArea` measurement side-effect free

### DIFF
--- a/masonry/src/widgets/label.rs
+++ b/masonry/src/widgets/label.rs
@@ -6,7 +6,6 @@ use std::mem::Discriminant;
 
 use accesskit::{Node, Role};
 use include_doc_path::include_doc_path;
-use smallvec::SmallVec;
 use tracing::{Span, trace_span};
 
 use crate::core::{
@@ -17,11 +16,12 @@ use crate::core::{
 use crate::imaging::Painter;
 use crate::kurbo::{Affine, Axis, Point, Size};
 use crate::layout::{AsUnit, LenReq, Length};
-use crate::parley::{FontContext, Layout, LayoutAccessibility, LayoutContext};
+use crate::parley::LayoutAccessibility;
 use crate::properties::{ContentColor, LineBreaking};
 use crate::theme::default_text_styles;
 use crate::util::debug_panic;
-use crate::{TextAlign, TextAlignOptions, theme};
+use crate::widgets::text_layout_cache::TextLayoutCache;
+use crate::{TextAlign, theme};
 
 /// A widget displaying non-interactive text.
 ///
@@ -38,15 +38,7 @@ use crate::{TextAlign, TextAlignOptions, theme};
 )]
 pub struct Label {
     /// Cached layouts.
-    layouts: Vec<TextLayout>,
-    /// Time tracking for cache usage.
-    cache_time: u8,
-    /// The currently active layout index.
-    ///
-    /// `usize::MAX` works well for none, as it will be overwritten before its used
-    /// for layout access, but will be read as-is during cache eviction.
-    /// During which any value larger than the cache capacity will be ignored.
-    active_layout: usize,
+    layouts: TextLayoutCache,
 
     text: ArcStr,
     styles: StyleSet,
@@ -61,116 +53,6 @@ pub struct Label {
     accessibility: LayoutAccessibility,
 }
 
-/// Text layout computation inputs and output.
-struct TextLayout {
-    /// Computed text layout.
-    layout: Layout<BrushIndex>,
-    /// Max advance value that was used when calculating this layout.
-    max_advance: Option<f32>,
-    /// Text alignment of this layout.
-    alignment: TextAlign,
-    /// Text alignment width of this layout.
-    alignment_width: f32,
-    /// Last use timestamp for cache eviction purposes.
-    last_used: u8,
-}
-
-impl TextLayout {
-    /// Text layout width differences less than 0.01 pixels can be considered equal.
-    const EPSILON: f32 = 0.01;
-
-    /// Creates a new [`TextLayout`] with the specified `max_advance` constraint and `timestamp`.
-    fn new(max_advance: Option<f32>, timestamp: u8) -> Self {
-        Self {
-            layout: Layout::new(),
-            max_advance,
-            alignment: TextAlign::Start,
-            alignment_width: -1., // Not aligned yet
-            last_used: timestamp,
-        }
-    }
-
-    /// Discards this layout, making it an obvious choice for cache eviction.
-    fn discard(&mut self) {
-        // Mark it as least recently used.
-        self.last_used = 0;
-        // Set a fake unlikely-to-be-seen max advance so it won't get any use.
-        self.max_advance = Some(-1.);
-    }
-
-    /// Align the text layout.
-    ///
-    /// This method ensures that alignment only happens when the inputs have changed.
-    fn align(&mut self, alignment: TextAlign, alignment_width: f32) {
-        if self.alignment == alignment
-            && (self.alignment_width - alignment_width).abs() < Self::EPSILON
-        {
-            return;
-        }
-        self.alignment = alignment;
-        self.alignment_width = alignment_width;
-        self.layout.align(
-            Some(self.alignment_width),
-            self.alignment,
-            TextAlignOptions::default(),
-        );
-    }
-
-    /// Returns `true` if this layout would be the result for `max_advance`.
-    ///
-    /// For example:
-    ///
-    /// `compute_layout(max_advance == 10) => layout.width == 8`
-    /// is also valid for `max_advance == 9`.
-    ///
-    /// This check assumes that Parley does greedy line-breaking,
-    /// which it does at the time of writing this.
-    fn satisfies(&self, max_advance: Option<f32>) -> bool {
-        // Check if the specified constraint is compatible with this layout's constraint.
-        self.max_advance.is_none_or(|layout_max_advance| {
-            max_advance.is_some_and(|max_advance| {
-                layout_max_advance - max_advance + Self::EPSILON >= 0.
-            })
-        }) &&
-        // Check if the computed layout fits into the specified constraint.
-        max_advance.is_none_or(|max_advance| {
-            max_advance - self.layout.width() + Self::EPSILON >= 0.
-        })
-    }
-
-    /// Returns `true` if this layout was more constrained than `max_advance`.
-    fn more_constrained(&self, max_advance: Option<f32>) -> bool {
-        self.max_advance.is_some_and(|layout_max_advance| {
-            max_advance.is_none_or(|max_advance| layout_max_advance < max_advance)
-        })
-    }
-
-    /// Returns `true` if the layouts are equal.
-    ///
-    /// That is if they have the same number of line breaks with the same reason at the same places.
-    fn equals(&self, other: &Self) -> bool {
-        if self.layout.len() != other.layout.len() {
-            return false;
-        }
-        let mut a = self.layout.lines();
-        let mut b = other.layout.lines();
-        loop {
-            match (a.next(), b.next()) {
-                (None, None) => return true,
-                (Some(a_line), Some(b_line)) => {
-                    if a_line.break_reason() != b_line.break_reason() {
-                        return false;
-                    }
-                    if a_line.text_range() != b_line.text_range() {
-                        return false;
-                    }
-                }
-                _ => return false,
-            }
-        }
-    }
-}
-
 // --- MARK: BUILDERS
 impl Label {
     /// Creates a new label with the given text.
@@ -181,9 +63,7 @@ impl Label {
         let mut styles = StyleSet::new(theme::TEXT_SIZE_NORMAL);
         default_text_styles(&mut styles);
         Self {
-            layouts: Vec::new(),
-            cache_time: 0,
-            active_layout: usize::MAX,
+            layouts: TextLayoutCache::new(),
             text: text.into(),
             styles,
             text_alignment: TextAlign::Start,
@@ -345,120 +225,6 @@ impl Label {
     /// Call this whenever text, styles, or fonts have changed.
     fn clear_cache(&mut self) {
         self.layouts.clear();
-        self.active_layout = usize::MAX;
-    }
-
-    /// Total number of text layouts to cache.
-    ///
-    /// Must be at least `2`, to allow for one active layout and one speculative one.
-    /// Must be less than `u8::MAX` because it's also used as the cache time reset value.
-    const CACHE_CAPACITY: usize = 5;
-
-    /// Increments and returns the cache timestamp.
-    fn cache_time(&mut self) -> u8 {
-        if self.cache_time == u8::MAX {
-            // Compress all last_used timestamps
-            let n = self.layouts.len();
-            let mut idx: SmallVec<[usize; Self::CACHE_CAPACITY]> = (0..n).collect();
-            idx.sort_unstable_by_key(|&i| self.layouts[i].last_used);
-            for (rank, &i) in idx.iter().enumerate() {
-                self.layouts[i].last_used = rank as u8;
-            }
-            self.cache_time = Self::CACHE_CAPACITY as u8;
-        } else {
-            self.cache_time += 1;
-        }
-        self.cache_time
-    }
-
-    /// Builds the text layout and breaks the text into lines.
-    ///
-    /// Backed by a cache layer.
-    fn build_and_break(
-        &mut self,
-        font_ctx: &mut FontContext,
-        layout_ctx: &mut LayoutContext<BrushIndex>,
-        max_advance: Option<f32>,
-    ) -> usize {
-        let timestamp = self.cache_time();
-
-        // Check if the cache already has a suitable entry.
-        // A suitable entry is one that was calculated with the same or larger constraint,
-        // and resulted in a layout that still fits within this newly requested constraint.
-        for (idx, layout) in self.layouts.iter_mut().enumerate() {
-            if layout.satisfies(max_advance) {
-                layout.last_used = timestamp;
-                return idx;
-            }
-        }
-
-        // No known compatible cache entry, so need to do text layout.
-        let (mut idx, layout) = if self.layouts.len() < Self::CACHE_CAPACITY {
-            // Create a new cache entry.
-            self.layouts.push(TextLayout::new(max_advance, timestamp));
-            (self.layouts.len() - 1, self.layouts.last_mut().unwrap())
-        } else {
-            // Repurpose the least recently used non-active cache entry.
-            let (idx, layout) = self
-                .layouts
-                .iter_mut()
-                .enumerate()
-                .filter(|(idx, _)| *idx != self.active_layout)
-                .min_by(|a, b| a.1.last_used.cmp(&b.1.last_used))
-                .unwrap();
-            layout.max_advance = max_advance;
-            layout.last_used = timestamp;
-            (idx, layout)
-        };
-
-        // TODO: Should we use a different scale?
-        // See https://github.com/linebender/xilem/issues/1264
-        let mut builder = layout_ctx.ranged_builder(font_ctx, &self.text, 1.0, true);
-        for prop in self.styles.inner().values() {
-            builder.push_default(prop.to_owned());
-        }
-        builder.build_into(&mut layout.layout, &self.text);
-
-        layout.layout.break_all_lines(max_advance);
-
-        // Check if the layout result matches an existing cache entry.
-        // This happens when slightly increasing max_advance, as we can't then safely pre-identify
-        // an existing cache entry because more text might fit inside this new larger constraint.
-        // However, if it actually resulted in the same layout as with a slightly lower constraint,
-        // then we don't want to have two cache entries with the same identical layout result.
-        if let Some((equal_idx, _)) = self
-            .layouts
-            .iter()
-            .enumerate()
-            // Only those that are more constrained than the new constraint are viable.
-            .filter(|(_, layout)| layout.more_constrained(max_advance))
-            // We want the one that is closest to the new constraint.
-            .max_by(|a, b| {
-                // Because we only look at more constrained entries,
-                // these are all guaranteed to be Option::Some.
-                a.1.max_advance
-                    .unwrap()
-                    .total_cmp(&b.1.max_advance.unwrap())
-            })
-            // Make sure that it actually matches the new layout.
-            .filter(|(_, layout)| layout.equals(&self.layouts[idx]))
-        {
-            // Though these two layouts are equal, we want to keep the older one.
-            // Because the old one might be the currently active layout.
-            let equal_layout = &mut self.layouts[equal_idx];
-            // Mark the old layout as applicable up to this new constraint.
-            equal_layout.max_advance = max_advance;
-            equal_layout.last_used = timestamp;
-
-            // Discard the new layout that we just created as it is a duplicate.
-            let layout = &mut self.layouts[idx];
-            layout.discard();
-
-            // Return the updated old entry.
-            idx = equal_idx;
-        }
-
-        idx
     }
 }
 
@@ -541,8 +307,14 @@ impl Widget for Label {
         .map(|v| v.get() as f32);
 
         let (font_ctx, layout_ctx) = ctx.text_contexts();
-        let layout_idx = self.build_and_break(font_ctx, layout_ctx, max_advance);
-        let layout = &self.layouts[layout_idx];
+        let layout_idx = self.layouts.build_and_break(
+            font_ctx,
+            layout_ctx,
+            &self.text,
+            &self.styles,
+            max_advance,
+        );
+        let layout = self.layouts.get(layout_idx);
 
         let length = if axis == inline {
             layout.layout.width() // Inline length
@@ -569,8 +341,15 @@ impl Widget for Label {
         };
 
         let (font_ctx, layout_ctx) = ctx.text_contexts();
-        self.active_layout = self.build_and_break(font_ctx, layout_ctx, max_advance);
-        let layout = &mut self.layouts[self.active_layout];
+        let layout_idx = self.layouts.build_and_break(
+            font_ctx,
+            layout_ctx,
+            &self.text,
+            &self.styles,
+            max_advance,
+        );
+        self.layouts.set_active(layout_idx);
+        let layout = self.layouts.active_mut();
 
         layout.align(self.text_alignment, inline_space);
 
@@ -602,7 +381,7 @@ impl Widget for Label {
         let cache = ctx.property_cache();
         let text_color = props.get::<ContentColor>(cache);
 
-        let layout = &self.layouts[self.active_layout];
+        let layout = self.layouts.active();
 
         render_text(
             painter,
@@ -628,7 +407,7 @@ impl Widget for Label {
         let cache = ctx.property_cache();
         let text_color = props.get::<ContentColor>(cache);
 
-        let layout = &self.layouts[self.active_layout];
+        let layout = self.layouts.active();
 
         self.accessibility.build_nodes(
             self.text.as_ref(),

--- a/masonry/src/widgets/mod.rs
+++ b/masonry/src/widgets/mod.rs
@@ -42,6 +42,7 @@ mod svg;
 mod switch;
 mod text_area;
 mod text_input;
+mod text_layout_cache;
 mod variable_label;
 mod virtual_scroll;
 mod zstack;

--- a/masonry/src/widgets/text_area.rs
+++ b/masonry/src/widgets/text_area.rs
@@ -23,6 +23,7 @@ use crate::properties::{CaretColor, ContentColor, SelectionColor};
 use crate::theme::default_text_styles;
 use crate::util::bounding_box_to_rect;
 use crate::util::debug_panic;
+use crate::widgets::text_layout_cache::TextLayoutCache;
 use crate::{TextAlign, theme};
 
 /// `TextArea` implements the core of interactive text.
@@ -48,6 +49,18 @@ pub struct TextArea<const USER_EDITABLE: bool> {
     // TODO: Placeholder text?
     /// The underlying `PlainEditor`, which provides a high-level interface for us to dispatch into.
     editor: PlainEditor<BrushIndex>,
+    /// Cached layouts used only by [`measure`](Widget::measure).
+    ///
+    /// Measurement must not mutate `editor`: [`measure`](Widget::measure) results are
+    /// cached, so they may only change when layout is requested, and speculative
+    /// measure calls must not invalidate the layout that [`paint`](Widget::paint) and
+    /// friends read from the editor. Instead of doing layout through the editor and
+    /// then undoing it, we measure with cached layouts built from the editor's
+    /// current text and styles, leaving the editor untouched.
+    ///
+    /// The cached layouts are built at the editor's default scale (`1.0`) and
+    /// quantization (`true`); `TextArea` never reconfigures these on the editor.
+    measure_layouts: TextLayoutCache,
     /// The generation of `editor` which we have rendered.
     ///
     /// TODO: Split into rendered and layout generation. This will make the `edited` mechanism in [`on_text_event`](Widget::on_text_event).
@@ -118,6 +131,7 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
         editor.set_text(text);
         Self {
             editor,
+            measure_layouts: TextLayoutCache::new(),
             rendered_generation: Generation::default(),
             word_wrap: true,
             last_max_advance: None,
@@ -247,6 +261,13 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
         self.editor.raw_text().is_empty()
     }
 
+    /// Clears the measurement layout cache.
+    ///
+    /// Call this whenever text, styles, or fonts have changed.
+    fn clear_measure_cache(&mut self) {
+        self.measure_layouts.clear();
+    }
+
     /// Returns the IME area from the editor, accounting for padding.
     ///
     /// This should only be called when the editor layout is available.
@@ -286,6 +307,7 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
     ) -> Option<StyleProperty> {
         let old = this.widget.insert_style_inner(property.into());
 
+        this.widget.clear_measure_cache();
         this.ctx.request_layout();
         old
     }
@@ -299,6 +321,7 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
     pub fn retain_styles(this: &mut WidgetMut<'_, Self>, f: impl FnMut(&StyleProperty) -> bool) {
         this.widget.editor.edit_styles().retain(f);
 
+        this.widget.clear_measure_cache();
         this.ctx.request_layout();
     }
 
@@ -318,6 +341,7 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
     ) -> Option<StyleProperty> {
         let old = this.widget.editor.edit_styles().remove(property);
 
+        this.widget.clear_measure_cache();
         this.ctx.request_layout();
         old
     }
@@ -339,6 +363,7 @@ impl<const EDITABLE: bool> TextArea<EDITABLE> {
         let (fctx, lctx) = this.ctx.text_contexts();
         this.widget.editor.driver(fctx, lctx).move_to_text_end();
 
+        this.widget.clear_measure_cache();
         this.ctx.request_layout();
     }
 
@@ -732,6 +757,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
                         ctx.submit_action::<Self::Action>(TextAction::Changed(
                             self.text().into_iter().collect(),
                         ));
+                        self.clear_measure_cache();
                         ctx.request_layout();
                     } else {
                         ctx.request_render();
@@ -782,6 +808,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
 
                 let new_generation = self.editor.generation();
                 if new_generation != self.rendered_generation {
+                    self.clear_measure_cache();
                     ctx.request_layout();
                     self.rendered_generation = new_generation;
                 }
@@ -800,6 +827,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
                         ctx.submit_action::<Self::Action>(TextAction::Changed(
                             self.text().into_iter().collect(),
                         ));
+                        self.clear_measure_cache();
                         ctx.request_layout();
                         self.rendered_generation = new_generation;
                     }
@@ -857,6 +885,7 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
                 //       We know that the lifecycle of dirty tracking in Parley's
                 //       editor will need to change eventually anyway...
                 let _ = self.editor.edit_styles();
+                self.clear_measure_cache();
                 ctx.request_layout();
             }
             Update::FocusChanged(_) => {
@@ -917,34 +946,24 @@ impl<const EDITABLE: bool> Widget for TextArea<EDITABLE> {
         }
         .map(|v| v.get() as f32);
 
-        let mut reset_max_advance = None;
-        if self.last_max_advance != max_advance {
-            reset_max_advance = Some(self.last_max_advance);
-            self.editor.set_width(max_advance);
-            self.last_max_advance = max_advance;
-        }
-
-        // TODO: PlainEditor::layout will do alignment and all,
-        //       but that's potentially wasted work for measure.
-        //       Should probably split up that PlainEditor method.
-
+        // Measure with cached layouts built from the editor's current text and styles,
+        // mirroring `PlainEditor`'s internal layout logic minus the alignment,
+        // which doesn't affect the measured size. The editor and its layout are
+        // deliberately left untouched, keeping `measure` free of side effects.
         let (fctx, lctx) = ctx.text_contexts();
-        let layout = self.editor.layout(fctx, lctx);
+        let layout_idx = self.measure_layouts.build_and_break(
+            fctx,
+            lctx,
+            self.editor.raw_text(),
+            self.editor.get_styles(),
+            max_advance,
+        );
+        let layout = &self.measure_layouts.get(layout_idx).layout;
+
         let text_width = max_advance.unwrap_or(layout.full_width());
         let text_size = Size::new(text_width.into(), layout.height().into());
 
-        let length = text_size.get_coord(axis);
-
-        // TODO: Remove this hack and do efficient side-effect free measurement with no alignment
-        // HACK: Perform layout again with the old value so that speculative measure() calls
-        //       won't affect paint() calls which expect the old layout() result to be present.
-        if let Some(reset_max_advance) = reset_max_advance {
-            self.editor.set_width(reset_max_advance);
-            self.last_max_advance = reset_max_advance;
-            self.editor.refresh_layout(fctx, lctx);
-        }
-
-        length.px()
+        text_size.get_coord(axis).px()
     }
 
     fn layout(&mut self, ctx: &mut LayoutCtx<'_>, _props: &PropertiesRef<'_>, size: Size) {
@@ -1116,11 +1135,85 @@ mod tests {
     use masonry_testing::TestHarnessParams;
 
     use super::*;
-    use crate::core::{KeyboardEvent, Modifiers, NewWidget, PropertySet};
+    use crate::core::{KeyboardEvent, Modifiers, NewWidget, PropertySet, WidgetTag};
+    use crate::layout::SizeDef;
     use crate::palette;
-    use crate::testing::TestHarness;
+    use crate::testing::{ModularWidget, TestHarness};
     use crate::theme::test_property_set;
     // Tests of alignment happen in Prose.
+
+    #[test]
+    fn measure_does_not_mutate_editor() {
+        let area_tag = WidgetTag::unique();
+        let parent_tag = WidgetTag::unique();
+
+        let area =
+            NewWidget::new(TextArea::new_immutable("String which will wrap")).with_tag(area_tag);
+        // A parent which measures its child at min- and max-content
+        // before laying it out to fit the available space.
+        let parent = NewWidget::new(ModularWidget::new_parent(area).layout_fn(
+            |child, ctx, _props, size| {
+                let context_size = size.into();
+                let _ = ctx.compute_size(child, SizeDef::MIN, context_size);
+                let _ = ctx.compute_size(child, SizeDef::MAX, context_size);
+                let child_size = ctx.compute_size(child, SizeDef::fit(size), context_size);
+                ctx.run_layout(child, child_size);
+                ctx.place_child(child, Point::ZERO);
+                ctx.derive_baselines(child);
+            },
+        ))
+        .with_tag(parent_tag);
+
+        let mut harness = TestHarness::create_with_size(test_property_set(), parent, (60, 40));
+
+        let generation = harness.get_widget(area_tag).inner().editor.generation();
+
+        // Relayout the parent without changing anything about the text area.
+        harness.edit_widget(parent_tag, |mut parent| {
+            parent.ctx.request_layout();
+        });
+
+        // We don't use assert_eq because `Generation` doesn't implement `Debug`.
+        assert!(
+            harness.get_widget(area_tag).inner().editor.generation() == generation,
+            "measuring the text area must not invalidate its editor"
+        );
+    }
+
+    #[test]
+    fn measure_reflects_edits() {
+        let area_tag = WidgetTag::unique();
+
+        let area = NewWidget::new(TextArea::new_editable("hello")).with_tag(area_tag);
+        // A parent which always lays out its child at the child's max-content size,
+        // so the child's final size tracks what `measure` reports.
+        let parent = NewWidget::new(ModularWidget::new_parent(area).layout_fn(
+            |child, ctx, _props, size| {
+                let child_size = ctx.compute_size(child, SizeDef::MAX, size.into());
+                ctx.run_layout(child, child_size);
+                ctx.place_child(child, Point::ZERO);
+                ctx.derive_baselines(child);
+            },
+        ));
+
+        let mut harness = TestHarness::create_with_size(test_property_set(), parent, (200, 40));
+
+        let area_id = harness.get_widget(area_tag).id();
+        harness.focus_on(Some(area_id));
+
+        let width = harness.get_widget(area_tag).ctx().border_box().width();
+
+        harness.process_text_event(TextEvent::Keyboard(KeyboardEvent {
+            key: Key::Character("words".into()),
+            ..Default::default()
+        }));
+
+        let new_width = harness.get_widget(area_tag).ctx().border_box().width();
+        assert!(
+            new_width > width,
+            "inserting text must grow the measured max-content width ({width} -> {new_width})"
+        );
+    }
 
     #[test]
     fn edit_wordwrap() {

--- a/masonry/src/widgets/text_layout_cache.rs
+++ b/masonry/src/widgets/text_layout_cache.rs
@@ -1,0 +1,305 @@
+// Copyright 2026 the Xilem Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! A cache of text layouts, shared by the text widgets.
+
+use smallvec::SmallVec;
+
+use crate::core::{BrushIndex, StyleSet};
+use crate::parley::{FontContext, Layout, LayoutContext};
+use crate::{TextAlign, TextAlignOptions};
+
+/// Text layout computation inputs and output.
+pub(crate) struct TextLayout {
+    /// Computed text layout.
+    pub(crate) layout: Layout<BrushIndex>,
+    /// Max advance value that was used when calculating this layout.
+    max_advance: Option<f32>,
+    /// Text alignment of this layout.
+    alignment: TextAlign,
+    /// Text alignment width of this layout.
+    alignment_width: f32,
+    /// Last use timestamp for cache eviction purposes.
+    last_used: u8,
+}
+
+impl TextLayout {
+    /// Text layout width differences less than 0.01 pixels can be considered equal.
+    const EPSILON: f32 = 0.01;
+
+    /// Creates a new [`TextLayout`] with the specified `max_advance` constraint and `timestamp`.
+    fn new(max_advance: Option<f32>, timestamp: u8) -> Self {
+        Self {
+            layout: Layout::new(),
+            max_advance,
+            alignment: TextAlign::Start,
+            alignment_width: -1., // Not aligned yet
+            last_used: timestamp,
+        }
+    }
+
+    /// Discards this layout, making it an obvious choice for cache eviction.
+    fn discard(&mut self) {
+        // Mark it as least recently used.
+        self.last_used = 0;
+        // Set a fake unlikely-to-be-seen max advance so it won't get any use.
+        self.max_advance = Some(-1.);
+    }
+
+    /// Align the text layout.
+    ///
+    /// This method ensures that alignment only happens when the inputs have changed.
+    pub(crate) fn align(&mut self, alignment: TextAlign, alignment_width: f32) {
+        if self.alignment == alignment
+            && (self.alignment_width - alignment_width).abs() < Self::EPSILON
+        {
+            return;
+        }
+        self.alignment = alignment;
+        self.alignment_width = alignment_width;
+        self.layout.align(
+            Some(self.alignment_width),
+            self.alignment,
+            TextAlignOptions::default(),
+        );
+    }
+
+    /// Returns `true` if this layout would be the result for `max_advance`.
+    ///
+    /// For example:
+    ///
+    /// `compute_layout(max_advance == 10) => layout.width == 8`
+    /// is also valid for `max_advance == 9`.
+    ///
+    /// This check assumes that Parley does greedy line-breaking,
+    /// which it does at the time of writing this.
+    fn satisfies(&self, max_advance: Option<f32>) -> bool {
+        // Check if the specified constraint is compatible with this layout's constraint.
+        self.max_advance.is_none_or(|layout_max_advance| {
+            max_advance.is_some_and(|max_advance| {
+                layout_max_advance - max_advance + Self::EPSILON >= 0.
+            })
+        }) &&
+        // Check if the computed layout fits into the specified constraint.
+        max_advance.is_none_or(|max_advance| {
+            max_advance - self.layout.width() + Self::EPSILON >= 0.
+        })
+    }
+
+    /// Returns `true` if this layout was more constrained than `max_advance`.
+    fn more_constrained(&self, max_advance: Option<f32>) -> bool {
+        self.max_advance.is_some_and(|layout_max_advance| {
+            max_advance.is_none_or(|max_advance| layout_max_advance < max_advance)
+        })
+    }
+
+    /// Returns `true` if the layouts are equal.
+    ///
+    /// That is if they have the same number of line breaks with the same reason at the same places.
+    fn equals(&self, other: &Self) -> bool {
+        if self.layout.len() != other.layout.len() {
+            return false;
+        }
+        let mut a = self.layout.lines();
+        let mut b = other.layout.lines();
+        loop {
+            match (a.next(), b.next()) {
+                (None, None) => return true,
+                (Some(a_line), Some(b_line)) => {
+                    if a_line.break_reason() != b_line.break_reason() {
+                        return false;
+                    }
+                    if a_line.text_range() != b_line.text_range() {
+                        return false;
+                    }
+                }
+                _ => return false,
+            }
+        }
+    }
+}
+
+/// A cache of [`TextLayouts`](TextLayout) for one piece of text.
+///
+/// Entries are keyed by their `max_advance` constraint, so within a layout pass
+/// measurements at different constraints and the final layout can share entries.
+/// The cache must be [cleared](Self::clear) whenever text, styles, or fonts change.
+pub(crate) struct TextLayoutCache {
+    /// Cached layouts.
+    layouts: Vec<TextLayout>,
+    /// Time tracking for cache usage.
+    cache_time: u8,
+    /// The currently active layout index.
+    ///
+    /// `usize::MAX` works well for none, as it will be overwritten before its used
+    /// for layout access, but will be read as-is during cache eviction.
+    /// During which any value larger than the cache capacity will be ignored.
+    active_layout: usize,
+}
+
+impl TextLayoutCache {
+    /// Total number of text layouts to cache.
+    ///
+    /// Must be at least `2`, to allow for one active layout and one speculative one.
+    /// Must be less than `u8::MAX` because it's also used as the cache time reset value.
+    const CACHE_CAPACITY: usize = 5;
+
+    /// Creates a new empty cache.
+    pub(crate) fn new() -> Self {
+        Self {
+            layouts: Vec::new(),
+            cache_time: 0,
+            active_layout: usize::MAX,
+        }
+    }
+
+    /// Clears the cache.
+    ///
+    /// Call this whenever text, styles, or fonts have changed.
+    pub(crate) fn clear(&mut self) {
+        self.layouts.clear();
+        self.active_layout = usize::MAX;
+    }
+
+    /// Returns the cached layout at `idx`.
+    pub(crate) fn get(&self, idx: usize) -> &TextLayout {
+        &self.layouts[idx]
+    }
+
+    /// Marks the layout at `idx` as the active one, protecting it from cache eviction.
+    ///
+    /// The active layout is the one that gets painted, so it must stay cached
+    /// even while speculative measurements churn through the other entries.
+    pub(crate) fn set_active(&mut self, idx: usize) {
+        self.active_layout = idx;
+    }
+
+    /// Returns the active layout.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no active layout has been [set](Self::set_active) since the
+    /// cache was created or [cleared](Self::clear).
+    pub(crate) fn active(&self) -> &TextLayout {
+        &self.layouts[self.active_layout]
+    }
+
+    /// Returns the active layout mutably.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no active layout has been [set](Self::set_active) since the
+    /// cache was created or [cleared](Self::clear).
+    pub(crate) fn active_mut(&mut self) -> &mut TextLayout {
+        &mut self.layouts[self.active_layout]
+    }
+
+    /// Increments and returns the cache timestamp.
+    fn cache_time(&mut self) -> u8 {
+        if self.cache_time == u8::MAX {
+            // Compress all last_used timestamps
+            let n = self.layouts.len();
+            let mut idx: SmallVec<[usize; Self::CACHE_CAPACITY]> = (0..n).collect();
+            idx.sort_unstable_by_key(|&i| self.layouts[i].last_used);
+            for (rank, &i) in idx.iter().enumerate() {
+                self.layouts[i].last_used = rank as u8;
+            }
+            self.cache_time = Self::CACHE_CAPACITY as u8;
+        } else {
+            self.cache_time += 1;
+        }
+        self.cache_time
+    }
+
+    /// Builds the text layout and breaks the text into lines.
+    ///
+    /// Backed by a cache layer.
+    pub(crate) fn build_and_break(
+        &mut self,
+        font_ctx: &mut FontContext,
+        layout_ctx: &mut LayoutContext<BrushIndex>,
+        text: &str,
+        styles: &StyleSet,
+        max_advance: Option<f32>,
+    ) -> usize {
+        let timestamp = self.cache_time();
+
+        // Check if the cache already has a suitable entry.
+        // A suitable entry is one that was calculated with the same or larger constraint,
+        // and resulted in a layout that still fits within this newly requested constraint.
+        for (idx, layout) in self.layouts.iter_mut().enumerate() {
+            if layout.satisfies(max_advance) {
+                layout.last_used = timestamp;
+                return idx;
+            }
+        }
+
+        // No known compatible cache entry, so need to do text layout.
+        let (mut idx, layout) = if self.layouts.len() < Self::CACHE_CAPACITY {
+            // Create a new cache entry.
+            self.layouts.push(TextLayout::new(max_advance, timestamp));
+            (self.layouts.len() - 1, self.layouts.last_mut().unwrap())
+        } else {
+            // Repurpose the least recently used non-active cache entry.
+            let (idx, layout) = self
+                .layouts
+                .iter_mut()
+                .enumerate()
+                .filter(|(idx, _)| *idx != self.active_layout)
+                .min_by(|a, b| a.1.last_used.cmp(&b.1.last_used))
+                .unwrap();
+            layout.max_advance = max_advance;
+            layout.last_used = timestamp;
+            (idx, layout)
+        };
+
+        // TODO: Should we use a different scale?
+        // See https://github.com/linebender/xilem/issues/1264
+        let mut builder = layout_ctx.ranged_builder(font_ctx, text, 1.0, true);
+        for prop in styles.inner().values() {
+            builder.push_default(prop.to_owned());
+        }
+        builder.build_into(&mut layout.layout, text);
+
+        layout.layout.break_all_lines(max_advance);
+
+        // Check if the layout result matches an existing cache entry.
+        // This happens when slightly increasing max_advance, as we can't then safely pre-identify
+        // an existing cache entry because more text might fit inside this new larger constraint.
+        // However, if it actually resulted in the same layout as with a slightly lower constraint,
+        // then we don't want to have two cache entries with the same identical layout result.
+        if let Some((equal_idx, _)) = self
+            .layouts
+            .iter()
+            .enumerate()
+            // Only those that are more constrained than the new constraint are viable.
+            .filter(|(_, layout)| layout.more_constrained(max_advance))
+            // We want the one that is closest to the new constraint.
+            .max_by(|a, b| {
+                // Because we only look at more constrained entries,
+                // these are all guaranteed to be Option::Some.
+                a.1.max_advance
+                    .unwrap()
+                    .total_cmp(&b.1.max_advance.unwrap())
+            })
+            // Make sure that it actually matches the new layout.
+            .filter(|(_, layout)| layout.equals(&self.layouts[idx]))
+        {
+            // Though these two layouts are equal, we want to keep the older one.
+            // Because the old one might be the currently active layout.
+            let equal_layout = &mut self.layouts[equal_idx];
+            // Mark the old layout as applicable up to this new constraint.
+            equal_layout.max_advance = max_advance;
+            equal_layout.last_used = timestamp;
+
+            // Discard the new layout that we just created as it is a duplicate.
+            let layout = &mut self.layouts[idx];
+            layout.discard();
+
+            // Return the updated old entry.
+            idx = equal_idx;
+        }
+
+        idx
+    }
+}


### PR DESCRIPTION
Hi, thanks for all of the work on `xilem` and the linebender projects in general. I've been using it for some time and have accumulated quite a few patches which I'd like to start contributing upstream if useful to the project.

I originally came up with this one when auditing my own widget set for correct definition of `measure` and ended up removing the hack in `measure` of masonry's `TextArea` along the way (from #1560):
```
// TODO: Remove this hack
  and do efficient side-effect free measurement with no
  alignment
```

`TextArea`'s`measure` worked by laying out `PlainEditor` with the new width, relayout, and then resetting the width, which means selection is re-resolved and text is shaped for a transient state. I demonstrated the issue with a new test that fails on `main`.

My approach for this attempt at a fix is to extract `Label`'s `TextLayoutCache` into a shared module and to re-use it from `TextArea`. The approach requires manually invalidating the cache, but avoiding that seems to require changes to the parley public API, so I was hesitant to go there without some initial feedback.

I directed Claude Code to make the changes and went through a few rounds of feedback and review with it before opening this PR. I also used Claude to help me understand more about how masonry works both in general and in relation to this change.  