### PR TITLE
Add tests for VariableLabel's AnimatedF32 (#1341)

### DIFF
--- a/masonry/src/widgets/variable_label.rs
+++ b/masonry/src/widgets/variable_label.rs
@@ -284,5 +284,88 @@ impl Widget for VariableLabel {
 // --- MARK: TESTS
 #[cfg(test)]
 mod tests {
-    // TODO - Add tests
+    use super::*;
+
+    #[test]
+    fn stable_value_does_not_animate() {
+        let mut value = AnimatedF32::stable(5.0);
+        assert_eq!(value.value(), 5.0);
+        assert_eq!(value.target(), 5.0);
+
+        // Advancing a stable value leaves it unchanged and reports completion.
+        let status = value.advance(100.0);
+        assert!(status.is_completed());
+        assert_eq!(value.value(), 5.0);
+    }
+
+    #[test]
+    fn move_to_zero_millis_jumps_immediately() {
+        let mut value = AnimatedF32::stable(0.0);
+        value.move_to(10.0, 0.0);
+        assert_eq!(value.target(), 10.0);
+        // With a zero-length animation the value reaches the target right away.
+        assert_eq!(value.value(), 10.0);
+    }
+
+    #[test]
+    fn move_to_negative_millis_jumps_immediately() {
+        let mut value = AnimatedF32::stable(0.0);
+        // A negative duration is invalid; the value snaps to the target.
+        value.move_to(10.0, -5.0);
+        assert_eq!(value.target(), 10.0);
+        assert_eq!(value.value(), 10.0);
+    }
+
+    #[test]
+    fn move_to_animates_linearly_over_time() {
+        let mut value = AnimatedF32::stable(0.0);
+        value.move_to(100.0, 10.0);
+
+        // Half-way through the animation the value is half-way to the target.
+        let status = value.advance(5.0);
+        assert_eq!(status, AnimationStatus::Ongoing);
+        assert_eq!(value.value(), 50.0);
+
+        // The remaining time reaches the target exactly and completes.
+        let status = value.advance(5.0);
+        assert!(status.is_completed());
+        assert_eq!(value.value(), 100.0);
+        assert_eq!(value.target(), 100.0);
+    }
+
+    #[test]
+    fn advance_past_target_clamps_to_target() {
+        let mut value = AnimatedF32::stable(0.0);
+        value.move_to(100.0, 10.0);
+
+        // Overshooting the duration must clamp to the target rather than sail past it.
+        let status = value.advance(1000.0);
+        assert!(status.is_completed());
+        assert_eq!(value.value(), 100.0);
+
+        // Once completed the value stays put even if advanced again.
+        let status = value.advance(1000.0);
+        assert!(status.is_completed());
+        assert_eq!(value.value(), 100.0);
+    }
+
+    #[test]
+    fn move_to_can_animate_downwards() {
+        let mut value = AnimatedF32::stable(100.0);
+        value.move_to(0.0, 10.0);
+
+        let status = value.advance(5.0);
+        assert_eq!(status, AnimationStatus::Ongoing);
+        assert_eq!(value.value(), 50.0);
+
+        let status = value.advance(5.0);
+        assert!(status.is_completed());
+        assert_eq!(value.value(), 0.0);
+    }
+
+    #[test]
+    fn animation_status_is_completed() {
+        assert!(AnimationStatus::Completed.is_completed());
+        assert!(!AnimationStatus::Ongoing.is_completed());
+    }
 }


### PR DESCRIPTION
## What

`masonry/src/widgets/variable_label.rs` had no tests (the test module was a `// TODO - Add tests` stub).

`VariableLabel` is a non-editable widget, so the pointer/IME interaction scenarios mentioned in #1341 do not apply to it. Its distinguishing feature is the animated font weight, driven by the `AnimatedF32` helper in the same module — which was entirely untested. These tests cover that state machine:

- a `stable` value does not move and reports completion immediately;
- `move_to` with a zero or negative duration snaps straight to the target;
- `move_to` interpolates linearly over time, in both increasing and decreasing directions;
- `advance` past the target clamps to the target (no overshoot) and stays put afterwards;
- `AnimationStatus::is_completed`.

All deterministic unit tests — no rendering/snapshot dependency.

## Notes

Partially addresses #1341 (the `VariableLabel` item). The editable text widgets (`TextArea`, `TextInput`, `Prose`) and richer IME-emulation tests are left for follow-up.

`cargo test -p masonry`, `cargo fmt --check`, and `cargo clippy -p masonry` all pass locally.