### PR TITLE
Gallery: `Slider` property controls

### DIFF
--- a/masonry/examples/gallery/horizontal_color_picker.rs
+++ b/masonry/examples/gallery/horizontal_color_picker.rs
@@ -1,0 +1,204 @@
+// Copyright 2026 the Xilem Authors and the Druid Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use masonry::{
+    core::{
+        AccessCtx, ActionCtx, ChildrenIds, ErasedAction, LayoutCtx, MeasureCtx, PaintCtx,
+        PropertiesMut, PropertiesRef, RegisterCtx, Widget, WidgetId, WidgetMut, WidgetPod,
+    },
+    imaging::Painter,
+    kurbo::{Axis, Point, Size},
+    layout::{AsUnit, LayoutSize, LenReq, Length, SizeDef},
+    peniko::Color,
+    properties::{Background, TrackColor, types::CrossAxisAlignment},
+    widgets::{Flex, SizedBox, Slider, SliderMoved},
+};
+
+use crate::demo::CONTENT_GAP;
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+enum Component {
+    R,
+    G,
+    B,
+    A,
+}
+
+impl Component {
+    const ALL: [Self; 4] = [Self::R, Self::G, Self::B, Self::A];
+
+    fn update(self, color: &mut Color, value: f32) {
+        color.components[match self {
+            Self::R => 0,
+            Self::G => 1,
+            Self::B => 2,
+            Self::A => 3,
+        }] = value;
+    }
+
+    fn get(self, color: &Color) -> f32 {
+        color.components[match self {
+            Self::R => 0,
+            Self::G => 1,
+            Self::B => 2,
+            Self::A => 3,
+        }]
+    }
+
+    fn visual_color(self) -> Color {
+        match self {
+            Self::R => Color::from_rgb8(0xff, 0x00, 0x00),
+            Self::G => Color::from_rgb8(0x00, 0xff, 0x00),
+            Self::B => Color::from_rgb8(0x00, 0x00, 0xff),
+            Self::A => Color::WHITE,
+        }
+    }
+}
+
+#[derive(PartialEq, Debug)]
+pub(crate) struct ColorSelected {
+    pub color: Color,
+}
+
+pub(crate) struct HorizontalColorPicker {
+    color: Color,
+    widget: WidgetPod<Flex>,
+    sliders: [(Component, WidgetId); 4],
+    preview_id: WidgetId,
+}
+
+impl HorizontalColorPicker {
+    pub(crate) fn new(color: Color) -> Self {
+        let mut body = Flex::row().cross_axis_alignment(CrossAxisAlignment::Stretch);
+
+        let sliders: [(Component, WidgetId); 4] = Component::ALL.map(|component| {
+            let widget = Slider::new(0., 1., component.get(&color) as f64)
+                .prepare()
+                .with_props(TrackColor {
+                    active: component.visual_color(),
+                    ..Default::default()
+                });
+            let id = widget.id();
+            body = std::mem::replace(&mut body, Flex::row())
+                .with(widget, 1.)
+                .with_fixed_spacer((CONTENT_GAP.get() / 2.0).px());
+            (component, id)
+        });
+
+        let preview = SizedBox::empty()
+            .width(Length::const_px(20.0))
+            .prepare()
+            .with_props(Background::Color(color));
+        let preview_id = preview.id();
+        body = body.with_fixed(preview);
+
+        Self {
+            color,
+            widget: body.prepare().to_pod(),
+            sliders,
+            preview_id,
+        }
+    }
+
+    #[allow(unused, reason = "Not yet used")]
+    pub(crate) fn set_color(this: &mut WidgetMut<'_, Self>, color: Color) {
+        for (component, wid) in this.widget.sliders.iter() {
+            let value = component.get(&color);
+            this.ctx.mutate_later(*wid, move |mut widget| {
+                if let Some(mut slider_widget) = widget.try_downcast::<Slider>() {
+                    Slider::set_value(&mut slider_widget, value as f64);
+                }
+            });
+        }
+        this.ctx
+            .mutate_later(this.widget.preview_id, move |mut widget| {
+                widget.insert_prop(Background::Color(color));
+            });
+    }
+}
+
+impl Widget for HorizontalColorPicker {
+    type Action = ColorSelected;
+
+    fn register_children(&mut self, ctx: &mut RegisterCtx<'_>) {
+        ctx.register_child(&mut self.widget);
+    }
+
+    fn measure(
+        &mut self,
+        ctx: &mut MeasureCtx<'_>,
+        _props: &PropertiesRef<'_>,
+        axis: Axis,
+        len_req: LenReq,
+        cross_length: Option<Length>,
+    ) -> Length {
+        let auto_length = len_req.into();
+        let context_size = LayoutSize::maybe(axis.cross(), cross_length);
+        ctx.compute_length(
+            &mut self.widget,
+            auto_length,
+            context_size,
+            axis,
+            cross_length,
+        )
+    }
+
+    fn on_action(
+        &mut self,
+        ctx: &mut ActionCtx<'_>,
+        _props: &mut PropertiesMut<'_>,
+        action: &ErasedAction,
+        source: WidgetId,
+    ) {
+        if let Some(SliderMoved { value }) = action.downcast_ref::<SliderMoved>()
+            && let Some(component) = self
+                .sliders
+                .iter()
+                .find(|(_, wid)| source == *wid)
+                .map(|(comp, _)| *comp)
+        {
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "Value is in range of [0.0, 1.0]"
+            )]
+            component.update(&mut self.color, *value as f32);
+            ctx.submit_action::<Self::Action>(ColorSelected { color: self.color });
+            let color = self.color;
+            ctx.mutate_later(self.preview_id, move |mut widget| {
+                widget.insert_prop(Background::Color(color));
+            });
+            ctx.set_handled();
+        }
+    }
+
+    fn layout(&mut self, ctx: &mut LayoutCtx<'_>, _props: &PropertiesRef<'_>, size: Size) {
+        let content_size = ctx.compute_size(&mut self.widget, SizeDef::fit(size), size.into());
+        ctx.run_layout(&mut self.widget, content_size);
+        ctx.place_child(&mut self.widget, Point::ORIGIN);
+        ctx.derive_baselines(&self.widget);
+    }
+
+    fn paint(
+        &mut self,
+        _ctx: &mut PaintCtx<'_>,
+        _props: &PropertiesRef<'_>,
+        _painter: &mut Painter<'_>,
+    ) {
+    }
+
+    fn accessibility_role(&self) -> accesskit::Role {
+        accesskit::Role::GenericContainer
+    }
+
+    fn accessibility(
+        &mut self,
+        _ctx: &mut AccessCtx<'_>,
+        _props: &PropertiesRef<'_>,
+        _node: &mut accesskit::Node,
+    ) {
+    }
+
+    fn children_ids(&self) -> ChildrenIds {
+        ChildrenIds::from_slice(&[self.widget.id()])
+    }
+}

