### PR TITLE
Update compiler version and MSRV.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,12 @@ env:
   # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
   # come automatically. If the version specified here is no longer the latest stable version,
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
-  RUST_STABLE_VER: "1.95" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
+  RUST_STABLE_VER: "1.97.1" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
   # The purpose of checking with the minimum supported Rust toolchain is to detect its staleness.
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,
   # plus all the README.md files of the affected packages.
-  RUST_MIN_VER: "1.92"
+  RUST_MIN_VER: "1.96"
   # List of packages that can not target Wasm.
   NO_WASM_PKGS: >-
     --exclude masonry_core
@@ -297,7 +297,7 @@ jobs:
 
       - name: Run cargo nextest on unsafe arena
         run: cargo nextest run -p tree_arena --locked --no-fail-fast --no-default-features
-  
+
       - name: Upload test results due to failure
         uses: actions/upload-artifact@v4
         if: failure()

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ version = "0.4.0"
 
 edition = "2024"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files.
-rust-version = "1.92"
+rust-version = "1.96"
 license = "Apache-2.0"
 repository = "https://github.com/linebender/xilem"
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ split-debuginfo="unpacked"
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Xilem has been verified to compile with **Rust 1.92** and later.
+This version of Xilem has been verified to compile with **Rust 1.96** and later.
 
 Future versions of Xilem might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/masonry/README.md
+++ b/masonry/README.md
@@ -208,7 +208,7 @@ If you want to use your own subscriber, simply set it before starting masonry - 
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Masonry has been verified to compile with **Rust 1.92** and later.
+This version of Masonry has been verified to compile with **Rust 1.96** and later.
 
 Future versions of Masonry might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/masonry_core/README.md
+++ b/masonry_core/README.md
@@ -84,7 +84,7 @@ The following crate [feature flags](https://doc.rust-lang.org/cargo/reference/fe
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Masonry Core has been verified to compile with **Rust 1.92** and later.
+This version of Masonry Core has been verified to compile with **Rust 1.96** and later.
 
 Future versions of Masonry Core might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/masonry_testing/README.md
+++ b/masonry_testing/README.md
@@ -89,7 +89,7 @@ For examples of this crate in use
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Masonry Testing has been verified to compile with **Rust 1.92** and later.
+This version of Masonry Testing has been verified to compile with **Rust 1.96** and later.
 
 Future versions of Masonry Testing might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/masonry_winit/README.md
+++ b/masonry_winit/README.md
@@ -96,7 +96,7 @@ fn main() {
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Masonry Winit has been verified to compile with **Rust 1.92** and later.
+This version of Masonry Winit has been verified to compile with **Rust 1.96** and later.
 
 Future versions of Masonry Winit might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/placehero/README.md
+++ b/placehero/README.md
@@ -43,7 +43,7 @@ The following crate [feature flags](https://doc.rust-lang.org/cargo/reference/fe
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Placehero has been verified to compile with **Rust 1.92** and later.
+This version of Placehero has been verified to compile with **Rust 1.96** and later.
 
 Future versions of Placehero might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/tree_arena/README.md
+++ b/tree_arena/README.md
@@ -101,7 +101,7 @@ This invariant is not checked by the compiler and thus relies on the logic to de
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Tree Arena has been verified to compile with **Rust 1.92** and later.
+This version of Tree Arena has been verified to compile with **Rust 1.96** and later.
 
 Future versions of Tree Arena might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/xilem/README.md
+++ b/xilem/README.md
@@ -172,7 +172,7 @@ The following crate [feature flags](https://doc.rust-lang.org/cargo/reference/fe
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Xilem has been verified to compile with **Rust 1.92** and later.
+This version of Xilem has been verified to compile with **Rust 1.96** and later.
 
 Future versions of Xilem might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/xilem_core/README.md
+++ b/xilem_core/README.md
@@ -64,7 +64,7 @@ Xilem Core supports running with `#![no_std]`, but does require [`alloc`][] to b
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Xilem Core has been verified to compile with **Rust 1.92** and later.
+This version of Xilem Core has been verified to compile with **Rust 1.96** and later.
 
 Future versions of Xilem Core might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/xilem_masonry/README.md
+++ b/xilem_masonry/README.md
@@ -42,7 +42,7 @@ See [Xilem][] or [Xilem Web][] instead.
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Xilem Masonry has been verified to compile with **Rust 1.92** and later.
+This version of Xilem Masonry has been verified to compile with **Rust 1.96** and later.
 
 Future versions of Xilem Masonry might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/xilem_web/README.md
+++ b/xilem_web/README.md
@@ -82,7 +82,7 @@ That is a simplifying assumption for most Rust code, but this is mismatched with
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Xilem Web has been verified to compile with **Rust 1.92** and later.
+This version of Xilem Web has been verified to compile with **Rust 1.96** and later.
 
 Future versions of Xilem Web might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.


### PR DESCRIPTION
This raises MSRV to 1.96 to unlock `assert_matches`.