### PR TITLE
Support `smol` as async runtime backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,8 +73,12 @@ checksum = "90e549dd7c6562b6a2ea807b44726e6241707db054a817dc4c7e2b8d3b39bfac"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
+ "async-channel",
+ "async-executor",
+ "async-task",
  "atspi",
  "futures-lite",
+ "futures-util",
  "serde",
  "tokio",
  "tokio-stream",
@@ -284,6 +288,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +325,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -2649,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -4346,6 +4372,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "smol_str"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4703,9 +4746,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -4720,9 +4763,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6417,6 +6460,7 @@ dependencies = [
  "masonry_winit",
  "profiling",
  "reqwest",
+ "smol",
  "time",
  "tokio",
  "tracing",
@@ -6442,6 +6486,7 @@ version = "0.4.0"
 dependencies = [
  "masonry",
  "smallvec",
+ "smol",
  "tokio",
  "tracing",
  "usvg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ masonry_imaging = { version = "0.4.0", path = "masonry_imaging", default-feature
 masonry_testing = { version = "0.4.0", path = "masonry_testing", default-features = false }
 masonry_winit = { version = "0.4.0", path = "masonry_winit", default-features = false }
 xilem_core = { version = "0.4.0", path = "xilem_core" }
-xilem_masonry = { version = "0.4.0", path = "xilem_masonry" }
+xilem_masonry = { version = "0.4.0", path = "xilem_masonry", default-features = false }
 xilem = { version = "0.4.0", path = "xilem", default-features = false }
 tree_arena = { version = "0.2.0", path = "tree_arena" }
 include_doc_path = { version = "0.1.0", path = "include_doc_path", package = "linebender_include_doc_path" }
@@ -85,7 +85,6 @@ bitflags = "2.11.0"
 accesskit = "0.24.0"
 accesskit_winit = { version = "0.32.2", default-features = false, features = [
     "accesskit_unix",
-    "tokio",
     "rwh_06",
 ] }
 accesskit_consumer = "0.35.0"
@@ -96,6 +95,8 @@ reqwest = { version = "0.12.28", default-features = false, features = [
     "rustls-tls",
 ] }
 divan = "0.1.21"
+tokio = { version = "1.53.1", features = ["rt", "rt-multi-thread", "time", "sync"] }
+smol = "2.0.2"
 
 [workspace.lints]
 # unsafe code is not allowed in Xilem or Masonry

--- a/masonry_winit/Cargo.toml
+++ b/masonry_winit/Cargo.toml
@@ -10,7 +10,6 @@ license.workspace = true
 repository.workspace = true
 
 [package.metadata.docs.rs]
-all-features = true
 # There are no platform specific docs.
 default-target = "x86_64-unknown-linux-gnu"
 targets = []
@@ -18,10 +17,12 @@ targets = []
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [features]
-default = ["imaging_vello"]
+default = ["imaging_vello", "accesskit-tokio"]
 imaging_vello = ["masonry_imaging/imaging_vello"]
 imaging_vello_hybrid = ["masonry_imaging/imaging_vello_hybrid"]
 imaging_skia = ["masonry_imaging/imaging_skia"]
+accesskit-tokio = ["accesskit_winit/tokio"]
+accesskit-async-io = ["accesskit_winit/async-io"]
 # Enables tracing using tracy if the default Masonry tracing is used.
 # https://github.com/wolfpld/tracy can be connected to when this feature is enabled.
 tracy = [

--- a/xilem/Cargo.toml
+++ b/xilem/Cargo.toml
@@ -15,7 +15,6 @@ exclude = [
 ]
 
 [package.metadata.docs.rs]
-all-features = true
 # There are no platform specific docs.
 default-target = "x86_64-unknown-linux-gnu"
 targets = []
@@ -32,7 +31,9 @@ debuggable = true
 name = "android.permission.INTERNET"
 
 [features]
-default = ["masonry/default", "masonry_winit/default"]
+default = ["masonry/default", "masonry_winit/default", "tokio-rt"]
+tokio-rt = ["dep:tokio", "xilem_masonry/tokio-rt", "masonry_winit/accesskit-tokio"]
+smol-rt = ["dep:smol", "xilem_masonry/smol-rt", "masonry_winit/accesskit-async-io"]
 
 [dependencies]
 xilem_core.workspace = true
@@ -41,7 +42,8 @@ masonry.workspace = true
 masonry_winit.workspace = true
 winit.workspace = true
 tracing.workspace = true
-tokio = { version = "1.50.0", features = ["rt", "rt-multi-thread", "time", "sync"] }
+tokio = { workspace = true, optional = true }
+smol = { workspace = true, optional = true }
 
 [dev-dependencies]
 # Used for `variable_clock`
@@ -69,18 +71,21 @@ name = "mason"
 # This actually enables scraping for all examples, not just this one.
 # However it is possible to set doc-scrape-examples to false for other specific examples.
 doc-scrape-examples = true
+required-features = ["tokio-rt"]
 
 [[example]]
 name = "calc"
 
 [[example]]
 name = "stopwatch"
+required-features = ["tokio-rt"]
 
 [[example]]
 name = "to_do_mvc"
 
 [[example]]
 name = "variable_clock"
+required-features = ["tokio-rt"]
 
 [[example]]
 name = "emoji_picker"
@@ -93,6 +98,11 @@ doc-scrape-examples = false
 
 [[example]]
 name = "http_cats"
+required-features = ["tokio-rt"]
+
+[[example]]
+name = "virtual_cats"
+required-features = ["tokio-rt"]
 
 # Also add to ANDROID_TARGETS in .github/ci.yml if adding a new Android example
 # and update the list in xilem/examples/android/README.md.
@@ -102,6 +112,7 @@ name = "mason_android"
 path = "examples/android/mason_android.rs"
 # cdylib is required for cargo-apk
 crate-type = ["cdylib"]
+required-features = ["tokio-rt"]
 
 [[example]]
 name = "calc_android"
@@ -114,6 +125,7 @@ name = "stopwatch_android"
 path = "examples/android/stopwatch_android.rs"
 # cdylib is required for cargo-apk
 crate-type = ["cdylib"]
+required-features = ["tokio-rt"]
 
 [[example]]
 name = "to_do_mvc_android"
@@ -126,6 +138,7 @@ name = "variable_clock_android"
 path = "examples/android/variable_clock_android.rs"
 # cdylib is required for cargo-apk
 crate-type = ["cdylib"]
+required-features = ["tokio-rt"]
 
 [[example]]
 name = "emoji_picker_android"
@@ -139,6 +152,7 @@ name = "http_cats_android"
 path = "examples/android/http_cats_android.rs"
 # cdylib is required for cargo-apk
 crate-type = ["cdylib"]
+required-features = ["tokio-rt"]
 
 [[example]]
 name = "canvas"

--- a/xilem/src/app.rs
+++ b/xilem/src/app.rs
@@ -8,8 +8,11 @@ use masonry::core::DefaultProperties;
 use masonry::peniko::{Blob, Color};
 use masonry::theme::{BACKGROUND_COLOR, default_property_set};
 use masonry_winit::app::{EventLoopBuilder, MasonryState, MasonryUserEvent, NewWindow, WindowId};
-use tokio::runtime::Runtime as TokioRuntime;
 use winit::error::EventLoopError;
+use xilem_masonry::runtime::Executor;
+
+#[cfg(feature = "tokio-rt")]
+use tokio::runtime::Runtime as TokioRuntime;
 
 use crate::core::map_state;
 use crate::window_options::WindowCallbacks;
@@ -22,7 +25,7 @@ use crate::{MasonryDriver, WidgetView, WindowOptions, WindowView};
 pub struct Xilem<State, Logic> {
     state: State,
     logic: Logic,
-    runtime: Arc<TokioRuntime>,
+    runtime: Arc<Executor>,
     default_properties: Option<DefaultProperties>,
     default_base_color: Color,
     // Font data to include in loading.
@@ -62,20 +65,33 @@ impl<State>
     where
         View: WidgetView<State>,
     {
-        Self::new_simple_with_tokio(
-            state,
-            logic,
-            window_options,
-            Arc::new(TokioRuntime::new().unwrap()),
-        )
+        Self::new_simple_with_executor(state, logic, window_options, Executor::new().into())
     }
 
     /// Same as [`Self::new_simple`] but allows passing an existing tokio runtime.
+    #[deprecated(
+        since = "0.4.0",
+        note = "use `Xilem::new_simple_with_executor` with `xilem_masonry::runtime::Executor` instead"
+    )]
+    #[cfg(feature = "tokio-rt")]
     pub fn new_simple_with_tokio<View>(
+        state: State,
+        logic: impl FnMut(&mut State) -> View + 'static,
+        window_options: WindowOptions<State>,
+        tokio_rt: Arc<TokioRuntime>,
+    ) -> Self
+    where
+        View: WidgetView<State>,
+    {
+        Self::new_simple_with_executor(state, logic, window_options, Arc::new(tokio_rt.into()))
+    }
+
+    /// Same as [`Self::new_simple`] but allows passing an existing runtime executor.
+    pub fn new_simple_with_executor<View>(
         state: State,
         mut logic: impl FnMut(&mut State) -> View + 'static,
         window_options: WindowOptions<State>,
-        tokio_rt: Arc<TokioRuntime>,
+        runtime: Arc<Executor>,
     ) -> Self
     where
         View: WidgetView<State>,
@@ -112,7 +128,7 @@ impl<State>
                     }),
                 )
             }),