--- a/masonry/examples/gallery/horizontal_color_picker.rs
+++ b/masonry/examples/gallery/horizontal_color_picker.rs
@@ -1,18 +1,16 @@
 // Copyright 2026 the Xilem Authors and the Druid Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::{
-    core::{
-        AccessCtx, ActionCtx, ChildrenIds, ErasedAction, LayoutCtx, MeasureCtx, PaintCtx,
-        PropertiesMut, PropertiesRef, RegisterCtx, Widget, WidgetId, WidgetMut, WidgetPod,
-    },
-    imaging::Painter,
-    kurbo::{Axis, Point, Size},
-    layout::{AsUnit, LayoutSize, LenReq, Length, SizeDef},
-    peniko::Color,
-    properties::{Background, TrackColor, types::CrossAxisAlignment},
-    widgets::{Flex, SizedBox, Slider, SliderMoved},
+use masonry::core::{
+    AccessCtx, ActionCtx, ChildrenIds, ErasedAction, LayoutCtx, MeasureCtx, PaintCtx,
+    PropertiesMut, PropertiesRef, RegisterCtx, Widget, WidgetId, WidgetMut, WidgetPod,
 };
+use masonry::imaging::Painter;
+use masonry::kurbo::{Axis, Point, Size};
+use masonry::layout::{AsUnit, LayoutSize, LenReq, Length, SizeDef};
+use masonry::peniko::Color;
+use masonry::properties::{Background, TrackColor, types::CrossAxisAlignment};
+use masonry::widgets::{Flex, SizedBox, Slider, SliderMoved};
 
 use crate::demo::CONTENT_GAP;
 
