### PR TITLE
Apply default font to fix number rendering in fontconfig environments

### DIFF
--- a/xilem_masonry/src/view/checkbox.rs
+++ b/xilem_masonry/src/view/checkbox.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 
 use masonry::core::{ArcStr, NewWidget};
 use masonry::parley::style::FontWeight;
-use masonry::parley::{FontFamily, StyleProperty};
+use masonry::parley::{FontFamily, FontFamilyName, GenericFamily, StyleProperty};
 use masonry::widgets::{self, CheckboxToggled};
 
 use crate::core::{MessageCtx, MessageResult, Mut, View, ViewMarker};
@@ -44,7 +44,7 @@ where
         checked,
         text_size: masonry::theme::TEXT_SIZE_NORMAL,
         weight: FontWeight::NORMAL,
-        font: FontFamily::List(std::borrow::Cow::Borrowed(&[])),
+        font: FontFamily::Single(FontFamilyName::Generic(GenericFamily::SystemUi)),
         disabled: false,
         phantom: PhantomData,
     }

--- a/xilem_masonry/src/view/text_input.rs
+++ b/xilem_masonry/src/view/text_input.rs
@@ -3,7 +3,7 @@
 
 use masonry::core::{ArcStr, NewWidget, PropertySet};
 use masonry::parley::style::FontWeight;
-use masonry::parley::{FontFamily, StyleProperty};
+use masonry::parley::{FontFamily, FontFamilyName, GenericFamily, StyleProperty};
 use masonry::peniko::Color;
 use masonry::properties::{CaretColor, ContentColor, PlaceholderColor, SelectionColor};
 use masonry::widgets::{self, TextAction};
@@ -88,7 +88,7 @@ where
         text_alignment: TextAlign::default(),
         text_size: masonry::theme::TEXT_SIZE_NORMAL,
         weight: FontWeight::NORMAL,
-        font: FontFamily::List(std::borrow::Cow::Borrowed(&[])),
+        font: FontFamily::Single(FontFamilyName::Generic(GenericFamily::SystemUi)),
         insert_newline: InsertNewline::default(),
         disabled: false,
         // Since we don't support setting the word wrapping, we can default to


### PR DESCRIPTION
In https://github.com/linebender/xilem/pull/1479, labels were set to use `SystemUi`, but checkboxes and text inputs were not updated at that time.

This PR implements this fix in the other two places it was missing, to fix rendering problems with numbers in specific environments:

<img width="467" height="129" alt="image" src="https://github.com/user-attachments/assets/77b9c4fd-1c4d-483b-9d61-dc5da32b4535" />

> These numbers are right next to the ascii text. This is what it looks like with this patch applied:
> 
> <img width="473" height="81" alt="image" src="https://github.com/user-attachments/assets/6de2fcc2-3892-42f8-9831-8a85c12ffeb3" />


BTW, per:

> Can't reproduce the linked issues

It seems that this issue might be related to Linux-specific `fontconfig` environments, as [I was able to reproduce these issues in a Wayland compositor/shell I'm building using Xilem](https://github.com/crutchcorn/hearthspace/issues/2)

Let me know if there's any additional changes I can apply to help this land.