-            tokio_rt,
+            runtime,
         )
     }
 }
@@ -138,10 +154,10 @@ where
     where
         State: AppState,
     {
-        Self::new_inner(state, logic, Arc::new(TokioRuntime::new().unwrap()))
+        Self::new_inner(state, logic, Arc::new(Executor::new()))
     }
 
-    fn new_inner(state: State, logic: Logic, runtime: Arc<TokioRuntime>) -> Self {
+    fn new_inner(state: State, logic: Logic, runtime: Arc<Executor>) -> Self {
         Self {
             state,
             logic,

--- a/xilem/src/driver.rs
+++ b/xilem/src/driver.rs
@@ -17,17 +17,18 @@ use crate::core::{
 };
 use crate::window_view::{WindowView, WindowViewState};
 use crate::{AppState, Color, ViewCtx};
+use xilem_masonry::runtime::Executor;
 
 /// The composition root of Xilem's Masonry backend.
 ///
 /// Owns the root state, the root view (kind of), the window state, the event loop proxy,
-/// the tokio runtime, etc.
+/// the async runtime executor, etc.
 pub struct MasonryDriver<State: 'static, Logic> {
     state: State,
     logic: Logic,
     windows: HashMap<WindowId, Window<State>>,
     proxy: Arc<MasonryProxy>,
-    runtime: Arc<tokio::runtime::Runtime>,
+    runtime: Arc<Executor>,
     default_base_color: Color,
     // Fonts which will be registered on startup.
     fonts: Vec<Blob<u8>>,
@@ -53,7 +54,7 @@ where
         // TODO: narrow down MasonryUserEvent in event_sink once masonry_winit supports custom event types
         // (we only ever use it to send MasonryUserEvent::Action with ASYNC_MARKER_WIDGET)
         event_sink: impl Fn(MasonryUserEvent) -> Result<(), MasonryUserEvent> + Send + Sync + 'static,
-        runtime: Arc<tokio::runtime::Runtime>,
+        runtime: Arc<Executor>,
         default_base_color: Color,
         fonts: Vec<Blob<u8>>,
         start_callback: Option<Box<dyn FnOnce(&mut MasonryState<'_>)>>,

--- a/xilem/src/lib.rs
+++ b/xilem/src/lib.rs
@@ -153,6 +153,9 @@ pub use masonry;
 pub use masonry::dpi;
 pub use masonry::palette;
 pub use masonry::{kurbo, peniko};
+#[cfg(feature = "smol-rt")]
+pub use smol;
+#[cfg(feature = "tokio-rt")]
 pub use tokio;
 pub use winit;
 pub use xilem_core as core;

--- a/xilem_masonry/Cargo.toml
+++ b/xilem_masonry/Cargo.toml
@@ -10,20 +10,22 @@ license.workspace = true
 repository.workspace = true
 
 [package.metadata.docs.rs]
-all-features = true
 # There are no platform specific docs.
 default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [features]
-default = ["masonry/default"]
+default = ["masonry/default", "tokio-rt"]
+tokio-rt = ["dep:tokio"]
+smol-rt = ["dep:smol"]
 
 [dependencies]
 xilem_core.workspace = true
 masonry.workspace = true
 smallvec.workspace = true
 tracing.workspace = true
-tokio = { version = "1.50.0", features = ["rt", "rt-multi-thread", "time", "sync"] }
+tokio = { workspace = true, optional = true }
+smol = { workspace = true, optional = true }
 usvg.workspace = true
 
 [lints]

--- a/xilem_masonry/src/lib.rs
+++ b/xilem_masonry/src/lib.rs
@@ -35,6 +35,7 @@
 pub use masonry;
 pub use xilem_core as core;
 
+pub mod runtime;
 pub mod style;
 pub mod view;
 

--- a/xilem_masonry/src/runtime.rs
+++ b/xilem_masonry/src/runtime.rs
@@ -1,0 +1,128 @@
+//! A simple shim for different async runtime backend.
+
+#[cfg(all(feature = "tokio-rt", feature = "smol-rt"))]
+compile_error!("Only one of `tokio-rt` or `smol-rt` can be enabled.");
+
+#[cfg(not(any(feature = "tokio-rt", feature = "smol-rt")))]
+compile_error!("One of `tokio-rt` or `smol-rt` must be enabled.");
+
+#[cfg(feature = "tokio-rt")]
+mod tokio_rt {
+    use std::sync::Arc;
+
+    use tokio::runtime::Runtime;
+    use tokio::task::JoinHandle;
+
+    pub use tokio::sync::mpsc::{
+        UnboundedReceiver as Receiver, UnboundedSender as Sender, unbounded_channel as channel,
+    };
+
+    /// Wrapper around [`tokio::task::JoinHandle`].
+    pub struct Handle(JoinHandle<()>);
+
+    impl Handle {
+        /// See [`tokio::task::JoinHandle::abort`].
+        pub fn abort(&mut self) {
+            self.0.abort();
+        }
+    }
+
+    /// Wrapper around [`tokio::runtime::Runtime`].
+    pub struct Executor(Arc<Runtime>);
+
+    impl Executor {
+        /// Create a new executor.
+        pub fn new() -> Self {
+            Self(Runtime::new().unwrap().into())
+        }
+
+        /// See [`tokio::runtime::Runtime::spawn`].
+        pub fn spawn(&self, fut: impl Future<Output = ()> + Send + 'static) -> Handle {
+            Handle(self.0.spawn(fut))
+        }
+    }
+
+    impl From<Arc<Runtime>> for Executor {
+        fn from(value: Arc<Runtime>) -> Self {
+            Self(value)
+        }
+    }
+
+    impl Default for Executor {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+}
+
+#[cfg(feature = "smol-rt")]
+mod smol_rt {
+    use smol::{Task, channel, spawn};
+
+    /// Wrapper around [`smol::Task`].
+    pub struct Handle(Option<Task<()>>);
+
+    impl Handle {
+        /// Abort the current task.
+        pub fn abort(&mut self) {
+            drop(self.0.take());
+        }
+    }
+
+    /// An unit struct represting `smol`'s async executor.
+    pub struct Executor;
+
+    impl Executor {
+        /// Create a bew executor,
+        pub fn new() -> Self {
+            Self
+        }
+
+        /// Spawn a new future.
+        pub fn spawn(&self, fut: impl Future<Output = ()> + Send + 'static) -> Handle {
+            Handle(Some(spawn(fut)))
+        }
+    }
+
+    impl Default for Executor {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    /// Wrapper around [`smol::channel::Sender`].
+    #[derive(Clone)]
+    pub struct Sender<T>(channel::Sender<T>);
+
+    /// Wrapper around [`smol::channel::Receiver`].
+    pub struct Receiver<T>(channel::Receiver<T>);
+
+    /// Wrapper around [`smol::channel::SendError`].
+    pub type SendError<T> = channel::SendError<T>;
+
+    impl<T> Sender<T> {
+        /// Send a message to the receiver.
+        pub fn send(&self, value: T) -> Result<(), SendError<T>> {
+            self.0.force_send(value).map(drop)
+        }
+    }
+
+    impl<T> Receiver<T> {
+        /// Receive message from the sender.
+        pub async fn recv(&mut self) -> Option<T> {
+            self.0.recv().await.ok()
+        }
+    }
+
+    /// Wrapper around [`smol::channel::unbounded`].
+    pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+        let (sender, receiver) = channel::unbounded();
+        (Sender(sender), Receiver(receiver))
+    }
+}
+
+#[cfg(feature = "tokio-rt")]
+pub use tokio_rt::*;
+
+#[cfg(feature = "smol-rt")]
+pub use smol_rt::*;

--- a/xilem_masonry/src/view/task.rs
+++ b/xilem_masonry/src/view/task.rs
@@ -5,21 +5,20 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use tokio::task::JoinHandle;
-
 use crate::ViewCtx;
 use crate::core::anymore::AnyDebug;
 use crate::core::{
     MessageCtx, MessageProxy, MessageResult, Mut, NoElement, View, ViewId, ViewMarker,
     ViewPathTracker,
 };
+use crate::runtime::Handle;
 
 /// Launch a task which will run until the view is no longer in the tree.
 /// `init_future` is given a [`MessageProxy`], which it will store in the future it returns.
 /// This `MessageProxy` can be used to send a message to `on_event`, which can then update
 /// the app's state.
 ///
-/// For example, this can be used with the time functions in [`tokio::time`].
+/// For example, this can be used with the time functions provided by the selected async runtime.
 ///
 /// Note that this task will not be updated if the view is rebuilt, so `init_future`
 /// cannot capture.
@@ -91,7 +90,7 @@ where
 {
     type Element = NoElement;
 
-    type ViewState = JoinHandle<()>;
+    type ViewState = Handle;
 
     fn build(&self, ctx: &mut ViewCtx, state: &mut State) -> (Self::Element, Self::ViewState) {
         let path: Arc<[ViewId]> = ctx.view_path().into();

--- a/xilem_masonry/src/view/worker.rs
+++ b/xilem_masonry/src/view/worker.rs
@@ -6,15 +6,13 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tokio::task::JoinHandle;
-
 use crate::ViewCtx;
 use crate::core::anymore::AnyDebug;
 use crate::core::{
     MessageCtx, MessageProxy, MessageResult, Mut, NoElement, Resource, View, ViewId, ViewMarker,
     ViewPathTracker,
 };
+use crate::runtime::{self, Handle, Receiver, Sender};
 
 // TODO: Update generic variable names to be more .
 
@@ -24,7 +22,7 @@ use crate::core::{
 /// This `MessageProxy` can be used to send a message to `on_event`, which can then update
 /// the app's state.
 ///
-/// For example, this can be used with the time functions in [`tokio::time`].
+/// For example, this can be used with the time functions provided by the selected async runtime.
 ///
 /// Note that this task will not be updated if the view is rebuilt, so `init_future`
 /// cannot capture.
@@ -34,20 +32,11 @@ pub fn worker<F, H, M, S, V, State, Action, Fut>(
     init_future: F,
     store_sender: S,
     on_response: H,
-) -> Worker<
-    State,
-    Action,
-    F,
-    H,
-    M,
-    impl Fn(&mut State, &mut Dummy, UnboundedSender<V>) + 'static,
-    V,
-    Dummy,
->
+) -> Worker<State, Action, F, H, M, impl Fn(&mut State, &mut Dummy, Sender<V>) + 'static, V, Dummy>
 where
-    F: Fn(MessageProxy<M>, UnboundedReceiver<V>) -> Fut,
+    F: Fn(MessageProxy<M>, Receiver<V>) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
-    S: Fn(&mut State, UnboundedSender<V>) + 'static,
+    S: Fn(&mut State, Sender<V>) + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
     M: AnyDebug + Send + 'static,
     State: 'static,
@@ -61,7 +50,7 @@ where
     };
     Worker {
         init_future,
-        store_sender: move |state: &mut State, _dummy: &mut Dummy, sender: UnboundedSender<V>| {
+        store_sender: move |state: &mut State, _dummy: &mut Dummy, sender: Sender<V>| {
             store_sender(state, sender);
         },
         on_response,
@@ -79,9 +68,9 @@ pub fn env_worker<F, H, M, S, V, Res, State, Action, Fut>(
     on_response: H,
 ) -> Worker<State, Action, F, H, M, S, V, Res>
 where
-    F: Fn(MessageProxy<M>, UnboundedReceiver<V>) -> Fut,
+    F: Fn(MessageProxy<M>, Receiver<V>) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
-    S: Fn(&mut State, &mut Res, UnboundedSender<V>),
+    S: Fn(&mut State, &mut Res, Sender<V>),
     H: Fn(&mut State, M) -> Action + 'static,
     M: AnyDebug + Send + 'static,
     Res: Resource,
@@ -119,21 +108,12 @@ pub fn worker_raw<M, V, S, F, H, State, Action, Fut>(
     init_future: F,
     store_sender: S,
     on_response: H,
-) -> Worker<
-    State,
-    Action,
-    F,
-    H,
-    M,
-    impl Fn(&mut State, &mut Dummy, UnboundedSender<V>) + 'static,
-    V,
-    Dummy,
->
+) -> Worker<State, Action, F, H, M, impl Fn(&mut State, &mut Dummy, Sender<V>) + 'static, V, Dummy>
 where
     // TODO(DJMcNab): Accept app_state here
-    F: Fn(MessageProxy<M>, UnboundedReceiver<V>) -> Fut,
+    F: Fn(MessageProxy<M>, Receiver<V>) -> Fut,
     Fut: Future<Output = ()> + Send + 'static,
-    S: Fn(&mut State, UnboundedSender<V>) + 'static,
+    S: Fn(&mut State, Sender<V>) + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
     M: AnyDebug + Send + 'static,
     State: 'static,
@@ -141,7 +121,7 @@ where
     Worker {
         init_future,
         on_response,
-        store_sender: move |state: &mut State, _dummy: &mut Dummy, sender: UnboundedSender<V>| {
+        store_sender: move |state: &mut State, _dummy: &mut Dummy, sender: Sender<V>| {
             store_sender(state, sender);
         },
         message: PhantomData,
@@ -163,24 +143,24 @@ impl<State, Action, F, H, M, Fut, S, V, Res> View<State, Action, ViewCtx>
 where
     Res: Resource,
     Action: 'static,
-    F: Fn(MessageProxy<M>, UnboundedReceiver<V>) -> Fut + 'static,
+    F: Fn(MessageProxy<M>, Receiver<V>) -> Fut + 'static,
     V: Send + 'static,
     Fut: Future<Output = ()> + Send + 'static,
-    S: Fn(&mut State, &mut Res, UnboundedSender<V>) + 'static,
+    S: Fn(&mut State, &mut Res, Sender<V>) + 'static,
     H: Fn(&mut State, M) -> Action + 'static,
     M: AnyDebug + Send + 'static,
     State: 'static,
 {
     type Element = NoElement;
 
-    type ViewState = JoinHandle<()>;
+    type ViewState = Handle;
 
     fn build(&self, ctx: &mut ViewCtx, app_state: &mut State) -> (Self::Element, Self::ViewState) {
         let path: Arc<[ViewId]> = ctx.view_path().into();
 
         let proxy = ctx.proxy();
 
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, rx) = runtime::channel();
         let env = ctx.environment();
         if TypeId::of::<Res>() != TypeId::of::<Dummy>() {
             let pos = env.get_slot_for_type::<Res>();

--- a/xilem_masonry/src/view_ctx.rs
+++ b/xilem_masonry/src/view_ctx.rs
@@ -9,6 +9,7 @@ use masonry::core::{FromDynWidget, Property, Widget, WidgetId, WidgetMut};
 
 use crate::Pod;
 use crate::core::{Environment, RawProxy, ViewId, ViewPathTracker};
+use crate::runtime::Executor;
 
 /// A context type passed to various methods of Xilem traits.
 pub struct ViewCtx {
@@ -18,7 +19,7 @@ pub struct ViewCtx {
     widget_map: HashMap<WidgetId, Vec<ViewId>>,
     id_path: Vec<ViewId>,
     proxy: Arc<dyn RawProxy>,
-    runtime: Arc<tokio::runtime::Runtime>,
+    runtime: Arc<Executor>,
     props_changed: HashSet<(WidgetId, TypeId)>,
     transforms_changed: HashSet<WidgetId>,
     environment: Environment,
@@ -80,8 +81,8 @@ impl ViewCtx {
         self.widget_map.remove(&widget.ctx.widget_id());
     }
 
-    /// Returns a reference to the app's tokio runtime.
-    pub fn runtime(&self) -> &tokio::runtime::Runtime {
+    /// Returns a reference to the app's async runtime executor.
+    pub fn runtime(&self) -> &Executor {
         &self.runtime
     }
 
@@ -139,7 +140,7 @@ impl ViewCtx {
     /// Creates a new `ViewCtx` for rebuilding the widget tree.
     ///
     /// You almost never need to call this method unless you're building your own framework.
-    pub fn new(proxy: Arc<dyn RawProxy>, runtime: Arc<tokio::runtime::Runtime>) -> Self {
+    pub fn new(proxy: Arc<dyn RawProxy>, runtime: Arc<Executor>) -> Self {
         Self {
             widget_map: HashMap::default(),
             id_path: Vec::new(),


### PR DESCRIPTION
As title.

Currently the `tokio` and `smol` backend are mutually exclusive and cannot be turned on at the same time. This can change, however I dont see any value in doing so.