@@ -100,7 +98,7 @@ impl HorizontalColorPicker {
         }
     }
 
-    #[allow(unused, reason = "Not yet used")]
+    #[expect(dead_code, reason = "Currently unused, available for future use.")]
     pub(crate) fn set_color(this: &mut WidgetMut<'_, Self>, color: Color) {
         for (component, wid) in this.widget.sliders.iter() {
             let value = component.get(&color);

--- a/masonry/examples/gallery/main.rs
+++ b/masonry/examples/gallery/main.rs
@@ -15,6 +15,7 @@ mod basics;
 mod checkbox;
 mod demo;
 mod divider;
+mod horizontal_color_picker;
 mod image;
 mod kitchen_sink;
 mod pagination;
@@ -44,6 +45,7 @@ use masonry_winit::app::{AppDriver, DriverCtx, NewWindow, WindowId};
 use masonry_winit::winit::window::Window;
 
 use crate::demo::{DemoPage, new_demo_shell_tags};
+use crate::horizontal_color_picker::{ColorSelected, HorizontalColorPicker};
 use crate::switch::SwitchDemo;
 
 const SIDEBAR_WIDTH: Length = Length::const_px(240.0);
@@ -268,11 +270,12 @@ fn main() {
         demos,
     };
 
-    let window_size = LogicalSize::new(900.0, 600.0);
+    let window_size = LogicalSize::new(1024.0, 600.0);
     let window_attributes = Window::default_attributes()
         .with_title("Masonry Gallery")
         .with_resizable(true)
-        .with_min_inner_size(window_size);
+        .with_min_inner_size(window_size)
+        .with_inner_size(window_size);
 
     masonry_winit::app::run(
         vec![NewWindow::new_with_id(

--- a/masonry/examples/gallery/slider.rs
+++ b/masonry/examples/gallery/slider.rs
@@ -14,12 +14,6 @@ use masonry::widgets::{Flex, Label, Slider, SliderMoved, Step, StepInput};
 use crate::demo::{CONTENT_GAP, DemoPage, ShellTags, wrap_in_shell};
 use crate::{ColorSelected, HorizontalColorPicker};
 
-fn desc(text: &str) -> NewWidget<Label> {
-    Label::new(text)
-        .with_style(StyleProperty::FontSize(14.0))
-        .prepare()
-        .with_props(Dimensions::width(120.px()))
-}
 pub(crate) struct SliderDemo {
     shell: ShellTags,
     value_label: WidgetTag<Label>,
@@ -70,6 +64,13 @@ impl DemoPage for SliderDemo {
     }
 
     fn build(&self) -> NewWidget<dyn Widget> {
+        fn desc(text: &str) -> NewWidget<Label> {
+            Label::new(text)
+                .with_style(StyleProperty::FontSize(14.0))
+                .prepare()
+                .with_props(Dimensions::width(120.px()))
+        }
+
         let slider =
             NewWidget::new(Slider::new(-1.0, 1.0, 0.0).with_step(0.001)).with_tag(self.slider);
 

--- a/masonry/examples/gallery/slider.rs
+++ b/masonry/examples/gallery/slider.rs
@@ -2,16 +2,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use masonry::app::RenderRoot;
-use masonry::core::{ErasedAction, Handled, NewWidget, StyleProperty, Widget, WidgetId, WidgetTag};
+use masonry::core::{
+    ErasedAction, FromDynWidget, Handled, NewWidget, StyleProperty, Widget, WidgetId, WidgetTag,
+};
+use masonry::layout::{AsUnit, Length};
+use masonry::peniko::Color;
 use masonry::properties::types::CrossAxisAlignment;
-use masonry::widgets::{Flex, Label, Slider, SliderMoved};
+use masonry::properties::{Dimensions, ThumbColor, ThumbRadius, TrackColor, TrackThickness};
+use masonry::widgets::{Flex, Label, Slider, SliderMoved, Step, StepInput};
 
 use crate::demo::{CONTENT_GAP, DemoPage, ShellTags, wrap_in_shell};
+use crate::{ColorSelected, HorizontalColorPicker};
 
+fn desc(text: &str) -> NewWidget<Label> {
+    Label::new(text)
+        .with_style(StyleProperty::FontSize(14.0))
+        .prepare()
+        .with_props(Dimensions::width(120.px()))
+}
 pub(crate) struct SliderDemo {
     shell: ShellTags,
     value_label: WidgetTag<Label>,
     slider: WidgetTag<Slider>,
+    track_active_color: WidgetTag<HorizontalColorPicker>,
+    track_inactive_color: WidgetTag<HorizontalColorPicker>,
+    track_thickness: WidgetTag<StepInput<f64>>,
+    thumb_color: WidgetTag<HorizontalColorPicker>,
+    thumb_radius: WidgetTag<StepInput<f64>>,
 }
 
 impl SliderDemo {
@@ -20,8 +37,27 @@ impl SliderDemo {
             shell,
             value_label: WidgetTag::unique(),
             slider: WidgetTag::unique(),
+            track_active_color: WidgetTag::unique(),
+            track_inactive_color: WidgetTag::unique(),
+            track_thickness: WidgetTag::unique(),
+            thumb_color: WidgetTag::unique(),
+            thumb_radius: WidgetTag::unique(),
         }
     }
+}
+
+// TODO: This default props should be get from the current theme.
+const DEFAULT_THUMB_COLOR: Color = masonry::theme::TEXT_COLOR;
+const DEFAULT_TRACK_ACTIVE_COLOR: Color = masonry::theme::ACCENT_COLOR;
+const DEFAULT_TRACK_INACTIVE_COLOR: Color = masonry::theme::ZYNC_800;
+const DEFAULT_TRACK_THICKNESS: f64 = 4.;
+const DEFAULT_THUMB_RADIUS: f64 = 7.;
+
+fn get_id<W>(rr: &RenderRoot, tag: WidgetTag<W>) -> WidgetId
+where
+    W: Widget + FromDynWidget + ?Sized,
+{
+    rr.get_widget_with_tag(tag).unwrap().id()
 }
 
 impl DemoPage for SliderDemo {
@@ -46,7 +82,67 @@ impl DemoPage for SliderDemo {
                 .with_tag(self.value_label),
             )
             .with_fixed_spacer(CONTENT_GAP)
-            .with_fixed(slider);
+            .with_fixed(slider)
+            .with_fixed_spacer(CONTENT_GAP)
+            .with_fixed(
+                Flex::row()
+                    .with_fixed(desc("Thumb Radius"))
+                    .with(
+                        StepInput::new(DEFAULT_THUMB_RADIUS, 0.1, 4.0, 30.0)
+                            .prepare()
+                            .with_tag(self.thumb_radius),
+                        1.,
+                    )
+                    .prepare(),
+            )
+            .with_fixed_spacer(CONTENT_GAP)
+            .with_fixed(
+                Flex::row()
+                    .with_fixed(desc("Thumb Color"))
+                    .with(
+                        HorizontalColorPicker::new(DEFAULT_THUMB_COLOR)
+                            .prepare()
+                            .with_tag(self.thumb_color),
+                        1.,
+                    )
+                    .prepare(),
+            )
+            .with_fixed_spacer(CONTENT_GAP)
+            .with_fixed(
+                Flex::row()
+                    .with_fixed(desc("Track Thickness"))
+                    .with(
+                        StepInput::new(DEFAULT_TRACK_THICKNESS, 0.1, 4.0, 30.0)
+                            .prepare()
+                            .with_tag(self.track_thickness),
+                        1.,
+                    )
+                    .prepare(),
+            )
+            .with_fixed_spacer(CONTENT_GAP)
+            .with_fixed(
+                Flex::row()
+                    .with_fixed(desc("Track Active Color"))
+                    .with(
+                        HorizontalColorPicker::new(DEFAULT_TRACK_ACTIVE_COLOR)
+                            .prepare()
+                            .with_tag(self.track_active_color),
+                        1.,
+                    )
+                    .prepare(),
+            )
+            .with_fixed_spacer(CONTENT_GAP)
+            .with_fixed(
+                Flex::row()
+                    .with_fixed(desc("Track Inactive Color"))
+                    .with(
+                        HorizontalColorPicker::new(DEFAULT_TRACK_INACTIVE_COLOR)
+                            .prepare()
+                            .with_tag(self.track_inactive_color),
+                        1.,
+                    )
+                    .prepare(),
+            );
 
         wrap_in_shell(self.shell, NewWidget::new(body).erased())
     }
@@ -57,18 +153,69 @@ impl DemoPage for SliderDemo {
         action: &ErasedAction,
         widget_id: WidgetId,
     ) -> Handled {
-        let Some(value) = action.downcast_ref::<SliderMoved>() else {
-            return Handled::No;
+        if let Some(value) = action.downcast_ref::<ColorSelected>() {
+            if get_id(render_root, self.thumb_color) == widget_id {
+                render_root.edit_widget_with_tag(self.slider, |mut slider| {
+                    slider.insert_prop(ThumbColor(value.color));
+                });
+            } else if get_id(render_root, self.track_active_color) == widget_id {
+                render_root.edit_widget_with_tag(self.slider, |mut slider| {
+                    if let Some(mut prop) = slider.insert_prop(TrackColor {
+                        ..Default::default()
+                    }) {
+                        prop.active = value.color;
+                        slider.insert_prop(prop);
+                    } else {
+                        slider.insert_prop(TrackColor {
+                            active: value.color,
+                            inactive: DEFAULT_TRACK_INACTIVE_COLOR,
+                        });
+                    }
+                });
+            } else if get_id(render_root, self.track_inactive_color) == widget_id {
+                render_root.edit_widget_with_tag(self.slider, |mut slider| {
+                    if let Some(mut prop) = slider.insert_prop(TrackColor {
+                        ..Default::default()
+                    }) {
+                        prop.inactive = value.color;
+                        slider.insert_prop(prop);
+                    } else {
+                        slider.insert_prop(TrackColor {
+                            active: DEFAULT_TRACK_ACTIVE_COLOR,
+                            inactive: value.color,
+                        });
+                    }
+                });
+            };
+            return Handled::Yes;
         };
-        let value = value.value;
 
-        let id = render_root.get_widget_with_tag(self.slider).unwrap().id();
-        if widget_id != id {
-            return Handled::No;
-        }
-        render_root.edit_widget_with_tag(self.value_label, |mut label| {
-            Label::set_text(&mut label, format!("Value: {value:.3}"));
-        });
-        Handled::Yes
+        if let Some(value) = action.downcast_ref::<SliderMoved>() {
+            let value = value.value;
+
+            if get_id(render_root, self.slider) == widget_id {
+                render_root.edit_widget_with_tag(self.value_label, |mut label| {
+                    Label::set_text(&mut label, format!("Value: {value:.3}"));
+                });
+            }
+            return Handled::Yes;
+        };
+
+        if let Some(value) = action.downcast_ref::<Step<f64>>() {
+            let value = value.value;
+
+            if get_id(render_root, self.thumb_radius) == widget_id {
+                render_root.edit_widget_with_tag(self.slider, |mut slider| {
+                    slider.insert_prop(ThumbRadius(Length::const_px(value)));
+                });
+            } else if get_id(render_root, self.track_thickness) == widget_id {
+                render_root.edit_widget_with_tag(self.slider, |mut slider| {
+                    slider.insert_prop(TrackThickness(Length::const_px(value)));
+                });
+            }
+            return Handled::Yes;
+        };
+
+        Handled::No
     }
 }


### PR DESCRIPTION
Added controls for checking `Slider` properties on the Gallery. The properties are all current properties used by `Slider` (`TrackThickness`, `TrackColor`, `ThumbColor` and `ThumbRadius`).

Additionally, created a new immature `HorizontalColorPicker` for the Gallery only, which its done by composition.