### PR TITLE
tree_arena: make the crate no_std + alloc

### DIFF
--- a/tree_arena/Cargo.toml
+++ b/tree_arena/Cargo.toml
@@ -16,11 +16,14 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [features]
+default = ["std", "safe_tree"]
+# Enable future features which require the standard library.
+# This feature is provided for forwards compatibility only, and current behaviour is the same whether or not it is enabled.
+std = []
 # This crate contains two implementations of a tree for use in masonry, one safe and the other unsafe.
 # The safe tree is known to work, and serves as the baseline implementation and is used by default.
 # The unsafe tree leverages a hashmap as an arena and is designed for higher performance: it leverages unsafe code to achieve this.
 # The unsafe tree is not yet fully tested, and is not used by default.
-default = ["safe_tree"]
 safe_tree = []
 
 [dependencies]

--- a/tree_arena/README.md
+++ b/tree_arena/README.md
@@ -34,6 +34,17 @@ The safe tree is the priority. This means:
 * If both versions are at feature parity, [Masonry][] can switch on the unsafe version for best performance.
 * Otherwise, [Masonry][] uses the safe version.
 
+## Features
+
+The following crate [feature flags](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features) are available:
+
+- `std` (enabled by default): Enable future features which require the standard library.
+  This feature is provided for forwards compatibility only, and current behaviour is the same whether or not it is enabled.
+- `safe_tree` (enabled by default): Use the safe tree implementation instead of the unsafe one.
+
+This crate is `no_std` compatible; to use it without the standard library, disable default features.
+Note that this also disables `safe_tree`, so re-enable it explicitly if you want the safe implementation.
+
 ## Architecture
 
 ### Safe Tree

--- a/tree_arena/src/lib.rs
+++ b/tree_arena/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#![no_std]
-
 // After you edit the crate's doc comment, run this command, then check README.md for any missing links
 // cargo rdme --workspace-project=tree_arena
 
@@ -14,6 +12,17 @@
 //! * The safe version may have features / APIs that the unsafe version doesn't yet have.
 //! * If both versions are at feature parity, [Masonry][] can switch on the unsafe version for best performance.
 //! * Otherwise, [Masonry][] uses the safe version.
+//!
+//! # Features
+//!
+//! The following crate [feature flags](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features) are available:
+//!
+//! - `std` (enabled by default): Enable future features which require the standard library.
+//!   This feature is provided for forwards compatibility only, and current behaviour is the same whether or not it is enabled.
+//! - `safe_tree` (enabled by default): Use the safe tree implementation instead of the unsafe one.
+//!
+//! This crate is `no_std` compatible; to use it without the standard library, disable default features.
+//! Note that this also disables `safe_tree`, so re-enable it explicitly if you want the safe implementation.
 //!
 //! # Architecture
 //!
@@ -66,7 +75,23 @@
 //!
 //! [Masonry]: https://crates.io/crates/masonry
 
+// LINEBENDER LINT SET - lib.rs - v3
+// See https://linebender.org/wiki/canonical-lints/
+// These lints shouldn't apply to examples or tests.
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+// These lints shouldn't apply to examples.
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+// Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
+#![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
+// END LINEBENDER LINT SET
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![no_std]
+
 extern crate alloc;
+
+#[cfg(feature = "std")]
+// Ensure that we don't compile if you're using the std feature on a platform without `std`
+extern crate std as _;
 
 type NodeId = u64;
 

--- a/tree_arena/src/lib.rs
+++ b/tree_arena/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#![no_std]
+
 // After you edit the crate's doc comment, run this command, then check README.md for any missing links
 // cargo rdme --workspace-project=tree_arena
 
@@ -63,6 +65,8 @@
 //! |From root  | O(Depth)     | O(1)     |
 //!
 //! [Masonry]: https://crates.io/crates/masonry
+
+extern crate alloc;
 
 type NodeId = u64;
 

--- a/tree_arena/src/tree_arena_safe.rs
+++ b/tree_arena/src/tree_arena_safe.rs
@@ -6,6 +6,8 @@
 //! The version in `tree_arena_unsafe.rs` uses unsafe code, but should have the
 //! exact same exported API as this module.
 
+use alloc::vec::Vec;
+
 use hashbrown::HashMap;
 
 use crate::NodeId;
@@ -573,7 +575,7 @@ impl<'arena, T> ArenaMutList<'arena, T> {
     /// and may change in any release.
     #[doc(hidden)]
     pub fn realloc_inner_storage(&mut self) {
-        std::hint::black_box(());
+        core::hint::black_box(());
     }
 }
 

--- a/tree_arena/src/tree_arena_unsafe.rs
+++ b/tree_arena/src/tree_arena_unsafe.rs
@@ -6,7 +6,9 @@
 //! A future version will likely use some kind of slotmap.
 
 #![allow(unsafe_code, reason = "Purpose is unsafe abstraction")]
-use std::cell::UnsafeCell;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::cell::UnsafeCell;
 
 use hashbrown::HashMap;
 
@@ -677,12 +679,12 @@ impl<'arena, T> ArenaMutList<'arena, T> {
         // By doubling the required capacity (plus a small constant for small capacities),
         // we hopefully guarantee that a reallocation will happen no matter the original capacity.
         let capacity = self.parent_arena.items.capacity();
-        let capacity = std::hint::black_box(capacity);
+        let capacity = core::hint::black_box(capacity);
         self.parent_arena.items.reserve(capacity + 32);
 
         // We try to discard the extra memory.
         // We use black_box to hide the fact that the above call to reserve could be elided.
-        if std::hint::black_box(true) {
+        if core::hint::black_box(true) {
             self.parent_arena.items.shrink_to_fit();
         }
     }


### PR DESCRIPTION
Hi there XIlem team! 

I've been experimenting with the Xilem architecture for a framework for embedded devices. `tree_arena` works really well in embedded devices too. The only thing is that my crate is `no_std + alloc` and in the `tree_arena` there are few `std` imports, that make impossible for me just to pull it as a dependency. This would be awesome so I don't have to vendor xilem in my repo / CI with this patch.

Please let me know if you want to actually see the embedded GUI library and I'll add some of you to my private repo. I am just no ready to share, it will be of course open source but want to validate a bunch of stuff before I release it.

Thanks for Xilem!

Changes:

- `lib.rs`: add `#![no_std]` and `extern crate alloc;` (the latter placed after the crate-level `//!` doc block so the module-doc position stays valid).
- `tree_arena_safe.rs`: add `use alloc::vec::Vec;` so the `Vec<NodeId>` return types still resolve without the std prelude. Replace `std::hint::black_box(())` in the hidden test helper with `core::hint::black_box(())` — same semantics, available on no_std.
- `tree_arena_unsafe.rs`: swap `use std::cell::UnsafeCell;` → `use core::cell::UnsafeCell;`, add `use alloc::{boxed::Box, vec::Vec};` for the `Box<UnsafeCell<…>>` and `Vec<NodeId>` fields, and the two `std::hint::black_box` → `core::hint::black_box` swaps in the `realloc_inner_storage` test helper.

Disclaimer:

I used some LLM agents to drive this change but is faily simple. I hope that is ok.